### PR TITLE
Move babel-eslint to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   },
   "dependencies": {
     "@braintree/sanitize-url": "^3.1.0",
-    "babel-eslint": "^10.1.0",
     "d3": "^5.7.0",
     "dagre": "^0.8.4",
     "dagre-d3": "^0.6.4",
@@ -67,6 +66,7 @@
     "@babel/register": "^7.0.0",
     "@percy/cypress": "*",
     "babel-core": "7.0.0-bridge.0",
+    "babel-eslint": "^10.1.0",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.4",
     "coveralls": "^3.0.2",


### PR DESCRIPTION
## :bookmark_tabs: Summary

It was added to runtime dependencies with bulk commit a4bf85b1b6f16154e1295ef329934d042ab8f46b

refs:
- https://github.com/mermaid-js/mermaid/pull/1586

## :straight_ruler: Design Decisions

Unlikely the eslint is needed runtime, so moved to devDependencies. Unable to deduct the purpose from the commit that introduced it.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
