### PR TITLE
Release/8.6.0

### DIFF
--- a/docs/8.6.0_docs.md
+++ b/docs/8.6.0_docs.md
@@ -6,9 +6,14 @@
 
 ## [CDN](https://unpkg.com/mermaid/)
 
-With version 8.6.0 comes the release of directives for mermaid and a new system for configurations, with the aim of establishing centralized, sane defaults and simple implementation.
+With version 8.6.0 comes the release of directives for mermaid, a new system for modifying configurations, with the aim of establishing centralized, sane defaults and simple implementation.
 
-the init directive is the main method of configuration for Site and Current Levels.
+`directives` allow for a diagram specific overriding of `config`, as it has been discussed in [Configurations](./Setup.md).
+This allows site users to input modifications to `config` alongside diagram definitions, when creating diagrams on a private webpage that supports mermaid. 
+
+**A likely application for this is in the creation of diagrams/charts inside company/organizational webpages, that rely on mermaid for diagram and chart rendering.**
+
+the `init` directive is the main method of configuration for Site and Current Levels.
 
 The three levels of are Configuration, Global, Site and Current.
 
@@ -35,19 +40,19 @@ The modifiable parts of the Configuration are limited by the secure array, which
 Site owners can add to the **secure** array using this command:
 mermaidAPI.initialize( { startOnLoad: true, secure: ['parameter1', 'parameter2'] } );
 
-default values for the **secure array** consists of: ['secure', 'securityLevel', 'startOnLoad', 'maxTextSize']. These default values are immutable.
+default values for the `secure array` consists of: ['secure', 'securityLevel', 'startOnLoad', 'maxTextSize']. These default values are immutable.
 
-Implementors can only modify configurations using directives, but cannot change the **secure** array.
+Implementors can only modify configurations using directives, but cannot change the `secure` array.
 
 # Modifying Configurations and directives:
-The Two types of directives: are “init” or “initialize” and “wrap”.
+The Two types of directives: are `init` or `initialize` and `wrap`.
 
 **Notes**: All directives are enclosed in `%%{ }%%.`
 
-Older versions of mermaid will not parse directives because `%%` will comment out the directive.
+Older versions of mermaid will not parse directives because `%%` will comment out the directive. This makes the update backward compatible.
 
 # Init
-init, or initialize: the init or initialize directive gives the user the ability to overwrite and change the values for configuration parameters, with respect to the secure array that is in effect.
+`init`, or `initialize`: the init or initialize directive gives the user the ability to overwrite and change the values for configuration parameters, with respect to the secure array that is in effect.
 
 | Parameter | Description |Type | Required | Values|
 | --- | --- | --- | --- | --- |

--- a/docs/8.6.0_docs.md
+++ b/docs/8.6.0_docs.md
@@ -42,9 +42,9 @@ Implementors can only modify configurations using directives, but cannot change 
 # Modifying Configurations and directives:
 The Two types of directives: are “init” or “initialize” and “wrap”.
 
-**Notes**: All directives are enclosed in %%{ }%%.
+**Notes**: All directives are enclosed in `%%{ }%%.`
 
-Older versions of mermaid will not parse directives because %% will comment out the directive.
+Older versions of mermaid will not parse directives because `%%` will comment out the directive.
 
 # Init
 init, or initialize: the init or initialize directive gives the user the ability to overwrite and change the values for configuration parameters, with respect to the secure array that is in effect.
@@ -55,17 +55,18 @@ init, or initialize: the init or initialize directive gives the user the ability
 
 **Notes:**
 
-init would be an argument-directive: %%{init: { **insert argument here**}}%%
+init would be an argument-directive: `%%{init: { **insert argument here**}}%%`
 
 The json object that is passed as {**argument** } must be valid, quoted json or it will be ignored.
     **for example**:
     
-%%{init: {"theme": default, "logLevel": 1 }}%%
+`%%{init: {"theme": default, "logLevel": 1 }}%%`
 
 Configurations that are passed through init cannot change the parameters in secure arrays of higher levels. In the event of a conflict, mermaid will give priority to secure arrays and parse the request, without changing the values of the parameters in conflict.
 
 When deployed within code, init is called before the graph/diagram description.
 **for example**:
+```
  %%{init: {"theme": "default", "logLevel": 1 }}%%
   graph LR
    a-->b
@@ -75,7 +76,7 @@ When deployed within code, init is called before the graph/diagram description.
    e-->f
    f-->g
    g-->
-
+```
 # Wrap
 | Parameter | Description |Type | Required | Values|
 | --- | --- | --- | --- | --- |
@@ -89,7 +90,7 @@ wrap respects manually added <br\> so if the user wants to break up their text, 
 
 It is a non-argument directive and can be executed thusly:
 
-%%{wrap}%%.
+`%%{wrap}%%` .
 
 **an example of text wrapping in a sequence diagram**:
 

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -13,7 +13,7 @@ In addition to the render function, a number of behavioral configuration options
 
 ## Configuration
 
-**Configuration methods in Mermaid version 8.6.0 have been updated, to learn more\[[click here][2]].**
+**Configuration methods in Mermaid version 8.6.0 have been updated to include `directives`, to learn more\[[click here][2]].**
 
 ## **What follows are config instructions for older versions**
 
