### PR TITLE
Add Notion to integrations.md

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -11,6 +11,7 @@ They also serve as proof of concept, for the variety of things that can be built
 - [Azure Devops](https://docs.microsoft.com/en-us/azure/devops/project/wiki/wiki-markdown-guidance?view=azure-devops#add-mermaid-diagrams-to-a-wiki-page) (**Native support**)
 - [Tuleap](https://docs.tuleap.org/user-guide/writing-in-tuleap.html#graphs) (**Native support**)
 - [Joplin](https://joplinapp.org) (**Native support**)
+- [Notion](https://notion.so) (**Native support**)
 - [GitHub](https://github.com)
   - [GitHub action: Compile mermaid to image](https://github.com/neenjaw/compile-mermaid-markdown-action)
   - [svg-generator](https://github.com/SimonKenyonShepard/mermaidjs-github-svg-generator)


### PR DESCRIPTION
## :bookmark_tabs: Summary
Notion [recently released](https://www.notion.so/What-s-New-157765353f2c4705bd45474e5ba8b46c) native support for Mermaid.js blocks. This PR adds Notion to the list of available integrations listed in the docs.