### PR TITLE
Removed docs reference to mermaidAPI.js

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -159,14 +159,13 @@ The main idea of the API is to be able to call a render function with the graph 
 will render the graph and call a callback with the resulting svg code. With this approach it is up to the site creator to
 fetch the graph definition from the site (perhaps from a textarea), render it and place the graph somewhere in the site.
 
-To do this, include mermaidAPI on your web website instead of mermaid.js. The example below show an outline of how this
-could be used. The example just logs the resulting svg to the javascript console.
+The example below show an outline of how this could be used. The example just logs the resulting svg to the javascript console.
 
 ```html
-<script src="mermaidAPI.js"></script>
+<script src="mermaid.js"></script>
 
 <script>
-    mermaidAPI.initialize({
+    mermaid.initialize({
         startOnLoad:false
     });
     $(function(){
@@ -178,7 +177,7 @@ could be used. The example just logs the resulting svg to the javascript console
         };
 
         var graphDefinition = 'graph TB\na-->b';
-        var graph = mermaidAPI.render('graphDiv', graphDefinition, insertSvg);
+        var graph = mermaid.render('graphDiv', graphDefinition, insertSvg);
     });
 </script>
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -165,7 +165,7 @@ The example below show an outline of how this could be used. The example just lo
 <script src="mermaid.js"></script>
 
 <script>
-    mermaid.initialize({
+    mermaid.mermaidAPI.initialize({
         startOnLoad:false
     });
     $(function(){
@@ -177,7 +177,7 @@ The example below show an outline of how this could be used. The example just lo
         };
 
         var graphDefinition = 'graph TB\na-->b';
-        var graph = mermaid.render('graphDiv', graphDefinition, insertSvg);
+        var graph = mermaid.mermaidAPI.render('graphDiv', graphDefinition, insertSvg);
     });
 </script>
 ```


### PR DESCRIPTION
## Summary
Remove reference to mermaidAPI.js in the API.md doc.  Also changed the code to `mermaid.render` because this statement is an alias to `mermaidAPI.render`, at least per mermaid.js [line 175](https://github.com/mermaid-js/mermaid/blob/develop/src/mermaid.js#L175),

## Design Descisions
I made this change because I recently called mermaid.js in this manner with version 8.4.3, e.g. `mermaid.render` instead of `mermaid.mermaidAPI.parse`. I feel appending the `mermaidAPI` is confusing or at least confused me when learning mermaid.js.

Resolves #1124
