### PR TITLE
Apply style settings to subgraphs in "flowchart" diagrams

### DIFF
--- a/cypress/integration/rendering/flowchart-v2.spec.js
+++ b/cypress/integration/rendering/flowchart-v2.spec.js
@@ -371,6 +371,38 @@ flowchart TD
       {htmlLabels: true, flowchart: {htmlLabels: true}, securityLevel: 'loose'}
     );
   });
+  it('62: should render styled subgraphs', () => {
+    imgSnapshotTest(
+      `
+      flowchart TB
+      A
+      B
+      subgraph foo[Foo SubGraph]
+        C
+        D
+      end
+      subgraph bar[Bar SubGraph]
+        E
+        F
+      end
+      G
 
+      A-->B
+      B-->C
+      C-->D
+      B-->D
+      D-->E
+      E-->A
+      E-->F
+      F-->D
+      F-->G
+      B-->G
+      G-->D
 
+      style foo fill:#F99,stroke-width:2px,stroke:#F0F,color:darkred
+      style bar fill:#999,stroke-width:10px,stroke:#0F0,color:blue
+      `,
+      {htmlLabels: true, flowchart: {htmlLabels: true}, securityLevel: 'loose'}
+    );
+  });
 });

--- a/cypress/integration/rendering/flowchart.spec.js
+++ b/cypress/integration/rendering/flowchart.spec.js
@@ -234,8 +234,8 @@ describe('Flowchart', () => {
       B-->G
       G-->D
 
-      style foo fill:#F99,stroke-width:2px,stroke:#F0F
-      style bar fill:#999,stroke-width:10px,stroke:#0F0
+      style foo fill:#F99,stroke-width:2px,stroke:#F0F,color:darkred
+      style bar fill:#999,stroke-width:10px,stroke:#0F0,color:blue
       `,
        { fontFamily: 'courier' }
     );

--- a/dist/flowchart.html
+++ b/dist/flowchart.html
@@ -501,8 +501,8 @@
     B-->G
     G-->D
 
-    style foo fill:#F99,stroke-width:2px,stroke:#F0F
-    style bar fill:#999,stroke-width:10px,stroke:#0F0
+    style foo fill:#F99,stroke-width:2px,stroke:#F0F,color:darkred
+    style bar fill:#999,stroke-width:10px,stroke:#0F0,color:blue
   </div>
 
   <h3>flowchart</h3>
@@ -532,8 +532,8 @@
     B-->G
     G-->D
 
-    style foo fill:#F99,stroke-width:2px,stroke:#F0F
-    style bar fill:#999,stroke-width:10px,stroke:#0F0
+    style foo fill:#F99,stroke-width:2px,stroke:#F0F,color:darkred
+    style bar fill:#999,stroke-width:10px,stroke:#0F0,color:blue
   </div>
 
   <hr/>

--- a/dist/index.html
+++ b/dist/index.html
@@ -293,8 +293,8 @@ graph TB
   B-->G
   G-->D
 
-  style foo fill:#F99,stroke-width:2px,stroke:#F0F
-  style bar fill:#999,stroke-width:10px,stroke:#0F0
+  style foo fill:#F99,stroke-width:2px,stroke:#F0F,color:darkred
+  style bar fill:#999,stroke-width:10px,stroke:#0F0,color:blue
   </div>
   <div class="mermaid">
       graph LR

--- a/src/dagre-wrapper/clusters.js
+++ b/src/dagre-wrapper/clusters.js
@@ -40,6 +40,7 @@ const rect = (parent, node) => {
   log.trace('Data ', node, JSON.stringify(node));
   // center the rect around its coordinate
   rect
+    .attr('style', node.style)
     .attr('rx', node.rx)
     .attr('ry', node.ry)
     .attr('x', node.x - node.width / 2 - halfPadding)
@@ -53,7 +54,7 @@ const rect = (parent, node) => {
     'translate(' +
       (node.x - bbox.width / 2) +
       ', ' +
-      (node.y - node.height / 2 - node.padding / 3 + 3) +
+      (node.y - node.height / 2 + node.padding / 3) +
       ')'
   );
 


### PR DESCRIPTION
## :bookmark_tabs: Summary
The new flowchart implementation now applies style settings to subgraph boxes.

Resolves #1751

## :straight_ruler: Design Decisions
Added style attribute to subgraph rect.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
