### PR TITLE
Bug/1030 Adjust babel config to account for IE11

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,9 +3,7 @@ module.exports = {
     [
       '@babel/preset-env',
       {
-        targets: {
-          node: 'current'
-        }
+        targets: "defaults, ie >= 11, current node"
       }
     ]
   ]


### PR DESCRIPTION
An attempt at adding IE11 compatibility (`ie >= 11`) while preserving the current requirements (`current node`) and following browserlist [best practices](https://github.com/browserslist/browserslist#best-practices) (`defaults`).

Unfortunately I have no clue if this actually does what I expect it to do. Also I do not know how to add browser compatibility testing. Someone should definitely review this. 