### PR TITLE
Fix infinite loop caused by date iteration

### DIFF
--- a/cypress/integration/rendering/gantt.spec.js
+++ b/cypress/integration/rendering/gantt.spec.js
@@ -54,4 +54,44 @@ describe('Sequencediagram', () => {
       {}
     );
   });
+  it('should render a gantt chart for issue #1060', () => {
+    imgSnapshotTest(
+      `
+      gantt
+      excludes weekdays 2017-01-10
+      title Projects Timeline
+  
+      section asdf
+          specs :done, :ps, 2019-05-10, 50d
+          Plasma      :pc, 2019-06-20, 60d
+          Rollup  :or, 2019-08-20, 50d
+      
+      section CEL
+              
+          plasma-chamber      :done, :pc, 2019-05-20, 60d
+          Plasma Implementation (Rust)      :por, 2019-06-20, 120d
+          Predicates (Atomic Swap)      :pred, 2019-07-20, 60d
+      
+      section DEX 💰
+          
+          History zkSNARK  :hs, 2019-08-10, 40d
+          Exit           :vs, after hs, 60d
+          PredicateSpec          :ps, 2019-09-1, 20d
+          PlasmaIntegration     :pi, after ps,40d
+      
+      
+      section Events 🏁
+      
+      ETHBoston :done, :eb, 2019-09-08, 3d
+      DevCon :active, :dc, 2019-10-08, 3d
+      
+      section Plasma Calls & updates ✨
+          OVM      :ovm, 2019-07-12, 120d
+      Plasma call 26 :pc26, 2019-08-21, 1d
+      Plasma call 27 :pc27, 2019-09-03, 1d
+      Plasma call 28 :pc28, 2019-09-17, 1d 
+        `,
+      {}
+    );
+  });
 });

--- a/src/diagrams/gantt/ganttDb.js
+++ b/src/diagrams/gantt/ganttDb.js
@@ -117,7 +117,7 @@ const checkTaskDates = function(task, dateFormat, excludes) {
 const fixTaskDates = function(startTime, endTime, dateFormat, excludes) {
   let invalid = false;
   let renderEndTime = null;
-  while (startTime.date() <= endTime.date()) {
+  while (startTime <= endTime) {
     if (!invalid) {
       renderEndTime = endTime.toDate();
     }

--- a/src/diagrams/gantt/ganttDb.spec.js
+++ b/src/diagrams/gantt/ganttDb.spec.js
@@ -174,6 +174,26 @@ describe('when using the ganttDb', function() {
     expect(tasks[6].task).toEqual('test7');
   });
 
+  it('should work when end date is the 31st', function() {
+    ganttDb.setDateFormat('YYYY-MM-DD');
+    ganttDb.addSection('Task endTime is on the 31st day of the month');
+    ganttDb.addTask('test1', 'id1,2019-09-30,11d');
+    ganttDb.addTask('test2', 'id2,after id1,20d');
+    const tasks = ganttDb.getTasks();
+
+    expect(tasks[0].startTime).toEqual(moment('2019-09-30', 'YYYY-MM-DD').toDate());
+    expect(tasks[0].endTime).toEqual(moment('2019-10-11', 'YYYY-MM-DD').toDate());
+    expect(tasks[1].renderEndTime).toBeNull(); // Fixed end
+    expect(tasks[0].id).toEqual('id1');
+    expect(tasks[0].task).toEqual('test1');
+
+    expect(tasks[1].startTime).toEqual(moment('2019-10-11', 'YYYY-MM-DD').toDate());
+    expect(tasks[1].endTime).toEqual(moment('2019-10-31', 'YYYY-MM-DD').toDate());
+    expect(tasks[1].renderEndTime).toBeNull(); // Fixed end
+    expect(tasks[1].id).toEqual('id2');
+    expect(tasks[1].task).toEqual('test2');
+  });
+
   describe('when setting inclusive end dates', function() {
     beforeEach(function() {
       ganttDb.setDateFormat('YYYY-MM-DD');


### PR DESCRIPTION
## :bookmark_tabs: Summary
This is a one line fix for a bug where there's an infinite loop when adjusting a date range that ends with a date of the 31st. The problem was that `startTime.date()` could never exceed `endTime.date()` when `endTime.date()` was the 31st. The code would continue to increment `startTime` indefinitely, causing the page to freeze.

Resolves #1060 

## :straight_ruler: Design Decisions
Instead of the while loop being conditional on comparing the days of the month (i.e. 1, 2, .. 30, 31), it compares the full date object, including the month and year.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
