### PR TITLE
WIP: Color flowchart arrow heads according to link style

### DIFF
--- a/cypress/integration/rendering/flowchart.spec.js
+++ b/cypress/integration/rendering/flowchart.spec.js
@@ -893,4 +893,14 @@ graph TD
       {htmlLabels: true, flowchart: {htmlLabels: true}, securityLevel: 'loose'}
     );
   });
+  it('66: arrow color from linkStyle classes', () => {
+    imgSnapshotTest(
+      `
+      flowchart LR
+        linkStyle default stroke:#f00,stroke-width:2px;
+        Lorem --> Ipsum --> Dolor
+      `,
+      {htmlLabels: true, flowchart: {htmlLabels: true}, securityLevel: 'loose'}
+    );
+  });
 });

--- a/src/dagre-wrapper/markers.js
+++ b/src/dagre-wrapper/markers.js
@@ -133,6 +133,7 @@ const point = (elem, type) => {
     .attr('markerWidth', 12)
     .attr('markerHeight', 12)
     .attr('orient', 'auto')
+    .attr('style', 'fill:#f00;stroke:#f00')
     .append('path')
     .attr('d', 'M 0 0 L 10 5 L 0 10 z')
     .attr('class', 'arrowMarkerPath')


### PR DESCRIPTION
## :bookmark_tabs: Summary
I'm trying to find a solution for #1236 where flowchart arrow heads are not colored according to style. The bug fix is not complete yet, I hope it's OK to open a Work-In-Progress pull request to discuss whether I'm on the right track here.

Resolves #1236

## :straight_ruler: Design Decisions
Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
