### PR TITLE
#2125 Switching default renderer for state diagrams

### DIFF
--- a/src/defaultConfig.js
+++ b/src/defaultConfig.js
@@ -966,7 +966,7 @@ top of the chart
      *
      * Default value: 'dagre-d3'
      */
-    defaultRenderer: 'dagre-d3'
+    defaultRenderer: 'dagre-wrapper'
   },
 
   /**


### PR DESCRIPTION
## :bookmark_tabs: Summary
Switches the default renderer for state diagrams so that stateDiagram and stateDiagram-v2 both use the new and improved renderer.

Resolves #2125

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
