### PR TITLE
Fix live editor link

### DIFF
--- a/docs/n00b-gettingStarted.md
+++ b/docs/n00b-gettingStarted.md
@@ -19,7 +19,7 @@ This section talks about the different ways to deploy Mermaid. Learning the [Syn
 
 > More in depth information can be found on [Usage](./usage.md).
 
-## 1. Using [The Live Editor](https://mermaidjs.github.io/mermaid-live-editor/edit).
+## 1. Using [The Live Editor](https://mermaid-js.github.io/mermaid-live-editor/edit).
 
 ![EditingProcess](./img/Editing-process.png)
 


### PR DESCRIPTION
## :bookmark_tabs: Summary
Fix live editor link in getting started docs.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
~- [ ] :computer: have added unit/e2e tests (if appropriate) ~
- [x] :bookmark: targeted `develop` branch 
