### PR TITLE
added hasBreaks and splitBreaks to common.js

### DIFF
--- a/src/diagrams/common/common.js
+++ b/src/diagrams/common/common.js
@@ -27,6 +27,14 @@ export const sanitizeText = (text, config) => {
 
 export const lineBreakRegex = /<br\s*\/?>/gi;
 
+export const hasBreaks = text => {
+  return /<br\s*[/]?>/gi.test(text);
+};
+
+export const splitBreaks = text => {
+  return text.split(/<br\s*[/]?>/gi);
+};
+
 const breakToPlaceholder = s => {
   return s.replace(lineBreakRegex, '#br#');
 };
@@ -38,5 +46,7 @@ const placeholderToBreak = s => {
 export default {
   getRows,
   sanitizeText,
+  hasBreaks,
+  splitBreaks,
   lineBreakRegex
 };

--- a/src/diagrams/sequence/sequenceDb.js
+++ b/src/diagrams/sequence/sequenceDb.js
@@ -1,5 +1,7 @@
 import mermaidAPI from '../../mermaidAPI';
 import configApi from '../../config';
+import common from '../common/common';
+import { logger } from '../../logger';
 
 let prevActor = undefined;
 let actors = {};
@@ -134,17 +136,19 @@ export const clear = function() {
 
 export const parseMessage = function(str) {
   const _str = str.trim();
-  return {
+  const message = {
     text: _str.replace(/^[:]?(?:no)?wrap:/, '').trim(),
     wrap:
       _str.match(/^[:]?(?:no)?wrap:/) === null
-        ? autoWrap()
+        ? common.hasBreaks(_str) || autoWrap()
         : _str.match(/^[:]?wrap:/) !== null
         ? true
         : _str.match(/^[:]?nowrap:/) !== null
         ? false
         : autoWrap()
   };
+  logger.debug('parseMessage:', message);
+  return message;
 };
 
 export const LINETYPE = {

--- a/src/diagrams/sequence/sequenceRenderer.js
+++ b/src/diagrams/sequence/sequenceRenderer.js
@@ -249,7 +249,7 @@ const drawNote = function(elem, noteModel) {
  */
 const drawMessage = function(g, msgModel) {
   const { startx, stopx, starty, message, type, sequenceIndex, wrap } = msgModel;
-  const lines = message.split(common.lineBreakRegex).length;
+  const lines = common.splitBreaks(message).length;
   let textDims = utils.calculateTextDimensions(message, conf.messageFont());
   const lineHeight = textDims.height / lines;
   msgModel.height += lineHeight;
@@ -461,7 +461,7 @@ function adjustLoopHeightForWrap(loopWidths, msg, preMargin, postMargin, addLoop
     msg.width = loopWidth;
     msg.wrap = true;
 
-    // const lines = msg.message.split(common.lineBreakRegex).length;
+    // const lines = common.splitBreaks(msg.message).length;
     const textDims = utils.calculateTextDimensions(msg.message, textConf);
     const totalOffset = Math.max(textDims.height, conf.labelBoxHeight);
     heightAdjust = postMargin + totalOffset;
@@ -864,7 +864,7 @@ const calculateActorMargins = function(actors, actorToMessageWidth) {
 const buildNoteModel = function(msg, actors) {
   let startx = actors[msg.from].x;
   let stopx = actors[msg.to].x;
-  let shouldWrap = msg.wrap && msg.message && !common.lineBreakRegex.test(msg.message);
+  let shouldWrap = msg.wrap && msg.message;
 
   let textDimensions = utils.calculateTextDimensions(
     shouldWrap ? utils.wrapLabel(msg.message, conf.width, conf.noteFont()) : msg.message,
@@ -958,7 +958,7 @@ const buildMessageModel = function(msg, actors) {
   const allBounds = fromBounds.concat(toBounds);
   const boundedWidth = Math.abs(toBounds[toIdx] - fromBounds[fromIdx]);
   const msgDims = utils.calculateTextDimensions(msg.message, conf.messageFont());
-  if (msg.wrap && msg.message && !common.lineBreakRegex.test(msg.message)) {
+  if (msg.wrap && msg.message) {
     msg.message = utils.wrapLabel(
       msg.message,
       Math.max(boundedWidth + 2 * conf.wrapPadding, conf.width),

--- a/src/utils.js
+++ b/src/utils.js
@@ -627,7 +627,7 @@ export const calculateTextDimensions = function(text, config) {
   // thus, we'll take the max width between the user supplied font family, and a default
   // of sans-serif.
   const fontFamilies = ['sans-serif', fontFamily];
-  const lines = text.split(common.lineBreakRegex);
+  const lines = common.splitBreaks(text);
   let dims = [];
 
   const body = select('body');


### PR DESCRIPTION
added hasBreaks and splitBreaks to common.js
updated parseMessage to set wrap: true when breaks are detected

## :bookmark_tabs: Summary
added hasBreaks and splitBreaks to common.js
updated parseMessage to set wrap: true when breaks are detected

## :straight_ruler: Design Decisions
common.lineBreakRegex does not seem to work in some scenarios. my obscure-js-foo is not strong with this one.

