### PR TITLE
Feature/1106 Release management

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,3 @@
+'Type: Bug / Error': 'bug/*'
+'Type: Enhancement': 'feature/*'
+'Type: Other': 'other/*'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
 name-template: '$NEXT_PATCH_VERSION'
-tag-template: 'v$NEXT_PATCH_VERSION'
+tag-template: '$NEXT_PATCH_VERSION'
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -16,4 +16,4 @@ template: |
 
   $CHANGES
 
-  Thanks to all contributors helping out!
+  🎉 **Thanks to all contributors helping with this release!** 🎉

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,19 @@
+name-template: '$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'Type: Enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'Type: Bug / Error'
+  - title: '🧰 Maintenance'
+    label: 'Type: Other'
+change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
+no-changes-template: 'This release contains minor changes and bugfixes.'
+template: |
+  # Release Notes
+
+  $CHANGES
+
+  Thanks to all contributors helping out!

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,13 @@
+name: Apply labels to PR
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  pr-labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PR
+        uses: TimonVS/pr-labeler-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -1,0 +1,15 @@
+name: Draft Release
+
+on:
+  push:
+    branches:
+      - development
+
+jobs:
+  draft-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Draft Release
+        uses: toolmantim/release-drafter@v5.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -3,7 +3,7 @@ name: Draft Release
 on:
   push:
     branches:
-      - development
+      - develop
 
 jobs:
   draft-release:

--- a/.github/workflows/release-preview-publish.yml
+++ b/.github/workflows/release-preview-publish.yml
@@ -8,15 +8,12 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [10.x]
     steps:
     - uses: actions/checkout@v1
-    - name: Setup Node.js ${{ matrix.node-version }}
+    - name: Setup Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 10.x
     - name: Install Yarn
       run: npm i yarn --global
 
@@ -24,7 +21,7 @@ jobs:
       run: npm i json --global
 
     - name: Install Packages
-      run: yarn install
+      run: yarn install --frozen-lockfile
 
     - name: Publish
       run: |

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -28,17 +28,19 @@ jobs:
 
     - name: Prepare release
       run: |
-        echo "Preparing release ${GITHUB_REF:10}"
-        git checkout -t origin/release/${GITHUB_REF:10}
-        npm version --no-git-tag-version --allow-same-version ${GITHUB_REF:10}
+        VERSION=${GITHUB_REF:10}
+        echo "Preparing release $VERSION"
+        git checkout -t origin/release/$VERSION
+        npm version --no-git-tag-version --allow-same-version $VERSION
         git add package.json
-        git commit -m "Bump version ${GITHUB_REF:10}"
+        git commit -m "Bump version $VERSION"
         git checkout -t origin/master
-        git merge -m "Release ${GITHUB_REF:10}" --no-ff release/${GITHUB_REF:10}
-        git push
+        git merge -m "Release $VERSION" --no-ff release/$VERSION
+        git push --no-verify
 
     - name: Publish
       run: |
-        npm set //registry.npmjs.org/:_authToken ${{ secrets.GITHUB_TOKEN }}
+        npm set //registry.npmjs.org/:_authToken $NPM_TOKEN
         npm publish
-
+      env:
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -35,7 +35,7 @@ jobs:
         git commit -m "Bump version ${GITHUB_REF:10}"
         git checkout -t origin/master
         git merge -m "Release ${GITHUB_REF:10}" --no-ff release/${GITHUB_REF:10}
-        git push --delete release/${GITHUB_REF:10}
+        git push
 
     - name: Publish
       run: |

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -29,10 +29,11 @@ jobs:
     - name: Prepare release
       run: |
         echo "Preparing release ${GITHUB_REF:10}"
+        git checkout -t origin/release/${GITHUB_REF:10}
         npm version --no-git-tag-version --allow-same-version ${GITHUB_REF:10}
         git add package.json
         git commit -m "Bump version ${GITHUB_REF:10}"
