### PR TITLE
Gantt: Add support for callback with parameters

### DIFF
--- a/docs/gantt.md
+++ b/docs/gantt.md
@@ -288,3 +288,48 @@ Param | Descriotion | Default value
 --- | --- | ---
 mirrorActor|Turns on/off the rendering of actors below the diagram as well as above it|false
 bottomMarginAdj|Adjusts how far down the graph ended. Wide borders styles with css could generate unwantewd clipping which is why this config param exists.|1
+
+## Interaction
+
+It is possible to bind a click event to a task, the click can lead to either a javascript callback or to a link which will be opened in the current browser tab. **Note**: This functionality is disabled when using `securityLevel='strict'` and enabled when using `securityLevel='loose'`.
+
+```
+click taskId call callback(arguments)
+click taskId href URL
+```
+
+* taskId is the id of the task
+* callback is the name of a javascript function defined on the page displaying the graph, the function will be called with the taskId as the parameter if no other arguments are specified..
+
+Beginners tip, a full example using interactive links in an html context:
+```
+<body>
+  <div class="mermaid">
+    gantt
+      dateFormat  YYYY-MM-DD
+
+      section Clickable
+      Visit mermaidjs           :active, cl1, 2014-01-07, 3d
+      Print arguments         :cl2, after cl1, 3d
+      Print task              :cl3, after cl2, 3d
+
+      click cl1 href "https://mermaidjs.github.io/"
+      click cl2 call printArguments("test1", "test2", test3)
+      click cl3 call printTask()
+  </div>
+
+  <script>
+    var printArguments = function(arg1, arg2, arg3) {
+      alert('printArguments called with arguments: ' + arg1 + ', ' + arg2 + ', ' + arg3);
+    }
+    var printTask = function(taskId) {
+      alert('taskId: ' + taskId);
+    }
+    var config = {
+      startOnLoad:true,
+      securityLevel:'loose',
+    };
+    mermaid.initialize(config);
+  </script>
+</body>
+```

--- a/src/diagrams/gantt/ganttDb.js
+++ b/src/diagrams/gantt/ganttDb.js
@@ -488,6 +488,11 @@ const setClickFun = function(id, functionName, functionArgs) {
     }
   }
 
+  /* if no arguments passed into callback, default to passing in id */
+  if (argList.length === 0) {
+    argList.push(id);
+  }
+
   let rawTask = findTaskById(id);
   if (typeof rawTask !== 'undefined') {
     pushFun(id, () => {

--- a/src/diagrams/gantt/parser/gantt.spec.js
+++ b/src/diagrams/gantt/parser/gantt.spec.js
@@ -106,4 +106,34 @@ describe('when parsing a gantt diagram it', function() {
       }
     });
   });
+  it('should parse callback specifier with no args', function() {
+    spyOn(ganttDb, 'setClickEvent');
+    const str =
+      'gantt\n' +
+      'dateFormat  YYYY-MM-DD\n' +
+      'section Clickable\n' +
+      'Visit mermaidjs           :active, cl1, 2014-01-07, 3d\n' +
+      'Calling a callback        :cl2, after cl1, 3d\n\n' +
+      'click cl1 href "https://mermaidjs.github.io/"\n' +
+      'click cl2 call ganttTestClick()\n';
+
+    expect(parserFnConstructor(str)).not.toThrow();
+    expect(ganttDb.setClickEvent).toHaveBeenCalledWith('cl2', 'ganttTestClick', null);
+  });
+  it('should parse callback specifier with arbitrary number of args', function() {
+    spyOn(ganttDb, 'setClickEvent');
+    const str =
+      'gantt\n' +
+      'dateFormat  YYYY-MM-DD\n' +
+      'section Clickable\n' +
+      'Visit mermaidjs           :active, cl1, 2014-01-07, 3d\n' +
+      'Calling a callback        :cl2, after cl1, 3d\n\n' +
+      'click cl1 href "https://mermaidjs.github.io/"\n' +
+      'click cl2 call ganttTestClick("test0", test1, test2)\n';
+
+    expect(parserFnConstructor(str)).not.toThrow();
+    const args = '"test1", "test2", "test3"';
+    expect(ganttDb.setClickEvent).toHaveBeenCalledWith('cl2', 'ganttTestClick', '"test0", test1, test2');
+  });
+
 });


### PR DESCRIPTION
This is meant to address: #921

After researching this issue I agreed with Dunning-Kruger that it seemed prudent to support passing in the node identifier as the callback parameter as a solution. I then found that the project already supports this for flowcharts. Gantt charts, on the other hand, already support passing in custom parameters to a callback function. This, however, was not reflected in the documentation. 

For continuity between flowchart and Gantt, I added in code to automatically pass in the task identifier to the callback function if no custom callback parameters are specified. I also added interaction documentation based off of the documentation for flowchart and #804. 

This would be my first contribution so any feedback would be appreciated.