### PR TITLE
#1317 : Add state id to state diagram.  Move description below separa…

### DIFF
--- a/src/diagrams/state/shapes.js
+++ b/src/diagrams/state/shapes.js
@@ -79,7 +79,7 @@ export const drawDescrState = (g, stateDef) => {
     .attr('y', getConfig().state.textHeight + 1.3 * getConfig().state.padding)
     .attr('font-size', getConfig().state.fontSize)
     .attr('class', 'state-title')
-    .text(stateDef.descriptions[0]);
+    .text(stateDef.id);
 
   const titleBox = title.node().getBBox();
   const titleHeight = titleBox.height;
@@ -94,7 +94,8 @@ export const drawDescrState = (g, stateDef) => {
         getConfig().state.dividerMargin +
         getConfig().state.textHeight
     )
-    .attr('class', 'state-description');
+    .attr('class', 'state-description')
+    .text(stateDef.descriptions[0]);
 
   let isFirst = true;
   let isSecond = true;


### PR DESCRIPTION
Fix issue #1317

## :bookmark_tabs: Summary
Add state id to state diagram.  Move state description below separator.

Resolves #1317

## :straight_ruler: Design Decisions
Make use of element id in a manner more consistent with other diagram types.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [ ] :bookmark: targeted `develop` branch 
