### PR TITLE
Add Tuleap in the integration list

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -9,6 +9,7 @@ They also serve as proof of concept, for the variety of things that can be built
 
 - [GitLab](https://docs.gitlab.com/ee/user/markdown.html#diagrams-and-flowcharts) (**Native support**)
 - [Azure Devops](https://docs.microsoft.com/en-us/azure/devops/project/wiki/wiki-markdown-guidance?view=azure-devops#add-mermaid-diagrams-to-a-wiki-page) (**Native support**)
+- [Tuleap](https://docs.tuleap.org/user-guide/writing-in-tuleap.html#graphs) (**Native support**)
 - [GitHub](https://github.com)
   - [Github action: Compile mermaid to image](https://github.com/neenjaw/compile-mermaid-markdown-action)
   - [svg-generator](https://github.com/SimonKenyonShepard/mermaidjs-github-svg-generator)


### PR DESCRIPTION
## :bookmark_tabs: Summary

[Tuleap](https://tuleap.org) open source agile development hub [just added](https://www.tuleap.org/resources/release-notes/tuleap-12-7/) support of mermaid.

This patch reference this integration in the integration list.

Resolves #1987

### :clipboard: Tasks
Make sure you
- [X] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [ ] :computer: have added unit/e2e tests (not relevant) 
- [X] :bookmark: targeted `develop` branch 