@@ -47,6 +47,29 @@ mermaid.initialize({
 </pre>
 
 A summary of all options and their defaults is found [here][3]. A description of each option follows below.
+
+
+| Parameter  | Description                                            | Type   | Required | Values                        |
+| ---------- | ------------------------------------------------------ | ------ | -------- | ----------------------------- |
+| config     | current mermaid configurations | Object | Required | All parameters and  values, except where prohibited by `secure`.  |
+ 
+**config here is an object that can be created either through `const` or `var` and is loaded by `mermaidAPI.initialize`.
+
+## secure
+
+This option controls which currentConfig keys are considered _secure_ and can only be changed via
+call to mermaidAPI.initialize. Calls to `mermaidAPI.reinitialize` cannot make changes to
+the `secure` keys in the current currentConfig. This prevents malicious graph directives from
+overriding a site's default security.
+
+| Parameter | Description |Type | Required | Values|
+| --- | --- | --- | --- | --- |
+| secure | Array of parameters that cannot be changed the `init` directive| Array | Required | Any parameters|
+
+The modifiable parts of the Configuration are limited by the secure array, which is an array of immutable parameters, this array can be expanded by site owners.
+
+**Notes**: `secure` arrays work like nesting dolls, with the Global Configurations’ secure array being the default and immutable list of immutable parameters, or the smallest doll, to which site owners may add to, but implementors may not modify it.
+
 
 ## theme
 
@@ -117,13 +140,6 @@ theme , the CSS style sheet
 ## Notes\*\*: This matters if you are using base tag settings.
 
 **Default value: false**.
-
-## secure
-
-This option controls which currentConfig keys are considered _secure_ and can only be changed via
-call to mermaidAPI.initialize. Calls to mermaidAPI.reinitialize cannot make changes to
-the `secure` keys in the current currentConfig. This prevents malicious graph directives from
-overriding a site's default security.
 
 ## flowchart
 

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -52,8 +52,10 @@ A summary of all options and their defaults is found [here][3]. A description of
 | Parameter  | Description                                            | Type   | Required | Values                        |
 | ---------- | ------------------------------------------------------ | ------ | -------- | ----------------------------- |
 | config     | current mermaid configurations | Object | Required | All parameters and  values, except where prohibited by `secure`.  |
- 
+
+**Notes:**
 **config here is an object that can be created either through `const` or `var` and is loaded by `mermaidAPI.initialize`.
+config, can be overriden using the `%%init%%` directive, after [Version 8.6.0](./8.6.0_docs.md) was introduced.
 
 ## secure
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -3,6 +3,7 @@
   - [mermaid](README.md)
   - [FAQ](faq.md)
   - [Usage](usage.md)
+  - [Integrations](integrations.md)
   - [Examples](examples.md)
   - [mermaid CLI](mermaidCLI.md)
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,3 +1,13 @@
+# Examples 
+
+**Edit this Page** [![N|Solid](./img/GitHub-Mark-32px.png)](https://github.com/mermaid-js/mermaid/blob/develop/docs/examples.md)
+
+This page contains a collection of examples of diagrams and charts that can be created through mermaid and its myriad applications. 
+
+## If you wish to learn how to support mermaid on your webpage, read the [Beginner's Guide](https://mermaid-js.github.io/mermaid/#/n00b-gettingStarted).
+
+## If you wish to learn about mermaid's syntax, Read the [Diagram Syntax](https://mermaid-js.github.io/mermaid/#/n00b-syntaxReference) section.
+
 ## Basic Pie Chart
 
 ```

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,4 +1,5 @@
 # Integrations
+**Edit this Page** [![N|Solid](./img/GitHub-Mark-32px.png)](https://github.com/mermaid-js/mermaid/blob/develop/docs/n00b-gettingStarted.md)
 
 The following is a list of different integrations and plugins where mermaid is being used
 

--- a/docs/n00b-gettingStarted.md
+++ b/docs/n00b-gettingStarted.md
@@ -5,15 +5,16 @@ Creating diagrams and charts using mermaid code is simple.
 The code is turned into a diagram in the web page with the use of a mermaid renderer.
 
 The mermaid renderer is a piece of javascript that parses mermaid definitions, when called.
-This then renders a diagram based on that code, which can be seen as 
+This then renders a diagram based on that code in SVG, alternatively it 
 
-Most web browsers, such as Firefox, Chrome and Safari, can render mermaid, Internet Explorer however cannot. The web browser also needs access to the online mermaid renderer which it downloads from https://cdn.jsdelivr.net/npm/mermaid
+Most web browsers, such as Firefox, Chrome and Safari, can render mermaid, Internet Explorer however cannot.
 
-## For beginners, there are three relatively easy ways you can use mermaid:
-1. Using the mermaid [live editor](https://mermaid-js.github.io/mermaid-live-editor/)
+## For beginners, there are four relatively easy ways you can use mermaid:
+1. Using the mermaid [live editor](https://mermaid-js.github.io/mermaid-live-editor/) For some popular video tutorials on the live editor go to [Overview](./n00b-overview.md).
 2. Using one of the many [mermaid plugins](https://mermaid-js.github.io/mermaid/#/integrations).
-3. Calling mermaid renderer with HTML, deployed in a friendly browser. 
-
+3. Calling mermaid renderer with HTML,click here for more in depth information on [Usage](./usage.md).
+4. Installing mermaid with npm and deploying it using a relative link in the `<script>` tag. 
+.
 # Following either of these examples, you can get started with creating your own diagrams using mermaid code.
 
 ## 1. The mermaid live editor:
@@ -22,12 +23,15 @@ Most web browsers, such as Firefox, Chrome and Safari, can render mermaid, Inter
 
 In the `Code` section one can write or edit raw mermaid code, and instantly `Preview` the rendered result on the panel beside it.
 
+**This is a great way to learn how to define a mermaid diagram.** 
+
+For some popular video tutorials on the live editor go to [Overview](./n00b-overview.md).
+
 ![Flowchart](./img/n00b-liveEditor.png) 
 
+**Notes:**
 
-You can also copy the code from the code section and paste it into either a mermaid plugin or in inside an html file, which will be taught in numbers 2 and 3. 
-
-It is also an easier way to develop diagrams. You can also click "Copy Markdown" to copy the markdown code for the diagram, that can then be pasted directly into your documentation. 
+You can also click "Copy Markdown" to copy the markdown code for the diagram, that can then be pasted directly into your documentation. 
 
 ![Flowchart](./img/liveEditorOptions.png)
 
@@ -68,6 +72,7 @@ When the mermaid plugin is installed on a Confluence server, one can insert a me
 ![Flowchart](./img/n00b-Confluence4.png)
 
 ---
+## There are two ways of hosting mermaid on a webpage. They will be discussed in 3 and 4, respectively.  
 
 ## 3. mermaid using any web server (or just a browser):
 **This is covered in detail in the [Usage section](https://mermaid-js.github.io/mermaid/#/usage)**
@@ -76,9 +81,8 @@ This method can be used with any common web server. Apache, IIS, nginx, node exp
 
 We do not need to install anything on the server, apart from a program (like Notepad++) that can generate an html file, which is then deployed by a web browser (such as Firefox, Chrome, Safari, but not Internet Explorer). 
 
-So if you want to really simplify things when testing this out, don't use a web server at all but just create the file locally and drag it into your browser window. It is the browser which does all the work of rendering mermaid!
+So if you want to really simplify things when testing this out, don't use a web server at all but just create an HTML file locally and drag it into your browser window. The browser will do the work of rendering the mermaid diagrams according to the descriptions you've given!
 
-### Here are instructions for creating an html file with mermaid code: 
 ### Note that all this is written in the html `<body>` section of the web page.
 
 When writing the html file, we give the web browser three instructions inside the html code:
@@ -90,20 +94,19 @@ b. The mermaid code for the diagram we want to create.
 c. The `mermaid.initialize()` command to start the rendering process. 
 
 
+## This is what needs to go into the html file (and all of them are important):
 
-
-This is what needs to go into the html file:
 
 
 ### a. The reference to the mermaid renderer has to be contained in a `<script src>` tag like so:
 
 ```
 <body>
-  <script src="https://cdn.jsdelivr.net/npm/mermaid@8.4.0/dist/mermaid.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
 </body>
 ```
 
-### b. The embedded mermaid code is similarly placed inside a `<div>` tag:
+### b. The embedded mermaid diagram definition is similarly placed inside a `<div>` tag:
 
 ```
 <body>
@@ -116,7 +119,7 @@ This is what needs to go into the html file:
   </div>
 </body>
 ```
-(take note that every mermaid chart/graph/diagram, has to have separate `<div>` tags.)
+(take note that every mermaid chart/graph/diagram definition, has to have separate `<div>` tags.)
 
 ### c. When initializing mermaid using `mermaid.initialize()`, mermaid takes all the `<div class="mermaid">` tags it can find in the html body and starts to render them one by one. This is done like so:
 
@@ -128,11 +131,12 @@ This is what needs to go into the html file:
 
 ### *Finally*
 ### If the three steps mentioned are followed you will end up with something like this:
+### Note that 
 
 ```
 <html>
   <body>
-    <script src="https://cdn.jsdelivr.net/npm/mermaid@8.6.0/dist/mermaid.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
     <script>mermaid.initialize({startOnLoad:true});</script>
 
     Here is one mermaid diagram:
@@ -153,16 +157,54 @@ This is what needs to go into the html file:
   </body>
 </html>
 ```
-### Save this to an html file and open it with a browser from the web server (or just drag it into your web browser window) and voila!
+### Save this to an html file and open it with a browser.
 
 ---
+## 4. Calling mermaid from a relative link. 
+This method is similar to 3, if only a little more involved.  The difference may be very subtle even, insignificant to a majority of people, but it offers its own advantages. 
+
+1. install node v10 or 12, which would have npm
+
+2. download yarn using npm.
+npm install -g yarn
+
+3. After yarn installs, enter the following command:
+    yarn add mermaid
+
+4. After downloading mermaid, you can then open the mermaid you’ve downloaded and go to the `dist` folder.
+
+5. Find the `mermaid.min.js` file, press the shift key and right click on and select copy as path from the options. 
+
+6. Paste it within the `script` tag as the `src`. 
+```
+<script src=[Paste the mermaid.min.js file address here]></script>
+ <script>mermaid.initialize({startOnLoad:true});</script>
+```
+7. It should look something like this
+```
+  <script src="C:\Users\myPC\mermaid\dist\mermaid.js"></script>
+  <script>mermaid.initialize({startOnLoad:true});</script>
+```
+8. Add the graph and diagram definitions as you would in number 3, be mindful of the `div` tags. 
+
+9. Save, load/edit your HTML file to your liking.  
+
+ 
+**Note** placing the HTML file on the same folder the mermaid filed you've downloaded is a good practice and allows you to shorten the address. 
+
+**As seen here:**
+```
+<script src=".\mermaid\dist\mermaid.min.js"></script>
+```
+
+
 
 **Three additional comments from Knut Sveidqvist, creator of mermaid:**
 - In early versions of mermaid, the `<script src>` tag was invoked in the `<head>` part of the web page. Nowdays we can place it directly in `<body>` as seen above. However, older parts of the documentation frequently reflects the previous way which still works.
   
 - We initialize the mermaid rendering with `mermaid.initialize()` directly in the html code. In principle this could be done through placing `mermaid.initialize()` inside of `mermaid.min.js`. We would then eliminate the need for this explicit line in the html. However, there are use cases where we do want to separate the two steps. Sometimes we want full control over when we start looking for `<div>`tags inside the web page with `mermaid.initialize()`, for example when we think that all `<div>` tags may not have been loaded by the time `mermaid.min.js` runs.
 
-- In the example above, `mermaid.min.js` is called using an absolute path. Even worse, the example includes the mermaid version number which of course will change as time goes by. However, the example makes it easy to understand what is going on - even though it is perhaps doomed in a way we do not want in a production environment. When going from testing mermaid out to getting serious with it, I would suggest one of the following approaches for calling `mermaid.min.js`:
+- In the third method, `mermaid.min.js` is called using an absolute path. Even worse, the example includes the mermaid version number which of course will change as time goes by. However, the example makes it easy to understand what is going on - even though it is perhaps doomed in a way we do not want in a production environment. When going from testing mermaid out to getting serious with it, I would suggest one of the following approaches for calling `mermaid.min.js`:
   
   1. If you do not enter a specific version, you automatically get the latest one.
   2. If you really need a specific version, hard code it (this is rare but it happens).

--- a/docs/n00b-gettingStarted.md
+++ b/docs/n00b-gettingStarted.md
@@ -12,8 +12,8 @@ Most web browsers, such as Firefox, Chrome and Safari, can render mermaid, Inter
 ## For beginners, there are four relatively easy ways you can use mermaid:
 1. Using the mermaid [live editor](https://mermaid-js.github.io/mermaid-live-editor/). For some popular video tutorials on the live editor go to [Overview](./n00b-overview.md).
 2. Using one of the many [mermaid plugins](https://mermaid-js.github.io/mermaid/#/integrations).
-3. Calling mermaid renderer with an absolute link through HTML.
-4. Installing mermaid with npm and hosting it on a webpage using a relative link in the `<script>` tag. 
+3. Using the mermaid API on your webpage. 
+4. Downloading mermaid and hosting it on your Web Page. 
 
 **Notes**: More in depth information can be found on [Usage](./usage.md).
 .
@@ -74,10 +74,10 @@ When the mermaid plugin is installed on a Confluence server, one can insert a me
 ![Flowchart](./img/n00b-Confluence4.png)
 
 ---
-## There are two ways of hosting mermaid on a webpage. They will be discussed in 3 and 4, respectively.  
+## The following are two ways of hosting mermaid on a webpage.  
+**This is covered in greater detail in the [Usage section](https://mermaid-js.github.io/mermaid/#/usage)**
 
-## 3. mermaid using any web server (or just a browser):
-**This is covered in detail in the [Usage section](https://mermaid-js.github.io/mermaid/#/usage)**
+## 3. Using the Mermaid API:
 
 This method can be used with any common web server. Apache, IIS, nginx, node express [...], you pick your favourite.
 
@@ -93,7 +93,7 @@ a. A reference for fetching the online mermaid renderer, which is written in Jav
 
 b. The mermaid code for the diagram we want to create.
 
-c. The `mermaid.initialize()` command to start the rendering process. 
+c. The `mermaid.initialize()` API call to start the rendering process. 
 
 
 ## This is what needs to go into the html file (and all of them are important), for the mermaidAPI to render the diagrams:
@@ -132,9 +132,8 @@ c. The `mermaid.initialize()` command to start the rendering process.
   <script>mermaid.initialize({startOnLoad:true});</script>
 </body>
 ```
-**Notes**:It is good practice to keep the `mermaid.initialize()` API call right next the `mermaid.min.js` `script` tag.
-          
-          startOnLoad is a parameter that can optionally be changed to false, this would then prevent mermaid from immediately rendering upon loading.
+**Notes**: It is good practice to keep the `mermaid.initialize()` API call right next the `mermaid.min.js` `script` tag.
+`startOnLoad` is a parameter that can optionally be changed to false, this would then prevent mermaid from immediately rendering upon loading.
 
 ### If the three steps mentioned are followed you will end up with something like this:
 

--- a/docs/n00b-gettingStarted.md
+++ b/docs/n00b-gettingStarted.md
@@ -1,16 +1,17 @@
 # A basic mermaid User-Guide for Beginners
+**Edit this Page** [![N|Solid](./img/GitHub-Mark-32px.png)](https://github.com/mermaid-js/mermaid/blob/develop/docs/n00b-gettingStarted.md)
 
 Creating diagrams and charts using mermaid code is simple.
+The code is turned into a diagram in the web page with the use of a mermaid renderer.
 
-But how is the code turned into a diagram in a web page? This is done with the use of a mermaid renderer.
-
-The mermaid renderer is very accessible, in essence it is a piece of javascript that can be called. 
+The mermaid renderer is a piece of javascript that parses mermaid definitions, when called.
+This then renders a diagram based on that code, which can be seen as 
 
 Most web browsers, such as Firefox, Chrome and Safari, can render mermaid, Internet Explorer however cannot. The web browser also needs access to the online mermaid renderer which it downloads from https://cdn.jsdelivr.net/npm/mermaid
 
 ## For beginners, there are three relatively easy ways you can use mermaid:
 1. Using the mermaid [live editor](https://mermaid-js.github.io/mermaid-live-editor/)
-2. Using one of the many mermaid plugins
+2. Using one of the many [mermaid plugins](https://mermaid-js.github.io/mermaid/#/integrations).
 3. Calling mermaid renderer with HTML, deployed in a friendly browser. 
 
 # Following either of these examples, you can get started with creating your own diagrams using mermaid code.
@@ -69,6 +70,7 @@ When the mermaid plugin is installed on a Confluence server, one can insert a me
 ---
 
 ## 3. mermaid using any web server (or just a browser):
+**This is covered in detail in the [Usage section](https://mermaid-js.github.io/mermaid/#/usage)**
 
 This method can be used with any common web server. Apache, IIS, nginx, node express [...], you pick your favourite.
 
@@ -76,8 +78,8 @@ We do not need to install anything on the server, apart from a program (like Not
 
 So if you want to really simplify things when testing this out, don't use a web server at all but just create the file locally and drag it into your browser window. It is the browser which does all the work of rendering mermaid!
 
-# Here are instructions for creating an html file with mermaid code: 
-# Note that all this is written in the html `<body>` section of the web page.
+### Here are instructions for creating an html file with mermaid code: 
+### Note that all this is written in the html `<body>` section of the web page.
 
 When writing the html file, we give the web browser three instructions inside the html code:
 
@@ -93,7 +95,7 @@ c. The `mermaid.initialize()` command to start the rendering process.
 This is what needs to go into the html file:
 
 
-# a. The reference to the mermaid renderer has to be contained in a `<script src>` tag like so:
+### a. The reference to the mermaid renderer has to be contained in a `<script src>` tag like so:
 
 ```
 <body>
@@ -101,7 +103,7 @@ This is what needs to go into the html file:
 </body>
 ```
 
-# b. The embedded mermaid code is similarly placed inside a `<div>` tag:
+### b. The embedded mermaid code is similarly placed inside a `<div>` tag:
 
 ```
 <body>
@@ -116,7 +118,7 @@ This is what needs to go into the html file:
 ```
 (take note that every mermaid chart/graph/diagram, has to have separate `<div>` tags.)
 
-# c. When initializing mermaid using `mermaid.initialize()`, mermaid takes all the `<div class="mermaid">` tags it can find in the html body and starts to render them one by one. This is done like so:
+### c. When initializing mermaid using `mermaid.initialize()`, mermaid takes all the `<div class="mermaid">` tags it can find in the html body and starts to render them one by one. This is done like so:
 
 ```
 <body>
@@ -124,8 +126,8 @@ This is what needs to go into the html file:
 </body>
 ```
 
-# *Finally*
-# If the three steps mentioned are followed you will end up with something like this:
+### *Finally*
+### If the three steps mentioned are followed you will end up with something like this:
 
 ```
 <html>
@@ -151,7 +153,7 @@ This is what needs to go into the html file:
   </body>
 </html>
 ```
-# Save this to an html file and open it with a browser from the web server (or just drag it into your web browser window) and voila!
+### Save this to an html file and open it with a browser from the web server (or just drag it into your web browser window) and voila!
 
 ---
 

--- a/docs/n00b-gettingStarted.md
+++ b/docs/n00b-gettingStarted.md
@@ -10,12 +10,14 @@ This then renders a diagram based on that code in SVG, alternatively it
 Most web browsers, such as Firefox, Chrome and Safari, can render mermaid, Internet Explorer however cannot.
 
 ## For beginners, there are four relatively easy ways you can use mermaid:
-1. Using the mermaid [live editor](https://mermaid-js.github.io/mermaid-live-editor/) For some popular video tutorials on the live editor go to [Overview](./n00b-overview.md).
+1. Using the mermaid [live editor](https://mermaid-js.github.io/mermaid-live-editor/). For some popular video tutorials on the live editor go to [Overview](./n00b-overview.md).
 2. Using one of the many [mermaid plugins](https://mermaid-js.github.io/mermaid/#/integrations).
-3. Calling mermaid renderer with HTML,click here for more in depth information on [Usage](./usage.md).
-4. Installing mermaid with npm and deploying it using a relative link in the `<script>` tag. 
+3. Calling mermaid renderer with an absolute link through HTML.
+4. Installing mermaid with npm and hosting it on a webpage using a relative link in the `<script>` tag. 
+
+**Notes**: More in depth information can be found on [Usage](./usage.md).
 .
-# Following either of these examples, you can get started with creating your own diagrams using mermaid code.
+# Following any of these examples, you can get started with creating your own diagrams using mermaid code.
 
 ## 1. The mermaid live editor:
 
@@ -94,11 +96,11 @@ b. The mermaid code for the diagram we want to create.
 c. The `mermaid.initialize()` command to start the rendering process. 
 
 
-## This is what needs to go into the html file (and all of them are important):
+## This is what needs to go into the html file (and all of them are important), for the mermaidAPI to render the diagrams:
 
 
 
-### a. The reference to the mermaid renderer has to be contained in a `<script src>` tag like so:
+### a. A reference to the address of the `mermaid.js` or the `mermaid.min.js` file has to be contained in a `<script src>` tag like so:
 
 ```
 <body>
@@ -106,7 +108,7 @@ c. The `mermaid.initialize()` command to start the rendering process.
 </body>
 ```
 
-### b. The embedded mermaid diagram definition is similarly placed inside a `<div>` tag:
+### b. The embedded mermaid diagram definition needs to be contains inside a `<div>` tag that signifies that it is a mermaid diagram:
 
 ```
 <body>
@@ -119,19 +121,23 @@ c. The `mermaid.initialize()` command to start the rendering process.
   </div>
 </body>
 ```
-(take note that every mermaid chart/graph/diagram definition, has to have separate `<div>` tags.)
+**Notes**: every mermaid chart/graph/diagram definition, has to have separate `<div>` tags.
 
-### c. When initializing mermaid using `mermaid.initialize()`, mermaid takes all the `<div class="mermaid">` tags it can find in the html body and starts to render them one by one. This is done like so:
+### c. The `mermaid.initialize()` API call
+
+`mermaid.initialize()` calls take all the definitions contained in `<div class="mermaid">` tags it can find in the html body and starts to render them one by one. It is called this way: 
 
 ```
 <body>
   <script>mermaid.initialize({startOnLoad:true});</script>
 </body>
 ```
+**Notes**:It is good practice to keep the `mermaid.initialize()` API call right next the `mermaid.min.js` `script` tag.
+          
+          startOnLoad is a parameter that can optionally be changed to false, this would then prevent mermaid from immediately rendering upon loading.
 
-### *Finally*
 ### If the three steps mentioned are followed you will end up with something like this:
-### Note that 
+
 
 ```
 <html>
@@ -157,27 +163,32 @@ c. The `mermaid.initialize()` command to start the rendering process.
   </body>
 </html>
 ```
-### Save this to an html file and open it with a browser.
+
+**Notes**: This has to be saved in an `HTML` file and opened with a browser.
 
 ---
 ## 4. Calling mermaid from a relative link. 
-This method is similar to 3, if only a little more involved.  The difference may be very subtle even, insignificant to a majority of people, but it offers its own advantages. 
+
+This method is similar to 3, if only a little more involved. The difference may be very subtle even, but it offers its own advantages, mainly in speed. 
 
 1. install node v10 or 12, which would have npm
 
-2. download yarn using npm.
-npm install -g yarn
+2. download yarn using npm by entering the command below:
+    npm install -g yarn
 
 3. After yarn installs, enter the following command:
     yarn add mermaid
 
-4. After downloading mermaid, you can then open the mermaid you’ve downloaded and go to the `dist` folder.
+4. After downloading mermaid, you can then open the mermaid file you’ve downloaded and go to the `dist` folder.
 
-5. Find the `mermaid.min.js` file, press the shift key and right click on and select copy as path from the options. 
+5. Find the `mermaid.min.js` file,
+    a. select the file.
+    b. press the shift key and right click on it
+    c. select copy as path from the options. 
 
 6. Paste it within the `script` tag as the `src`. 
 ```
-<script src=[Paste the mermaid.min.js file address here]></script>
+<script src="Paste the mermaid.min.js file address here"></script>
  <script>mermaid.initialize({startOnLoad:true});</script>
 ```
 7. It should look something like this
@@ -185,12 +196,13 @@ npm install -g yarn
   <script src="C:\Users\myPC\mermaid\dist\mermaid.js"></script>
   <script>mermaid.initialize({startOnLoad:true});</script>
 ```
-8. Add the graph and diagram definitions as you would in number 3, be mindful of the `div` tags. 
+8. Add the graph and diagram definitions as you would in number 3.
+    a. be mindful of the `div` tags. 
 
 9. Save, load/edit your HTML file to your liking.  
 
  
-**Note** placing the HTML file on the same folder the mermaid filed you've downloaded, is a good practice and allows you to shorten the address on the `src` section.
+**Note** placing the HTML file on the same folder the `mermaid` file you've downloaded is a good practice and allows you to shorten the address on the `src` section.
 
 **As seen here, in this full example:**
 ```
@@ -211,7 +223,7 @@ npm install -g yarn
      B --> C[Server1]
      B --> D[Server2]
   </div>
-  <script src="C:\Users\elanc\mermaid\dist\mermaid.js"></script>
+  <script src="C:\Users\MyPC\mermaid\dist\mermaid.js"></script>
   <script>mermaid.initialize({startOnLoad:true});</script>
 </body>
 </html>

--- a/docs/n00b-gettingStarted.md
+++ b/docs/n00b-gettingStarted.md
@@ -12,7 +12,7 @@ Most web browsers, such as Firefox, Chrome and Safari, can render mermaid, Inter
 ## For beginners, there are four relatively easy ways you can use mermaid:
 1. Using the mermaid [live editor](https://mermaid-js.github.io/mermaid-live-editor/). For some popular video tutorials on the live editor go to [Overview](./n00b-overview.md).
 2. Using one of the many [mermaid plugins](https://mermaid-js.github.io/mermaid/#/integrations).
-3. Using the mermaid API on your webpage. 
+3. Hosting mermaid on a webpage, with an absolute link.
 4. Downloading mermaid and hosting it on your Web Page. 
 
 **Notes**: More in depth information can be found on [Usage](./usage.md).
@@ -77,7 +77,7 @@ When the mermaid plugin is installed on a Confluence server, one can insert a me
 ## The following are two ways of hosting mermaid on a webpage.  
 **This is covered in greater detail in the [Usage section](https://mermaid-js.github.io/mermaid/#/usage)**
 
-## 3. Using the Mermaid API:
+## 3. Using the Mermaid API: The quick and dirty way of deploying mermaid
 
 This method can be used with any common web server. Apache, IIS, nginx, node express [...], you pick your favourite.
 

--- a/docs/n00b-gettingStarted.md
+++ b/docs/n00b-gettingStarted.md
@@ -45,7 +45,7 @@ Thanks to the growing popularity of mermaid, many plugins already exist which in
 One example in the list is the [Atlassian Confluence mermaid plugin](https://marketplace.atlassian.com/apps/1214124/mermaid-plugin-for-confluence?hosting=server&tab=overview) 
 
 When the mermaid plugin is installed on a Confluence server, one can insert a mermaid object into any Confluence page.
-# Here is a step by step process for using the mermaid-Confluence plugin:
+### Here is a step by step process for using the mermaid-Confluence plugin:
 
 ---
 

--- a/docs/n00b-gettingStarted.md
+++ b/docs/n00b-gettingStarted.md
@@ -190,11 +190,31 @@ npm install -g yarn
 9. Save, load/edit your HTML file to your liking.  
 
  
-**Note** placing the HTML file on the same folder the mermaid filed you've downloaded is a good practice and allows you to shorten the address. 
+**Note** placing the HTML file on the same folder the mermaid filed you've downloaded, is a good practice and allows you to shorten the address on the `src` section.
 
-**As seen here:**
+**As seen here, in this full example:**
 ```
-<script src=".\mermaid\dist\mermaid.min.js"></script>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+</head>
+<body>
+  <div class="mermaid">
+  graph LR
+      A --- B
+      B-->C[fa:fa-ban forbidden]
+      B-->D(fa:fa-spinner);
+  </div>
+  <div class="mermaid">
+     graph TD
+     A[Client] --> B[Load Balancer]
+     B --> C[Server1]
+     B --> D[Server2]
+  </div>
+  <script src="C:\Users\elanc\mermaid\dist\mermaid.js"></script>
+  <script>mermaid.initialize({startOnLoad:true});</script>
+</body>
+</html>
 ```
 
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,15 +6,18 @@
 ### npm package 
 
 ```
-1.You will need to isntall node v10 or 12, which would have npm.
+1.You will need to insall node v10 or 12, which would have npm.
 
 2. download yarn using npm.
 
-2. enter the following command:
+3. enter the following command:
     yarn add mermaid
 
-3. You can then add mermaid as a dev dependency using this command: 
+4. At this point, you can add mermaid as a dev dependency using this command: 
     yarn add --dev mermaid
+
+5. alternatively, you can deploy it using the script tag in an HTML file with mermaid diagram descriptions. This is explored in greater depth in the [User Guide for Beginners](./n00b-gettingStarted.md)
+ 
 ```
 
 ### CDN

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,31 +30,33 @@ For the majority of beginners, using the live editor or suppoting mermaid on a w
 4. At this point, you can add mermaid as a dev dependency using this command: 
     yarn add --dev mermaid
 
-5. alternatively, you can deploy it using the script tag in an HTML file with mermaid diagram descriptions. 
+5. Alternatively, you can also deploy mermaid using the script tag in an HTML file with mermaid diagram descriptions.
+    as is shown in the example below
 ```
-For 
 
 ## Hosting mermaid on a web page.
 
 **Notes**: This topic explored in greater depth in the [User Guide for Beginners](./n00b-gettingStarted.md)
 
-The easiest way to integrate mermaid on a web page requires two elements:
-1. Inclusion of the mermaid address in the html page using a `script` tag, in the `src` section.
+The easiest way to integrate mermaid on a web page requires three elements:
+
+1. Inclusion of the mermaid address in the html page using a `script` tag, in the `src` section.Example:
 
   `<script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>`
   
-2. The `mermaidAPI` call, in a separate `script` tag.
+2. The `mermaidAPI` call, in a separate `script` tag. Example:
 
   `<script>mermaid.initialize({startOnLoad:true});</script>`
   
-3. A graph definition, inside `<div>` tags labeled `class=mermaid`.
-
-`<div class="mermaid">
+3. A graph definition, inside `<div>` tags labeled `class=mermaid`. Example: 
+```
+<div class="mermaid">
      graph LR
       A --- B
       B-->C[fa:fa-ban forbidden]
       B-->D(fa:fa-spinner);
-</div>`
+</div>
+```
 
 **If these things are in place mermaid starts at the page load event and when fired (when the page has loaded) it will
 locate the graph definitions inside the `div` tags with `class="mermaid"` on the page and transform them to svg charts or diagrams.**
@@ -115,14 +117,6 @@ If you are taking resposibility for the diagram source security you can set the 
     mermaidAPI.initialize({	
         securityLevel: 'loose'	
     });	
-```	
-
-
-
-```javascript
-    mermaidAPI.initialize({
-        securityLevel: 'loose'
-    });
 ```
 
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -92,7 +92,7 @@ Mermaid can load multiple diagrams, in the same page.
 
 ## To enable click event and tags in nodes	
 
- A `securityLevel` configuration was introduced which sets the level of trust to be used on the parsed diagrams. In version 8.2 a security improvement was introduced.
+ A `securityLevel` configuration has to first be cleared, `securityLevel` sets the level of trust for the parsed diagrams. This was introduce in version 8.2 as a security improvement, aimed at preventing malicious use. 
  
 ## securityLevel
 
@@ -118,18 +118,6 @@ If you are taking resposibility for the diagram source security you can set the 
         securityLevel: 'loose'	
     });	
 ```
-
-
-## To enable click event and tags in nodes:
-
-In version 8.2 a security improvement was introduced. A `securityLevel` configuration was introduced which sets the level of trust to be used on the parsed diagrams.
-
-* **true**: (default) tags in text are encoded, click functionality is disabled
-* false: tags in text are allowed, click functionality is enabled
-
-⚠️ **Note** : This changes the default behaviour of mermaid so that after upgrade to 8.2, if the `securityLevel` is not configured, tags in flowcharts are encoded as tags and clicking is prohibited.
-
-If your application is taking resposibility for the diagram source security you can set the `securityLevel` accordingly. By doing this clicks and tags are again allowed.
 
 
 ### Labels out of bounds
@@ -160,6 +148,7 @@ If your page has other fonts in its body those might be used instead of the merm
     }
 ```
 # This likely requires a `script.js` file, separate from the `HTML`. 
+
 ### Calling `mermaid.init`
 
 By default, `mermaid.init` will be called when the document is ready, finding all elements with

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -53,8 +53,8 @@ locate the graphs on the page and transform them to svg files.
   <script>mermaid.initialize({startOnLoad:true});</script>
 ```
 
-Further down on your page mermaid will look for tags with `class="mermaid"`. From these tags mermaid will try to
-read the chart definiton and replace it with the svg chart.
+Further down on your page mermaid will look for `div` tags with `class="mermaid"`. From these tags mermaid will try to
+read the chart definiton and render it as an svg chart.
 
 
 ### Define a chart like thi:
@@ -142,7 +142,7 @@ If your application is taking resposibility for the diagram source security you 
 ```
 
 
-### Labels out of bounds
+## Labels out of bounds
 
 If you use dynamically loaded fonts that are loaded through CSS, such as Google fonts, mermaid should wait for the
 whole page to load (dom + assets, particularly the fonts file).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,6 +1,18 @@
 # Usage
 **Edit this Page** [![N|Solid](./img/GitHub-Mark-32px.png)](https://github.com/mermaid-js/mermaid/blob/develop/docs/usage.md)
 
+mermaid is a javascript tool that makes use of a markdown based syntax to render customizable diagrams and charts, for greater speed and ease. 
+
+mermaid was made to 0help Documentation catch up with Development, in quickly changing projects.
+
+## Using mermaid
+
+For the majority of beginners, using the live editor or deploying mermaid through their browsers is all they would have use for mermaid.
+
+**To learn more go to 
+
+# It only gets geekiers beyond this point.
+
 ## Installation
 
 ### npm package 
@@ -30,7 +42,7 @@ Please note that you can switch versions through the dropdown box at the top rig
 ## Simple usage on a web page
 
 The easiest way to integrate mermaid on a web page requires two elements:
-1. Inclusion of the mermaid framework in the html page using a script tag
+1. Inclusion of the mermaid address in the html page using a script tag
 2. A graph definition on the web page
 
 If these things are in place mermaid listens to the page load event and when fired (when the page has loaded) it will
@@ -39,7 +51,7 @@ locate the graphs on the page and transform them to svg files.
 ### Include mermaid on your web page:
 
 ```html
-  <script src="https://cdn.jsdelivr.net/npm/mermaid@8.6.0/dist/mermaid.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
   <script>mermaid.initialize({startOnLoad:true});</script>
 ```
 
@@ -83,7 +95,7 @@ Would end up like this:
       B-->C[fa:fa-ban forbidden]
       B-->D(fa:fa-spinner);
   </div>
- <script src="https://cdn.jsdelivr.net/npm/mermaid@8.6.0/dist/mermaid.min.js"></script>
+ <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
  <script>mermaid.initialize({startOnLoad:true});</script>
 </body>
 </html>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -7,10 +7,9 @@ mermaid was made to 0help Documentation catch up with Development, in quickly ch
 
 ## Using mermaid
 
-For the majority of beginners, using the live editor or deploying mermaid through their browsers is all they would have use for mermaid.
+For the majority of beginners, using the live editor or suppoting mermaid on a webpage would cover their uses for mermaid. 
 
-**Learn more on [Getting Started](https://mermaid-js.github.io/mermaid/#/n00b-gettingStarted).**
-
+**To learn how to use  [Getting Started](https://mermaid-js.github.io/mermaid/#/n00b-gettingStarted).**
 
 ## Installation
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -80,19 +80,36 @@ locate the graph definitions inside the `div` tags with `class="mermaid"` on the
 </html>
 ```
 
+## Notes: 
+An id attribute is also added to mermaid tags without one.
+
+Mermaid can load multiple diagrams, in the same page.
+
 ### Try it out, save this code as HTML and load it using any browser.(Please don't use Internet Explorer though.) 
 
 
 ## To enable click event and tags in nodes	
 
-In version 8.2 a security improvement was introduced. A `securityLevel` configuration was introduced which sets the level of trust to be used on the parsed diagrams.	
+ A `securityLevel` configuration was introduced which sets the level of trust to be used on the parsed diagrams. In version 8.2 a security improvement was introduced.
+ 
+## securityLevel
 
-* **true**: (default) tags in text are encoded, click functionality is disabled	
-* false: tags in text are allowed, click functionality is enabled	
+| Parameter     | Description                       | Type   | Required | Values                    |
+| ------------- | --------------------------------- | ------ | -------- | ------------------------- |
+| securitylevel | Level of trust for parsed diagram | String | Required | Strict, Loose, antiscript |
+
+\*\*Notes:
+
+-   **strict**: (**default**) tags in text are encoded, click functionality is disabeled
+-   **loose**: tags in text are allowed, click functionality is enabled
+-   **antiscript**: html tags in text are allowed, (only script element is removed), click functionality is enabled
+
 
 ⚠️ **Note** : This changes the default behaviour of mermaid so that after upgrade to 8.2, if the `securityLevel` is not configured, tags in flowcharts are encoded as tags and clicking is prohibited.	
 
-If your application is taking resposibility for the diagram source security you can set the `securityLevel` accordingly. By doing this clicks and tags are again allowed.	
+If you are taking resposibility for the diagram source security you can set the `securityLevel` to a value of your choosing . By doing this clicks and tags are again allowed.	
+
+## To chage `securityLevel` with `mermaidAPI.initialize`: 
 
 ```javascript	
     mermaidAPI.initialize({	
@@ -100,10 +117,14 @@ If your application is taking resposibility for the diagram source security you 
     });	
 ```	
 
-## Notes: 
-An id attribute is also added to mermaid tags without one.
 
-Mermaid can load multiple diagrams, in the same page.
+
+```javascript
+    mermaidAPI.initialize({
+        securityLevel: 'loose'
+    });
+```
+
 
 ## To enable click event and tags in nodes:
 
@@ -115,12 +136,6 @@ In version 8.2 a security improvement was introduced. A `securityLevel` configur
 ⚠️ **Note** : This changes the default behaviour of mermaid so that after upgrade to 8.2, if the `securityLevel` is not configured, tags in flowcharts are encoded as tags and clicking is prohibited.
 
 If your application is taking resposibility for the diagram source security you can set the `securityLevel` accordingly. By doing this clicks and tags are again allowed.
-
-```javascript
-    mermaidAPI.initialize({
-        securityLevel: 'loose'
-    });
-```
 
 
 ### Labels out of bounds

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,13 +9,12 @@ mermaid was made to 0help Documentation catch up with Development, in quickly ch
 
 For the majority of beginners, using the live editor or deploying mermaid through their browsers is all they would have use for mermaid.
 
-**To learn more go to 
+**Learn more on [Getting Started](https://mermaid-js.github.io/mermaid/#/n00b-gettingStarted).**
 
-# It only gets geekiers beyond this point.
 
 ## Installation
 
-### npm package 
+### Using the npm package 
 
 ```
 1.You will need to insall node v10 or 12, which would have npm.
@@ -42,8 +41,8 @@ Please note that you can switch versions through the dropdown box at the top rig
 ## Simple usage on a web page
 
 The easiest way to integrate mermaid on a web page requires two elements:
-1. Inclusion of the mermaid address in the html page using a script tag
-2. A graph definition on the web page
+1. Inclusion of the mermaid address in the html page using a `script` tag, in the `src` section.
+2. A graph definition, inside `<div>` tags labeled `class=mermaid`.
 
 If these things are in place mermaid listens to the page load event and when fired (when the page has loaded) it will
 locate the graphs on the page and transform them to svg files.
@@ -100,9 +99,11 @@ Would end up like this:
 </body>
 </html>
 ```
-## Try it out, save this code as HTML and load it. 
 
-### To enable click event and tags in nodes	
+### Try it out, save this code as HTML and load it. 
+
+
+## To enable click event and tags in nodes	
 
 In version 8.2 a security improvement was introduced. A `securityLevel` configuration was introduced which sets the level of trust to be used on the parsed diagrams.	
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,13 +5,17 @@ mermaid is a javascript tool that makes use of a markdown based syntax to render
 
 mermaid was made to 0help Documentation catch up with Development, in quickly changing projects.
 
+### CDN
+
+https://unpkg.com/mermaid/
+
+Please note that you can switch versions through the dropdown box at the top right.
+
 ## Using mermaid
 
 For the majority of beginners, using the live editor or suppoting mermaid on a webpage would cover their uses for mermaid. 
 
-**To learn how to use  [Getting Started](https://mermaid-js.github.io/mermaid/#/n00b-gettingStarted).**
-
-## Installation
+## Installing and Hosting mermaid on a webpage
 
 ### Using the npm package 
 
@@ -26,57 +30,34 @@ For the majority of beginners, using the live editor or suppoting mermaid on a w
 4. At this point, you can add mermaid as a dev dependency using this command: 
     yarn add --dev mermaid
 
-5. alternatively, you can deploy it using the script tag in an HTML file with mermaid diagram descriptions. This is explored in greater depth in the [User Guide for Beginners](./n00b-gettingStarted.md)
- 
+5. alternatively, you can deploy it using the script tag in an HTML file with mermaid diagram descriptions. 
 ```
+For 
 
-### CDN
+## Hosting mermaid on a web page.
 
-https://unpkg.com/mermaid/
-
-Please note that you can switch versions through the dropdown box at the top right.
-
-
-## Simple usage on a web page
+**Notes**: This topic explored in greater depth in the [User Guide for Beginners](./n00b-gettingStarted.md)
 
 The easiest way to integrate mermaid on a web page requires two elements:
 1. Inclusion of the mermaid address in the html page using a `script` tag, in the `src` section.
-2. A graph definition, inside `<div>` tags labeled `class=mermaid`.
 
-If these things are in place mermaid listens to the page load event and when fired (when the page has loaded) it will
-locate the graphs on the page and transform them to svg files.
+  `<script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>`
+  
+2. The `mermaidAPI` call, in a separate `script` tag.
 
-### Include mermaid on your web page:
+  `<script>mermaid.initialize({startOnLoad:true});</script>`
+  
+3. A graph definition, inside `<div>` tags labeled `class=mermaid`.
 
-```html
-  <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
-  <script>mermaid.initialize({startOnLoad:true});</script>
-```
-
-Further down on your page mermaid will look for `div` tags with `class="mermaid"`. From these tags mermaid will try to
-read the chart definiton and render it as an svg chart.
-
-
-### Define a chart like thi:
-
-```html
-<div class="mermaid">
+`<div class="mermaid">
      graph LR
       A --- B
       B-->C[fa:fa-ban forbidden]
       B-->D(fa:fa-spinner);
-</div>
-```
+</div>`
 
-Would end up like this:
-
-```html
-<div class="mermaid" id="mermaidChart0">
-    <svg>
-        Chart ends up here
-    </svg>
-</div>
-```
+**If these things are in place mermaid starts at the page load event and when fired (when the page has loaded) it will
+locate the graph definitions inside the `div` tags with `class="mermaid"` on the page and transform them to svg charts or diagrams.**
 
 ## Simple full example:
 
@@ -99,7 +80,7 @@ Would end up like this:
 </html>
 ```
 
-### Try it out, save this code as HTML and load it. 
+### Try it out, save this code as HTML and load it using any browser.(Please don't use Internet Explorer though.) 
 
 
 ## To enable click event and tags in nodes	
@@ -142,7 +123,7 @@ If your application is taking resposibility for the diagram source security you 
 ```
 
 
-## Labels out of bounds
+### Labels out of bounds
 
 If you use dynamically loaded fonts that are loaded through CSS, such as Google fonts, mermaid should wait for the
 whole page to load (dom + assets, particularly the fonts file).
@@ -169,7 +150,7 @@ If your page has other fonts in its body those might be used instead of the merm
         font-family: 'trebuchet ms', verdana, arial;
     }
 ```
-
+# This likely requires a `script.js` file, separate from the `HTML`. 
 ### Calling `mermaid.init`
 
 By default, `mermaid.init` will be called when the document is ready, finding all elements with
@@ -399,6 +380,7 @@ mermaid_config.startOnLoad = true;
 
 ## Using the mermaid.init call
 
+# 
 Is it possible to set some configuration via the mermaid object. The two parameters that are supported using this
 approach are:
 


### PR DESCRIPTION
Grafted definitions and tables around for more uniform information throughout. 

Added a fourth way of using mermaid, to reference the mermaid.min.js file through a relative link. 

and a few other, cosmetic changes to the docs. 