### PR TITLE
feat: add ability to overlap notes and messages

### DIFF
--- a/cypress/integration/rendering/sequencediagram.spec.js
+++ b/cypress/integration/rendering/sequencediagram.spec.js
@@ -83,6 +83,29 @@ context('Sequence diagram', () => {
       {}
     );
   });
+  it('should render a sequence diagram with par_over', () => {
+    imgSnapshotTest(
+      `
+        sequenceDiagram
+        participant Alice
+        participant Bob
+        participant John
+        par_over Section title
+          Alice ->> Bob: Message 1<br>Second line
+          Bob ->> John: Message 2
+        end
+        par_over Two line<br>section title
+          Note over Alice: Alice note
+          Note over Bob: Bob note<br>Second line
+          Note over John: John note
+        end
+        par_over Mixed section
+          Alice ->> Bob: Message 1
+          Note left of Bob: Alice/Bob Note
+        end
+      `
+    );
+  });
   context('font settings', () => {
     it('should render different note fonts when configured', () => {
       imgSnapshotTest(

--- a/demos/index.html
+++ b/demos/index.html
@@ -512,6 +512,25 @@
     John-->>Alice: Hi Alice,<br />I can hear you!
     John-->>Alice: I feel great!
   </div>
+  <div class="mermaid">
+    sequenceDiagram
+    participant Alice
+    participant Bob
+    participant John
+    par_over Section title
+      Alice ->> Bob: Message 1<br>Second line
+      Bob ->> John: Message 2
+    end
+    par_over Two line<br>section title
+      Note over Alice: Alice note
+      Note over Bob: Bob note<br>Second line
+      Note over John: John note
+    end
+    par_over Mixed section
+      Alice ->> Bob: Message 1
+      Note left of Bob: Alice/Bob Note
+    end
+  </div>
 
   <hr />
 

--- a/src/diagrams/sequence/parser/sequenceDiagram.jison
+++ b/src/diagrams/sequence/parser/sequenceDiagram.jison
@@ -43,6 +43,7 @@
 "alt"                                                           { this.begin('LINE'); return 'alt'; }
 "else"                                                          { this.begin('LINE'); return 'else'; }
 "par"                                                           { this.begin('LINE'); return 'par'; }
+"par_over"                                                      { this.begin('LINE'); return 'par_over'; }
 "and"                                                           { this.begin('LINE'); return 'and'; }
 <LINE>(?:[:]?(?:no)?wrap:)?[^#\n;]*                             { this.popState(); return 'restOfLine'; }
 "end"                                                           return 'end';
@@ -149,6 +150,14 @@ statement
 	{
 		// Parallel start
 		$3.unshift({type: 'parStart', parText:yy.parseMessage($2), signalType: yy.LINETYPE.PAR_START});
+		// Content in par is already in $3
+		// End
+		$3.push({type: 'parEnd', signalType: yy.LINETYPE.PAR_END});
+		$$=$3;}
+  | par_over restOfLine par_sections end
+	{
+		// Parallel (overlapped) start
+		$3.unshift({type: 'parStart', parText:yy.parseMessage($2), signalType: yy.LINETYPE.PAR_OVER_START});
 		// Content in par is already in $3
 		// End
 		$3.push({type: 'parEnd', signalType: yy.LINETYPE.PAR_END});

--- a/src/diagrams/sequence/sequenceDb.js
+++ b/src/diagrams/sequence/sequenceDb.js
@@ -180,6 +180,7 @@ export const LINETYPE = {
   RECT_END: 23,
   SOLID_POINT: 24,
   DOTTED_POINT: 25,
+  PAR_OVER_START: 26,
 };
 
 export const ARROWTYPE = {

--- a/src/diagrams/sequence/sequenceDiagram.spec.js
+++ b/src/diagrams/sequence/sequenceDiagram.spec.js
@@ -812,6 +812,29 @@ end`;
     expect(messages[1].from).toBe('Alice');
     expect(messages[2].from).toBe('Bob');
   });
+  it('it should handle par_over statements', function () {
+    const str = `
+sequenceDiagram
+par_over Parallel overlap
+Alice ->> Bob: Message
+Note left of Alice: Alice note
+Note right of Bob: Bob note
+end`;
+
+    mermaidAPI.parse(str);
+    const actors = parser.yy.getActors();
+
+    expect(actors.Alice.description).toBe('Alice');
+    expect(actors.Bob.description).toBe('Bob');
+
+    const messages = parser.yy.getMessages();
+
+    expect(messages.length).toBe(5);
+    expect(messages[0].message).toBe('Parallel overlap');
+    expect(messages[1].from).toBe('Alice');
+    expect(messages[2].from).toBe('Alice');
+    expect(messages[3].from).toBe('Bob');
+  });
   it('it should handle special characters in signals', function () {
     const str = 'sequenceDiagram\n' + 'Alice->Bob: -:<>,;# comment';
 


### PR DESCRIPTION
## :bookmark_tabs: Summary
Add ability to overlap (in time) notes and messages in a sequence diagram with new directive `par_over`

Resolves #2087

## :straight_ruler: Design Decisions
- This new directive works the same as `par` except: each message or note inside is positioned with the same top position
- The code currently only checks for the innermost loop being `par_over`, since it is not immediately clear what should happen in other cases
- Because the messages and notes are always vertical aligned to the top, messages with a variable number of lines of text aren't lined up

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
