### PR TITLE
Added Mermaid in open source docs to tutorial page

### DIFF
--- a/docs/Tutorials.md
+++ b/docs/Tutorials.md
@@ -37,6 +37,13 @@ https://codepen.io/janzeteachesit/pen/OWWZKN
 
 https://codepen.io/Ryuno-Ki/pen/LNxwgR
 
+## Mermaid in open source docs
+
+[K8s.io Diagram Guide](https://kubernetes.io/docs/contribute/style/diagram-guide/)
+
+[K8s.dev blog: Improve your documentation with Mermaid.js diagrams](https://www.kubernetes.dev/blog/2021/12/01/improve-your-documentation-with-mermaid.js-diagrams/)
+
+
 ## Jupyter Integration with mermaid-js
 
 Here's an example of Python integration with mermaid-js which uses the mermaid.ink service, that displays the graph in a Jupyter notebook.


### PR DESCRIPTION
## :bookmark_tabs: Summary
Added `Mermaid in open source docs` section to tutorials page. Included links to Kubernetes docs discussing Mermaid.js.

Resolves # N/A

## :straight_ruler: Design Decisions

N/A

### :clipboard: Tasks
Make sure you
- [ ] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [ ] :computer: have added unit/e2e tests (if appropriate) 
- [ ] :bookmark: targeted `develop` branch 
