### PR TITLE
Set text color for flowchart link labels according to linkStyle definitions

### DIFF
--- a/cypress/integration/rendering/flowchart.spec.js
+++ b/cypress/integration/rendering/flowchart.spec.js
@@ -549,6 +549,8 @@ it('25: Handle link click events (link, anchor, mailto, other protocol, script)'
       `graph LR
       A[red<br>text] -->|red<br>text| B(blue<br>text)
       C[/red<br/>text/] -->|blue<br/>text| D{blue<br/>text}
+      E{{default<br />style}} -->|default<br />style| F([default<br />style])
+      linkStyle default color:Sienna;
       linkStyle 0 color:red;
       linkStyle 1 stroke:DarkGray,stroke-width:2px,color:#0000ff
       style A color:red;
@@ -567,6 +569,8 @@ it('25: Handle link click events (link, anchor, mailto, other protocol, script)'
       `graph LR
       A[red<br>text] -->|red<br>text| B(blue<br>text)
       C[/red<br/>text/] -->|blue<br/>text| D{blue<br/>text}
+      E{{default<br />style}} -->|default<br />style| F([default<br />style])
+      linkStyle default color:Sienna;
       linkStyle 0 color:red;
       linkStyle 1 stroke:DarkGray,stroke-width:2px,color:#0000ff
       style A color:red;

--- a/cypress/integration/rendering/flowchart.spec.js
+++ b/cypress/integration/rendering/flowchart.spec.js
@@ -512,7 +512,7 @@ describe('Flowchart', () => {
     );
   });
 
