### PR TITLE
Fix the flowchart syntax in the documentation

### DIFF
--- a/docs/flowchart.md
+++ b/docs/flowchart.md
@@ -421,7 +421,7 @@ graph TD
     B -->|Yes| C[OK];
     C --> D[Rethink];
     D --> B;
-    B ---->|No| E[End];
+    B -->|No| E[End];
 ```
 
 ```mermaid
@@ -430,7 +430,7 @@ graph TD
     B -->|Yes| C[OK];
     C --> D[Rethink];
     D --> B;
-    B ---->|No| E[End];
+    B -->|No| E[End];
 ```
 
 > **Note** Links may still be made longer than the requested number of ranks
@@ -446,7 +446,7 @@ graph TD
     B -- Yes --> C[OK];
     C --> D[Rethink];
     D --> B;
-    B -- No ----> E[End];
+    B -- No --> E[End];
 ```
 
 ```mermaid
@@ -455,7 +455,7 @@ graph TD
     B -->|Yes| C[OK];
     C --> D[Rethink];
     D --> B;
-    B ---->|No| E[End];
+    B -- No --> E[End];
 ```
 
 For dotted or thick links, the characters to add are equals signs or dots,


### PR DESCRIPTION
## :bookmark_tabs: Summary

Otherwise the following exception is thrown:

```
Uncaught Error: Parse error on line 6:
...D --> B;    B ---->|No| E[End];
----------------------^
Expecting 'SPACE', 'GRAPH', 'DIR', 'subgraph', 'end', 'AMP', 'TAGEND', 'START_LINK', 'STR', 'STYLE', 'LINKSTYLE', 'CLASSDEF', 'CLASS', 'CLICK', 'DOWN', 'UP', 'DEFAULT', 'NUM', 'COMMA', 'ALPHA', 'COLON', 'MINUS', 'BRKT', 'DOT', 'PCT', 'TAGSTART', 'PUNCTUATION', 'UNICODE_TEXT', 'PLUS', 'EQUALS', 'MULT', 'UNDERSCORE', got 'PIPE'
    at Xt.parseError (flow.jison:293)
    at Xt.parse (flow.jison:363)
    at he (flowRenderer.js:285)
    at Object.render (mermaidAPI.js:331)
    at r.code ((index):47)
    at c.tok (docsify.min.js:1)
    at c.parse (docsify.min.js:1)
    at Function.c.parse [as parser] (docsify.min.js:1)
    at docsify.min.js:1
    at docsify.min.js:1
```

This exception prevents the page `/#/flowchart` from loading (i.e. blank page).
The error can be seen in the devtools console when running `docsify` locally from the `develop` branch.

## :straight_ruler: Design Decisions

Not sure if this is the right way to fix this issue.
Maybe it's a known limitation in the syntax? Maybe it's a bug in Mermaid and it should be possible to use `B ---->|No| E[End];`?

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :bookmark: targeted `develop` branch 
