### PR TITLE
Feature/1309 er diagram plant uml

### DIFF
--- a/cypress/integration/rendering/erDiagram.spec.js
+++ b/cypress/integration/rendering/erDiagram.spec.js
@@ -6,8 +6,8 @@ describe('Entity Relationship Diagram', () => {
     imgSnapshotTest(
       `
     erDiagram
-        CUSTOMER !-?< ORDER : places
-        ORDER !-!< LINE-ITEM : contains
+        CUSTOMER ||--o{ ORDER : places
+        ORDER ||--|{ LINE-ITEM : contains
       `,
       {logLevel : 1}
     );
@@ -18,9 +18,9 @@ describe('Entity Relationship Diagram', () => {
     imgSnapshotTest(
       `
     erDiagram
-        CUSTOMER !-?< CUSTOMER : refers
-        CUSTOMER !-?< ORDER : places
-        ORDER !-!< LINE-ITEM : contains
+        CUSTOMER ||..o{ CUSTOMER : refers
+        CUSTOMER ||--o{ ORDER : places
+        ORDER ||--|{ LINE-ITEM : contains
       `,
       {logLevel : 1}
     );
@@ -31,8 +31,8 @@ describe('Entity Relationship Diagram', () => {
     imgSnapshotTest(
       `
     erDiagram
-        CUSTOMER !-!< ADDRESS : "invoiced at"
-        CUSTOMER !-!< ADDRESS : "receives goods at"
+        CUSTOMER ||--|{ ADDRESS : "invoiced at"
+        CUSTOMER ||--|{ ADDRESS : "receives goods at"
       `,
       {logLevel : 1}
     );
@@ -43,28 +43,27 @@ describe('Entity Relationship Diagram', () => {
     imgSnapshotTest(
       `
     erDiagram
-        A !-!< B : likes
-        B !-!< C : likes
-        C !-!< A : likes
+        A ||--|{ B : likes
+        B ||--|{ C : likes
+        C ||--|{ A : likes
       `,
       {logLevel : 1}
     );
     cy.get('svg');
-
   });
 
   it('should render a not-so-simple ER diagram', () => {
     imgSnapshotTest(
       `
     erDiagram
-        DELIVERY-ADDRESS !-?< ORDER : receives
-        CUSTOMER >!-!< DELIVERY-ADDRESS : has
-        CUSTOMER !-?< ORDER : places
-        CUSTOMER !-?< INVOICE : "liable for"
-        INVOICE !-!< ORDER : covers
-        ORDER !-!< ORDER-ITEM : includes
-        PRODUCT-CATEGORY !-!< PRODUCT : contains
-        PRODUCT !-?< ORDER-ITEM : "ordered in"
+        CUSTOMER }|..|{ DELIVERY-ADDRESS : has
+        CUSTOMER ||--o{ ORDER : places
+        CUSTOMER ||--o{ INVOICE : "liable for"
+        DELIVERY-ADDRESS ||--o{ ORDER : receives
+        INVOICE ||--|{ ORDER : covers
+        ORDER ||--|{ ORDER-ITEM : includes
+        PRODUCT-CATEGORY ||--|{ PRODUCT : contains
+        PRODUCT ||--o{ ORDER-ITEM : "ordered in"
       `,
       {logLevel : 1}
     );
@@ -76,13 +75,13 @@ describe('Entity Relationship Diagram', () => {
       [
       `
     erDiagram
-        CUSTOMER !-?< ORDER : places
-        ORDER !-!< LINE-ITEM : contains
+        CUSTOMER ||--o{ ORDER : places
+        ORDER ||--|{ LINE-ITEM : contains
       `,
       `
     erDiagram
-        CUSTOMER !-?< ORDER : places
-        ORDER !-!< LINE-ITEM : contains
+        CUSTOMER ||--o{ ORDER : places
+        ORDER ||--|{ LINE-ITEM : contains
       `
       ],
       {logLevel : 1}

--- a/docs/entityRelationshipDiagram.md
+++ b/docs/entityRelationshipDiagram.md
@@ -2,18 +2,20 @@
 
 > An entity–relationship model (or ER model) describes interrelated things of interest in a specific domain of knowledge. A basic ER model is composed of entity types (which classify the things of interest) and specifies relationships that can exist between entities (instances of those entity types). Wikipedia.
 
-Note that practitioners of ER modelling almost always refer to entity types simply as entities.  For example the CUSTOMER entity type would be referred to simply as the CUSTOMER entity.  This is so common it would be inadvisable to do anything else, but technically an entity is an abstract instance of an entity type, and this is what an ER diagram shows - abstract instances, and the relationships between them.  This is why entities are always named using singular nouns.
+Note that practitioners of ER modelling almost always refer to entity types simply as entities.  For example the CUSTOMER entity type would be referred to simply as the CUSTOMER entity.  This is so common it would be inadvisable to do anything else, but technically an entity is an abstract *instance* of an entity type, and this is what an ER diagram shows - abstract instances, and the relationships between them.  This is why entities are always named using singular nouns.
 
 Mermaid can render ER diagrams
 ```
 erDiagram
-    CUSTOMER !-?< ORDER : places
-    ORDER !-!< LINE-ITEM : contains
+    CUSTOMER ||--o{ ORDER : places
+    ORDER ||--|{ LINE-ITEM : contains
+    CUSTOMER }|..|{ : DELIVERY-ADDRESS : uses 
 ```
 ```mermaid
 erDiagram
-    CUSTOMER !-?< ORDER : places
-    ORDER !-!< LINE-ITEM : contains
+    CUSTOMER ||--o{ ORDER : places
+    ORDER ||--|{ LINE-ITEM : contains
+    CUSTOMER }|..|{ : DELIVERY-ADDRESS : uses 
 ```
 
 Entity names are often capitalised, although there is no accepted standard on this, and it is not required in Mermaid.
@@ -28,4 +30,51 @@ ER diagrams are a new feature in Mermaid and are **experimental**.  There are li
 
 ### Entities and Relationships
 
-To be completed
+Mermaid syntax for ER diagrams is compatible with PlantUML, with an extension to label the relationship.  Each statement consists of the following parts, all of which are mandatory:
+```
+    <first-entity> <relationship> <second-entity> : <relationship-label>
+```
+Where:
+
+- `first-entity` is the name of an entity.  Names must begin with an alphabetic character and may also contain digits and hyphens
+- `relationship` describes the way that both entities inter-relate.  See below.
+- `second-entity` is the name of the other entity
+- `relationship-label` describes the relationship from the perspective of the first entity.
+
+For example:
+
+```
+    PROPERTY ||--|{ ROOM : contains
+```
+
+This statement can be read as *a property contains one or more rooms, and a room is part of one and only one property*. You can see that the label here is from the first entity's perspective: a property contains a room, but a room does not contain a property.  When considered from the perspective of the second entity, the equivalent label is usually very easy to infer. (Some ER diagrams label relationships from both perspectives, but this is not supported here, and is usually superfluous).
+
+### Relationship Syntax
+
+The `relationship` part of each statement can be broken down into three sub-components: 
+
+- the cardinality of the first entity with respect to the second, 
+- whether the relationship confers identity on a 'child' entity
+- the cardinality of the second entity with respect to the first
+
+Cardinality is a property that describes how many elements of another entity can be related to the entity in question.  In the above example a `PROPERTY` can have one or more `ROOM` instances associated to it, whereas a `ROOM` can only be associated with one `PROPERTY`.  In each cardinality marker there are two characters.  The outermost character represents a maximum value, and the innermost character represents a minimum value.  The table below summarises possible cardinalities.
+
+| Value (left) | Value (right) | Meaning                                                |
+|:------------:|:-------------:|--------------------------------------------------------|
+|     `|o`     |       `o|`    | Zero or one                                            |
+|     `||`     |       `||`    | Exactly one                                            |
+|     `}o`     |       `o{`    | Zero or more (no upper limit)                          |
+|     `}|`     |       `|{`    | One or more (no upper limit)                           |
+
+### Identification
+
+Relationships may be classified as either *identifying* or *non-identifying* and these are rendered with either solid or dashed lines respectively. This is relevant when one of the entities in question can not have independent existence without the other.  For example a firm that insures people to drive cars might need to store data on `NAMED-DRIVER`s. In modelling this we might start out by observing that a `CAR` can be driven by many `PERSON` instances, and a `PERSON` can drive many `CAR`s - both entities can exist without the other, so this is a non-identifying relationship that we might specify in Mermaid as: `PERSON }|..|{ CAR : "driver"`.  Note the two dots in the middle of the relationship that will result in a dashed line being drawn between the two entities.  But when this many-to-many relationship is resolved into two one-to-many relationships, we observe that a `NAMED-DRIVER` cannot exist without both a `PERSON` and a `CAR` - the relationships become identifying and would be specified using hyphens, which translate to a solid line: 
+
+```
+    CAR ||--o{ NAMED-DRIVER : allows
+    PERSON ||--o{ NAMED-DRIVER : is
+```
+### Other Things
+
+- If you want the relationship label to be more than one word, you must use double quotes around the phrase
+- If you don't want a label at all on a relationship, you must use an empty double-quoted string

--- a/src/diagrams/er/erDb.js
+++ b/src/diagrams/er/erDb.js
@@ -8,22 +8,15 @@ let relationships = [];
 let title = '';
 
 const Cardinality = {
-  ONLY_ONE_TO_ONE_OR_MORE: 'ONLY_ONE_TO_ONE_OR_MORE',
-  ONLY_ONE_TO_ZERO_OR_MORE: 'ONLY_ONE_TO_ZERO_OR_MORE',
-  ZERO_OR_ONE_TO_ZERO_OR_MORE: 'ZERO_OR_ONE_TO_ZERO_OR_MORE',
-  ZERO_OR_ONE_TO_ONE_OR_MORE: 'ZERO_OR_ONE_TO_ONE_OR_MORE',
-  ONE_OR_MORE_TO_ONLY_ONE: 'ONE_OR_MORE_TO_ONLY_ONE',
-  ZERO_OR_MORE_TO_ONLY_ONE: 'ZERO_OR_MORE_TO_ONLY_ONE',
-  ZERO_OR_MORE_TO_ZERO_OR_ONE: 'ZERO_OR_MORE_TO_ZERO_OR_ONE',
-  ONE_OR_MORE_TO_ZERO_OR_ONE: 'ONE_OR_MORE_TO_ZERO_OR_ONE',
-  ZERO_OR_ONE_TO_ONLY_ONE: 'ZERO_OR_ONE_TO_ONLY_ONE',
-  ONLY_ONE_TO_ONLY_ONE: 'ONLY_ONE_TO_ONLY_ONE',
-  ONLY_ONE_TO_ZERO_OR_ONE: 'ONLY_ONE_TO_ZERO_OR_ONE',
-  ZERO_OR_ONE_TO_ZERO_OR_ONE: 'ZERO_OR_ONE_TO_ZERO_OR_ONE',
-  ZERO_OR_MORE_TO_ZERO_OR_MORE: 'ZERO_OR_MORE_TO_ZERO_OR_MORE',
-  ZERO_OR_MORE_TO_ONE_OR_MORE: 'ZERO_OR_MORE_TO_ONE_OR_MORE',
-  ONE_OR_MORE_TO_ZERO_OR_MORE: 'ONE_OR_MORE_TO_ZERO_OR_MORE',
-  ONE_OR_MORE_TO_ONE_OR_MORE: 'ONE_OR_MORE_TO_ONE_OR_MORE'
+  ZERO_OR_ONE: 'ZERO_OR_ONE',
+  ZERO_OR_MORE: 'ZERO_OR_MORE',
+  ONE_OR_MORE: 'ONE_OR_MORE',
+  ONLY_ONE: 'ONLY_ONE'
+};
+
+const Identification = {
+  NON_IDENTIFYING: 'NON_IDENTIFYING',
+  IDENTIFYING: 'IDENTIFYING'
 };
 
 const addEntity = function(name) {
@@ -40,14 +33,14 @@ const getEntities = () => entities;
  * @param entA The first entity in the relationship
  * @param rolA The role played by the first entity in relation to the second
  * @param entB The second entity in the relationship
- * @param card The cardinality of the relationship between the two entities
+ * @param rSpec The details of the relationship between the two entities
  */
-const addRelationship = function(entA, rolA, entB, card) {
+const addRelationship = function(entA, rolA, entB, rSpec) {
   let rel = {
     entityA: entA,
     roleA: rolA,
     entityB: entB,
-    cardinality: card
+    relSpec: rSpec
   };
 
   relationships.push(rel);
@@ -73,6 +66,7 @@ const clear = function() {
 
 export default {
   Cardinality,
+  Identification,
   addEntity,
   getEntities,
   addRelationship,

--- a/src/diagrams/er/parser/erDiagram.jison
+++ b/src/diagrams/er/parser/erDiagram.jison
@@ -10,26 +10,20 @@
 <string>["]               { this.popState(); }
 <string>[^"]*             { return 'STR'; }
 "erDiagram"               return 'ER_DIAGRAM';
+\|o                       return 'ZERO_OR_ONE';
+\}o                       return 'ZERO_OR_MORE';
+\}\|                      return 'ONE_OR_MORE';
+\|\|                      return 'ONLY_ONE';
+o\|                       return 'ZERO_OR_ONE';
+o\{                       return 'ZERO_OR_MORE';
+\|\{                      return 'ONE_OR_MORE';
+\.\.                      return 'NON_IDENTIFYING';
+\-\-                      return 'IDENTIFYING';
+\.\-                      return 'NON_IDENTIFYING';
+\-\.                      return 'NON_IDENTIFYING';
 [A-Za-z][A-Za-z0-9\-]*    return 'ALPHANUM';
-\>\?\-\?\<                return 'ZERO_OR_MORE_TO_ZERO_OR_MORE';
-\>\?\-\!\<                return 'ZERO_OR_MORE_TO_ONE_OR_MORE';
-\>\!\-\!\<                return 'ONE_OR_MORE_TO_ONE_OR_MORE';
-\>\!\-\?\<                return 'ONE_OR_MORE_TO_ZERO_OR_MORE';
-\!\-\!\<                  return 'ONLY_ONE_TO_ONE_OR_MORE';
-\!\-\?\<                  return 'ONLY_ONE_TO_ZERO_OR_MORE';
-\?\-\?\<                  return 'ZERO_OR_ONE_TO_ZERO_OR_MORE';
-\?\-\!\<                  return 'ZERO_OR_ONE_TO_ONE_OR_MORE';
-\>\!\-\!                  return 'ONE_OR_MORE_TO_ONLY_ONE';
-\>\?\-\!                  return 'ZERO_OR_MORE_TO_ONLY_ONE';
-\>\?\-\?                  return 'ZERO_OR_MORE_TO_ZERO_OR_ONE';
-\>\!\-\?                  return 'ONE_OR_MORE_TO_ZERO_OR_ONE';
-\?\-\!                    return 'ZERO_OR_ONE_TO_ONLY_ONE';
-\!\-\!                    return 'ONLY_ONE_TO_ONLY_ONE';
-\!\-\?                    return 'ONLY_ONE_TO_ZERO_OR_ONE';
-\?\-\?                    return 'ZERO_OR_ONE_TO_ZERO_OR_ONE';
 .                         return yytext[0];
 <<EOF>>                   return 'EOF';
-
 
 /lex
 
@@ -46,8 +40,8 @@ document
     ;
 
 statement
-    : entityName relationship entityName ':' role 
-      { 
+    : entityName relSpec entityName ':' role
+      {
           yy.addEntity($1); 
           yy.addEntity($3); 
           yy.addRelationship($1, $5, $3, $2);
@@ -55,26 +49,27 @@ statement
       };
 
 entityName
-    : 'ALPHANUM' { $$ = $1; }
+    : 'ALPHANUM' { $$ = $1; /*console.log('Entity: ' + $1);*/ }
     ;
 
-relationship
-    : 'ONLY_ONE_TO_ONE_OR_MORE'      { $$ = yy.Cardinality.ONLY_ONE_TO_ONE_OR_MORE; }
-    | 'ONLY_ONE_TO_ZERO_OR_MORE'     { $$ = yy.Cardinality.ONLY_ONE_TO_ZERO_OR_MORE; }
-    | 'ZERO_OR_ONE_TO_ZERO_OR_MORE'  { $$ = yy.Cardinality.ZERO_OR_ONE_TO_ZERO_OR_MORE; }
-    | 'ZERO_OR_ONE_TO_ONE_OR_MORE'   { $$ = yy.Cardinality.ZERO_OR_ONE_TO_ONE_OR_MORE; }
-    | 'ONE_OR_MORE_TO_ONLY_ONE'      { $$ = yy.Cardinality.ONE_OR_MORE_TO_ONLY_ONE; }
-    | 'ZERO_OR_MORE_TO_ONLY_ONE'     { $$ = yy.Cardinality.ZERO_OR_MORE_TO_ONLY_ONE; }
-    | 'ZERO_OR_MORE_TO_ZERO_OR_ONE'  { $$ = yy.Cardinality.ZERO_OR_MORE_TO_ZERO_OR_ONE; }
-    | 'ONE_OR_MORE_TO_ZERO_OR_ONE'   { $$ = yy.Cardinality.ONE_OR_MORE_TO_ZERO_OR_ONE; }
-    | 'ZERO_OR_ONE_TO_ONLY_ONE'      { $$ = yy.Cardinality.ZERO_OR_ONE_TO_ONLY_ONE; }
-    | 'ONLY_ONE_TO_ONLY_ONE'         { $$ = yy.Cardinality.ONLY_ONE_TO_ONLY_ONE; }
-    | 'ONLY_ONE_TO_ZERO_OR_ONE'      { $$ = yy.Cardinality.ONLY_ONE_TO_ZERO_OR_ONE; }
-    | 'ZERO_OR_ONE_TO_ZERO_OR_ONE'   { $$ = yy.Cardinality.ZERO_OR_ONE_TO_ZERO_OR_ONE; }
-    | 'ZERO_OR_MORE_TO_ZERO_OR_MORE' { $$ = yy.Cardinality.ZERO_OR_MORE_TO_ZERO_OR_MORE; }
-    | 'ZERO_OR_MORE_TO_ONE_OR_MORE'  { $$ = yy.Cardinality.ZERO_OR_MORE_TO_ONE_OR_MORE; }
-    | 'ONE_OR_MORE_TO_ONE_OR_MORE'   { $$ = yy.Cardinality.ONE_OR_MORE_TO_ONE_OR_MORE; }
-    | 'ONE_OR_MORE_TO_ZERO_OR_MORE'  { $$ = yy.Cardinality.ONE_OR_MORE_TO_ZERO_OR_MORE; }
+relSpec
+    : cardinality relType cardinality
+      {
+        $$ = { cardA: $3, relType: $2, cardB: $1 };
+        /*console.log('relSpec: ' + $3 + $2 + $1);*/
+      }
+    ;
+
+cardinality
+    : 'ZERO_OR_ONE'                  { $$ = yy.Cardinality.ZERO_OR_ONE; }
+    | 'ZERO_OR_MORE'                 { $$ = yy.Cardinality.ZERO_OR_MORE; }
+    | 'ONE_OR_MORE'                  { $$ = yy.Cardinality.ONE_OR_MORE; }
+    | 'ONLY_ONE'                     { $$ = yy.Cardinality.ONLY_ONE; }
+    ; 
+
+relType
+    : 'NON_IDENTIFYING'              { $$ = yy.Identification.NON_IDENTIFYING;  }
+    | 'IDENTIFYING'                  { $$ = yy.Identification.IDENTIFYING; }
     ;
 
 role

--- a/src/diagrams/er/parser/erDiagram.spec.js
+++ b/src/diagrams/er/parser/erDiagram.spec.js
@@ -15,7 +15,7 @@ describe('when parsing ER diagram it...', function() {
   });
 
   it('should associate two entities correctly', function() {
-    erDiagram.parser.parse('erDiagram\nCAR !-?< DRIVER : "insured for"');
+    erDiagram.parser.parse('erDiagram\nCAR ||--o{ DRIVER : "insured for"');
     const entities = erDb.getEntities();
     const relationships = erDb.getRelationships();
     const carEntity = entities.CAR;
@@ -24,12 +24,14 @@ describe('when parsing ER diagram it...', function() {
     expect(carEntity).toBe('CAR');
     expect(driverEntity).toBe('DRIVER');
     expect(relationships.length).toBe(1);
-    expect(relationships[0].cardinality).toBe(erDb.Cardinality.ONLY_ONE_TO_ZERO_OR_MORE);
+    expect(relationships[0].relSpec.cardA).toBe(erDb.Cardinality.ZERO_OR_MORE);
+    expect(relationships[0].relSpec.cardB).toBe(erDb.Cardinality.ONLY_ONE);
+    expect(relationships[0].relSpec.relType).toBe(erDb.Identification.IDENTIFYING);
   });
 
   it('should not create duplicate entities', function() {
-    const line1 = 'CAR !-?< DRIVER : "insured for"';
-    const line2 = 'DRIVER !-! LICENSE : has';
+    const line1 = 'CAR ||--o{ DRIVER : "insured for"';
+    const line2 = 'DRIVER ||--|| LICENSE : has';
     erDiagram.parser.parse(`erDiagram\n${line1}\n${line2}`);
     const entities = erDb.getEntities();
 
@@ -38,7 +40,7 @@ describe('when parsing ER diagram it...', function() {
 
   it('should create the role specified', function() {
     const teacherRole = 'is teacher of';
-    const line1 = `TEACHER >?-?< STUDENT : "${teacherRole}"`;
+    const line1 = `TEACHER }o--o{ STUDENT : "${teacherRole}"`;
     erDiagram.parser.parse(`erDiagram\n${line1}`);
     const rels = erDb.getRelationships();
 
@@ -46,13 +48,13 @@ describe('when parsing ER diagram it...', function() {
   });
 
   it('should allow recursive relationships', function() {
-    erDiagram.parser.parse('erDiagram\nNODE !-?< NODE : "leads to"');
+    erDiagram.parser.parse('erDiagram\nNODE ||--o{ NODE : "leads to"');
     expect(Object.keys(erDb.getEntities()).length).toBe(1);
   });
 
   it('should allow more than one relationship between the same two entities', function() {
-    const line1 = 'CAR !-?< PERSON : "insured for"';
-    const line2 = 'CAR >?-! PERSON : "owned by"';
+    const line1 = 'CAR ||--o{ PERSON : "insured for"';
+    const line2 = 'CAR }o--|| PERSON : "owned by"';
     erDiagram.parser.parse(`erDiagram\n${line1}\n${line2}`);
     const entities = erDb.getEntities();
     const rels     = erDb.getRelationships();
@@ -69,149 +71,178 @@ describe('when parsing ER diagram it...', function() {
     /* TODO */
   });
 
+
   it('should handle only-one-to-one-or-more relationships', function() {
-    erDiagram.parser.parse('erDiagram\nA !-!< B : has');
+    erDiagram.parser.parse('erDiagram\nA ||--|{ B : has');
     const rels = erDb.getRelationships();
 
     expect(Object.keys(erDb.getEntities()).length).toBe(2);
     expect(rels.length).toBe(1);
-    expect(rels[0].cardinality).toBe(erDb.Cardinality.ONLY_ONE_TO_ONE_OR_MORE);
+    expect(rels[0].relSpec.cardA).toBe(erDb.Cardinality.ONE_OR_MORE);
+    expect(rels[0].relSpec.cardB).toBe(erDb.Cardinality.ONLY_ONE);
   });
 
   it('should handle only-one-to-zero-or-more relationships', function() {
-    erDiagram.parser.parse('erDiagram\nA !-?< B : has');
+    erDiagram.parser.parse('erDiagram\nA ||..o{ B : has');
     const rels = erDb.getRelationships();
 
     expect(Object.keys(erDb.getEntities()).length).toBe(2);
     expect(rels.length).toBe(1);
-    expect(rels[0].cardinality).toBe(erDb.Cardinality.ONLY_ONE_TO_ZERO_OR_MORE);
+    expect(rels[0].relSpec.cardA).toBe(erDb.Cardinality.ZERO_OR_MORE);
+    expect(rels[0].relSpec.cardB).toBe(erDb.Cardinality.ONLY_ONE);
 
   });
 
   it('should handle zero-or-one-to-zero-or-more relationships', function() {
-    erDiagram.parser.parse('erDiagram\nA ?-?< B : has');
+    erDiagram.parser.parse('erDiagram\nA |o..o{ B : has');
     const rels = erDb.getRelationships();
 
     expect(Object.keys(erDb.getEntities()).length).toBe(2);
     expect(rels.length).toBe(1);
-    expect(rels[0].cardinality).toBe(erDb.Cardinality.ZERO_OR_ONE_TO_ZERO_OR_MORE);
+    expect(rels[0].relSpec.cardA).toBe(erDb.Cardinality.ZERO_OR_MORE);
+    expect(rels[0].relSpec.cardB).toBe(erDb.Cardinality.ZERO_OR_ONE);
   });
 
   it('should handle zero-or-one-to-one-or-more relationships', function() {
-    erDiagram.parser.parse('erDiagram\nA ?-!< B : has');
+    erDiagram.parser.parse('erDiagram\nA |o--|{ B : has');
     const rels = erDb.getRelationships();
 
     expect(Object.keys(erDb.getEntities()).length).toBe(2);
     expect(rels.length).toBe(1);
-    expect(rels[0].cardinality).toBe(erDb.Cardinality.ZERO_OR_ONE_TO_ONE_OR_MORE);
+    expect(rels[0].relSpec.cardA).toBe(erDb.Cardinality.ONE_OR_MORE);
+    expect(rels[0].relSpec.cardB).toBe(erDb.Cardinality.ZERO_OR_ONE);
   });
 
   it('should handle one-or-more-to-only-one relationships', function() {
-    erDiagram.parser.parse('erDiagram\nA >!-! B : has');
+    erDiagram.parser.parse('erDiagram\nA }|--|| B : has');
     const rels = erDb.getRelationships();
 
     expect(Object.keys(erDb.getEntities()).length).toBe(2);
     expect(rels.length).toBe(1);
-    expect(rels[0].cardinality).toBe(erDb.Cardinality.ONE_OR_MORE_TO_ONLY_ONE);
+    expect(rels[0].relSpec.cardA).toBe(erDb.Cardinality.ONLY_ONE);
+    expect(rels[0].relSpec.cardB).toBe(erDb.Cardinality.ONE_OR_MORE);
   });
 
   it('should handle zero-or-more-to-only-one relationships', function() {
-    erDiagram.parser.parse('erDiagram\nA >?-! B : has');
+    erDiagram.parser.parse('erDiagram\nA }o--|| B : has');
     const rels = erDb.getRelationships();
 
     expect(Object.keys(erDb.getEntities()).length).toBe(2);
     expect(rels.length).toBe(1);
-    expect(rels[0].cardinality).toBe(erDb.Cardinality.ZERO_OR_MORE_TO_ONLY_ONE);
+    expect(rels[0].relSpec.cardA).toBe(erDb.Cardinality.ONLY_ONE);
+    expect(rels[0].relSpec.cardB).toBe(erDb.Cardinality.ZERO_OR_MORE);
   });
 
   it('should handle zero-or-more-to-zero-or-one relationships', function() {
-    erDiagram.parser.parse('erDiagram\nA >?-? B : has');
+    erDiagram.parser.parse('erDiagram\nA }o..o| B : has');
     const rels = erDb.getRelationships();
 
     expect(Object.keys(erDb.getEntities()).length).toBe(2);
     expect(rels.length).toBe(1);
-    expect(rels[0].cardinality).toBe(erDb.Cardinality.ZERO_OR_MORE_TO_ZERO_OR_ONE);
+    expect(rels[0].relSpec.cardA).toBe(erDb.Cardinality.ZERO_OR_ONE);
+    expect(rels[0].relSpec.cardB).toBe(erDb.Cardinality.ZERO_OR_MORE);
   });
 
   it('should handle one-or-more-to-zero-or-one relationships', function() {
-    erDiagram.parser.parse('erDiagram\nA >!-? B : has');
+    erDiagram.parser.parse('erDiagram\nA }|..o| B : has');
     const rels = erDb.getRelationships();
 
     expect(Object.keys(erDb.getEntities()).length).toBe(2);
     expect(rels.length).toBe(1);
-    expect(rels[0].cardinality).toBe(erDb.Cardinality.ONE_OR_MORE_TO_ZERO_OR_ONE);
+    expect(rels[0].relSpec.cardA).toBe(erDb.Cardinality.ZERO_OR_ONE);
+    expect(rels[0].relSpec.cardB).toBe(erDb.Cardinality.ONE_OR_MORE);
   });
 
   it('should handle zero-or-one-to-only-one relationships', function() {
-    erDiagram.parser.parse('erDiagram\nA ?-! B : has');
+    erDiagram.parser.parse('erDiagram\nA |o..|| B : has');
     const rels = erDb.getRelationships();
 
     expect(Object.keys(erDb.getEntities()).length).toBe(2);
     expect(rels.length).toBe(1);
-    expect(rels[0].cardinality).toBe(erDb.Cardinality.ZERO_OR_ONE_TO_ONLY_ONE);
+    expect(rels[0].relSpec.cardA).toBe(erDb.Cardinality.ONLY_ONE);
+    expect(rels[0].relSpec.cardB).toBe(erDb.Cardinality.ZERO_OR_ONE);
   });
 
   it('should handle only-one-to-only-one relationships', function() {
-    erDiagram.parser.parse('erDiagram\nA !-! B : has');
+    erDiagram.parser.parse('erDiagram\nA ||..|| B : has');
     const rels = erDb.getRelationships();
 
     expect(Object.keys(erDb.getEntities()).length).toBe(2);
     expect(rels.length).toBe(1);
-    expect(rels[0].cardinality).toBe(erDb.Cardinality.ONLY_ONE_TO_ONLY_ONE);
+    expect(rels[0].relSpec.cardA).toBe(erDb.Cardinality.ONLY_ONE);
+    expect(rels[0].relSpec.cardB).toBe(erDb.Cardinality.ONLY_ONE);
   });
 
   it('should handle only-one-to-zero-or-one relationships', function() {
-    erDiagram.parser.parse('erDiagram\nA !-? B : has');
+    erDiagram.parser.parse('erDiagram\nA ||--o| B : has');
     const rels = erDb.getRelationships();
 
     expect(Object.keys(erDb.getEntities()).length).toBe(2);
     expect(rels.length).toBe(1);
-    expect(rels[0].cardinality).toBe(erDb.Cardinality.ONLY_ONE_TO_ZERO_OR_ONE);
+    expect(rels[0].relSpec.cardA).toBe(erDb.Cardinality.ZERO_OR_ONE);
+    expect(rels[0].relSpec.cardB).toBe(erDb.Cardinality.ONLY_ONE);
   });
 
   it('should handle zero-or-one-to-zero-or-one relationships', function() {
-    erDiagram.parser.parse('erDiagram\nA ?-? B : has');
+    erDiagram.parser.parse('erDiagram\nA |o..o| B : has');
     const rels = erDb.getRelationships();
 
     expect(Object.keys(erDb.getEntities()).length).toBe(2);
     expect(rels.length).toBe(1);
-    expect(rels[0].cardinality).toBe(erDb.Cardinality.ZERO_OR_ONE_TO_ZERO_OR_ONE);
+    expect(rels[0].relSpec.cardA).toBe(erDb.Cardinality.ZERO_OR_ONE);
+    expect(rels[0].relSpec.cardB).toBe(erDb.Cardinality.ZERO_OR_ONE);
   });
 
   it('should handle zero-or-more-to-zero-or-more relationships', function() {
-    erDiagram.parser.parse('erDiagram\nA >?-?< B : has');
+    erDiagram.parser.parse('erDiagram\nA }o--o{ B : has');
     const rels = erDb.getRelationships();
 
     expect(Object.keys(erDb.getEntities()).length).toBe(2);
     expect(rels.length).toBe(1);
-    expect(rels[0].cardinality).toBe(erDb.Cardinality.ZERO_OR_MORE_TO_ZERO_OR_MORE);
+    expect(rels[0].relSpec.cardA).toBe(erDb.Cardinality.ZERO_OR_MORE);
+    expect(rels[0].relSpec.cardB).toBe(erDb.Cardinality.ZERO_OR_MORE);
   });
 
   it('should handle one-or-more-to-one-or-more relationships', function() {
-    erDiagram.parser.parse('erDiagram\nA >!-!< B : has');
+    erDiagram.parser.parse('erDiagram\nA }|..|{ B : has');
     const rels = erDb.getRelationships();
 
     expect(Object.keys(erDb.getEntities()).length).toBe(2);
     expect(rels.length).toBe(1);
-    expect(rels[0].cardinality).toBe(erDb.Cardinality.ONE_OR_MORE_TO_ONE_OR_MORE);
+    expect(rels[0].relSpec.cardA).toBe(erDb.Cardinality.ONE_OR_MORE);
+    expect(rels[0].relSpec.cardB).toBe(erDb.Cardinality.ONE_OR_MORE);
   });
 
   it('should handle zero-or-more-to-one-or-more relationships', function() {
-    erDiagram.parser.parse('erDiagram\nA >?-!< B : has');
+    erDiagram.parser.parse('erDiagram\nA }o--|{ B : has');
     const rels = erDb.getRelationships();
 
     expect(Object.keys(erDb.getEntities()).length).toBe(2);
     expect(rels.length).toBe(1);
-    expect(rels[0].cardinality).toBe(erDb.Cardinality.ZERO_OR_MORE_TO_ONE_OR_MORE);
+    expect(rels[0].relSpec.cardA).toBe(erDb.Cardinality.ONE_OR_MORE);
+    expect(rels[0].relSpec.cardB).toBe(erDb.Cardinality.ZERO_OR_MORE);
   });
 
   it('should handle one-or-more-to-zero-or-more relationships', function() {
-    erDiagram.parser.parse('erDiagram\nA >!-?< B : has');
+    erDiagram.parser.parse('erDiagram\nA }|..o{ B : has');
     const rels = erDb.getRelationships();
 
     expect(Object.keys(erDb.getEntities()).length).toBe(2);
     expect(rels.length).toBe(1);
-    expect(rels[0].cardinality).toBe(erDb.Cardinality.ONE_OR_MORE_TO_ZERO_OR_MORE);
+    expect(rels[0].relSpec.cardA).toBe(erDb.Cardinality.ZERO_OR_MORE);
+    expect(rels[0].relSpec.cardB).toBe(erDb.Cardinality.ONE_OR_MORE);
+  });
+
+  it('should represent identifying relationships properly', function() {
+    erDiagram.parser.parse('erDiagram\nHOUSE ||--|{ ROOM : contains');
+    const rels = erDb.getRelationships();
+    expect(rels[0].relSpec.relType).toBe(erDb.Identification.IDENTIFYING);
+  });
+
+  it('should represent non-identifying relationships properly', function() {
+    erDiagram.parser.parse('erDiagram\n PERSON ||..o{ POSSESSION : owns');
+    const rels = erDb.getRelationships();
+    expect(rels[0].relSpec.relType).toBe(erDb.Identification.NON_IDENTIFYING);
   });
 
   it('should not accept a syntax error', function() {

--- a/src/mermaidAPI.js
+++ b/src/mermaidAPI.js
@@ -353,23 +353,28 @@ const config = {
    */
   er: {
     /**
+     * The amount of padding around the diagram as a whole so that embedded diagrams have margins, expressed in pixels
+     */
+    diagramPadding: 20,
+
+    /**
      * Directional bias for layout of entities. Can be either 'TB', 'BT', 'LR', or 'RL',
      * where T = top, B = bottom, L = left, and R = right.
      */
     layoutDirection: 'TB',
 
     /**
-     * The mimimum width of an entity box
+     * The mimimum width of an entity box, expressed in pixels
      */
     minEntityWidth: 100,
 
     /**
-     * The minimum height of an entity box
+     * The minimum height of an entity box, expressed in pixels
      */
     minEntityHeight: 75,
 
     /**
-     * The minimum internal padding between the text in an entity box and the enclosing box borders
+     * The minimum internal padding between the text in an entity box and the enclosing box borders, expressed in pixels
      */
     entityPadding: 15,
 
@@ -382,13 +387,6 @@ const config = {
      * Fill color of entity boxes
      */
     fill: 'honeydew',
-
-    /**
-     * Opacity of entity boxes - if you want to see how the crows feet
-     * retain their elegant joins to the boxes regardless of the angle of incidence
-     * then override this to something less than 100%
-     */
-    fillOpacity: '100%',
 
     /**
      * Font size


### PR DESCRIPTION
## :bookmark_tabs: Summary
Alters the syntax for newly implemented ER diagrams so that it is compatible with PlantUML ERD syntax

Resolves #1309 

## :straight_ruler: Design Decisions
A fairly straight-forward change to the jison parsing logic to use different syntax for specifying relationships between entities.  For example, the original syntax I implemented for an one-to-many was `EntityA !-?< EntityB : label` and the new syntax for this is `EntityA ||--o{ EntityB : label`.

The `: label` part is an extension to PlantUML, because it is very convenient/common to label relationships.

Also PlantUML syntax allows the distinction between identifying and non-identifying relationships which I hadn't previously implemented.  This is now supported by using either hyphens or dots in the middle part of the relationship specifier.  Hyphens are rendered as a s solid line, whereas dots are rendered as a dashed line.  The docs have been updated to give a better overview.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
