### PR TITLE
Improve docs around escape characters

### DIFF
--- a/docs/flowchart.md
+++ b/docs/flowchart.md
@@ -497,6 +497,8 @@ It is possible to escape characters using the syntax exemplified here.
         A["A double quote:#quot;"] -->B["A dec char:#9829;"]
 ```
 
+Numbers given are base 10, so `#` can be encoded as `#35;`. It is also supported to use HTML character names.
+
 ## Subgraphs
 
 ```

--- a/docs/sequenceDiagram.md
+++ b/docs/sequenceDiagram.md
@@ -347,6 +347,23 @@ sequenceDiagram
     John-->>Alice: Great!
 ```
 
+## Entity codes to escape characters
+
+It is possible to escape characters using the syntax exemplified here.
+
+```
+sequenceDiagram
+    A->>B: I #9829; you!
+    B->>A: I #9829; you #infin; times more!
+```
+```mermaid
+sequenceDiagram
+    A->>B: I #9829; you!
+    B->>A: I #9829; you #infin; times more!
+```
+
+Numbers given are base 10, so `#` can be encoded as `#35;`. It is also supported to use HTML character names.
+
 ## sequenceNumbers
 
 It is possible to get a sequence number attached to each arrow in a sequence diagram. This can be configured when adding mermaid to the website as shown below:


### PR DESCRIPTION
## :bookmark_tabs: Summary

It took me some time to figure out how one would escape the `#` character. The improvements would have helped me.

## :straight_ruler: Design Decisions

Only docs changes. It might make sense to have a general character escape section somewhere but I could not figure out which page would be suited best.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [ ] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
