### PR TITLE
Feature/issue 1206 parsing crashing browser in class diagram

### DIFF
--- a/src/diagrams/class/classDiagram.spec.js
+++ b/src/diagrams/class/classDiagram.spec.js
@@ -67,7 +67,7 @@ describe('class diagram, ', function () {
       parser.parse(str);
     });
 
-    it('should break when double  {  are encountered while defining generic class with brackets', function() {
+    it('should break when another `{`is encountered before closing the first one while defining generic class with brackets', function() {
       const str =
         'classDiagram\n' +
         'class Dummy_Class~T~ {\n' +
@@ -80,6 +80,25 @@ describe('class diagram, ', function () {
         '   flightNumber : Integer\n' +
         '   departureTime : Date\n' +
         '}';
+      let testPased =false;
+      try{
+        parser.parse(str);
+      }catch (error){
+        console.log(error.name);
+        testPased = true;
+      }
+      expect(testPased).toBe(true);
+    });
+
+    it('should break when EOF is encountered before closing the first `{` while defining generic class with brackets', function() {
+      const str =
+        'classDiagram\n' +
+        'class Dummy_Class~T~ {\n' +
+        'String data\n' +
+        '  void methods()\n' +
+        '}\n' +
+        '\n' +
+        'class Dummy_Class {\n';
       let testPased =false;
       try{
         parser.parse(str);

--- a/src/diagrams/class/classDiagram.spec.js
+++ b/src/diagrams/class/classDiagram.spec.js
@@ -67,6 +67,29 @@ describe('class diagram, ', function () {
       parser.parse(str);
     });
 
+    it('should break when double  {  are encountered while defining generic class with brackets', function() {
+      const str =
+        'classDiagram\n' +
+        'class Dummy_Class~T~ {\n' +
+        'String data\n' +
+        '  void methods()\n' +
+        '}\n' +
+        '\n' +
+        'class Dummy_Class {\n' +
+        'class Flight {\n' +
+        '   flightNumber : Integer\n' +
+        '   departureTime : Date\n' +
+        '}';
+      let testPased =false;
+      try{
+        parser.parse(str);
+      }catch (error){
+        console.log(error.name);
+        testPased = true;
+      }
+      expect(testPased).toBe(true);
+    });
+
     it('should handle generic class with brackets', function() {
       const str =
         'classDiagram\n' +
@@ -79,8 +102,6 @@ describe('class diagram, ', function () {
         '   flightNumber : Integer\n' +
         '   departureTime : Date\n' +
         '}';
-
-      parser.parse(str);
     });
 
     it('should handle class definitions', function() {

--- a/src/diagrams/class/parser/classDiagram.jison
+++ b/src/diagrams/class/parser/classDiagram.jison
@@ -14,6 +14,8 @@
 \s+                     /* skip whitespace */
 "classDiagram"          return 'CLASS_DIAGRAM';
 [\{]                    { this.begin("struct"); /*console.log('Starting struct');*/return 'STRUCT_START';}
+<struct><<EOF>>         return "EOF_IN_STRUCT";
+<struct>[\{]            return "OPEN_IN_STRUCT";
 <struct>\}           { /*console.log('Ending struct');*/this.popState(); return 'STRUCT_STOP';}}
 <struct>[\n]              /* nothing */
 <struct>[^\{\}\n]*     { /*console.log('lex-member: ' + yytext);*/  return "MEMBER";}


### PR DESCRIPTION
## :bookmark_tabs: Summary
Class Diagram parsing (in some cases) leads to crashing live-editor in browsers.

Resolves #1206 

## :straight_ruler: Design Decisions
Fixes the JISON to not allow EOF or another '{' character until the first one is closed with corresponding '}' bracket.

### :clipboard: Tasks
Make sure you
- [X] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [X] :computer: have added unit/e2e tests (if appropriate) 
- [X] :bookmark: targeted `develop` branch 
