### PR TITLE
cleanup helper dom elements before rendering

### DIFF
--- a/cypress/integration/other/rerender.spec.js
+++ b/cypress/integration/other/rerender.spec.js
@@ -1,5 +1,11 @@
 /* eslint-env jest */
 describe('Rerendering', () => {
+    it('should be able to render after an error has occured', () => {
+      const url = 'http://localhost:9000/render-after-error.html';
+      cy.viewport(1440, 1024);
+      cy.visit(url);
+      cy.get('#graphDiv').should('exist');
+    });
 
     it('should be able to render and rerender a graph via API', () => {
       const url = 'http://localhost:9000/rerender.html';

--- a/cypress/platform/render-after-error.html
+++ b/cypress/platform/render-after-error.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <title>Mermaid Quick Test Page</title>
+        <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgo=">
+    </head>
+    <body>
+        <div id="graph">
+        </div>
+
+        <script src="./mermaid.js"></script>
+        <script>
+
+         mermaid.init({ startOnLoad: false });
+         mermaid.mermaidAPI.initialize();
+
+         try{
+             mermaid.mermaidAPI.render("graphDiv",
+                                       `>`);
+         } catch(e){}
+
+         mermaid.mermaidAPI.render("graphDiv",
+                                   `graph LR\n a --> b`, html => {
+                                      document.getElementById('graph').innerHTML=html;
+         });
+
+        </script>
+
+    </body>
+</html>

--- a/src/mermaidAPI.js
+++ b/src/mermaidAPI.js
@@ -728,7 +728,7 @@ const render = function(id, _txt, cb, container) {
     }
     const element = document.querySelector('#' + 'd' + id);
     if (element) {
-      element.innerHTML = '';
+      element.remove();
     }
 
     select('body')


### PR DESCRIPTION
## :bookmark_tabs: Summary

If MermaidAPI.render crashes it can leave a `d` div element in the dom which causes future render calls to fail.

Here is a js fiddle reproducing the problem
https://jsfiddle.net/bwstyle/qj8p3vze/19/

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
