### PR TITLE
#1205 Adding parsing exception for then an inactive participant is inactivated

### DIFF
--- a/src/diagrams/sequence/sequenceDiagram.spec.js
+++ b/src/diagrams/sequence/sequenceDiagram.spec.js
@@ -214,6 +214,33 @@ describe('when parsing a sequenceDiagram', function() {
     expect(messages[7].type).toBe(parser.yy.LINETYPE.ACTIVE_END);
     expect(messages[7].from.actor).toBe('Carol');
   });
+  it('it should handle fail parsing when activating an inactive participant', function() {
+    const str =
+      `sequenceDiagram
+    participant user as End User
+    participant Server as Server
+    participant System as System
+    participant System2 as System2
+
+    user->>+Server: Test
+    user->>+Server: Test2
+    user->>System: Test
+    Server->>-user: Test
+    Server->>-user: Test2
+
+    %% The following deactivation of Server will fail
+    Server->>-user: Test3`;
+
+    let error = false;
+    try {
+      parser.parse(str);
+    } catch(e) {
+      console.log(e.hash);
+      error = true;
+    }
+    expect(error).toBe(true);
+  });
+
   it('it should handle comments in a sequenceDiagram', function() {
     const str =
       'sequenceDiagram\n' +


### PR DESCRIPTION

## :bookmark_tabs: Summary
Making sure the participant id active when adding an inactivation signal.

Resolves #1205 

## :straight_ruler: Design Decisions
When an inactivation signal is encounteted for an inactive node  an error is thrown. One is manifactured to resemble the jison parsing errors.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [-] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
