### PR TITLE
Add section on showing parallel blocks for sequence diagrams

### DIFF
--- a/docs/sequenceDiagram.md
+++ b/docs/sequenceDiagram.md
@@ -235,6 +235,52 @@ sequenceDiagram
     end
 ```
 
+## Parallel
+
+It is possible to show actions that are happening in parallel.
+
+This is done by the notation
+
+```
+par [Action 1]
+... statements ...
+and [Action 2]
+... statements ...
+and [Action N]
+... statements ...
+end
+```
+
+See the example below:
+
+```mermaid
+sequenceDiagram
+    par Alice to Bob
+        Alice->>Bob: Hello guys!
+    and Alice to John
+        Alice->>John: Hello guys!
+    end
+    Bob-->>Alice: Hi Alice!
+    John-->>Alice: Hi Alice!
+```
+
+It is also possible to nest parallel blocks.
+
+```mermaid
+sequenceDiagram
+    par Alice to Bob
+        Alice->>Bob: Go help John
+    and Alice to John
+        Alice->>John: I want this done today
+        par John to Charlie
+            John->>Charlie: Can we do this today?
+        and John to Diana
+            John->>Diana: Can you help us today?
+        end
+    end
+```
+
+
 ## Background Highlighting
 It is possible to highlight flows by providing colored background rects. This is done by the notation
 
@@ -452,4 +498,3 @@ Param | Description | Default value
 --- | --- | ---
 mirrorActor | Turns on/off the rendering of actors below the diagram as well as above it | false
 bottomMarginAdj | Adjusts how far down the graph ended. Wide borders styles with css could generate unwanted clipping which is why this config param exists. | 1
-

--- a/docs/sequenceDiagram.md
+++ b/docs/sequenceDiagram.md
@@ -326,7 +326,7 @@ sequenceDiagram
 
 ## sequenceNumbers
 
-It is possiebl to get a sequence number attached to each arrow in a sequence diagram. This can be configured when adding mermaid to the website as shown below:
+It is possible to get a sequence number attached to each arrow in a sequence diagram. This can be configured when adding mermaid to the website as shown below:
 ```
     <script>
       mermaid.initialize({

--- a/docs/sequenceDiagram.md
+++ b/docs/sequenceDiagram.md
@@ -77,7 +77,6 @@ Type | Description
 -x   | Solid line with a cross at the end (async)
 --x  | Dotted line with a cross at the end (async)
 
-
 ## Activations
 
 It is possible to activate and deactivate an actor. (de)activation can be dedicated declarations:
@@ -127,7 +126,6 @@ sequenceDiagram
     John-->>-Alice: I feel great!
 ```
 
-
 ## Notes
 
 It is possible to add notes to a sequence diagram. This is done by the notation
@@ -159,7 +157,6 @@ sequenceDiagram
     Note over Alice,John: A typical interaction
 ```
 
-
 ## Loops
 
 It is possible to express loops in a sequence diagram. This is done by the notation
@@ -186,7 +183,6 @@ sequenceDiagram
         John-->Alice: Great!
     end
 ```
-
 
 ## Alt
 
@@ -280,8 +276,8 @@ sequenceDiagram
     end
 ```
 
-
 ## Background Highlighting
+
 It is possible to highlight flows by providing colored background rects. This is done by the notation
 
 The colors are defined using rgb and rgba syntax.
@@ -386,9 +382,7 @@ loopLine     | Defines styles for the lines in the loop box.
 note         | Styles for the note box.
 noteText     | Styles for the text on in the note boxes.
 
-
 ### Sample stylesheet
-
 
 ```css
 body {
@@ -471,7 +465,6 @@ text.actor {
     font-size:14px;
 }
 ```
-
 
 ## Configuration
 


### PR DESCRIPTION
## :bookmark_tabs: Summary
Add section on showing parallel blocks for sequence diagrams

Support was already added as part of issue #425 and PR #470. 
But it is missing from the docs at https://mermaid-js.github.io/mermaid/#/sequenceDiagram.

## :straight_ruler: Design Decisions
This is mainly an update to the sequenceDiagram.md.

Additionally, I also:
* Fixed markdown lint warnings [MD012](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md012---multiple-consecutive-blank-lines) and [MD022](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md022---headings-should-be-surrounded-by-blank-lines) on that same markdown file
* Fixed typo "possiebl"

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [X] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
