### PR TITLE
Double Circle Node Shape

### DIFF
--- a/cypress/integration/rendering/flowchart-v2.spec.js
+++ b/cypress/integration/rendering/flowchart-v2.spec.js
@@ -368,7 +368,7 @@ flowchart TD
       I{{red text}} -->|default style| J[/blue text/]
       K[\\ red text\\] -->|default style| L[/blue text\\]
       M[\\ red text/] -->|default style| N[blue text];
-      O()(red text)() -->|default style| P()(blue text)();
+      O(((red text))) -->|default style| P(((blue text)));
       linkStyle default color:Sienna;
       style A stroke:#ff0000,fill:#ffcccc,color:#ff0000;
       style B stroke:#0000ff,fill:#ccccff,color:#0000ff;

--- a/cypress/integration/rendering/flowchart-v2.spec.js
+++ b/cypress/integration/rendering/flowchart-v2.spec.js
@@ -368,6 +368,7 @@ flowchart TD
       I{{red text}} -->|default style| J[/blue text/]
       K[\\ red text\\] -->|default style| L[/blue text\\]
       M[\\ red text/] -->|default style| N[blue text];
+      O()(red text)() -->|default style| P()(blue text)();
       linkStyle default color:Sienna;
       style A stroke:#ff0000,fill:#ffcccc,color:#ff0000;
       style B stroke:#0000ff,fill:#ccccff,color:#0000ff;
@@ -383,6 +384,8 @@ flowchart TD
       style L stroke:#0000ff,fill:#ccccff,color:#0000ff;
       style M stroke:#ff0000,fill:#ffcccc,color:#ff0000;
       style N stroke:#0000ff,fill:#ccccff,color:#0000ff;
+      style O stroke:#ff0000,fill:#ffcccc,color:#ff0000;
+      style P stroke:#0000ff,fill:#ccccff,color:#0000ff;
       `,
       { htmlLabels: true, flowchart: { htmlLabels: true }, securityLevel: 'loose', logLevel: 2 }
     );

--- a/demos/flowchart.html
+++ b/demos/flowchart.html
@@ -1047,7 +1047,7 @@
     L1[/red text\] <-->|default style| L2[/blue text\]
     M1[\red text/] <-->|default style| M2[\blue text/]
     N1[red text] <-->|default style| N2[blue text]
-    O1()(red text)() <-->|default style| O2()(blue text)()
+    O1(((red text))) <-->|default style| O2(((blue text)))
     linkStyle default color:Sienna;
     style A1 stroke:#ff0000,fill:#ffcccc,color:#ff0000
     style B1 stroke:#ff0000,fill:#ffcccc,color:#ff0000

--- a/demos/flowchart.html
+++ b/demos/flowchart.html
@@ -1047,6 +1047,7 @@
     L1[/red text\] <-->|default style| L2[/blue text\]
     M1[\red text/] <-->|default style| M2[\blue text/]
     N1[red text] <-->|default style| N2[blue text]
+    O1()(red text)() <-->|default style| O2()(blue text)()
     linkStyle default color:Sienna;
     style A1 stroke:#ff0000,fill:#ffcccc,color:#ff0000
     style B1 stroke:#ff0000,fill:#ffcccc,color:#ff0000
@@ -1062,6 +1063,7 @@
     style L1 stroke:#ff0000,fill:#ffcccc,color:#ff0000
     style M1 stroke:#ff0000,fill:#ffcccc,color:#ff0000
     style N1 stroke:#ff0000,fill:#ffcccc,color:#ff0000
+    style O1 stroke:#ff0000,fill:#ffcccc,color:#ff0000
     style A2 stroke:#0000ff,fill:#ccccff,color:#0000ff
     style B2 stroke:#0000ff,fill:#ccccff,color:#0000ff
     style C2 stroke:#0000ff,fill:#ccccff,color:#0000ff
@@ -1076,6 +1078,7 @@
     style L2 stroke:#0000ff,fill:#ccccff,color:#0000ff
     style M2 stroke:#0000ff,fill:#ccccff,color:#0000ff
     style N2 stroke:#0000ff,fill:#ccccff,color:#0000ff
+    style O2 stroke:#0000ff,fill:#ccccff,color:#0000ff
   </div>
 
   <hr/>

--- a/docs/flowchart.md
+++ b/docs/flowchart.md
@@ -145,7 +145,7 @@ flowchart TD
 
 ```mermaid-example
 flowchart TD
