### PR TITLE
ignore build files in dist folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ node_modules/
 coverage/
 .idea/
 
+dist/*.js
+dist/*.map
+
 yarn-error.log
 .npmrc
 token


### PR DESCRIPTION
## :bookmark_tabs: Summary
Distributing the build files in our dist folder causes trouble so they should be ignored again for the moment.

Resolves #1423

## :straight_ruler: Design Decisions
Reset git ignore file to the state of ignoring dist/*js and dist/*.map

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
