### PR TITLE
Document <<choice>> in the state diagram page

### DIFF
--- a/docs/stateDiagram.md
+++ b/docs/stateDiagram.md
@@ -228,6 +228,28 @@ stateDiagram-v2
 
 *You can not define transitions between internal states belonging to different composite states*
 
+## Choice
+
+Sometimes you need to model a choice between two or more paths, you can do so using &lt;&lt;choice&gt;&gt;.
+
+```
+stateDiagram-v2
+    state if_state <<choice>>
+    [*] --> IsPositive
+    IsPositive --> if_state
+    if_state --> False: if n < 0
+    if_state --> True : if n >= 0
+```
+
+```mermaid
+stateDiagram-v2
+    state if_state <<choice>>
+    [*] --> IsPositive
+    IsPositive --> if_state
+    if_state --> False: if n < 0
+    if_state --> True : if n >= 0
+```
+
 ## Forks
 
 It is possible to specify a fork in the diagram using &lt;&lt;fork&gt;&gt; &lt;&lt;join&gt;&gt;.


### PR DESCRIPTION
Add documentation for `<<choice>>` in state diagrams.

I noticed it is supported but not documented, so I wrote it.

Preview:
![image](https://user-images.githubusercontent.com/15343819/118270001-44ba3180-b4b7-11eb-9662-377024da9168.png)

