### PR TITLE
Add class name literals.

### DIFF
--- a/src/diagrams/class/classDiagram.spec.js
+++ b/src/diagrams/class/classDiagram.spec.js
@@ -8,10 +8,30 @@ describe('class diagram, ', function () {
       parser.yy = classDb;
     });
 
+    it('should handle backquoted class names', function() {
+      const str =
+        'classDiagram\n' +
+        'class `Car`';
+
+      parser.parse(str);
+    });
+
     it('should handle relation definitions', function () {
       const str =
         'classDiagram\n' +
         'Class01 <|-- Class02\n' +
+        'Class03 *-- Class04\n' +
+        'Class05 o-- Class06\n' +
+        'Class07 .. Class08\n' +
+        'Class09 -- Class1';
+
+      parser.parse(str);
+    });
+
+    it('should handle backquoted relation definitions', function () {
+      const str =
+        'classDiagram\n' +
+        '`Class01` <|-- Class02\n' +
         'Class03 *-- Class04\n' +
         'Class05 o-- Class06\n' +
         'Class07 .. Class08\n' +
@@ -67,6 +87,17 @@ describe('class diagram, ', function () {
       parser.parse(str);
     });
 
+    it('should handle generic class with a literal name', function() {
+      const str =
+        'classDiagram\n' +
+        'class `Car`~T~\n' +
+        'Driver -- `Car` : drives >\n' +
+        '`Car` *-- Wheel : have 4 >\n' +
+        '`Car` -- Person : < owns';
+
+      parser.parse(str);
+    });
+
     it('should break when another `{`is encountered before closing the first one while defining generic class with brackets', function() {
       const str =
         'classDiagram\n' +
@@ -113,6 +144,22 @@ describe('class diagram, ', function () {
       const str =
         'classDiagram\n' +
         'class Dummy_Class~T~ {\n' +
+        'String data\n' +
+        '  void methods()\n' +
+        '}\n' +
+        '\n' +
+        'class Flight {\n' +
+        '   flightNumber : Integer\n' +
+        '   departureTime : Date\n' +
+        '}';
+
+        parser.parse(str);
+    });
+
+    it('should handle generic class with brackets and a literal name', function() {
+      const str =
+        'classDiagram\n' +
+        'class `Dummy_Class`~T~ {\n' +
         'String data\n' +
         '  void methods()\n' +
         '}\n' +

--- a/src/diagrams/class/parser/classDiagram.jison
+++ b/src/diagrams/class/parser/classDiagram.jison
@@ -7,6 +7,7 @@
 /* lexical grammar */
 %lex
 %x string
+%x bqstring
 %x generic
 %x struct
 %x href
@@ -48,6 +49,10 @@
 ["]                   this.begin("string");
 <string>["]           this.popState();
 <string>[^"]*         return "STR";
+
+[`]                   this.begin("bqstring");
+<bqstring>[`]         this.popState();
+<bqstring>[^`]+       return "BQUOTE_STR";
 
 /*
 ---interactivity command---
@@ -214,10 +219,15 @@ statements
     ;
 
 className
-    : alphaNumToken { $$=$1; }
+    : 
+    | alphaNumToken { $$=$1; }
+    | classLiteralName { $$=$1; }
     | alphaNumToken className { $$=$1+$2; }
+    | classLiteralName className { $$=$1+$2; }
     | alphaNumToken GENERICTYPE className { $$=$1+'~'+$2+$3; }
+    | classLiteralName GENERICTYPE className { $$=$1+'~'+$2+$3; }
     | alphaNumToken GENERICTYPE { $$=$1+'~'+$2; }
+    | classLiteralName GENERICTYPE { $$=$1+'~'+$2; }
     ;
 
 statement
@@ -308,5 +318,7 @@ textToken      : textNoTagsToken | TAGSTART | TAGEND | '=='  | '--' | PCT | DEFA
 textNoTagsToken: alphaNumToken | SPACE | MINUS | keywords ;
 
 alphaNumToken  : UNICODE_TEXT | NUM | ALPHA;
+
+classLiteralName : BQUOTE_STR;
 
 %%


### PR DESCRIPTION
## :bookmark_tabs: Summary
Add the ability to have literal class names.

This helps with, but does not fully resolve:

- #1506
- #1546
- #1635

## :straight_ruler: Design Decisions
We've frequently discovered while using mermaid issues with the allowed class names.  We work in Ruby, so not being able to have a double colon ("::") in our class names is a big blocker to switching to mermaid.  This PR allows class name literals to be enclosed in backticks, so literal class names may be used even if they contain special characters.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
