### PR TITLE
Workflow: Check if `README.md` and `docs/README.md` are in sync

### DIFF
--- a/.github/workflows/check-readme-in-sync.yml
+++ b/.github/workflows/check-readme-in-sync.yml
@@ -1,0 +1,34 @@
+# Reference: https://github.com/Yash-Singh1/eslint-plugin-userscripts/blob/main/.github/workflows/readme-in-sync.yml
+
+name: Check if README and docs/README are in sync
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+    branches:
+      - master
+      - develop
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Check for difference in README.md and docs/README.md
+        run: |
+          if [ -z "$(diff README.md docs/README.md --brief)" ]
+          then
+            echo "README.md and docs/README.md are in sync"
+          else
+            echo "Make sure that README.md and docs/README.md are in sync"
+            echo
+            echo "Difference:"
+            echo
+            diff README.md docs/README.md -u
+            exit 1
+          fi


### PR DESCRIPTION
## :bookmark_tabs: Summary
This PR adds a GitHub workflow that checks if `README.md` and `docs/README.md` have the same content.

This is part of issue #2456. (Documentation section)

## :straight_ruler: Design Decisions
### About workflow's triggers
In the [contribution guide](https://github.com/kuanyi-ng/mermaid/blob/develop/CONTRIBUTING.md#committing-documentation), it said that documentation-related changes can be committed directly to the `develop` branch.
So I made this workflow to target `push` and `pull_request` events for both `master` and `develop` branches.

### Possible improvements (for another PR)
1. Output which `README.md` is newer so it's easier to sync both `README.md` files.
  a. still don't have a concrete idea on how to determine if one `README.md` is newer than the other
  a. this information might be available from `git log` or `git blame`
2. Sync the content of `README.md` and `docs/README.md` as a part of the workflow.
  a. it might be possible to automatically apply the changes to either one of the READMEs. 
3. Also check if `CHANGELOG.md` and `docs/CHANGELOG.md` have the same content.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [ ] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
