### PR TITLE
Feature/Multiline sequence message alignment

### DIFF
--- a/docs/mermaidAPI.md
+++ b/docs/mermaidAPI.md
@@ -174,6 +174,14 @@ margin around notes.
 Space between messages.
 **Default value 35**.
 
+### messageAlign
+
+Multiline message alignment. Possible values are:
+
+-   left
+-   center **default**
+-   right
+
 ### mirrorActors
 
 mirror actors under diagram.

--- a/src/diagrams/sequence/sequenceRenderer.js
+++ b/src/diagrams/sequence/sequenceRenderer.js
@@ -24,6 +24,8 @@ const conf = {
   noteMargin: 10,
   // Space between messages
   messageMargin: 35,
+  // Multiline message alignment
+  messageAlign: 'center',
   // mirror actors under diagram
   mirrorActors: false,
   // Depending on css styling this might need adjustment
@@ -230,26 +232,38 @@ const drawMessage = function(elem, startx, stopx, verticalPos, msg, sequenceInde
   const g = elem.append('g');
   const txtCenter = startx + (stopx - startx) / 2;
 
-  let textElem;
+  let textElems = [];
   let counterBreaklines = 0;
   let breaklineOffset = 17;
   const breaklines = msg.message.split(/<br\s*\/?>/gi);
   for (const breakline of breaklines) {
-    textElem = g
-      .append('text') // text label for the x axis
-      .attr('x', txtCenter)
-      .attr('y', verticalPos - 7 + counterBreaklines * breaklineOffset)
-      .style('text-anchor', 'middle')
-      .attr('class', 'messageText')
-      .text(breakline.trim());
+    textElems.push(
+      g
+        .append('text') // text label for the x axis
+        .attr('x', txtCenter)
+        .attr('y', verticalPos - 7 + counterBreaklines * breaklineOffset)
+        .style('text-anchor', 'middle')
+        .attr('class', 'messageText')
+        .text(breakline.trim())
+    );
     counterBreaklines++;
   }
   const offsetLineCounter = counterBreaklines - 1;
   const totalOffset = offsetLineCounter * breaklineOffset;
 
-  bounds.bumpVerticalPos(totalOffset);
+  let textWidths = textElems.map(function(textElem) {
+    return (textElem._groups || textElem)[0][0].getBBox().width;
+  });
+  let textWidth = Math.max(...textWidths);
+  for (const textElem of textElems) {
+    if (conf.messageAlign === 'left') {
+      textElem.attr('x', txtCenter - textWidth / 2).style('text-anchor', 'start');
+    } else if (conf.messageAlign === 'right') {
+      textElem.attr('x', txtCenter + textWidth / 2).style('text-anchor', 'end');
+    }
+  }
 
-  let textWidth = (textElem._groups || textElem)[0][0].getBBox().width;
+  bounds.bumpVerticalPos(totalOffset);
 
   let line;
   if (startx === stopx) {

--- a/src/diagrams/sequence/sequenceRenderer.js
+++ b/src/diagrams/sequence/sequenceRenderer.js
@@ -247,6 +247,8 @@ const drawMessage = function(elem, startx, stopx, verticalPos, msg, sequenceInde
   const offsetLineCounter = counterBreaklines - 1;
   const totalOffset = offsetLineCounter * breaklineOffset;
 
+  bounds.bumpVerticalPos(totalOffset);
+
   let textWidth = (textElem._groups || textElem)[0][0].getBBox().width;
 
   let line;
@@ -295,9 +297,9 @@ const drawMessage = function(elem, startx, stopx, verticalPos, msg, sequenceInde
   } else {
     line = g.append('line');
     line.attr('x1', startx);
-    line.attr('y1', verticalPos);
+    line.attr('y1', verticalPos + totalOffset);
     line.attr('x2', stopx);
-    line.attr('y2', verticalPos);
+    line.attr('y2', verticalPos + totalOffset);
     bounds.insert(
       startx,
       bounds.getVerticalPos() - 10 + totalOffset,

--- a/src/mermaidAPI.js
+++ b/src/mermaidAPI.js
@@ -230,6 +230,14 @@ const config = {
     messageMargin: 35,
 
     /**
+     * Multiline message alignment. Possible values are:
+     *   * left
+     *   * center **default**
+     *   * right
+     */
+    messageAlign: 'center',
+
+    /**
      * mirror actors under diagram.
      * **Default value true**.
      */
@@ -809,6 +817,7 @@ export default mermaidAPI;
  *       boxTextMargin:5,
  *       noteMargin:10,
  *       messageMargin:35,
+ *       messageAlign:'center',
  *       mirrorActors:true,
  *       bottomMarginAdj:1,
  *       useMaxWidth:true,


### PR DESCRIPTION
## :bookmark_tabs: Summary
Please first take a look at PR #1314 , it contains a fix for multiline messages in sequence diagrams.
This PR is an additional improvement which let the user set the alignment of these multiline messages.

It introduces a new configuration option `messageAlign` which takes 3 possible values:

  - `left`: align text to the left
  - `center` **(default)**: text is align in the middle, current alignment
  - `right`: align text to the right

## :straight_ruler: Design Decisions
To left/right align the text, I change the style attribute `text-anchor` and I move the center alignment line according to the maximum width of text lines.

## :camera: Example

Here is a basic HTTP request/response diagram where text alignment is useful:

![example](https://user-images.githubusercontent.com/2905530/77479310-d54f3180-6e1f-11ea-9e4f-11d001c521cf.png)

## :interrobang: Why two PRs ?
The first PR #1314  is IMHO easier (no additional parameter, no change in flow or logic). This one require a new parameter and a double iteration is mandatory to calculate max text width.  

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
