### PR TITLE
Fix broken image path

### DIFF
--- a/docs/flowchart.md
+++ b/docs/flowchart.md
@@ -1,6 +1,6 @@
 # Flowcharts - Basic Syntax
 
-**Edit this Page** [![N|Solid](.img/GitHub-Mark-32px.png)](https://github.com/mermaid-js/mermaid/blob/develop/docs/flowchart.md)
+**Edit this Page** [![N|Solid](img/GitHub-Mark-32px.png)](https://github.com/mermaid-js/mermaid/blob/develop/docs/flowchart.md)
 
 ## Graph
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

The image path used for the GitHub icon for the Edit this page link is broken on the Flowchart doc page.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: no unit/e2e tests necessary
- [x] :bookmark: targeted `develop` branch 
