### PR TITLE
Adds railroadDiagram as an alias for gitGraph

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -209,7 +209,7 @@ export const detectType = function (text, cnf) {
     return 'state';
   }
 
-  if (text.match(/^\s*gitGraph/)) {
+  if (text.match(/^\s*gitGraph/) || text.match(/^\s*railroadDiagram/)) {
     return 'git';
   }
   if (text.match(/^\s*flowchart/)) {


### PR DESCRIPTION
## :bookmark_tabs: Summary
The new `gitGraph` is similar to a [railroad diagram](https://en.wikipedia.org/wiki/Syntax_diagram). This PR adds it as an alias.

Resolves #2734

## :straight_ruler: Design Decisions
This is implemented similaly to `requirementDiagram` and `requirement`, just adding another `text.match` to match `railroadDiagram` as a git graph.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
