### PR TITLE
#1217 Better matching of words beginning with as as matching token 

### DIFF
--- a/docs/mermaidAPI.md
+++ b/docs/mermaidAPI.md
@@ -275,11 +275,12 @@ mermaidAPI.initialize({
 ### Parameters
 
 -   `id`  the id of the element to be rendered
--   `txt`  the graph definition
+-   `_txt`  
 -   `cb`  callback which is called after rendering is finished with the svg code as inparam.
 -   `container`  selector to element in which a div with the graph temporarily will be inserted. In one is
     provided a hidden div will be inserted in the body of the page instead. The element will be removed when rendering is
     completed.
+-   `txt`  the graph definition
 
 ## 
 

--- a/src/diagrams/state/parser/stateDiagram.jison
+++ b/src/diagrams/state/parser/stateDiagram.jison
@@ -48,7 +48,7 @@
 <STATE>.*"[[fork]]"                   {this.popState();yytext=yytext.slice(0,-8).trim();/*console.warn('Fork Fork: ',yytext);*/return 'FORK';}
 <STATE>.*"[[join]]"                   {this.popState();yytext=yytext.slice(0,-8).trim();/*console.warn('Fork Join: ',yytext);*/return 'JOIN';}
 <STATE>["]                   this.begin("STATE_STRING");
-<STATE>"as"\s*         {this.popState();this.pushState('STATE_ID');return "AS";}
+<STATE>\s*"as"\s+         {this.popState();this.pushState('STATE_ID');return "AS";}
 <STATE_ID>[^\n\{]*         {this.popState();/* console.log('STATE_ID', yytext);*/return "ID";}
 <STATE_STRING>["]              this.popState();
 <STATE_STRING>[^"]*         { /*console.log('Long description:', yytext);*/return "STATE_DESCR";}

--- a/src/diagrams/state/stateDiagram.spec.js
+++ b/src/diagrams/state/stateDiagram.spec.js
@@ -53,6 +53,39 @@ describe('state diagram, ', function() {
 
       parser.parse(str);
     });
+
+    it('handle "as" in state names', function() {
+      const str = `stateDiagram
+      assemble
+      state assemble
+      `;
+
+      parser.parse(str);
+    });
+    it('handle "as" in state names 1', function() {
+      const str = `stateDiagram
+      assemble
+      state assemble
+      `;
+
+      parser.parse(str);
+    });
+    it('handle "as" in state names 2', function() {
+      const str = `stateDiagram
+      assembleas
+      state assembleas
+      `;
+
+      parser.parse(str);
+    });
+    it('handle "as" in state names 3', function() {
+      const str = `stateDiagram
+      state "as" as as
+      `;
+
+      parser.parse(str);
+    });
+
     it('scale', function() {
       const str = `stateDiagram\n
         scale 350 width


### PR DESCRIPTION

## :bookmark_tabs: Summary
This allows removes incorrect matching if as in the state definition in stateDiagram.

Resolves #1217

## :straight_ruler: Design Decisions
Updated the grammar to be more strict when looking for the as keyword.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
