### PR TITLE
fix typos in doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ Finally, if it is not in the documentation, no one will know about it and then *
 
 The docs are located in the docs folder and are ofc written in markdown. Just pick the right section and start typing. If you want to add to the structure as in adding a new section and new file you do that via the _navbar.md.
 
-The changes in master is reflected in http://mermaid-js.github.io/mermaid/ once released the updates are commited to https://mermaid-js.github.io/#/
+The changes in master is reflected in http://mermaid-js.github.io/mermaid/ once released the updates are committed to https://mermaid-js.github.io/#/
 
 ## Last words
 

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -1019,7 +1019,7 @@ Pushes in a directive to the configuration
 
 | Parameter | Description                                                   | Type       | Required | Values                                       |
 | --------- | ------------------------------------------------------------- | ---------- | -------- | -------------------------------------------- |
-| conf      | base set of values, which currentConfig coul be **reset** to. | Dictionary | Required | Any Values, with respect to the secure Array |
+| conf      | base set of values, which currentConfig could be **reset** to. | Dictionary | Required | Any Values, with respect to the secure Array |
 
 **Notes**: (default: current siteConfig ) (optional, default `getSiteConfig()`)
 

--- a/docs/breakingChanges.md
+++ b/docs/breakingChanges.md
@@ -36,7 +36,7 @@ or
 <link rel="stylesheet" href="mermaid.forest.min.css">
 ```
 
-Now it is not needed to do so. And there are no more CSS files in distrubtion files.
+Now it is not needed to do so. And there are no more CSS files in distribution files.
 
 You just
 

--- a/docs/developer-docs/configuration.md
+++ b/docs/developer-docs/configuration.md
@@ -21,7 +21,7 @@ sequenceDiagram
 
 ## Initialize
 
-Intialize call is calloed **only once**. It is called by the site integrator in order to override the default configuration on a site level.
+Initialize call is called **only once**. It is called by the site integrator in order to override the default configuration on a site level.
 
 ## configApi.reset
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -48,7 +48,7 @@ The docs are located in the `docs` folder and are written in Markdown. Just pick
 
 > **All the documents displayed in the github.io page are listed in [sidebar.md](https://github.com/mermaid-js/mermaid/edit/develop/docs/_sidebar.md)**.
 
-The contents of [https://mermaid-js.github.io/mermaid/](https://mermaid-js.github.io/mermaid/) are based on the docs from the `master` branch. Updates commited to the `master` branch are reflected in the [Mermaid Docs](https://mermaid-js.github.io/mermaid/) once released.
+The contents of [https://mermaid-js.github.io/mermaid/](https://mermaid-js.github.io/mermaid/) are based on the docs from the `master` branch. Updates committed to the `master` branch are reflected in the [Mermaid Docs](https://mermaid-js.github.io/mermaid/) once released.
 
 ## How to Contribute to Documentation
 
@@ -97,7 +97,8 @@ it('should render forks and joins', () => {
         { logLevel: 0 }
     );
     cy.get('svg');
-});
+});
+
 ```
 
 ### Any Questions or Suggestions?

--- a/docs/diagrams-and-syntax-and-examples/flowchart.md
+++ b/docs/diagrams-and-syntax-and-examples/flowchart.md
@@ -505,7 +505,7 @@ defined in the linkStyle statement will belong to the fourth link in the graph:
 linkStyle 3 stroke:#ff3,stroke-width:4px,color:red;
 ```
 
-You can specify default to apply to all links, or you can give a list of link order numbers seperated by a comma.
+You can specify default to apply to all links, or you can give a list of link order numbers separated by a comma.
 
 Instead of giving a styles option, you can also use custom d3 curve types with the following syntax:
 

--- a/docs/gantt.md
+++ b/docs/gantt.md
@@ -6,7 +6,7 @@
  Gantt Charts will record each scheduled task as one continuous bar that extends from the left to the right. The x axis represents time and the y records the different tasks and the order in which they are to be completed.
 
 
- It is important to remember that when a date, day, or collection of dates specific to a task are "excluded", the Gantt Chart will accomodate those changes by extending an equal number of days, towards the right, not by creating a gap inside the task.
+ It is important to remember that when a date, day, or collection of dates specific to a task are "excluded", the Gantt Chart will accommodate those changes by extending an equal number of days, towards the right, not by creating a gap inside the task.
  As shown here ![](./img/Gantt-excluded-days-within.png)
 
 
@@ -111,7 +111,7 @@ The default input date format is `YYYY-MM-DD`. You can define your custom ``date
 dateFormat YYYY-MM-DD
 ```
 
-The following formating options are supported:
+The following formatting options are supported:
 
 ```
 Input       Example             Description:
@@ -146,7 +146,7 @@ The default output date format is YYYY-MM-DD. You can define your custom ``axisF
 axisFormat  %Y-%m-%d
 ```
 
-The following formating strings are supported:
+The following formatting strings are supported:
 
 ```
 %a - abbreviated weekday name.

--- a/docs/n00b-gettingStarted.md
+++ b/docs/n00b-gettingStarted.md
@@ -118,7 +118,7 @@ c. The `mermaid.initialize()` call, which dictates the appearance of diagrams an
 ```
 
 **Notes**:
-Rendering in Mermaid is initalized by `mermaid.initialize()` call. You can place `mermaid.initialize()` inside `mermaid.min.js` for brevity. However, doing the opposite lets you control when it starts looking for `<div>`tags inside the web page with `mermaid.initialize()`. This is useful when you think that not all `<div>` tags may have loaded on the execution of `mermaid.min.js` file.
+Rendering in Mermaid is initialized by `mermaid.initialize()` call. You can place `mermaid.initialize()` inside `mermaid.min.js` for brevity. However, doing the opposite lets you control when it starts looking for `<div>`tags inside the web page with `mermaid.initialize()`. This is useful when you think that not all `<div>` tags may have loaded on the execution of `mermaid.min.js` file.
 
 `startOnLoad` is one of the parameters that can be defined by `mermaid.initialize()`
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -24,7 +24,7 @@ The following are a list of **Deployable themes**, sample `%%init%%` directives 
 ## Site-wide Themes
 Site-wide themes are declared via `initialize` by site owners.
 
-Example of `Initalize` call setting `theme` to `base`:
+Example of `Initialize` call setting `theme` to `base`:
 ```javascript
     mermaidAPI.initialize({
         'securityLevel': 'loose', 'theme': 'base'


### PR DESCRIPTION
## :bookmark_tabs: Summary


Fix some typos in doc.


### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [ ] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
