### PR TITLE
#1143 Adding support in grammar for multiple nodes in dependency decl…

### DIFF
--- a/cypress/platform/current.html
+++ b/cypress/platform/current.html
@@ -5,7 +5,7 @@
       rel="stylesheet"
     />
     <style>
-      body {background: white}
+      body {background: black}
       h1 { color: white;}
       .arrowheadPath {fill: red;}
 
@@ -17,17 +17,12 @@
   <body>
     <h1>info below</h1>
     <div style="display: flex;width: 100%; height: 100%">
-      <div class="mermaid" style="width: 100%; height: 100%">gantt
-        dateFormat  YYYY-MM-DD
-        axisFormat  %d/%m
-        title Adding GANTT diagram to mermaid
-        excludes weekdays 2014-01-10
-
-        apple :a, 2017-07-20, 1w
-        banana :crit, b, 2017-07-23, 1d
-        cherry :active, c, after b a, 1d
-
-
+      <div class="mermaid" style="width: 100%; height: 100%">
+        graph LR
+          a[gorillan vaggar]|b[apan hoppar]--> c --> d
+          subgraph "One Two"
+            a1-->a2-->a3
+          end
       </div>
 </div>
   <script src="./mermaid.js"></script>

--- a/src/diagrams/flowchart/flowDb.js
+++ b/src/diagrams/flowchart/flowDb.js
@@ -498,7 +498,6 @@ export const indexNodes = function() {
 };
 
 export const getSubGraphs = function() {
-  console.warn(subGraphs);
   return subGraphs;
 };
 

