### PR TITLE
Fix styling of flowchart nodes with links when class definitions are assigned

### DIFF
--- a/cypress/integration/rendering/flowchart.spec.js
+++ b/cypress/integration/rendering/flowchart.spec.js
@@ -374,6 +374,7 @@ describe('Flowchart', () => {
         click B testClick "click test"
         classDef someclass fill:#f96;
         class A someclass;
+        class C someclass;
       `,
       {
         listUrl: false,
@@ -409,7 +410,9 @@ describe('Flowchart', () => {
       click A "index.html#link-clicked" "link test"
       click B testClick "click test"
       classDef someclass fill:#f96;
-      class A someclass;`,
+      class A someclass;
+      class C someclass;
+      `,
       { flowchart: { htmlLabels: false } }
     );
   });

--- a/dist/index.html
+++ b/dist/index.html
@@ -289,16 +289,17 @@ graph TB
       style 456ac9b0d15a8b7f1e71073221059886 fill:#f9f,stroke:#333,stroke-width:4px
   </div>
   <div class="mermaid">
-graph TD
-A[Christmas] -->|Get money| B(Go shopping)
-B --> C{{Let me think...<br />Do I want something for work,<br />something to spend every free second with,<br />or something to get around?}}
-C -->|One| D[Laptop]
-C -->|Two| E[iPhone]
-C -->|Three| F[Car]
-click A "index.html#link-clicked" "link test"
-click B testClick "click test"
-classDef someclass fill:#f96;
-class A someclass;
+    graph TD
+    A[Christmas] -->|Get money| B(Go shopping)
+    B --> C{{Let me think...<br />Do I want something for work,<br />something to spend every free second with,<br />or something to get around?}}
+    C -->|One| D[Laptop]
+    C -->|Two| E[iPhone]
+    C -->|Three| F[Car]
+    click A "index.html#link-clicked" "link test"
+    click B testClick "click test"
+    classDef someclass fill:#f96;
+    class A someclass;
+    class C someclass;
   </div>
   <div class="mermaid">
     graph TD
@@ -312,6 +313,7 @@ class A someclass;
     click B testClick "click test"
     classDef someclass fill:#f96;
     class A someclass;
+    class C someclass;
   </div>
   <div class="mermaid">
     graph LR

--- a/src/diagrams/flowchart/flowRenderer.js
+++ b/src/diagrams/flowchart/flowRenderer.js
@@ -461,6 +461,7 @@ export const draw = function(text, id) {
       const node = d3.select('#' + id + ' [id="' + key + '"]');
       if (node) {
         const link = document.createElementNS('http://www.w3.org/2000/svg', 'a');
+        link.setAttributeNS('http://www.w3.org/2000/svg', 'class', vertex.classes.join(' '));
         link.setAttributeNS('http://www.w3.org/2000/svg', 'href', vertex.link);
         link.setAttributeNS('http://www.w3.org/2000/svg', 'rel', 'noopener');
 


### PR DESCRIPTION
## :bookmark_tabs: Summary
Bugfix: Class definition is not applied to flowchart nodes with links.

Resolves #1212

## :straight_ruler: Design Decisions
Assigned classes to the anchor item as well to keep its contents styled according to class definitions. Modified tests in dist/index.html and cypress integration by applying a classDef to nodes with and without links.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