-  it('24.1: Keep node label text (if already defined) when a style is applied', () => {
+  it('24: Keep node label text (if already defined) when a style is applied', () => {
     imgSnapshotTest(
       `graph LR
       A(( )) -->|step 1| B(( ))
@@ -524,7 +524,7 @@ describe('Flowchart', () => {
       { flowchart: { htmlLabels: false } }
     );
   });
-it('24.2: Handle link click events (link, anchor, mailto, other protocol, script)', () => {
+it('25: Handle link click events (link, anchor, mailto, other protocol, script)', () => {
     imgSnapshotTest(
       `graph TB
       TITLE["Link Click Events<br>(click the nodes below)"]
@@ -544,11 +544,13 @@ it('24.2: Handle link click events (link, anchor, mailto, other protocol, script
       );
   });
 
-  it('25: Set node text color according to style when html labels are enabled', () => {
+  it('26: Set text color of nodes and links according to styles when html labels are enabled', () => {
     imgSnapshotTest(
       `graph LR
-      A[red<br>text] --> B(blue<br>text)
-      C[/red<br/>text/] --> D{blue<br/>text}
+      A[red<br>text] -->|red<br>text| B(blue<br>text)
+      C[/red<br/>text/] -->|blue<br/>text| D{blue<br/>text}
+      linkStyle 0 color:red;
+      linkStyle 1 stroke:DarkGray,stroke-width:2px,color:#0000ff
       style A color:red;
       style B color:blue;
       style C stroke:#ff0000,fill:#ffcccc,color:#ff0000
@@ -560,11 +562,13 @@ it('24.2: Handle link click events (link, anchor, mailto, other protocol, script
     );
   });
 
-  it('26: Set node text color according to style when html labels are disabled', () => {
+  it('27: Set text color of nodes and links according to styles when html labels are disabled', () => {
     imgSnapshotTest(
       `graph LR
-      A[red<br>text] --> B(blue<br>text)
-      C[/red<br/>text/] --> D{blue<br/>text}
+      A[red<br>text] -->|red<br>text| B(blue<br>text)
+      C[/red<br/>text/] -->|blue<br/>text| D{blue<br/>text}
+      linkStyle 0 color:red;
+      linkStyle 1 stroke:DarkGray,stroke-width:2px,color:#0000ff
       style A color:red;
       style B color:blue;
       style C stroke:#ff0000,fill:#ffcccc,color:#ff0000

--- a/dist/index.html
+++ b/dist/index.html
@@ -371,8 +371,10 @@ graph TB
   <hr/>
   <div class="mermaid">
     graph LR
-    A[red<br>text] --> B(blue<br>text)
-    C[/red<br/>text/] --> D{blue<br/>text}
+    A[red<br>text] -->|red<br>text| B(blue<br>text)
+    C[/red<br/>text/] -->|blue<br/>text| D{blue<br/>text}
+    linkStyle 0 color:red;
+    linkStyle 1 stroke:DarkGray,stroke-width:2px,color:#0000ff
     style A color:red;
     style B color:blue;
     style C stroke:#ff0000,fill:#ffcccc,color:#ff0000

--- a/dist/index.html
+++ b/dist/index.html
@@ -373,6 +373,8 @@ graph TB
     graph LR
     A[red<br>text] -->|red<br>text| B(blue<br>text)
     C[/red<br/>text/] -->|blue<br/>text| D{blue<br/>text}
+    E{{default<br />style}} -->|default<br />style| F([default<br />style])
+    linkStyle default color:Sienna;
     linkStyle 0 color:red;
     linkStyle 1 stroke:DarkGray,stroke-width:2px,color:#0000ff
     style A color:red;

--- a/docs/flowchart.md
+++ b/docs/flowchart.md
@@ -497,7 +497,7 @@ Instead of ids, the order number of when the link was defined in the graph is us
 defined in the linkStyle statement will belong to the fourth link in the graph:
 
 ```
-linkStyle 3 stroke:#ff3,stroke-width:4px;
+linkStyle 3 stroke:#ff3,stroke-width:4px,color:red;
 ```
 
 

--- a/src/diagrams/flowchart/flowRenderer.js
+++ b/src/diagrams/flowchart/flowRenderer.js
@@ -152,8 +152,12 @@ export const addEdges = function(edges, g) {
   let cnt = 0;
 
   let defaultStyle;
+  let defaultLabelStyle;
+
   if (typeof edges.defaultStyle !== 'undefined') {
-    defaultStyle = edges.defaultStyle.toString().replace(/,/g, ';');
+    const defaultStyles = getStylesFromArray(edges.defaultStyle);
+    defaultStyle = defaultStyles.style;
+    defaultLabelStyle = defaultStyles.labelStyle;
   }
 
   edges.forEach(function(edge) {
@@ -180,6 +184,9 @@ export const addEdges = function(edges, g) {
           style = 'fill:none';
           if (typeof defaultStyle !== 'undefined') {
             style = defaultStyle;
+          }
+          if (typeof defaultLabelStyle !== 'undefined') {
+            labelStyle = defaultLabelStyle;
           }
           break;
         case 'dotted':
@@ -219,9 +226,9 @@ export const addEdges = function(edges, g) {
 
         if (typeof edge.style === 'undefined') {
           edgeData.style = edgeData.style || 'stroke: #333; stroke-width: 1.5px;fill:none';
-        } else {
-          edgeData.labelStyle = edgeData.labelStyle.replace('color:', 'fill:');
         }
+
+        edgeData.labelStyle = edgeData.labelStyle.replace('color:', 'fill:');
       }
     }
     // Add the edge to the graph

--- a/src/diagrams/flowchart/flowRenderer.js
+++ b/src/diagrams/flowchart/flowRenderer.js
@@ -176,6 +176,25 @@ export const addVertices = function(vert, g, svgId) {
  * @param {Object} g The graph object
  */
 export const addEdges = function(edges, g) {
+  const styleFromStyleArr = function(styleStr, arr, { label }) {
+    if (!label) {
+      // Create a compound style definition from the style definitions found for the node in the graph definition
+      for (let i = 0; i < arr.length; i++) {
+        if (typeof arr[i] !== 'undefined') {
+          styleStr = styleStr + arr[i] + ';';
+        }
+      }
+    } else {
+      // create the style definition for the text, if property is a text-property
+      for (let i = 0; i < arr.length; i++) {
+        if (typeof arr[i] !== 'undefined') {
+          if (arr[i].startsWith('color:')) styleStr = styleStr + arr[i] + ';';
+        }
+      }
+    }
+    return styleStr;
+  };
+
   let cnt = 0;
 
   let defaultStyle;
@@ -195,10 +214,11 @@ export const addEdges = function(edges, g) {
     }
 
     let style = '';
+    let labelStyle = '';
+
     if (typeof edge.style !== 'undefined') {
-      edge.style.forEach(function(s) {
-        style = style + s + ';';
-      });
+      style = styleFromStyleArr(style, edge.style, { label: false });
+      labelStyle = styleFromStyleArr(labelStyle, edge.style, { label: true });
     } else {
       switch (edge.stroke) {
         case 'normal':
@@ -215,7 +235,9 @@ export const addEdges = function(edges, g) {
           break;
       }
     }
+
     edgeData.style = style;
+    edgeData.labelStyle = labelStyle;
 
     if (typeof edge.interpolate !== 'undefined') {
       edgeData.curve = interpolateToCurve(edge.interpolate, d3.curveLinear);
@@ -242,6 +264,8 @@ export const addEdges = function(edges, g) {
 
         if (typeof edge.style === 'undefined') {
           edgeData.style = edgeData.style || 'stroke: #333; stroke-width: 1.5px;fill:none';
+        } else {
+          edgeData.labelStyle = edgeData.labelStyle.replace('color:', 'fill:');
         }
       }
     }

--- a/src/diagrams/flowchart/flowRenderer.spec.js
+++ b/src/diagrams/flowchart/flowRenderer.spec.js
@@ -92,44 +92,40 @@ describe('the flowchart renderer', function() {
         expect(addedNodes[0][1].label.lastChild.innerHTML).toEqual('Line'); // <tspan> node, line 2
       });
     });
-  });
 
-  [
-    [['fill:#fff'], 'fill:#fff;', ''],
-    [['color:#ccc'], 'color:#ccc;', 'color:#ccc;'],
-    [['fill:#fff', 'color:#ccc'], 'fill:#fff;color:#ccc;', 'color:#ccc;'],
     [
-      ['fill:#fff', 'color:#ccc', 'text-align:center'],
-      'fill:#fff;color:#ccc;text-align:center;',
-      'color:#ccc;text-align:center;'
-    ]
-  ].forEach(function([style, expectedStyle, expectedLabelStyle]) {
-    it(`should add the styles to style and/or labelStyle for style ${style}`, function() {
-      const addedNodes = [];
-      const mockG = {
-        setNode: function(id, object) {
-          addedNodes.push([id, object]);
-        }
-      };
-      addVertices(
-        {
-          v1: {
-            type: 'rect',
-            id: 'my-node-id',
-            classes: [],
-            styles: style,
-            text: 'my vertex text'
+      [['fill:#fff'], 'fill:#fff;', ''],
+      [['color:#ccc'], '', 'color:#ccc;'],
+      [['fill:#fff', 'color:#ccc'], 'fill:#fff;', 'color:#ccc;'],
+      [['fill:#fff', 'color:#ccc', 'text-align:center'], 'fill:#fff;', 'color:#ccc;text-align:center;']
+    ].forEach(function([style, expectedStyle, expectedLabelStyle]) {
+      it(`should add the styles to style and/or labelStyle for style ${style}`, function() {
+        const addedNodes = [];
+        const mockG = {
+          setNode: function(id, object) {
+            addedNodes.push([id, object]);
           }
-        },
-        mockG,
-        'svg-id'
-      );
-      expect(addedNodes).toHaveLength(1);
-      expect(addedNodes[0][0]).toEqual('my-node-id');
-      expect(addedNodes[0][1]).toHaveProperty('id', 'my-node-id');
-      expect(addedNodes[0][1]).toHaveProperty('labelType', 'svg');
-      expect(addedNodes[0][1]).toHaveProperty('style', expectedStyle);
-      expect(addedNodes[0][1]).toHaveProperty('labelStyle', expectedLabelStyle);
+        };
+        addVertices(
+          {
+            v1: {
+              type: 'rect',
+              id: 'my-node-id',
+              classes: [],
+              styles: style,
+              text: 'my vertex text'
+            }
+          },
+          mockG,
+          'svg-id'
+        );
+        expect(addedNodes).toHaveLength(1);
+        expect(addedNodes[0][0]).toEqual('my-node-id');
+        expect(addedNodes[0][1]).toHaveProperty('id', 'my-node-id');
+        expect(addedNodes[0][1]).toHaveProperty('labelType', 'svg');
+        expect(addedNodes[0][1]).toHaveProperty('style', expectedStyle);
+        expect(addedNodes[0][1]).toHaveProperty('labelStyle', expectedLabelStyle);
+      });
     });
   });
 
@@ -159,6 +155,33 @@ describe('the flowchart renderer', function() {
       addedEdges.forEach(function(edge) {
         expect(edge).toHaveProperty('label', 'Multi\nLine');
         expect(edge).toHaveProperty('labelpos', 'c');
+      });
+    });
+
+    [
+      [['stroke:DarkGray'], 'stroke:DarkGray;', ''],
+      [['color:red'], '', 'fill:red;'],
+      [['stroke:DarkGray', 'color:red'], 'stroke:DarkGray;', 'fill:red;'],
+      [['stroke:DarkGray', 'color:red', 'stroke-width:2px'], 'stroke:DarkGray;stroke-width:2px;', 'fill:red;']
+    ].forEach(function([style, expectedStyle, expectedLabelStyle]) {
+      it(`should add the styles to style and/or labelStyle for style ${style}`, function() {
+        const addedEdges = [];
+        const mockG = {
+          setEdge: function(s, e, data, c) {
+            addedEdges.push(data);
+          }
+        };
+        addEdges(
+          [
+            { style: style, text: 'styling' }
+          ],
+          mockG,
+          'svg-id'
+        );
+
+        expect(addedEdges).toHaveLength(1);
+        expect(addedEdges[0]).toHaveProperty('style', expectedStyle);
+        expect(addedEdges[0]).toHaveProperty('labelStyle', expectedLabelStyle);
       });
     });
   });

--- a/src/utils.js
+++ b/src/utils.js
@@ -201,6 +201,24 @@ const calcCardinalityPosition = (isRelationTypePresent, points, initialPosition)
   return cardinalityPosition;
 };
 
+export const getStylesFromArray = arr => {
+  let style = '';
+  let labelStyle = '';
+
+  for (let i = 0; i < arr.length; i++) {
+    if (typeof arr[i] !== 'undefined') {
+      // add text properties to label style definition
+      if (arr[i].startsWith('color:') || arr[i].startsWith('text-align:')) {
+        labelStyle = labelStyle + arr[i] + ';';
+      } else {
+        style = style + arr[i] + ';';
+      }
+    }
+  }
+
+  return { style: style, labelStyle: labelStyle };
+};
+
 export default {
   detectType,
   isSubstringInArray,
@@ -208,5 +226,6 @@ export default {
   calcLabelPosition,
   calcCardinalityPosition,
   sanitize,
-  formatUrl
+  formatUrl,
+  getStylesFromArray
 };


### PR DESCRIPTION
## :bookmark_tabs: Summary
The link label text can be colored by using `color` settings in the `linkStyle` definition.

Resolves #962

## :straight_ruler: Design Decisions
Applied color settings to edge label style. Extended the tests for label text color (dist/index.html and cypress integration test) and linkStyle example in the docs.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
