### PR TITLE
Added my plugin for google docs

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -108,6 +108,8 @@ They also serve as proof of concept, for the variety of things that can be built
   - [Mermaid Preview](https://s3.amazonaws.com/extend.brackets/alanhohn.mermaid-preview/alanhohn.mermaid-preview-1.0.2.zip)
 - [Iodide](https://github.com/iodide-project/iodide)
   - [iodide-mermaid-plugin](https://github.com/iodide-project/iodide-mermaid-plugin)
+- [Google docs](https://docs.google.com/)
+  - [Mermaid plugin for google docs](https://workspace.google.com/marketplace/app/mermaid/636321283856)
 
 ## Document Generation
 


### PR DESCRIPTION
## :bookmark_tabs: Summary
Added a link to the google docs integration of mermaid
The plugin is free and open source at https://github.com/renanlecaro/mermaid-gdocs 
It lets you create a diagram, insert it in any google document, then edit it later.
It uses the alt description of the image to store the source of the diagram. 
It hotlinks to the latest version of mermaid, to avoid having to update it every time a new version is published

## :straight_ruler: Design Decisions
I wasn't sure in which category to put it, but as there's draw.io there, i thought it would make sense to use the editors category

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
