### PR TITLE
Fix config param name. Drop duplicated field in css example.

### DIFF
--- a/docs/sequenceDiagram.md
+++ b/docs/sequenceDiagram.md
@@ -468,7 +468,6 @@ text.actor {
 
 .note {
     stroke: #decc93;
-    stroke: #ccccff;
     fill: #fff5ad;
 }
 
@@ -503,7 +502,7 @@ mermaid.sequenceConfig = {
 
 | Param             | Description                                                                                                                                | Default value                  |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------ |
-| mirrorActor       | Turns on/off the rendering of actors below the diagram as well as above it                                                                 | false                          |
+| mirrorActors       | Turns on/off the rendering of actors below the diagram as well as above it                                                                 | false                          |
 | bottomMarginAdj   | Adjusts how far down the graph ended. Wide borders styles with css could generate unwanted clipping which is why this config param exists. | 1                              |
 | actorFontSize     | Sets the font size for the actor's description                                                                                             | 14                             |
 | actorFontFamily   | Sets the font family for the actor's description                                                                                           | "Open-Sans", "sans-serif"      |


### PR DESCRIPTION
## :bookmark_tabs: Summary
There is a wrong name of config param - `mirrorActor` in the documentation (missing `s`). 
sample stylesheet in `.note` has duplicated `stroke` param.


Resolves  - 

## :straight_ruler: -

### :clipboard: Tasks
Make sure you
- [ ] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [ ] :computer: have added unit/e2e tests (if appropriate) 
- [ ] :bookmark: targeted `develop` branch 
