### PR TITLE
Narrow down console logging when flowchart subgraphs are added

### DIFF
--- a/src/diagrams/flowchart/flowDb.js
+++ b/src/diagrams/flowchart/flowDb.js
@@ -453,7 +453,7 @@ export const addSubGraph = function(_id, list, _title) {
   subCount = subCount + 1;
   const subGraph = { id: id, nodes: nodeList, title: title.trim(), classes: [] };
 
-  console.log('Adding', subGraph.id, subGraph.nodes);
+  logger.info('Adding', subGraph.id, subGraph.nodes);
 
   /**
    * Deletes an id from all subgraphs


### PR DESCRIPTION
## :bookmark_tabs: Summary
Adding flowchart subgraphs is now only logged at log level "info" (2).

Resolves #1742

## :straight_ruler: Design Decisions
Replaced `console.log(...)` with `logger.info(...)`.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
