### PR TITLE
Include bower_components/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/*
+bower_components/


### PR DESCRIPTION
We should prevent `bower_components` from accidentally getting committed
