### PR TITLE
Change ERD fontSize config to an integer to prevent NaN errors

### DIFF
--- a/src/diagrams/er/erRenderer.js
+++ b/src/diagrams/er/erRenderer.js
@@ -45,10 +45,13 @@ const drawEntities = function(svgNode, entities, graph) {
       .append('text')
       .attr('id', textId)
       .attr('x', 0)
-      .attr('y', (conf.fontSize + 2 * conf.entityPadding) / 2)
+      .attr('y', 0)
       .attr('dominant-baseline', 'middle')
       .attr('text-anchor', 'middle')
-      .attr('style', 'font-family: ' + getConfig().fontFamily + '; font-size: ' + conf.fontSize)
+      .attr(
+        'style',
+        'font-family: ' + getConfig().fontFamily + '; font-size: ' + conf.fontSize + 'px'
+      )
       .text(id);
 
     // Calculate the width and height of the entity
@@ -227,7 +230,10 @@ const drawRelationshipFromLayout = function(svg, rel, g, insert) {
     .attr('y', labelPoint.y)
     .attr('text-anchor', 'middle')
     .attr('dominant-baseline', 'middle')
-    .attr('style', 'font-family: ' + getConfig().fontFamily + '; font-size: ' + conf.fontSize)
+    .attr(
+      'style',
+      'font-family: ' + getConfig().fontFamily + '; font-size: ' + conf.fontSize + 'px'
+    )
     .text(rel.roleA);
 
   // Figure out how big the opaque 'container' rectangle needs to be

--- a/src/mermaidAPI.js
+++ b/src/mermaidAPI.js
@@ -525,9 +525,9 @@ const config = {
     fill: 'honeydew',
 
     /**
-     * Font size
+     * Font size (expressed as an integer representing a number of  pixels)
      */
-    fontSize: '12px'
+    fontSize: 12
   }
 };
 


### PR DESCRIPTION
## :bookmark_tabs: Summary
Change the fontSize config from a string to an integer to prevent NaN errors

Resolves #1362 

## :straight_ruler: Design Decisions
This was a simple fix - the original code expressed the fontSize option for ERDs (in mermaidAPI.js) as a string, for example '12px'.  But during positioning and sizing of nodes this value was used in simple arithmetic (e.g. to add padding).  In fact that code itself was not necessary because the position and sizing of nodes is taken care of elsewhere, however the attempt to add a string to a padding factor was causing NaN errors during rendering.  These errors were not fatal, and rendering worked anyway, but the errors needed to be sorted.  This was as  simple as:
- Change the config option to an integer in mermaidAPI.js (which is consistent with other diagram types)
- Change a few lines of code in the renderer to get rid of the unnecessary padding calculation
- Change a couple of lines of code in the renderer to add the 'px' suffix to the style attribute of entity names and relationship labels

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
