### PR TITLE
Switch default renderer for class diagrams to the next generation renderer

### DIFF
--- a/src/defaultConfig.js
+++ b/src/defaultConfig.js
@@ -900,7 +900,7 @@ top of the chart
      *
      * Default value: 'dagre-d3'
      */
-    defaultRenderer: 'dagre-d3',
+    defaultRenderer: 'dagre-wrapper',
   },
   git: {
     arrowMarkerAbsolute: false,


### PR DESCRIPTION
The new version of class diagrams have better looks & support for htmlLabels. This will be the default renderer from now on. The new renderer will open the possibilities for future new functionalities and synergies with the other diagrams.

It will still be able to revert to the old version by changing defaultRenderer to 'dagre-d3' in your configuration under the class section.
## :bookmark_tabs: Summary
Brief description about the content of your PR.

Resolves #<your issue id here>

## :straight_ruler: Design Decisions
Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
