### PR TITLE
Make gitGraph commit IDs out of hexadecimal chars

### DIFF
--- a/src/diagrams/git/gitGraphAst.js
+++ b/src/diagrams/git/gitGraphAst.js
@@ -9,7 +9,7 @@ let seq = 0;
 
 function makeid(length) {
   var result = '';
-  var characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  var characters = '0123456789abcdef';
   var charactersLength = characters.length;
   for (var i = 0; i < length; i++) {
     result += characters.charAt(Math.floor(Math.random() * charactersLength));


### PR DESCRIPTION
## :bookmark_tabs: Summary
This PR makes the commit IDs created by gitGraph to look a bit more like actual short hashes from Git.

## :straight_ruler: Design Decisions
I just set the characters back to what they were prior to #1408 changes.


### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [ ] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
