### PR TITLE
Reference mkdocs-mermaid2-plugin for MkDocs

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -132,7 +132,7 @@ They also serve as proof of concept, for the variety of things that can be built
 - [jSDoc](https://jsdoc.app/)
   - [jsdoc-mermaid](https://github.com/Jellyvision/jsdoc-mermaid)
 - [MkDocs](https://mkdocs.org)
-  - [MarkdownMermaid](https://github.com/sebastienwarin/mkdocs-mermaid-plugin)
+  - [mkdocs-mermaid2-plugin](https://github.com/fralau/mkdocs-mermaid2-plugin)
 - [Type Doc](https://typedoc.org/)
   - [typedoc-plugin-mermaid](https://www.npmjs.com/package/typedoc-plugin-mermaid)
 - [Docsy Hugo Theme](https://www.docsy.dev/docs/adding-content/lookandfeel/#diagrams-with-mermaid) (Native support in theme)


### PR DESCRIPTION
`mkdocs-mermaid2-plugin` is also based on https://github.com/pugong/mkdocs-mermaid-plugin but it adds a good documentation.

## :bookmark_tabs: Summary
Change the referenced plugin for MkDocs

Resolves # -
I didn't open a new issue for this. 

## :straight_ruler: Design Decisions
Describe the way your implementation works or what design decisions you made if applicable.
I checked the linked plugin and mermaid2. The second includes detailed docs that made it easy to use. 

### :clipboard: Tasks
Make sure you
- [ ] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [ ] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
