### PR TITLE
Fix for issue #73

### DIFF
--- a/src/diagrams/sequenceDiagram/svgDraw.js
+++ b/src/diagrams/sequenceDiagram/svgDraw.js
@@ -26,7 +26,7 @@ exports.drawText = function(elem , textData){
     textElem.style('text-anchor', textData.anchor);
     textElem.attr('fill', textData.fill);
 
-    textData.text.split('<br>').forEach(function(rowText){
+    textData.text.split(/<br\/?>/ig).forEach(function(rowText){
         var span = textElem.append('tspan');
         span.attr('x', textData.x +textData.textMargin);
         span.attr('dy', textData.dy);


### PR DESCRIPTION
Should now correctly line break for `<br>`, `<BR>`, `<br/>`, `<BR/>`

graph.txt:

```
sequenceDiagram
  participant Alice
  participant Bob
  Alice->John: Hello John, how are you?
  loop Healthcheck
  John->John: Fight against hypochondria
  end
  Note right of John: Rational thoughts <br/>prevail...
  John-->Alice: Great!
  John->Bob: How about you?
  Bob-->John: Jolly good
```

mermaid output:
![mermaid txt](https://cloud.githubusercontent.com/assets/8934224/5586209/a59ec9b0-9093-11e4-8ddf-94c3830705a0.png) 

`phantomjs -v` outputs `1.9.8`
