### PR TITLE
Remove console.log from common.js

### DIFF
--- a/src/diagrams/common/common.js
+++ b/src/diagrams/common/common.js
@@ -18,8 +18,6 @@ export const removeEscapes = (text) => {
     return String.fromCharCode(parseInt(match.replace(/\\u/g, ''), 16));
   });
 
-  console.log(newStr);
-
   newStr = newStr.replace(/\\x([0-9a-f]{2})/gi, (_, c) => String.fromCharCode(parseInt(c, 16)));
   newStr = newStr.replace(/\\[\d\d\d]{3}/gi, function (match) {
     return String.fromCharCode(parseInt(match.replace(/\\/g, ''), 8));


### PR DESCRIPTION
Remove console.log from removeEscapes method

## :bookmark_tabs: Summary

Removes a console.log introduced in https://github.com/mermaid-js/mermaid/commit/6f800be33be08d543f27b1fc995b23a4fdeecd01

## :straight_ruler: Design Decisions
n/a
### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
