### PR TITLE
mermaid.ganttConfig is not initialised.

### DIFF
--- a/src/mermaid.js
+++ b/src/mermaid.js
@@ -74,6 +74,8 @@ const init = function() {
 
   if (typeof mermaid.ganttConfig !== 'undefined') {
     mermaidAPI.initialize({ gantt: mermaid.ganttConfig });
+  } else {
+    mermaidAPI.initialize({ gantt: conf.gantt });
   }
 
   let txt;


### PR DESCRIPTION
`mermaid.ganttConfig` is not initialised somehow.
This may not be the correct solution, but fixes the issue.

## :bookmark_tabs: Summary
Fixes the color rendering of gantt charts which was broken because `mermaidAPI` 
was not being initialized with proper ganttConfig.
Resolves #1487

## :straight_ruler: Design Decisions
As `mermaid.ganttConfig` is always `undefined`, I've initialised `mermaidAPI` with
the `conf.gantt`.


### :clipboard: Tasks
Make sure you
- [X] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [X] :computer: have added unit/e2e tests (if appropriate) 
- [X] :bookmark: targeted `develop` branch 
