### PR TITLE
Updated the mkdocs-mermaid-plugin link

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -112,7 +112,7 @@ The following is a list of different integrations and plugins where mermaid is b
 - [jSDoc](https://jsdoc.app/)
   - [jsdoc-mermaid](https://github.com/Jellyvision/jsdoc-mermaid)
 - [MkDocs](https://mkdocs.org)
-  - [MarkdownMermaid](https://github.com/pugong/mkdocs-mermaid-plugin)
+  - [MarkdownMermaid](https://github.com/sebastienwarin/mkdocs-mermaid-plugin)
 - [Type Doc](https://typedoc.org/)
   - [typedoc-plugin-mermaid](https://www.npmjs.com/package/typedoc-plugin-mermaid)
 


### PR DESCRIPTION
I've updated a link in the integrations documentation section.

It appears that https://github.com/sebastienwarin/mkdocs-mermaid-plugin has been more recently updated and is more feature rich (allowing for options to override the mermaid rendering defaults).

