### PR TITLE
fix(#1193): render multiple relations

### DIFF
--- a/src/diagrams/class/classRenderer.js
+++ b/src/diagrams/class/classRenderer.js
@@ -505,9 +505,14 @@ export const draw = function(text, id) {
     logger.info(
       'tjoho' + getGraphId(relation.id1) + getGraphId(relation.id2) + JSON.stringify(relation)
     );
-    g.setEdge(getGraphId(relation.id1), getGraphId(relation.id2), {
-      relation: relation
-    });
+    g.setEdge(
+      getGraphId(relation.id1),
+      getGraphId(relation.id2),
+      {
+        relation: relation
+      },
+      relation.title || 'DEFAULT'
+    );
   });
   dagre.layout(g);
   g.nodes().forEach(function(v) {


### PR DESCRIPTION
## :bookmark_tabs: Summary
Resolves #1193

## :straight_ruler: Design Decisions
In graphlib edges have an ID that is constructed from the nodes being linked plus an (optional) name. If two edges are provided with the same nodes and name (or no name at all) then they overwrite each other. Mermaid's class diagram parser already collected the relations correctly but added them without name. I'm now using the relation label as a natural choice for the edges name. This fixes the problem.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [ ] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
