### PR TITLE
Support for underscore in classDiagrams class names

### DIFF
--- a/docs/classDiagram.md
+++ b/docs/classDiagram.md
@@ -44,7 +44,7 @@ Mermaid can render class diagrams.
           +String beakColor
           +swim()
           +quack()
-       }
+      }
       class Fish{
           -int sizeInFeet
           -canEat()
@@ -69,7 +69,7 @@ A single instance of a class in the diagram contains three compartments:
 ```
 classDiagram
     class BankAccount
-    BankAccount : +String onwer
+    BankAccount : +String owner
     BankAccount : +Bigdecimal balance
     BankAccount : +deposit(amount)
     BankAccount : +withdrawl(amount)
@@ -77,7 +77,7 @@ classDiagram
 ```mermaid
 classDiagram
     class BankAccount
-    BankAccount : +String onwer
+    BankAccount : +String owner
     BankAccount : +BigDecimal balance
     BankAccount : +deposit(amount)
     BankAccount : +withdrawl(amount)
@@ -98,6 +98,9 @@ classDiagram
     class Animal
     Vehicle <|-- Car
 ```
+
+Naming convention: a class name should be composed of alphanumeric (unicode allowed) and underscore characters.
+
 ## Defining Members of a class
 
 UML provides mechanisms to represent class members, such as attributes and methods, and additional information about them.
@@ -117,7 +120,7 @@ There are two ways to define the members of a class, and regardless of the which
 
  ```
   class BankAccount
-  BankAccount : +String onwer
+  BankAccount : +String owner
   BankAccount : +BigDecimal balance
   BankAccount : +deposit(amount)
   BankAccount : +withdrawl(amount)
@@ -125,7 +128,7 @@ There are two ways to define the members of a class, and regardless of the which
   ```mermaid
     classDiagram
     class BankAccount
-    BankAccount : +String onwer
+    BankAccount : +String owner
     BankAccount : +BigDecimal balance
     BankAccount : +deposit(amount)
     BankAccount : +withdrawl(amount)
@@ -134,7 +137,7 @@ There are two ways to define the members of a class, and regardless of the which
 - Associate members of a class using **{}** brackets, where members are grouped within curly brackets. Suitable for defining multiple members at once. For example:
 ```
 class BankAccount{
-    +String onwer
+    +String owner
     +BigDecimal balance
     +deposit(amount)
     +withdrawl(amount)
@@ -143,7 +146,7 @@ class BankAccount{
 ```mermaid
     classDiagram
     class BankAccount{
-        +String onwer
+        +String owner
         +BigDecimal balance
         +deposit(amount)
         +withdrawl(amount)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mermaid",
-  "version": "8.3.1",
+  "version": "8.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/diagrams/class/classDiagram.spec.js
+++ b/src/diagrams/class/classDiagram.spec.js
@@ -64,7 +64,7 @@ describe('class diagram, ', function() {
     it('should handle parsing of method statements  grouped by brackets', function() {
       const str =
         'classDiagram\n' +
-        'class Dummy {\n' +
+        'class Dummy_Class {\n' +
         'String data\n' +
         '  void methods()\n' +
         '}\n' +

--- a/src/diagrams/class/parser/classDiagram.jison
+++ b/src/diagrams/class/parser/classDiagram.jison
@@ -43,8 +43,8 @@
 \%                    return 'PCT';
 "="                   return 'EQUALS';
 \=                    return 'EQUALS';
-[A-Za-z]+             return 'ALPHA';
-[!"#$%&'*+,-.`?\\_/]  return 'PUNCTUATION';
+\w+                   return 'ALPHA';
+[!"#$%&'*+,-.`?\\/]   return 'PUNCTUATION';
 [0-9]+                 return 'NUM';
 [\u00AA\u00B5\u00BA\u00C0-\u00D6\u00D8-\u00F6]|
 [\u00F8-\u02C1\u02C6-\u02D1\u02E0-\u02E4\u02EC\u02EE\u0370-\u0374\u0376\u0377]|


### PR DESCRIPTION
Hello, please review a contributing beginner pull request to this awesome library.
I tried to keep the changes as simple as possible to fix that particular issue, because it seems high value compared to time spent for the fix. 

- Resolves #656
Class diagram ALPHA pattern now include underscore

 - [x] unit test 
 - [x] documentation