-        git checkout master
+        git checkout -t origin/master
         git merge -m "Release ${GITHUB_REF:10}" --no-ff release/${GITHUB_REF:10}
         git push --delete release/${GITHUB_REF:10}
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -23,8 +23,8 @@ jobs:
     - name: Install Json
       run: npm i json --global
 
-    #- name: Install Packages
-    #  run: yarn install --frozen-lockfile
+    - name: Install Packages
+      run: yarn install --frozen-lockfile
 
     - name: Prepare release
       run: |

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -25,14 +25,16 @@ jobs:
 
     - name: Prepare release
       run: |
-        echo "Preparing release ${GITHUB_REF}"
+        echo "Preparing release ${GITHUB_REF:10}"
+        npm version --no-git-tag-version --allow-same-version ${GITHUB_REF:10}
+        git add package.json
+        git commit -m "Bump version ${GITHUB_REF:10}"
         git checkout master
-        git merge -m "Release ${GITHUB_REF}" --no-ff release/${GITHUB_REF}
-        git push --delete release/${GITHUB_REF}
+        git merge -m "Release ${GITHUB_REF:10}" --no-ff release/${GITHUB_REF:10}
+        git push --delete release/${GITHUB_REF:10}
 
     - name: Publish
       run: |
-        npm version --no-git-tag-version --allow-same-version ${GITHUB_REF}
         npm set //registry.npmjs.org/:_authToken ${{ secrets.GITHUB_TOKEN }}
         npm publish
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - uses: fregante/setup-git-token@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Setup Node.js
       uses: actions/setup-node@v1

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -20,8 +20,8 @@ jobs:
     - name: Install Json
       run: npm i json --global
 
-    - name: Install Packages
-      run: yarn install --frozen-lockfile
+    #- name: Install Packages
+    #  run: yarn install --frozen-lockfile
 
     - name: Prepare release
       run: |

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,38 @@
+name: Publish release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10.x
+    - name: Install Yarn
+      run: npm i yarn --global
+
+    - name: Install Json
+      run: npm i json --global
+
+    - name: Install Packages
+      run: yarn install --frozen-lockfile
+
+    - name: Prepare release
+      run: |
+        echo "Preparing release ${GITHUB_REF:11}"
+        git checkout master
+        git merge -m "Release ${GITHUB_REF:11}" --no-ff release/${GITHUB_REF:11}
+        git push --delete release/${GITHUB_REF:11}
+
+    - name: Publish
+      run: |
+        npm version --no-git-tag-version --allow-same-version ${GITHUB_REF:11}
+        npm set //registry.npmjs.org/:_authToken ${{ secrets.GITHUB_TOKEN }}
+        npm publish
+

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -25,14 +25,14 @@ jobs:
 
     - name: Prepare release
       run: |
-        echo "Preparing release ${GITHUB_REF:11}"
+        echo "Preparing release ${GITHUB_REF}"
         git checkout master
-        git merge -m "Release ${GITHUB_REF:11}" --no-ff release/${GITHUB_REF:11}
-        git push --delete release/${GITHUB_REF:11}
+        git merge -m "Release ${GITHUB_REF}" --no-ff release/${GITHUB_REF}
+        git push --delete release/${GITHUB_REF}
 
     - name: Publish
       run: |
-        npm version --no-git-tag-version --allow-same-version ${GITHUB_REF:11}
+        npm version --no-git-tag-version --allow-same-version ${GITHUB_REF}
         npm set //registry.npmjs.org/:_authToken ${{ secrets.GITHUB_TOKEN }}
         npm publish
 


### PR DESCRIPTION
Resolves #1106

This pr adds several workflows automating the release management.

### PR Labeler
This workflow will label PRs based on their branch name.

### Release drafter
This workflow automatically drafts a release once triggered on `develop` and creates/updates release notes based on merged PRs. It uses the PR labels to categorise them so we need to make sure they are always present and people stick to the conventions.

### Release publish
This workflow is triggered once a release is published. It will gather the version from the release tag, so the release tag should always match the version (which should be set automatically in the draft release). It bumps the package version accordingly, creates a merge from the release branch to `master` and then publishes the package to npm.