### PR TITLE
Add `mkdocs-material` to the integrations

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -136,6 +136,7 @@ They also serve as proof of concept, for the variety of things that can be built
   - [jsdoc-mermaid](https://github.com/Jellyvision/jsdoc-mermaid)
 - [MkDocs](https://mkdocs.org)
   - [mkdocs-mermaid2-plugin](https://github.com/fralau/mkdocs-mermaid2-plugin)
+  - [mkdocs-material](https://github.com/squidfunk/mkdocs-material), check the [docs](https://squidfunk.github.io/mkdocs-material/reference/diagrams/)
 - [Type Doc](https://typedoc.org/)
   - [typedoc-plugin-mermaid](https://www.npmjs.com/package/typedoc-plugin-mermaid)
 - [Docsy Hugo Theme](https://www.docsy.dev/docs/adding-content/lookandfeel/#diagrams-with-mermaid) (Native support in theme)


### PR DESCRIPTION
## :bookmark_tabs: Summary
The [MkDocs-Material](https://squidfunk.github.io/mkdocs-material/) library recently added [mermaid diagrams](https://squidfunk.github.io/mkdocs-material/reference/diagrams/) to the base product.

Resolves #-
I didn't open a new issue for this.

## :straight_ruler: Design Decisions
This library makes it very very easy to add mermaid diagrams to the docs pages.

### :clipboard: Tasks
Make sure you
- [ ] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [ ] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