-    id1()(This is the text in the circle)()
+    id1(((This is the text in the circle)))
 ```
 
 ## Links between nodes

--- a/docs/flowchart.md
+++ b/docs/flowchart.md
@@ -141,6 +141,13 @@ flowchart TD
     B[\Go shopping/]
 ```
 
+### Double circle
+
+```mermaid-example
+flowchart TD
+    id1()(This is the text in the circle)()
+```
+
 ## Links between nodes
 
 Nodes can be connected with links/edges. It is possible to have different types of links or attach a text string to a link.

--- a/src/dagre-wrapper/nodes.js
+++ b/src/dagre-wrapper/nodes.js
@@ -1002,8 +1002,6 @@ export const insertNode = (elem, node, dir) => {
   let newEl;
   let el;
 
-  console.log(shapes);
-
   // Add link when appropriate
   if (node.link) {
     newEl = elem

--- a/src/dagre-wrapper/nodes.js
+++ b/src/dagre-wrapper/nodes.js
@@ -552,6 +552,42 @@ const circle = (parent, node) => {
   return shapeSvg;
 };
 
+const doublecircle = (parent, node) => {
+  const { shapeSvg, bbox, halfPadding } = labelHelper(parent, node, undefined, true);
+  const gap = 5;
+  const circleGroup = shapeSvg.insert('g', ':first-child');
+  const outerCircle = circleGroup.insert('circle');
+  const innerCircle = circleGroup.insert('circle');
+
+  // center the circle around its coordinate
+  outerCircle
+    .attr('style', node.style)
+    .attr('rx', node.rx)
+    .attr('ry', node.ry)
+    .attr('r', bbox.width / 2 + halfPadding + gap)
+    .attr('width', bbox.width + node.padding + gap * 2)
+    .attr('height', bbox.height + node.padding + gap * 2);
+
+  innerCircle
+    .attr('style', node.style)
+    .attr('rx', node.rx)
+    .attr('ry', node.ry)
+    .attr('r', bbox.width / 2 + halfPadding)
+    .attr('width', bbox.width + node.padding)
+    .attr('height', bbox.height + node.padding);
+
+  log.info('DoubleCircle main');
+
+  updateNodeBounds(node, outerCircle);
+
+  node.intersect = function (point) {
+    log.info('DoubleCircle intersect', node, bbox.width / 2 + halfPadding + gap, point);
+    return intersect.circle(node, bbox.width / 2 + halfPadding + gap, point);
+  };
+
+  return shapeSvg;
+};
+
 const subroutine = (parent, node) => {
   const { shapeSvg, bbox } = labelHelper(parent, node, undefined, true);
 
@@ -941,6 +977,7 @@ const shapes = {
   rectWithTitle,
   choice,
   circle,
+  doublecircle,
   stadium,
   hexagon,
   rect_left_inv_arrow,
@@ -964,6 +1001,8 @@ let nodeElems = {};
 export const insertNode = (elem, node, dir) => {
   let newEl;
   let el;
+
+  console.log(shapes);
 
   // Add link when appropriate
   if (node.link) {

--- a/src/diagrams/flowchart/flowRenderer-v2.js
+++ b/src/diagrams/flowchart/flowRenderer-v2.js
@@ -131,6 +131,9 @@ export const addVertices = function (vert, g, svgId) {
       case 'group':
         _shape = 'rect';
         break;
+      case 'doublecircle':
+        _shape = 'doublecircle';
+        break;
       default:
         _shape = 'rect';
     }

--- a/src/diagrams/flowchart/flowRenderer.spec.js
+++ b/src/diagrams/flowchart/flowRenderer.spec.js
@@ -26,7 +26,6 @@ describe('the flowchart renderer', function () {
       ['subroutine', 'subroutine'],
       ['cylinder', 'cylinder'],
       ['group', 'rect'],
-      ['doublecircle', 'doublecircle'],
     ].forEach(function ([type, expectedShape, expectedRadios = 0]) {
       it(`should add the correct shaped node to the graph for vertex type ${type}`, function () {
         const addedNodes = [];

--- a/src/diagrams/flowchart/flowRenderer.spec.js
+++ b/src/diagrams/flowchart/flowRenderer.spec.js
@@ -26,6 +26,7 @@ describe('the flowchart renderer', function () {
       ['subroutine', 'subroutine'],
       ['cylinder', 'cylinder'],
       ['group', 'rect'],
+      ['doublecircle', 'doublecircle'],
     ].forEach(function ([type, expectedShape, expectedRadios = 0]) {
       it(`should add the correct shaped node to the graph for vertex type ${type}`, function () {
         const addedNodes = [];

--- a/src/diagrams/flowchart/parser/flow-singlenode.spec.js
+++ b/src/diagrams/flowchart/parser/flow-singlenode.spec.js
@@ -161,7 +161,7 @@ describe('[Singlenodes] when parsing', () => {
 
   it('should handle a single double circle node', function () {
     // Silly but syntactically correct
-    const res = flow.parser.parse('graph TD;a()(A)();');
+    const res = flow.parser.parse('graph TD;a(((A)));');
 
     const vert = flow.parser.yy.getVertices();
     const edges = flow.parser.yy.getEdges();
@@ -172,7 +172,7 @@ describe('[Singlenodes] when parsing', () => {
 
   it('should handle a single double circle node with whitespace after it', function () {
     // Silly but syntactically correct
-    const res = flow.parser.parse('graph TD;a()(A)()   ;');
+    const res = flow.parser.parse('graph TD;a(((A)))   ;');
 
     const vert = flow.parser.yy.getVertices();
     const edges = flow.parser.yy.getEdges();
@@ -183,7 +183,7 @@ describe('[Singlenodes] when parsing', () => {
 
   it('should handle a single double circle node with html in it (SN3)', function () {
     // Silly but syntactically correct
-    const res = flow.parser.parse('graph TD;a()(A <br> end)();');
+    const res = flow.parser.parse('graph TD;a(((A <br> end)));');
 
     const vert = flow.parser.yy.getVertices();
     const edges = flow.parser.yy.getEdges();

--- a/src/diagrams/flowchart/parser/flow-singlenode.spec.js
+++ b/src/diagrams/flowchart/parser/flow-singlenode.spec.js
@@ -159,6 +159,40 @@ describe('[Singlenodes] when parsing', () => {
     expect(vert['a'].text).toBe('A <br> end');
   });
 
+  it('should handle a single double circle node', function () {
+    // Silly but syntactically correct
+    const res = flow.parser.parse('graph TD;a()(A)();');
+
+    const vert = flow.parser.yy.getVertices();
+    const edges = flow.parser.yy.getEdges();
+
+    expect(edges.length).toBe(0);
+    expect(vert['a'].type).toBe('doublecircle');
+  });
+
+  it('should handle a single double circle node with whitespace after it', function () {
+    // Silly but syntactically correct
+    const res = flow.parser.parse('graph TD;a()(A)()   ;');
+
+    const vert = flow.parser.yy.getVertices();
+    const edges = flow.parser.yy.getEdges();
+
+    expect(edges.length).toBe(0);
+    expect(vert['a'].type).toBe('doublecircle');
+  });
+
+  it('should handle a single double circle node with html in it (SN3)', function () {
+    // Silly but syntactically correct
+    const res = flow.parser.parse('graph TD;a()(A <br> end)();');
+
+    const vert = flow.parser.yy.getVertices();
+    const edges = flow.parser.yy.getEdges();
+
+    expect(edges.length).toBe(0);
+    expect(vert['a'].type).toBe('doublecircle');
+    expect(vert['a'].text).toBe('A <br> end');
+  });
+
   it('should handle a single node with alphanumerics starting on a char', function () {
     // Silly but syntactically correct
     const res = flow.parser.parse('graph TD;id1;');

--- a/src/diagrams/flowchart/parser/flow.jison
+++ b/src/diagrams/flowchart/parser/flow.jison
@@ -121,8 +121,8 @@ that id.
 "[|"                  return 'VERTEX_WITH_PROPS_START';
 "[("                  return 'CYLINDERSTART';
 ")]"                  return 'CYLINDEREND';
-"()("                 return 'DOUBLECIRCLESTART';
-")()"                 return 'DOUBLECIRCLEEND';
+"((("                 return 'DOUBLECIRCLESTART';
+")))"                 return 'DOUBLECIRCLEEND';
 \-                    return 'MINUS';
 "."                   return 'DOT';
 [\_]                  return 'UNDERSCORE';

--- a/src/diagrams/flowchart/parser/flow.jison
+++ b/src/diagrams/flowchart/parser/flow.jison
@@ -121,6 +121,8 @@ that id.
 "[|"                  return 'VERTEX_WITH_PROPS_START';
 "[("                  return 'CYLINDERSTART';
 ")]"                  return 'CYLINDEREND';
+"()("                 return 'DOUBLECIRCLESTART';
+")()"                 return 'DOUBLECIRCLEEND';
 \-                    return 'MINUS';
 "."                   return 'DOT';
 [\_]                  return 'UNDERSCORE';
@@ -373,6 +375,8 @@ node: vertex
 
 vertex:  idString SQS text SQE
         {$$ = $1;yy.addVertex($1,$3,'square');}
+    | idString DOUBLECIRCLESTART text DOUBLECIRCLEEND
+        {$$ = $1;yy.addVertex($1,$3,'doublecircle');}
     | idString PS PS text PE PE
         {$$ = $1;yy.addVertex($1,$4,'circle');}
     | idString '(-' text '-)'


### PR DESCRIPTION
## :bookmark_tabs: Summary
This PR adds the double circle shape to the available shapes of flowchart nodes. A double circle can be created using the following notation:
```mermaid-example
flowchart TD
    A()(red text)() <-->|default style| B()(blue text)()
    style A stroke:#ff0000,fill:#ffcccc,color:#ff0000
    style B stroke:#0000ff,fill:#ccccff,color:#0000ff
```
which produces the following diagram:
![The diagram produced by the above code](https://user-images.githubusercontent.com/44903310/154368759-7999dc09-76ad-4fb6-a5cc-57540a26dae6.png)

Resolves #2391 (not directly, since the issue is about state diagrams and this PR is adding it to flowcharts, but still useful.)

## :straight_ruler: Design Decisions
- The syntax to create a double circle: `()(text)()` - can obviously be changed easily by changing the grammar. I thought about it since it seems better than just a circle in a circle (`((((text))))`).
- The double circle is being created using a group of two circles, like [here](https://stackoverflow.com/a/32369927). I am doing it this way because it seems like the clearest and most intuitive solution, which usually produces the best results (see [here](https://css-tricks.com/how-to-add-a-double-border-to-svg-shapes/#aa-option-1-transforms)).
- The gap between the two circles is fixed to `5px`, which I thought looked nice. It might be better to try to change it based on the size of the circle, but for now, it just uses the const [`gap`](https://github.com/Guy-Adler/mermaid/blob/1fc10a7857de8f4728f014c1eed1087c3535a4af/src/dagre-wrapper/nodes.js#L557) which is set to 5px.
- The change is only implemented on flowRenderer-v2, but for some reason only works when *not* specifying v2 in the diagram type.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
