### PR TITLE
Update sequenceDiagram.md

### DIFF
--- a/docs/sequenceDiagram.md
+++ b/docs/sequenceDiagram.md
@@ -16,6 +16,10 @@ sequenceDiagram
     John-->>Alice: Great!
 ```
 
+## A note on nodes, the word "end" could potentially break the diagram, due to the way that the mermaid language is scripted.
+## If unavoidable, one must use parentheses(), quotation marks "", or brackets {},[], to enclose the word "end". i.e : (end), [end], {end}.
+
+
 ## Syntax
 
 ### Participants


### PR DESCRIPTION
-The word "end" breaks sequence diagrams.

-Added a workaround for the diagram-breaking node name "end". 

