### PR TITLE
Add initThrowsErrors()

### DIFF
--- a/src/mermaid.js
+++ b/src/mermaid.js
@@ -37,7 +37,7 @@ const init = function () {
       this.parseError(e);
     }
   }
-}
+};
 
 const initThrowsErrors = function () {
   const conf = mermaidAPI.getConfig();

--- a/src/mermaid.js
+++ b/src/mermaid.js
@@ -117,7 +117,7 @@ const initThrowsErrors = function () {
     if (init) {
       log.debug('Detected early reinit: ', init);
     }
-    
+
     mermaidAPI.render(
       id,
       txt,

--- a/src/mermaid.js
+++ b/src/mermaid.js
@@ -28,6 +28,18 @@ import utils from './utils';
  * @param nodes a css selector or an array of nodes
  */
 const init = function () {
+  try {
+    initThrowsErrors();
+  } catch (e) {
+    log.warn('Syntax Error rendering');
+    log.warn(e);
+    if (this.parseError) {
+      this.parseError(e);
+    }
+  }
+}
+
+const initThrowsErrors = function () {
   const conf = mermaidAPI.getConfig();
   // console.log('Starting rendering diagrams (init) - mermaid.init', conf);
   let nodes;
@@ -105,27 +117,19 @@ const init = function () {
     if (init) {
       log.debug('Detected early reinit: ', init);
     }
-
-    try {
-      mermaidAPI.render(
-        id,
-        txt,
-        (svgCode, bindFunctions) => {
-          element.innerHTML = svgCode;
-          if (typeof callback !== 'undefined') {
-            callback(id);
-          }
-          if (bindFunctions) bindFunctions(element);
-        },
-        element
-      );
-    } catch (e) {
-      log.warn('Syntax Error rendering');
-      log.warn(e);
-      if (this.parseError) {
-        this.parseError(e);
-      }
-    }
+    
+    mermaidAPI.render(
+      id,
+      txt,
+      (svgCode, bindFunctions) => {
+        element.innerHTML = svgCode;
+        if (typeof callback !== 'undefined') {
+          callback(id);
+        }
+        if (bindFunctions) bindFunctions(element);
+      },
+      element
+    );
   }
 };
 


### PR DESCRIPTION
## :bookmark_tabs: Summary
looking into several issues related to propagating the syntax errors from mermaid to other clients, e.g. mermaid-cli. By inspecting the code of mermaid.js (https://github.com/mermaid-js/mermaid/blob/d0408832868b45f70756f9d9ebcd6271eab20218/src/mermaid.js#L122), I can see that all errors are caught on the mermaid level and never propagated to the clients. That is a problem described in several issues. One is here (https://github.com/mermaid-js/mermaid-cli/issues/138)

Resolves #2378

## :straight_ruler: Design Decisions
Make another function called init(), rename existing one to initThrowsErrors(). The new init() calls initThrowsErrors() and try-catch lives in init(). Then clients can choose either to call init() or initThrowsErrors()

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [ ] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