--- a/src/diagrams/flowchart/flowDb.js
+++ b/src/diagrams/flowchart/flowDb.js
@@ -102,7 +102,7 @@ export const addVertex = function(_id, text, type, style, classes) {
  * @param type
  * @param linktext
  */
-export const addLink = function(_start, _end, type, linktext) {
+export const addSingleLink = function(_start, _end, type, linktext) {
   let start = _start;
   let end = _end;
   if (start[0].match(/\d/)) start = MERMAID_DOM_ID_PREFIX + start;
@@ -126,6 +126,14 @@ export const addLink = function(_start, _end, type, linktext) {
     edge.stroke = type.stroke;
   }
   edges.push(edge);
+};
+export const addLink = function(_start, _end, type, linktext) {
+  let i, j;
+  for (i = 0; i < _start.length; i++) {
+    for (j = 0; j < _end.length; j++) {
+      addSingleLink(_start[i], _end[j], type, linktext);
+    }
+  }
 };
 
 /**
@@ -490,6 +498,7 @@ export const indexNodes = function() {
 };
 
 export const getSubGraphs = function() {
+  console.warn(subGraphs);
   return subGraphs;
 };
 

--- a/src/diagrams/flowchart/parser/flow-singlenode.spec.js
+++ b/src/diagrams/flowchart/parser/flow-singlenode.spec.js
@@ -22,6 +22,16 @@ describe('[Singlenodes] when parsing', () => {
     expect(edges.length).toBe(0);
     expect(vert['A'].styles.length).toBe(0);
   });
+  it('should handle a single node with white space after it (SN1)', function() {
+    // Silly but syntactically correct
+    const res = flow.parser.parse('graph TD;A ;');
+
+    const vert = flow.parser.yy.getVertices();
+    const edges = flow.parser.yy.getEdges();
+
+    expect(edges.length).toBe(0);
+    expect(vert['A'].styles.length).toBe(0);
+  });
 
   it('should handle a single square node', function() {
     // Silly but syntactically correct

--- a/src/diagrams/flowchart/parser/flow.jison
+++ b/src/diagrams/flowchart/parser/flow.jison
@@ -8,6 +8,7 @@
 %lex
 %x string
 %x dir
+%x vertex
 %%
 \%\%[^\n]*\n*           /* do nothing */
 ["]                     this.begin("string");
@@ -19,6 +20,7 @@
 "interpolate"         return 'INTERPOLATE';
 "classDef"            return 'CLASSDEF';
 "class"               return 'CLASS';
+"EPA"               return 'EPA';
 "click"               return 'CLICK';
 "graph"      {if(yy.lex.firstGraph()){this.begin("dir");}  return 'GRAPH';}
 "subgraph"            return 'subgraph';
@@ -94,6 +96,7 @@
 "<"                   return 'TAGSTART';
 ">"                   return 'TAGEND';
 "^"                   return 'UP';
+"\|"                   return 'SEP';
 "v"                   return 'DOWN';
 [A-Za-z]+             return 'ALPHA';
 "\\]"                 return 'TRAPEND';
@@ -247,7 +250,7 @@ spaceList
 
 statement
     : verticeStatement separator
-    { $$=$1}
+    { console.warn('finat vs', $1.nodes); $$=$1.nodes}
     | styleStatement separator
     {$$=[];}
     | linkStyleStatement separator
@@ -285,12 +288,15 @@ separator: NEWLINE | SEMI | EOF ;
 //         {$$ = [$1];yy.setClass($1,$3)}
 //    ;
 
-verticeStatement: verticeStatement link node { yy.addLink($1[0],$3[0],$2); $$ = $3.concat($1) }
-    |node { $$ = $1 }
+
+verticeStatement: verticeStatement link node { console.warn('vs',$1.stmt,$3); yy.addLink($1.stmt,$3,$2); $$ = { stmt: $3, nodes: $3.concat($1.nodes) } }
+    |node {console.warn('noda', $1); $$ = {stmt: $1, nodes:$1 }}
     ;
 
 node: vertex
-        { $$ = [$1];}
+        { console.warn('nod', $1);$$ = [$1];}
+    | node PIPE vertex
+        { $$ = [$1[0], $3]; console.warn('pip', $1, $3, $$); }
     | vertex STYLE_SEPARATOR idString
         {$$ = [$1];yy.setClass($1,$3)}
     ;
@@ -348,7 +354,7 @@ vertex:  idString SQS text SQE
     | idString SQS text TAGSTART spaceList
         {$$ = $1;yy.addVertex($1,$3,'odd_right');} */
     | idString
-        {$$ = $1;yy.addVertex($1);}
+        {console.warn('h: ', $1);$$ = $1;yy.addVertex($1);}
     | idString spaceList
         {$$ = $1;yy.addVertex($1);}
     ;

--- a/src/diagrams/flowchart/parser/flow.jison
+++ b/src/diagrams/flowchart/parser/flow.jison
@@ -20,7 +20,6 @@
 "interpolate"         return 'INTERPOLATE';
 "classDef"            return 'CLASSDEF';
 "class"               return 'CLASS';
-"EPA"               return 'EPA';
 "click"               return 'CLICK';
 "graph"      {if(yy.lex.firstGraph()){this.begin("dir");}  return 'GRAPH';}
 "subgraph"            return 'subgraph';
@@ -250,7 +249,7 @@ spaceList
 
 statement
     : verticeStatement separator
-    { console.warn('finat vs', $1.nodes); $$=$1.nodes}
+    { /* console.warn('finat vs', $1.nodes); */ $$=$1.nodes}
     | styleStatement separator
     {$$=[];}
     | linkStyleStatement separator
@@ -289,74 +288,48 @@ separator: NEWLINE | SEMI | EOF ;
 //    ;
 
 
-verticeStatement: verticeStatement link node { console.warn('vs',$1.stmt,$3); yy.addLink($1.stmt,$3,$2); $$ = { stmt: $3, nodes: $3.concat($1.nodes) } }
-    |node {console.warn('noda', $1); $$ = {stmt: $1, nodes:$1 }}
+verticeStatement: verticeStatement link node
+        { /* console.warn('vs',$1.stmt,$3); */ yy.addLink($1.stmt,$3,$2); $$ = { stmt: $3, nodes: $3.concat($1.nodes) } }
+    |  verticeStatement link node spaceList
+        { /* console.warn('vs',$1.stmt,$3); */ yy.addLink($1.stmt,$3,$2); $$ = { stmt: $3, nodes: $3.concat($1.nodes) } }
+    |node spaceList {/*console.warn('noda', $1);*/ $$ = {stmt: $1, nodes:$1 }}
+    |node { /*console.warn('noda', $1);*/ $$ = {stmt: $1, nodes:$1 }}
     ;
 
 node: vertex
-        { console.warn('nod', $1);$$ = [$1];}
-    | node PIPE vertex
-        { $$ = [$1[0], $3]; console.warn('pip', $1, $3, $$); }
+        { /* console.warn('nod', $1); */ $$ = [$1];}
+    | node spaceList vertex
+        { $$ = [$1[0], $3]; /*console.warn('pip', $1, $3, $$);*/ }
     | vertex STYLE_SEPARATOR idString
         {$$ = [$1];yy.setClass($1,$3)}
     ;
 
 vertex:  idString SQS text SQE
         {$$ = $1;yy.addVertex($1,$3,'square');}
-    |  idString SQS text SQE spaceList
-        {$$ = $1;yy.addVertex($1,$3,'square');}
     | idString PS PS text PE PE
-        {$$ = $1;yy.addVertex($1,$4,'circle');}
-    | idString PS PS text PE PE spaceList
         {$$ = $1;yy.addVertex($1,$4,'circle');}
     | idString '(-' text '-)'
         {$$ = $1;yy.addVertex($1,$3,'ellipse');}
-    | idString '(-' text '-)' spaceList
-        {$$ = $1;yy.addVertex($1,$3,'ellipse');}
     | idString STADIUMSTART text STADIUMEND
-        {$$ = $1;yy.addVertex($1,$3,'stadium');}
-    | idString STADIUMSTART text STADIUMEND spaceList
         {$$ = $1;yy.addVertex($1,$3,'stadium');}
     | idString PS text PE
         {$$ = $1;yy.addVertex($1,$3,'round');}
-    | idString PS text PE spaceList
-        {$$ = $1;yy.addVertex($1,$3,'round');}
     | idString DIAMOND_START text DIAMOND_STOP
-        {$$ = $1;yy.addVertex($1,$3,'diamond');}
-    | idString DIAMOND_START text DIAMOND_STOP spaceList
         {$$ = $1;yy.addVertex($1,$3,'diamond');}
     | idString DIAMOND_START DIAMOND_START text DIAMOND_STOP DIAMOND_STOP
         {$$ = $1;yy.addVertex($1,$4,'hexagon');}
-    | idString DIAMOND_START DIAMOND_START text DIAMOND_STOP DIAMOND_STOP spaceList
-        {$$ = $1;yy.addVertex($1,$4,'hexagon');}
     | idString TAGEND text SQE
-        {$$ = $1;yy.addVertex($1,$3,'odd');}
-    | idString TAGEND text SQE spaceList
         {$$ = $1;yy.addVertex($1,$3,'odd');}
     | idString TRAPSTART text TRAPEND
         {$$ = $1;yy.addVertex($1,$3,'trapezoid');}
-    | idString TRAPSTART text TRAPEND spaceList
-        {$$ = $1;yy.addVertex($1,$3,'trapezoid');}
     | idString INVTRAPSTART text INVTRAPEND
-        {$$ = $1;yy.addVertex($1,$3,'inv_trapezoid');}
-    | idString INVTRAPSTART text INVTRAPEND spaceList
         {$$ = $1;yy.addVertex($1,$3,'inv_trapezoid');}
     | idString TRAPSTART text INVTRAPEND
         {$$ = $1;yy.addVertex($1,$3,'lean_right');}
-    | idString TRAPSTART text INVTRAPEND spaceList
-        {$$ = $1;yy.addVertex($1,$3,'lean_right');}
     | idString INVTRAPSTART text TRAPEND
         {$$ = $1;yy.addVertex($1,$3,'lean_left');}
-    | idString INVTRAPSTART text TRAPEND spaceList
-        {$$ = $1;yy.addVertex($1,$3,'lean_left');}
-/*  | idString SQS text TAGSTART
-        {$$ = $1;yy.addVertex($1,$3,'odd_right');}
-    | idString SQS text TAGSTART spaceList
-        {$$ = $1;yy.addVertex($1,$3,'odd_right');} */
     | idString
-        {console.warn('h: ', $1);$$ = $1;yy.addVertex($1);}
-    | idString spaceList
-        {$$ = $1;yy.addVertex($1);}
+        { /*console.warn('h: ', $1);*/$$ = $1;yy.addVertex($1);}
     ;
 
 

--- a/src/diagrams/flowchart/parser/subgraph.spec.js
+++ b/src/diagrams/flowchart/parser/subgraph.spec.js
@@ -16,6 +16,7 @@ describe('when parsing subgraphs', function() {
     const subgraphs = flow.parser.yy.getSubGraphs();
     expect(subgraphs.length).toBe(1);
     const subgraph = subgraphs[0];
+
     expect(subgraph.nodes.length).toBe(2);
     expect(subgraph.nodes[0]).toBe('a2');
     expect(subgraph.nodes[1]).toBe('a1');

--- a/src/diagrams/flowchart/parser/subgraph.spec.js
+++ b/src/diagrams/flowchart/parser/subgraph.spec.js
@@ -192,6 +192,15 @@ describe('when parsing subgraphs', function() {
     expect(edges[0].type).toBe('arrow');
   });
 
+  it('should handle subgraphs3', function() {
+    const res = flow.parser.parse('graph TD\nA-->B\nsubgraph myTitle   \n\n    c-->d \nend\n');
+
+    const vert = flow.parser.yy.getVertices();
+    const edges = flow.parser.yy.getEdges();
+
+    expect(edges[0].type).toBe('arrow');
+  });
+
   it('should handle nested subgraphs', function() {
     const str =
       'graph TD\n' +

--- a/src/diagrams/pie/parser/pie.jison
+++ b/src/diagrams/pie/parser/pie.jison
@@ -49,7 +49,7 @@ line
 
 statement
 	:  STR VALUE {
-		console.log('str:'+$1+' value: '+$2)
+		/*console.log('str:'+$1+' value: '+$2)*/
 		yy.addSection($1,yy.cleanupValue($2));  }
 	| title {yy.setTitle($1.substr(6));$$=$1.substr(6);}
 	;


### PR DESCRIPTION
## Summary
Making it possible to add edges between multiple node in one statement like below:
`A | B | C | D --> E`

This is equivalent to:
```
   A --> E
   B --> E
   C --> E
   D --> E
```

## Design Descisions
It is currently allowed to have a , in a node id which makes the obvious separator character ',' unavailable.

Resolves #834 
