### PR TITLE
chore(ci) : fix pr-labeler failure

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,4 +1,3 @@
 'Type: Bug / Error': 'bug/*'
 'Type: Enhancement': 'feature/*'
 'Type: Other': 'other/*'
-'Type: Dependabot': 'dependabot/*'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,6 +1,6 @@
 name: Apply labels to PR
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:


### PR DESCRIPTION
## :bookmark_tabs: Summary

Resolves #2297

## 📏 Design Decisions

I have removed dependabot label in .github/pr-labeler.yml as the PR are already labeled by dependabot

### :clipboard: Tasks
Make sure you
- [X] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [ ] :computer: have added unit/e2e tests (if appropriate) 
- [X] :bookmark: targeted `develop` branch 
