### PR TITLE
fix(sequencediagram): draw arrowheads on top of activation boxes

### DIFF
--- a/demos/sequence.html
+++ b/demos/sequence.html
@@ -40,7 +40,8 @@
 		Note over John: After a few more moments, John<br />finally snaps out of it.
 		end
 		alt either this
-		Alice->>John: Yes
+		Alice->>+John: Yes
+    John-->>-Alice: OK
 		else or this
 		Alice->>John: No
 		else or this will happen


### PR DESCRIPTION
## :bookmark_tabs: Summary
Activating arrowheads were placed under the activated box. This PR makes it so arrowheads (and messages in general) are always on top. 

Resolves #2826

![image](https://user-images.githubusercontent.com/22191473/161312193-b02cea23-ce36-49fd-ad05-8ccf98aabfb4.png)

## :straight_ruler: Design Decisions
Arrowheads are covered by the activation boxes as they are drawn before the activation boxes.
This PR draws all messages at the end of the parsing of the instruction while updating bounds during parsing. 
Another implementation solution would have been to create the message DOM elements without appending them during parsing (as the same time as bound update), storing them and appending them at the end of parsing. 

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
