### PR TITLE
Re-align gantt chart dateFormat table with spaces

### DIFF
--- a/docs/gantt.md
+++ b/docs/gantt.md
@@ -148,26 +148,26 @@ dateFormat YYYY-MM-DD
 The following formating options are supported:
 
 ```
-Input	Example	Description:
-YYYY	2014	4 digit year
-YY	14	2 digit year
-Q	1..4	Quarter of year. Sets month to first month in quarter.
-M MM	1..12	Month number
-MMM MMMM	January..Dec	Month name in locale set by moment.locale()
-D DD	1..31	Day of month
-Do	1st..31st	Day of month with ordinal
-DDD DDDD	1..365	Day of year
-X	1410715640.579	Unix timestamp
-x	1410715640579	Unix ms timestamp
-H HH	0..23	24 hour time
-h hh	1..12	12 hour time used with a A.
-a A	am pm	Post or ante meridiem
-m mm	0..59	Minutes
-s ss	0..59	Seconds
-S	0..9	Tenths of a second
-SS	0..99	Hundreds of a second
-SSS	0..999	Thousandths of a second
-Z ZZ	+12:00	Offset from UTC as +-HH:mm, +-HHmm, or Z
+Input       Example             Description:
+YYYY        2014                4 digit year
+YY          14                  2 digit year
+Q           1..4                Quarter of year. Sets month to first month in quarter.
+M MM        1..12               Month number
+MMM MMMM    January..Dec        Month name in locale set by moment.locale()
+D DD        1..31               Day of month
+Do          1st..31st           Day of month with ordinal
+DDD DDDD    1..365              Day of year
+X           1410715640.579      Unix timestamp
+x           1410715640579       Unix ms timestamp
+H HH        0..23               24 hour time
+h hh        1..12               12 hour time used with a A.
+a A         am pm               Post or ante meridiem
+m mm        0..59               Minutes
+s ss        0..59               Seconds
+S           0..9                Tenths of a second
+SS          0..99               Hundreds of a second
+SSS         0..999              Thousandths of a second
+Z ZZ        +12:00              Offset from UTC as +-HH:mm, +-HHmm, or Z
 ```
 
 More info in: http://momentjs.com/docs/#/parsing/string-format/


### PR DESCRIPTION
With tabs, the table does not render in a readable way.  This commit is
replacing tabs with spaces.