### PR TITLE
fix: autonumber bug

### DIFF
--- a/src/diagrams/sequence/sequenceDb.js
+++ b/src/diagrams/sequence/sequenceDb.js
@@ -139,6 +139,7 @@ export const autoWrap = () => wrapEnabled;
 export const clear = function () {
   actors = {};
   messages = [];
+  sequenceNumbersEnabled = false;
 };
 
 export const parseMessage = function (str) {

--- a/src/diagrams/sequence/sequenceDiagram.spec.js
+++ b/src/diagrams/sequence/sequenceDiagram.spec.js
@@ -1619,4 +1619,24 @@ participant Alice
       models.lastActor().y + models.lastActor().height + mermaid.sequence.boxMargin
     );
   });
+  it('it should hide sequence numbers when autonumber is removed when autonumber is enabled', function () {
+    const str1 = `
+sequenceDiagram
+autonumber
+Alice->Bob:Hello Bob, how are you?
+Note right of Bob: Bob thinks
+Bob-->Alice: I am good thanks!`;
+
+    mermaidAPI.parse(str1);
+    expect(parser.yy.showSequenceNumbers()).toBe(true);
+
+    const str2 = `
+sequenceDiagram
+Alice->Bob:Hello Bob, how are you?
+Note right of Bob: Bob thinks
+Bob-->Alice: I am good thanks!`;
+
+    mermaidAPI.parse(str2);
+    expect(parser.yy.showSequenceNumbers()).toBe(false);
+  });
 });

--- a/src/mermaidAPI.js
+++ b/src/mermaidAPI.js
@@ -94,6 +94,7 @@ function parse(text) {
       parser.parser.yy = flowDb;
       break;
     case 'sequence':
+      sequenceDb.clear();
       parser = sequenceParser;
       parser.parser.yy = sequenceDb;
       break;


### PR DESCRIPTION
## :bookmark_tabs: Summary
Fixed the problem of abnormal display of autonumber in the sequence diagram.

Resolves #<your issue id here>

## :straight_ruler: Design Decisions
The reason for the exception is that the last autonumber mark is not cleared in the clear function.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
