### PR TITLE
fix: re-write id generator

### DIFF
--- a/src/mermaid.js
+++ b/src/mermaid.js
@@ -78,7 +78,7 @@ const init = function() {
     mermaidAPI.updateSiteConfig({ gantt: mermaid.ganttConfig });
   }
 
-  const idGeneratior = utils.initIdGeneratior(conf.deterministicIds, conf.deterministicIDSeed);
+  const idGeneratior = new utils.initIdGeneratior(conf.deterministicIds, conf.deterministicIDSeed);
 
   let txt;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -794,11 +794,11 @@ export const configureSvgSize = function(svgElem, height, width, useMaxWidth) {
 };
 
 export const initIdGeneratior = class iterator {
-  constructor (deterministic, seed) {
+  constructor(deterministic, seed) {
     this.deterministic = deterministic;
     this.seed = seed;
 
-    this.count = seed ? seed.length : 0
+    this.count = seed ? seed.length : 0;
   }
 
   next() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -793,17 +793,19 @@ export const configureSvgSize = function(svgElem, height, width, useMaxWidth) {
   d3Attrs(svgElem, attrs);
 };
 
-export const initIdGeneratior = function(deterministic, seed) {
-  if (!deterministic) return { next: () => Date.now() };
-  class iterator {
-    constructor() {
-      return (this.count = seed ? seed.length : 0);
-    }
-    next() {
-      return this.count++;
-    }
+export const initIdGeneratior = class iterator {
+  constructor (deterministic, seed) {
+    this.deterministic = deterministic;
+    this.seed = seed;
+
+    this.count = seed ? seed.length : 0
   }
-  return new iterator();
+
+  next() {
+    if (!this.deterministic) return Date.now();
+
+    return this.count++;
+  }
 };
 
 export default {

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -256,7 +256,7 @@ describe('when calculating SVG size', function() {
 
 describe('when initializing the id generator', function () {
   it('should return a random number generator based on Date', function (done) {
-    const idGenerator = utils.initIdGeneratior(false)
+    const idGenerator = new utils.initIdGeneratior(false)
     expect(typeof idGenerator.next).toEqual('function')
     const lastId = idGenerator.next()
     setTimeout(() => {
@@ -266,7 +266,7 @@ describe('when initializing the id generator', function () {
   });
 
   it('should return a non random number generator', function () {
-    const idGenerator = utils.initIdGeneratior(true)
+    const idGenerator = new utils.initIdGeneratior(true)
     expect(typeof idGenerator.next).toEqual('function')
     const start = 0
     const lastId = idGenerator.next()
@@ -275,7 +275,7 @@ describe('when initializing the id generator', function () {
   });
 
   it('should return a non random number generator based on seed', function () {
-    const idGenerator = utils.initIdGeneratior(true, 'thisIsASeed')
+    const idGenerator = new utils.initIdGeneratior(true, 'thisIsASeed')
     expect(typeof idGenerator.next).toEqual('function')
     const start = 11
     const lastId = idGenerator.next()


### PR DESCRIPTION
## :bookmark_tabs: Summary

this is a continuation of the fix I introduced in #1935 and now that the latest cli was released, I was able to use it in production examples, but I ran into yet another problem ...

## :straight_ruler: Design Decisions

it seems, that after compiling / minification, the `initIdGenerator` method, produces corrupted behaviour, due to the nature of how it's originally written _(a function that returns a class instance)_

here's the result of the compiled / minified output:

![image](https://user-images.githubusercontent.com/183195/114456966-7d5ea680-9bab-11eb-84a0-47191cf821af.png)

note the line: 

```js
for (var a, o = H.initIdGeneratior(r.deterministicIds, r.deterministicIDSeed).next, s = function (r) {
```

by declaring the variable `o` as `o = H.initIdGeneratior(r.deterministicIds, r.deterministicIDSeed).next` the context of `this` is lost when later called `o()` and thus the `counter` in the original class is pointing to a non-existing property....

**this is not an issue in the source code, but rather the babel compiled result** so this wasn't captured in any tests for that reason...

all this resulted in `Cannot read property 'count' of undefined` when `deterministicIds = true` 

I re-wrote the function call very simply to keep the same original code structure without having to do a major re-write of anything else inter-connected or related...

I then ran `build` and `minify` steps and manually replaced the `mermaid.min.js` file manually at `node_modules/@mermaid-js/mermaid-cli/mermaid.min.js` and tested the CLI to confirm no further issues. (and confirmed that deterministicIds are in fact working)


### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
