### PR TITLE
gitGraph dot and minus should be valid branch name

### DIFF
--- a/src/diagrams/git/parser/gitGraph.jison
+++ b/src/diagrams/git/parser/gitGraph.jison
@@ -1,10 +1,9 @@
-
 /*
  * Parse following
  * gitGraph:
  *  commit
  *  commit
- *  branch 
+ *  branch
  */
 %lex
 
@@ -14,28 +13,28 @@
 
 %%
 
-(\r?\n)+                           return 'NL';
-\s+                             /* skip all whitespace */
-\#[^\n]*                        /* skip comments */
-\%%[^\n]*                       /* skip comments */
-"gitGraph"                      return 'GG';
-"commit"                        return 'COMMIT';
-"branch"                        return 'BRANCH';
-"merge"                         return 'MERGE';
-"reset"                         return 'RESET';
-"checkout"                         return 'CHECKOUT';
-"LR"                            return 'DIR';
-"BT"                            return 'DIR';
-":"                             return ':';
-"^"                             return 'CARET'
-"options"\r?\n                       this.begin("options");
-<options>"end"\r?\n                   this.popState();
-<options>[^\n]+\r?\n                 return 'OPT';
-["]                             this.begin("string");
-<string>["]                     this.popState();
-<string>[^"]*                     return 'STR';
-[a-zA-Z][a-zA-Z0-9_]+           return 'ID';
-<<EOF>>                         return 'EOF';
+(\r?\n)+                               return 'NL';
+\s+                                    /* skip all whitespace */
+\#[^\n]*                               /* skip comments */
+\%%[^\n]*                              /* skip comments */
+"gitGraph"                             return 'GG';
+"commit"                               return 'COMMIT';
+"branch"                               return 'BRANCH';
+"merge"                                return 'MERGE';
+"reset"                                return 'RESET';
+"checkout"                             return 'CHECKOUT';
+"LR"                                   return 'DIR';
+"BT"                                   return 'DIR';
+":"                                    return ':';
+"^"                                    return 'CARET'
+"options"\r?\n                         this.begin("options");
+<options>"end"\r?\n                    this.popState();
+<options>[^\n]+\r?\n                   return 'OPT';
+["]                                    this.begin("string");
+<string>["]                            this.popState();
+<string>[^"]*                          return 'STR';
+[a-zA-Z][-_\.a-zA-Z0-9]*[-_a-zA-Z0-9]  return 'ID';
+<<EOF>>                                return 'EOF';
 
 /lex
 


### PR DESCRIPTION
## :bookmark_tabs: Summary
gitGraph dot and minus should be valid branch name, like `v1.0.1-rc1`

and should not end with `dot`, like `v1.0.1-rc1.`

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [ ] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 

GitGraph unit/e2e tests are not yet ready, so I tested locally:

![image](https://user-images.githubusercontent.com/3764335/85190818-9c274000-b2ee-11ea-8ad4-0a2cfced113b.png)

![image](https://user-images.githubusercontent.com/3764335/85190839-c678fd80-b2ee-11ea-8784-88e5ea6d116e.png)

![image](https://user-images.githubusercontent.com/3764335/85190848-e6102600-b2ee-11ea-9a67-5d5b449d54df.png)

