### PR TITLE
Error typos in flowDb

### DIFF
--- a/src/diagrams/flowchart/flowDb.js
+++ b/src/diagrams/flowchart/flowDb.js
@@ -65,7 +65,7 @@ export const addVertex = function(_id, text, type, style, classes) {
   if (typeof text !== 'undefined') {
     txt = sanitize(text.trim());
 
-    // strip quotes if string starts and exnds with a quote
+    // strip quotes if string starts and ends with a quote
     if (txt[0] === '"' && txt[txt.length - 1] === '"') {
       txt = txt.substring(1, txt.length - 1);
     }


### PR DESCRIPTION
## Summary
Find a typo in flowDb.js during reading the source code.

## Design Decisions
fix typos
`// strip quotes if string starts and exnds with a quote` to `// strip quotes if string starts and ends with a quote`
