### PR TITLE
Fixed Unequal Arrow Bug

### DIFF
--- a/src/diagrams/flowchart/styles.js
+++ b/src/diagrams/flowchart/styles.js
@@ -38,7 +38,7 @@ const getStyles = (options) =>
 
   .edgePath .path {
     stroke: ${options.lineColor};
-    stroke-width: 1.5px;
+    stroke-width: 2.0px;
   }
 
   .flowchart-link {


### PR DESCRIPTION
## :bookmark_tabs: Summary
Changed the strokewidth attribute of .edgepath and .path

Resolves #1794 

## :straight_ruler: Design Decisions
Checked the given input in the developer console and concluded that changing the strokewidth attribute from 1.5px to 2px fixes the unequal arrowhead issue.

### :clipboard: Tasks
Make sure you
- [ ] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [ ] :computer: have added unit/e2e tests (if appropriate) 
- [ ] :bookmark: targeted `develop` branch 
