### PR TITLE
Updated docs to use mermaid 8.14

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
     />
     <!-- <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css"> -->
     <link rel="stylesheet" href="theme.css" />
-    <script src="//cdn.jsdelivr.net/npm/mermaid@8.13.0/dist/mermaid.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/mermaid@8.14.0/dist/mermaid.min.js"></script>
     <!-- <script src="http://localhost:9000/mermaid.js"></script> -->
     <script>
       // prettier-ignore


### PR DESCRIPTION
## :bookmark_tabs: Summary
Updates the docs. 8.13.0 -> 8.14.0

In 8.13.0, a bug #2548 caused ER comments to render incorrectly. The problem was fixed in release 8.13.9.
However, the docs continue to use 8.13.0. So the bug persists ([details](https://github.com/mermaid-js/mermaid/issues/2548#issuecomment-1066117678)) in the docs despite the fix.

#2548 can likely be closed after this PR is merged.

## :straight_ruler: Design Decisions
The latest version is 8.14. After confirming that 8.14 exists on the [cdn](https://cdn.jsdelivr.net/npm/mermaid@8.14.0/dist/mermaid.min.js), I incremented the version from 8.13.0 -> 8.14.0 so that the docs get the fix that released in 8.13.9, but also so they reflect the latest mermaid has to offer.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :bookmark: targeted `develop` branch 

### 📷 Pics
Before:
![image](https://user-images.githubusercontent.com/58531251/158066468-515a561b-aeeb-4739-8372-eb7904c673f7.png)

After:
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/58531251/158066419-39cc3570-752c-4b63-8781-8d1ba2b8376f.png">

