### PR TITLE
docs: fix broken image links in gantt.md

### DIFF
--- a/docs/gantt.md
+++ b/docs/gantt.md
@@ -7,11 +7,11 @@
 
 
  It is important to remember that when a date, day, or collection of dates specific to a task are "excluded", the Gantt Chart will accomodate those changes by extending an equal number of days, towards the right, not by creating a gap inside the task.
- As shown here ![](.img/Gantt-excluded-days-within.png)
+ As shown here ![](./img/Gantt-excluded-days-within.png)
 
 
  However, if the excluded dates are between two tasks that are set to start consecutively, the excluded dates will be skipped graphically and left blank, and the following task will begin after the end of the excluded dates.
- As shown here ![](.img/Gantt-long-weekend-look.png)
+ As shown here ![](./img/Gantt-long-weekend-look.png)
 
  A Gantt chart is useful for tracking the amount of time it would take before a project is finished, but it can also be used to graphically represent "non-working days", with a few tweaks.
 


### PR DESCRIPTION
## :bookmark_tabs: Summary
Two image links are broken; fixed by adding slashes (`![](.img/...` -> `![](./img/...`)

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :bookmark: targeted `develop` branch 
