### PR TITLE
docs(integrations): add link to mdbook-mermaid

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -141,6 +141,8 @@ They also serve as proof of concept, for the variety of things that can be built
 - [Docsy Hugo Theme](https://www.docsy.dev/docs/adding-content/lookandfeel/#diagrams-with-mermaid) (Native support in theme)
 - [Codedoc](https://codedoc.cc/)
   - [codedoc-mermaid-plugin](https://www.npmjs.com/package/codedoc-mermaid-plugin)
+- [mdbook](https://rust-lang.github.io/mdBook/index.html)
+  - [mdbook-mermaid](https://github.com/badboy/mdbook-mermaid)
 
 ## Browser Extensions
 


### PR DESCRIPTION
`mdbook` is the de facto standard tool for Rust documentation. 
It supports third-party plugins, one of which is mdbook-mermaid.

See: https://github.com/rust-lang/mdBook/wiki/Third-party-plugins