### PR TITLE
fix: Assign proper namespaces to foreignObject children

### DIFF
--- a/src/diagrams/sequence/svgDraw.js
+++ b/src/diagrams/sequence/svgDraw.js
@@ -532,7 +532,7 @@ const _drawTextCandidateFunc = (function() {
       .attr('height', height);
 
     const text = f
-      .append('div')
+      .append('xhtml:div')
       .style('display', 'table')
       .style('height', '100%')
       .style('width', '100%');

--- a/src/diagrams/user-journey/svgDraw.js
+++ b/src/diagrams/user-journey/svgDraw.js
@@ -370,7 +370,7 @@ const _drawTextCandidateFunc = (function() {
       .attr('position', 'fixed');
 
     const text = f
-      .append('div')
+      .append('xhtml:div')
       .style('display', 'table')
       .style('height', '100%')
       .style('width', '100%');


### PR DESCRIPTION
## :bookmark_tabs: Summary
This fixes a bug where if the mermaid diagram is rendered directly (without being taken out as `innerHTML` and going through the HTML parser again after it was first rendered), journey diagrams will not properly show task text, due to these foreignObjects being created in the `svg` namespace. This patch adds the `xhtml` namespace for the `div` elements so that they are created in the proper namespace.

Illustration of the problem:
![image](https://user-images.githubusercontent.com/609710/120940082-5e7f1b00-c6e9-11eb-9804-792def7b112c.png)

## :straight_ruler: Design Decisions
Inspired by the usage of `xhtml:div` here: https://github.com/mermaid-js/mermaid/blob/e6e94ad57ea06ef8627bf91ddfbd88f5082952bf/src/dagre-wrapper/createLabel.js#L65

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [ ] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
