### PR TITLE
Fix mermaidAPI configuration example in the docs

### DIFF
--- a/docs/mermaidAPI.md
+++ b/docs/mermaidAPI.md
@@ -105,6 +105,18 @@ Flag for setting whether or not a html tag should be used for rendering labels
 on the edges.
 **Default value true**.
 
+### nodeSpacing
+
+Defines the spacing between nodes on the same level (meaning horizontal spacing for
+TB or BT graphs, and the vertical spacing for LR as well as RL graphs).
+**Default value 50**.
+
+### rankSpacing
+
+Defines the spacing between nodes on different levels (meaning vertical spacing for
+TB or BT graphs, and the horizontal spacing for LR as well as RL graphs).
+**Default value 50**.
+
 ### curve
 
 How mermaid renders curves for flowcharts. Possible values are

--- a/docs/mermaidAPI.md
+++ b/docs/mermaidAPI.md
@@ -19,7 +19,7 @@ These are the default options which can be overridden with the initialization ca
 <pre>
 mermaid.initialize({
   flowchart:{
-     htmlLabels: false
+    htmlLabels: false
   }
 });
 </pre>
@@ -27,7 +27,7 @@ mermaid.initialize({
 **Example 2:**
 
 <pre>
- <script>
+&lt;script>
   var config = {
     startOnLoad:true,
     flowchart:{
@@ -39,10 +39,10 @@ mermaid.initialize({
     securityLevel:'loose',
   };
   mermaid.initialize(config);
-</script>
-
+&lt;/script>
 </pre>
-A summary of all options and their defaults is found [here](https://github.com/knsv/mermaid/blob/master/docs/mermaidAPI.md#mermaidapi-configuration-defaults). A description of each option follows below.
+
+A summary of all options and their defaults is found [here][2]. A description of each option follows below.
 
 ## theme
 
@@ -333,3 +333,5 @@ mermaidAPI.initialize({
 </pre>
 
 [1]: https://github.com/knsv/mermaid/blob/master/docs/mermaidAPI.md#render
+
+[2]: https://github.com/knsv/mermaid/blob/master/docs/mermaidAPI.md#mermaidapi-configuration-defaults

--- a/src/mermaidAPI.js
+++ b/src/mermaidAPI.js
@@ -143,6 +143,20 @@ const config = {
     htmlLabels: true,
 
     /**
+     * Defines the spacing between nodes on the same level (meaning horizontal spacing for
+     * TB or BT graphs, and the vertical spacing for LR as well as RL graphs).
+     * **Default value 50**.
+     */
+    nodeSpacing: 50,
+
+    /**
+     * Defines the spacing between nodes on different levels (meaning vertical spacing for
+     * TB or BT graphs, and the horizontal spacing for LR as well as RL graphs).
+     * **Default value 50**.
+     */
+    rankSpacing: 50,
+
+    /**
      * How mermaid renders curves for flowcharts. Possible values are
      *   * basis
      *   * linear **default**

--- a/src/mermaidAPI.js
+++ b/src/mermaidAPI.js
@@ -52,14 +52,14 @@ for (const themeName of ['default', 'forest', 'dark', 'neutral']) {
  * <pre>
  * mermaid.initialize({
  *   flowchart:{
- *      htmlLabels: false
+ *     htmlLabels: false
  *   }
  * });
  * </pre>
  *
  * **Example 2:**
  * <pre>
- *  <script>
+ * &lt;script>
  *   var config = {
  *     startOnLoad:true,
  *     flowchart:{
@@ -71,7 +71,7 @@ for (const themeName of ['default', 'forest', 'dark', 'neutral']) {
  *     securityLevel:'loose',
  *   };
  *   mermaid.initialize(config);
- * </script>
+ * &lt;/script>
  * </pre>
  * A summary of all options and their defaults is found [here](https://github.com/knsv/mermaid/blob/master/docs/mermaidAPI.md#mermaidapi-configuration-defaults). A description of each option follows below.
  *


### PR DESCRIPTION
## :bookmark_tabs: Summary
Fixed the script tags in the documentation so the second configuration example in the mermaidAPI section is displayed as well.