### PR TITLE
Support dashes in actor names in sequence diagrams

### DIFF
--- a/src/diagrams/sequence/parser/sequenceDiagram.jison
+++ b/src/diagrams/sequence/parser/sequenceDiagram.jison
@@ -58,10 +58,10 @@
 "deactivate"                                                    { this.begin('ID'); return 'deactivate'; }
 "title"                                                         return 'title';
 "sequenceDiagram"                                               return 'SD';
-"autonumber" 			                                              return 'autonumber';
+"autonumber" 			                                        return 'autonumber';
 ","                                                             return ',';
 ";"                                                             return 'NL';
-[^\+\->:\n,;]+                                                  { yytext = yytext.trim(); return 'ACTOR'; }
+[^\+\->:\n,;]+((?!(\-x|\-\-x))[\-]*[^\+\->:\n,;]+)*             { yytext = yytext.trim(); return 'ACTOR'; }
 "->>"                                                           return 'SOLID_ARROW';
 "-->>"                                                          return 'DOTTED_ARROW';
 "->"                                                            return 'SOLID_OPEN_ARROW';

--- a/src/diagrams/sequence/sequenceDiagram.spec.js
+++ b/src/diagrams/sequence/sequenceDiagram.spec.js
@@ -93,6 +93,23 @@ Bob-->Alice: I am good thanks!`;
     expect(messages[0].from).toBe('Alice');
     expect(messages[1].from).toBe('Bob');
   });
+  it('it should handle dashes in actor names', function() {
+    const str = `
+sequenceDiagram
+Alice-in-Wonderland->Bob:Hello Bob, how are - you?
+Bob-->Alice-in-Wonderland:I am good thanks!`;
+
+    mermaidAPI.parse(str);
+    const actors = parser.yy.getActors();
+    expect(actors["Alice-in-Wonderland"].description).toBe('Alice-in-Wonderland');
+    actors.Bob.description = 'Bob';
+
+    const messages = parser.yy.getMessages();
+
+    expect(messages.length).toBe(2);
+    expect(messages[0].from).toBe('Alice-in-Wonderland');
+    expect(messages[1].from).toBe('Bob');
+  });
   it('it should alias participants', function() {
     const str = `
 sequenceDiagram


### PR DESCRIPTION
## :bookmark_tabs: Summary
Changed the RegEx for an actor in the Jison parser for sequence diagram to support dashes in the middle of names.

Resolves #1228 

## :straight_ruler: Design Decisions
Changed the grammar in Jison so now an actor name has to start with the previous valid characters and then can have multiple dashes in the middle and end with a previously valid character.

`<valid_char> (<dash>*<valid_char>+)*`

### :clipboard: Tasks
Make sure you
- [X] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [X] :bookmark: targeted `develop` branch 
