### PR TITLE
changes tick contrast for gantt chart

### DIFF
--- a/src/themes/gantt.scss
+++ b/src/themes/gantt.scss
@@ -54,7 +54,7 @@
 
 .grid .tick {
   stroke: $gridColor;
-  opacity: 0.3;
+  opacity: 0.8;
   shape-rendering: crispEdges;
   text {
     font-family: 'trebuchet ms', verdana, arial;


### PR DESCRIPTION
## Summary
changed `.grid .tick` opacity to 0.8 to meet accessibility standards for a contrast ratio of 4.5:1

Resolves #995 
