### PR TITLE
Fix typo in n00b-syntaxReference.md

### DIFF
--- a/docs/diagrams-and-syntax-and-examples/n00b-syntaxReference.md
+++ b/docs/diagrams-and-syntax-and-examples/n00b-syntaxReference.md
@@ -8,9 +8,9 @@ title: Diagram syntax intro
 If you are new to mermaid, read the [Getting Started](../getting-started/n00b-gettingStarted.md) and [Overview](../overview/n00b-overview.md) sections, to learn the basics of mermaid.
 Video Tutorials can be found at the bottom of the Overview Section.
 
-This section is a list of diagram types supported by mermaid. Below is a list of links to aricles that explain the syntax of the diagrams or charts that 0can be called.
+This section is a list of diagram types supported by mermaid. Below is a list of links to aricles that explain the syntax of the diagrams or charts that can be called.
 
-They also  detail how diagrams can be defined, or described in the manner with which the diagram is to be rendered by the renderer.
+They also detail how diagrams can be defined, or described in the manner with which the diagram is to be rendered by the renderer.
 
 ### The benefits of text based diagramming are its speed and modifiability. mermaid allows for easy maintenance and modification of diagrams. This means your diagrams will always be up to date and closely follow your code and improve your documentation.  
 


### PR DESCRIPTION
## :bookmark_tabs: Summary
Fix typo in n00b-syntaxReference.md. `s/0can/can/` and remove a double space.

## :straight_ruler: Design Decisions
N/A

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
