### PR TITLE
expanded documentation on date formats for gantt

### DIFF
--- a/docs/gantt.md
+++ b/docs/gantt.md
@@ -127,23 +127,21 @@ Tbd
 
 ## Setting dates
 
-Tbd
+`dateFormat` defines the format of the date **input** of your gantt elements. How these dates are represented in the rendered chart **output** are defined by `axisFormat`.
 
 
-### Date format
+### Input date format 
 
-The default date format is YYYY-MM-DD. You can define your ``dateFormat``. For example: 2020-3-7
+The default input date format is `YYYY-MM-DD`. You can define your custom ``dateFormat``.
 
 ```
-dateFormat YYYY MM DD
+dateFormat YYYY-MM-DD
 ```
 
+The following formating options are supported:
 
-### Diagram definition
-
+```tsc
 Input	Example	Description:
-
-```
 YYYY	2014	4 digit year
 YY	14	2 digit year
 Q	1..4	Quarter of year. Sets month to first month in quarter.
@@ -154,8 +152,6 @@ Do	1st..31st	Day of month with ordinal
 DDD DDDD	1..365	Day of year
 X	1410715640.579	Unix timestamp
 x	1410715640579	Unix ms timestamp
-
-Input	Example	Description
 H HH	0..23	24 hour time
 h hh	1..12	12 hour time used with a A.
 a A	am pm	Post or ante meridiem
@@ -166,11 +162,17 @@ SS	0..99	Hundreds of a second
 SSS	0..999	Thousandths of a second
 Z ZZ	+12:00	Offset from UTC as +-HH:mm, +-HHmm, or Z
 ```
-
 More info in: http://momentjs.com/docs/#/parsing/string-format/
 
+### Output date format on the axis
 
-### Scale
+The default output date format is YYYY-MM-DD. You can define your custom ``axisFormat``, like `2020-Q1` for the first quarter of the year 2020.
+
+```
+axisFormat  %Y-%m-%d 
+```
+
+The following formating strings are supported:
 
 ```
 %a - abbreviated weekday name.

--- a/docs/gantt.md
+++ b/docs/gantt.md
@@ -140,7 +140,7 @@ dateFormat YYYY-MM-DD
 
 The following formating options are supported:
 
-```tsc
+```
 Input	Example	Description:
 YYYY	2014	4 digit year
 YY	14	2 digit year
@@ -162,6 +162,7 @@ SS	0..99	Hundreds of a second
 SSS	0..999	Thousandths of a second
 Z ZZ	+12:00	Offset from UTC as +-HH:mm, +-HHmm, or Z
 ```
+
 More info in: http://momentjs.com/docs/#/parsing/string-format/
 
 ### Output date format on the axis


### PR DESCRIPTION
## :bookmark_tabs: Summary
expanded documentation on date formats for gantt - the previous version didn't pay attention to the difference between input and output formats.

## :straight_ruler: Design Decisions
none

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [ ] :computer: have added unit/e2e tests (if appropriate) 
- [ ] :bookmark: targeted `develop` branch 
