### PR TITLE
Change "graph" to "flowchart"

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ __The following are some examples of the diagrams, charts and graphs that can be
 </td></tr>
 <tr>
     <td><pre>
-graph TD
+flowchart TD
 A[Hard] -->|Text| B(Round)
 B --> C{Decision}
 C -->|One| D[Result 1]


### PR DESCRIPTION
It seems like the keyword "graph" has been deprecated in favor of "flowchart".  There are some features that "flowchart" renders that "graph" doesn't - the new arrowheads, for instance.  If there's not a reason to leave it as "graph", I propose the example be updated to avoid confusion.