### PR TITLE
The vertical position was wrongly based on index in sorted array.

### DIFF
--- a/src/diagrams/gantt/ganttRenderer.js
+++ b/src/diagrams/gantt/ganttRenderer.js
@@ -189,6 +189,9 @@ export const draw = function(text, id) {
       })
       .attr('height', theBarHeight)
       .attr('transform-origin', function(d, i) {
+        // Ignore the incoming i value and use our order instead
+        i = d.order;
+
         return (
           (
             timeScale(d.startTime) +


### PR DESCRIPTION


## :bookmark_tabs: Summary
The vertical transformation-origin was based on the index of the task in the sorted tasks array. It must be computed on d.order like y value.

Resolves #1651 

## :straight_ruler: Design Decisions
Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks
Make sure you
- [ X] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [ ] :computer: have added unit/e2e tests (if appropriate) 
- [ X] :bookmark: targeted `develop` branch 
