### PR TITLE
Git graph not clearing 

### DIFF
--- a/src/diagrams/git/gitGraphRenderer.js
+++ b/src/diagrams/git/gitGraphRenderer.js
@@ -302,6 +302,7 @@ export const draw = function(txt, id, ver) {
   try {
     const parser = gitGraphParser.parser;
     parser.yy = db;
+    parser.yy.clear();
 
     logger.debug('in gitgraph renderer', txt + '\n', 'id:', id, ver);
     // Parse the graph definition


### PR DESCRIPTION
## Summary
Mermaid is not fully clearing git graphs upon re-draw, and must be re-initialized to resolve it.

Example: You can see that bug on the [live editor](https://mermaidjs.github.io/mermaid-live-editor/#/edit/eyJjb2RlIjoiZ2l0R3JhcGg6XG5vcHRpb25zXG57XG4gICAgXCJub2RlU3BhY2luZ1wiOiAxNTAsXG4gICAgXCJub2RlUmFkaXVzXCI6IDEwXG59XG5lbmRcbmNvbW1pdFxuYnJhbmNoIG5ld2JyYW5jaFxuY2hlY2tvdXQgbmV3YnJhbmNoXG5jb21taXRcbmNoZWNrb3V0IG1hc3RlclxuY29tbWl0XG5tZXJnZSBuZXdicmFuY2hcbiIsIm1lcm1haWQiOnsidGhlbWUiOiJkZWZhdWx0In19) once you click  “link to view”. You’ll see a simple git graph on the right, with a number of extra commits added without branches to the left. Upon refresh of that page, you’ll see only the simplified graph

## Design Descisions

 In the mermaid source, the file “src/diagrams/git/gitGraphRenderer.js” does not contain the exported function “clear” anywhere. This is an exported function in “src/diagrams/git/gitGraphAst.js” (defined on line 179 and exported in line 230). When compared to the other renderers in “src/diagrams/”, only infoRenderer.js does not contain a line which calls “clear()”. When “parser.yy.clear()” is added to line 305, the git graph does not repeat commits. This function is also called as a part of the “beforeEach” function in the unit tests.

There are no unit tests added due to the lack of an existing git renderer spec file and the lack of exports in the render to support simple testing validation.

This does not currently resolve a bug, since I did not open one. If that is the correct process, please let me know and I will open and attach a bug to this PR.