### PR TITLE
docs: update wrong event name in Concurrency section.

### DIFF
--- a/docs/stateDiagram.md
+++ b/docs/stateDiagram.md
@@ -308,8 +308,8 @@ stateDiagram-v2
         CapsLockOn --> CapsLockOff : EvCapsLockPressed
         --
         [*] --> ScrollLockOff
-        ScrollLockOff --> ScrollLockOn : EvCapsLockPressed
-        ScrollLockOn --> ScrollLockOff : EvCapsLockPressed
+        ScrollLockOff --> ScrollLockOn : EvScrollLockPressed
+        ScrollLockOn --> ScrollLockOff : EvScrollLockPressed
     }
 ```
 
@@ -327,8 +327,8 @@ stateDiagram-v2
         CapsLockOn --> CapsLockOff : EvCapsLockPressed
         --
         [*] --> ScrollLockOff
-        ScrollLockOff --> ScrollLockOn : EvCapsLockPressed
-        ScrollLockOn --> ScrollLockOff : EvCapsLockPressed
+        ScrollLockOff --> ScrollLockOn : EvScrollLockPressed
+        ScrollLockOn --> ScrollLockOff : EvScrollLockPressed
     }
 ```
 


### PR DESCRIPTION
## :bookmark_tabs: Summary
In the State diagrams chapter was wrong wording of event name "EvCapsLockPressed" with "ScrollLock" state.

## :straight_ruler: Design Decisions
I change event name "EvCapsLockPressed" to "EvScrollLockPressed".

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :bookmark: targeted `develop` branch 
