### PR TITLE
Optional starting value for sequence diagram auto numbering

### DIFF
--- a/src/diagrams/sequence/parser/sequenceDiagram.jison
+++ b/src/diagrams/sequence/parser/sequenceDiagram.jison
@@ -28,6 +28,7 @@
 <arg_directive>((?:(?!\}\%\%).|\n)*)                            return 'arg_directive';
 [\n]+                                                           return 'NEWLINE';
 \s+                                                             /* skip all whitespace */
+\d+                                                             return 'NUMBER';
 <ID,ALIAS,LINE>((?!\n)\s)+                                      /* skip same-line whitespace */
 <INITIAL,ID,ALIAS,LINE,arg_directive,type_directive,open_directive>\#[^\n]*   /* skip comments */
 \%%(?!\{)[^\n]*                                                 /* skip comments */
@@ -59,6 +60,7 @@
 "title"                                                         return 'title';
 "sequenceDiagram"                                               return 'SD';
 "autonumber"                                                    return 'autonumber';
+"start from"                                                    return 'start_from';
 ","                                                             return ',';
 ";"                                                             return 'NEWLINE';
 [^\+\->:\n,;]+((?!(\-x|\-\-x|\-\)|\-\-\)))[\-]*[^\+\->:\n,;]+)*             { yytext = yytext.trim(); return 'ACTOR'; }
@@ -113,7 +115,8 @@ statement
 	| 'participant_actor' actor 'AS' restOfLine 'NEWLINE' {$2.type='addActor';$2.description=yy.parseMessage($4); $$=$2;}
 	| 'participant_actor' actor 'NEWLINE' {$2.type='addActor'; $$=$2;}
 	| signal 'NEWLINE'
-	| autonumber {yy.enableSequenceNumbers()}
+	| 'autonumber' 'start_from' 'NUMBER' 'NEWLINE' {yy.enableSequenceNumbers($3)}
+	| 'autonumber' 'NEWLINE' {yy.enableSequenceNumbers(1)}
 	| 'activate' actor 'NEWLINE' {$$={type: 'activeStart', signalType: yy.LINETYPE.ACTIVE_START, actor: $2};}
 	| 'deactivate' actor 'NEWLINE' {$$={type: 'activeEnd', signalType: yy.LINETYPE.ACTIVE_END, actor: $2};}
 	| note_statement 'NEWLINE'

--- a/src/diagrams/sequence/sequenceDb.js
+++ b/src/diagrams/sequence/sequenceDb.js
@@ -9,6 +9,7 @@ const notes = [];
 let title = '';
 let titleWrapped = false;
 let sequenceNumbersEnabled = false;
+let sequenceNumbersStart = 1;
 let wrapEnabled = false;
 
 export const parseDirective = function (statement, context, type) {
@@ -124,10 +125,12 @@ export const getTitle = function () {
 export const getTitleWrapped = function () {
   return titleWrapped;
 };
-export const enableSequenceNumbers = function () {
+export const enableSequenceNumbers = function (start) {
   sequenceNumbersEnabled = true;
+  sequenceNumbersStart = start;
 };
 export const showSequenceNumbers = () => sequenceNumbersEnabled;
+export const getSequenceNumbersStart = () => sequenceNumbersStart;
 
 export const setWrap = function (wrapSetting) {
   wrapEnabled = wrapSetting;
@@ -403,6 +406,7 @@ export default {
   setWrap,
   enableSequenceNumbers,
   showSequenceNumbers,
+  getSequenceNumbersStart,
   getMessages,
   getActors,
   getActor,

--- a/src/diagrams/sequence/sequenceRenderer.js
+++ b/src/diagrams/sequence/sequenceRenderer.js
@@ -574,7 +574,7 @@ export const draw = function (text, id) {
   }
 
   // Draw the messages/signals
-  let sequenceIndex = 1;
+  let sequenceIndex = sequenceDb.getSequenceNumbersStart();
   messages.forEach(function (msg) {
     let loopModel, noteModel, msgModel;
 


### PR DESCRIPTION
## :bookmark_tabs: Summary
This change allows users to specify a starting value for `autonumbers` in sequence diagrams. To describe my usecase: I have a very large sequence diagram that I want to split into multiple smaller ones while guaranteeing unique sequence ids.

Example:

```
sequenceDiagram
  autonumber start from 4
  Kenobi->>+Grievous: Hello there!
  Grievous-->>Kenobi: General Kenobi!
  deactivate Grievous
```
which renders to

![image](https://user-images.githubusercontent.com/51596/135448688-0f1d91e5-683e-4dff-a7d7-e6f4f320c181.png)


## :straight_ruler: Design Decisions
To fit the verbose syntax of mermaid (compare `note left of ...`), I've adapted autonumber to take an optional argument using the command `start from`.
This argument is passed to the function `enableSequenceNumbers` - it might be cleaner to offer a separate setter, e.g. `setSequenceNumbersStart`.

It currently is not possible to set the start value from mermaid's config, nor are there test. I'll start implementing this once this general idea is accepted.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [ ] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
