### PR TITLE
Fixed SequenceDiagram over note horizontal position

### DIFF
--- a/src/diagrams/sequence/sequenceRenderer.js
+++ b/src/diagrams/sequence/sequenceRenderer.js
@@ -639,14 +639,12 @@ export const draw = function(text, id) {
         } else {
           // Multi-actor over
           forceWidth = Math.abs(startx - stopx) + conf.actorMargin;
+          let x =
+            startx < stopx
+              ? startx + (actors[msg.from].width - conf.actorMargin) / 2
+              : stopx + (actors[msg.to].width - conf.actorMargin) / 2;
 
-          drawNote(
-            diagram,
-            (startx + stopx + noteWidth - forceWidth) / 2,
-            bounds.getVerticalPos(),
-            msg,
-            forceWidth
-          );
+          drawNote(diagram, x, bounds.getVerticalPos(), msg, forceWidth);
         }
         break;
       case parser.yy.LINETYPE.ACTIVE_START:


### PR DESCRIPTION
Previous expression with noteWidth does not make sense as noteWidth is
not used in case of note over two participants - forceWidth is used
instead. It tried to be symmetrical over cases A,B and B,A but failed.

Can be seen with messages over conf.width size (cannot reproduce in the
live editor as it seems to use not the last version where the code
does not use noteWidth).

The changed code explicitly calculates which of the actors is the
"left" one and starts rendering half margin to the left of its cetral
line.
