### PR TITLE
docs(README): Point to live editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ But not having diagrams or docs ruins productivity and hurts organizational lear
 Mermaid addresses this problem by cutting the time, effort and tooling that is required to create modifiable diagrams and charts, for smarter and more reusable content.
 The text definitions for Mermaid diagrams allows for it to be updated easily, it can also be made part of production scripts (and other pieces of code).
 So less time needs to be spent on documenting, as a separate and laborious task. <br/>
-Even non-programmers can create diagrams through the [Mermaid Live Editor](https://github.com/mermaid-js/mermaid-live-editor).<br/>
+Even non-programmers can create diagrams through the [Mermaid Live Editor](https://mermaid-js.github.io/mermaid-live-editor/).<br/>
 [Tutorials](./docs/Tutorials.md) has video tutorials.
 Use Mermaid with your favorite applications, check out the list of [Integrations and Usages of Mermaid](./docs/integrations.md).
 


### PR DESCRIPTION
Perhaps it makes more sense to point directly to the live editor where a user can start playing around, instead of the repo for the live editor (which is still reachable from the editor itself).

## :bookmark_tabs: Summary
Change link to point to live editor (instead of its repo).


## :straight_ruler: Design Decisions
Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
