### PR TITLE
Fix padding for entities with no attributes

### DIFF
--- a/src/diagrams/er/erRenderer.js
+++ b/src/diagrams/er/erRenderer.js
@@ -32,7 +32,7 @@ export const setConf = function(cnf) {
 const drawAttributes = (groupNode, entityTextNode, attributes) => {
   const heightPadding = conf.entityPadding / 3; // Padding internal to attribute boxes
   const widthPadding = conf.entityPadding / 3; // Ditto
-  const attrFontSize = conf.fontSize * 0.8;
+  const attrFontSize = conf.fontSize * 0.85;
   const labelBBox = entityTextNode.node().getBBox();
   const attributeNodes = []; // Intermediate storage for attribute nodes created so that we can do a second pass
   let maxTypeWidth = 0;
@@ -90,10 +90,15 @@ const drawAttributes = (groupNode, entityTextNode, attributes) => {
   const bBox = {
     width: Math.max(
       conf.minEntityWidth,
-      Math.max(labelBBox.width + widthPadding * 2, maxTypeWidth + maxNameWidth + widthPadding * 4)
+      Math.max(
+        labelBBox.width + conf.entityPadding * 2,
+        maxTypeWidth + maxNameWidth + widthPadding * 4
+      )
     ),
     height:
-      attributes.length > 0 ? cumulativeHeight : Math.max(conf.minEntityHeight, cumulativeHeight)
+      attributes.length > 0
+        ? cumulativeHeight
+        : Math.max(conf.minEntityHeight, labelBBox.height + conf.entityPadding * 2)
   };
 
   // There might be some spare width for padding out attributes if the entity name is very long

--- a/src/diagrams/er/parser/erDiagram.jison
+++ b/src/diagrams/er/parser/erDiagram.jison
@@ -18,7 +18,7 @@
 "erDiagram"                     return 'ER_DIAGRAM';
 "{"                             { this.begin("block"); return 'BLOCK_START'; }
 <block>\s+                      /* skip whitespace in block */
-<block>[A-Za-z][A-Za-z0-9\-_]+  { return 'ATTRIBUTE_WORD'; }
+<block>[A-Za-z][A-Za-z0-9\-_]*  { return 'ATTRIBUTE_WORD'; }
 <block>[\n]+                    /* nothing */
 <block>"}"                      { this.popState(); return 'BLOCK_STOP'; }
 <block>.                        return yytext[0];


### PR DESCRIPTION
## :bookmark_tabs: Summary
Minor changes to sort out padding for entities with no attributes defined. (Also fixed a bug I noticed in the jison which prevented single-character attribute names and types)

Resolves #1756 

## :straight_ruler: Design Decisions
Just needed to set the minimum width (and height) correctly 

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
