### PR TITLE
Missed test case for allowing site owner to append to `secure` field set

### DIFF
--- a/src/mermaidAPI.spec.js
+++ b/src/mermaidAPI.spec.js
@@ -65,6 +65,28 @@ describe('when using mermaidAPI and ', function() {
       expect(mermaidAPI.getSiteConfig()).toEqual(siteConfig)
       expect(mermaidAPI.getConfig()).toEqual(siteConfig);
     });
+    it('should allow site config secure to global defaults', function() {
+      let config = {
+        logLevel: 0,
+        secure: ['foo']
+      };
+      mermaidAPI.initialize(config);
+      const siteConfig = mermaidAPI.getSiteConfig();
+      expect(mermaidAPI.getConfig().logLevel).toBe(0);
+      expect(mermaidAPI.getConfig().secure).toContain('foo');
+      config = {
+        logLevel: 3,
+        securityLevel: 'loose',
+        secure: ['foo', 'bar']
+      };
+      mermaidAPI.reinitialize(config);
+      expect(mermaidAPI.getConfig().secure).toEqual(mermaidAPI.getSiteConfig().secure);
+      expect(mermaidAPI.getConfig().securityLevel).toBe('strict');
+      expect(mermaidAPI.getConfig().secure).not.toContain('bar');
+      mermaidAPI.reset();
+      expect(mermaidAPI.getSiteConfig()).toEqual(siteConfig)
+      expect(mermaidAPI.getConfig()).toEqual(siteConfig);
+    });
     it('should prevent changes to site defaults (sneaky)', function() {
       let config = {
         logLevel: 0

--- a/src/utils.js
+++ b/src/utils.js
@@ -443,6 +443,13 @@ export const assignWithDepth = function(dst, src, config) {
   if (Array.isArray(src) && !Array.isArray(dst)) {
     src.forEach(s => assignWithDepth(dst, s, config));
     return dst;
+  } else if (Array.isArray(src) && Array.isArray(dst)) {
+    src.forEach(s => {
+      if (dst.indexOf(s) === -1) {
+        dst.push(s);
+      }
+    });
+    return dst;
   }
   if (typeof dst === 'undefined' || depth <= 0) {
     if (dst !== undefined && dst !== null && typeof dst === 'object' && typeof src === 'object') {


### PR DESCRIPTION
Missed logic for default-appending src array values where not existing within dst array in assignWithDepth function

## :bookmark_tabs: Summary
Missed a case to allow site owner to append to the `secure` fields array

## :straight_ruler: Design Decisions
Added test case to utils.spec.js
