### PR TITLE
Mocking of clock in gantt tests

### DIFF
--- a/cypress/integration/rendering/gantt.spec.js
+++ b/cypress/integration/rendering/gantt.spec.js
@@ -2,6 +2,9 @@
 import { imgSnapshotTest } from '../../helpers/util.js';
 
 describe('Gantt diagram', () => {
+  beforeEach(()=>{
+    cy.clock((new Date('1010-10-10')).getTime())
+  })
   it('should render a gantt chart', () => {
     imgSnapshotTest(
       `


### PR DESCRIPTION
## :bookmark_tabs: Summary
Makign sure the date is mocket in the rendering tests of gantt diagram. This will avoid generating false positivs every day when the date changes.
Resolves #1448

### :clipboard: Tasks
Make sure you
- [ ] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [ ] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
