### PR TITLE
fixed typo in `Setup.md`

### DIFF
--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -97,7 +97,7 @@ Default value: '"trebuchet ms", verdana, arial, sans-serif;'.
 
 **Notes**:
 
--   **strict**: (**default**) tags in text are encoded, click functionality is disabeled
+-   **strict**: (**default**) tags in text are encoded, click functionality is disabled
 -   **loose**: tags in text are allowed, click functionality is enabled
 -   **antiscript**: html tags in text are allowed, (only script element is removed), click functionality is enabled
 

--- a/src/defaultConfig.js
+++ b/src/defaultConfig.js
@@ -89,7 +89,7 @@ const config = {
    *
    * **Notes**:
    *
-   * - **strict**: (**default**) tags in text are encoded, click functionality is disabeled
+   * - **strict**: (**default**) tags in text are encoded, click functionality is disabled
    * - **loose**: tags in text are allowed, click functionality is enabled
    * - **antiscript**: html tags in text are allowed, (only script element is removed), click functionality is enabled
    */


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fixed typo in `securityLevel` document.

