### PR TITLE
Bug/1247 Fix "window is not defined" with ssr

### DIFF
--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -50,7 +50,8 @@ export const jsConfig = () => {
       filename: '[name].js',
       library: 'mermaid',
       libraryTarget: 'umd',
-      libraryExport: 'default'
+      libraryExport: 'default',
+      globalObject: 'typeof self !== "undefined" ? self : this'
     },
     module: {
       rules: [amdRule, jsRule, scssRule, jisonRule]


### PR DESCRIPTION
## :bookmark_tabs: Summary
Resolves #1247

Fix this issue by applying the workaround mentioned in https://github.com/webpack/webpack/issues/6784.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
