### PR TITLE
dateFormat must not have ':'

### DIFF
--- a/docs/theming.md
+++ b/docs/theming.md
@@ -461,7 +461,7 @@ classDiagram
 ### Gantt
 ```
 gantt
-       dateFormat                :YYYY-MM-DD
+       dateFormat                YYYY-MM-DD
        title                     Adding GANTT diagram functionality to mermaid
        excludes                  :excludes the named dates/days from being included in a charted task..
        section A section
@@ -491,7 +491,7 @@ gantt
 
 ```mermaid
 gantt
-       dateFormat                :YYYY-MM-DD
+       dateFormat                YYYY-MM-DD
        title                     Adding GANTT diagram functionality to mermaid
        excludes                  :excludes the named dates/days from being included in a charted task..
        section A section


### PR DESCRIPTION
## :bookmark_tabs: Summary
dateFormat should not have ': colon'

## :straight_ruler: Design Decisions
According to the Docs (as well as in testing) the dateFormat should not have the ': colon' before it else it fails, hence the Adding mermaid > Theming > Examples > Gantt  | The Gantt example itself has wrong dates on the axis and does not show the "section A section" .. "Completed task"

![image](https://user-images.githubusercontent.com/3067891/115959771-21324580-a50e-11eb-82a4-dda9676bb857.png)

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 