### PR TITLE
Ensure empty quoted relationship labels are accepted in ER diagrams

### DIFF
--- a/cypress/integration/rendering/erDiagram.spec.js
+++ b/cypress/integration/rendering/erDiagram.spec.js
@@ -88,4 +88,17 @@ describe('Entity Relationship Diagram', () => {
     );
     cy.get('svg');
   });
+
+  it('should render an ER diagram with blank or empty labels', () => {
+    imgSnapshotTest(
+      `
+    erDiagram
+        BOOK }|..|{ AUTHOR : ""
+        BOOK }|..|{ GENRE : " "
+        AUTHOR }|..|{ GENRE : "  "
+      `,
+      {logLevel : 1}
+    );
+    cy.get('svg');
+  });
 });

--- a/src/diagrams/er/parser/erDiagram.jison
+++ b/src/diagrams/er/parser/erDiagram.jison
@@ -1,14 +1,11 @@
 %lex
 
-%x string
 %options case-insensitive
 
 %%
 \s+                       /* skip whitespace */
 [\s]+                     return 'SPACE';
-["]                       { this.begin("string");}
-<string>["]               { this.popState(); }
-<string>[^"]*             { return 'STR'; }
+\"[^"]*\"                 return 'WORD';
 "erDiagram"               return 'ER_DIAGRAM';
 \|o                       return 'ZERO_OR_ONE';
 \}o                       return 'ZERO_OR_MORE';
@@ -73,7 +70,7 @@ relType
     ;
 
 role
-    : 'STR'       { $$ = $1; }
+    : 'WORD'      { $$ = $1.replace(/"/g, ''); }
     | 'ALPHANUM'  { $$ = $1; }
     ;
 %%

--- a/src/diagrams/er/parser/erDiagram.spec.js
+++ b/src/diagrams/er/parser/erDiagram.spec.js
@@ -252,4 +252,21 @@ describe('when parsing ER diagram it...', function() {
     }).toThrowError();
   });
 
+  it('should allow an empty quoted label', function() {
+    erDiagram.parser.parse('erDiagram\nCUSTOMER ||--|{ ORDER : ""');
+    const rels = erDb.getRelationships();
+    expect(rels[0].roleA).toBe('');
+  });
+
+  it('should allow an non-empty quoted label', function() {
+    erDiagram.parser.parse('erDiagram\nCUSTOMER ||--|{ ORDER : "places"');
+    const rels = erDb.getRelationships();
+    expect(rels[0].roleA).toBe('places');
+  });
+
+  it('should allow an non-empty unquoted label', function() {
+    erDiagram.parser.parse('erDiagram\nCUSTOMER ||--|{ ORDER : places');
+    const rels = erDb.getRelationships();
+    expect(rels[0].roleA).toBe('places');
+  });
 });


### PR DESCRIPTION
## :bookmark_tabs: Summary
Fixed a bug so that empty double-quoted relationship labels do not cause an error

Resolves #1415 

## :straight_ruler: Design Decisions
A relatively simple fix to the jison file to allow empty labels.  Also added a few unit tests and an e2e test to catch any future regression issues

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
