### PR TITLE
Fix example header: "A commit flow diagram."

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -140,7 +140,7 @@ sequenceDiagram
 
 ```
 
-A commit flow diagram.
+## A commit flow diagram.
 ```mermaid
 gitGraph:
     commit "Ashish"


### PR DESCRIPTION
## :bookmark_tabs: Summary
Hey, I was checking the docs and saw the title was not header for example "A commit flow diagram.".

Resolves -- I didn't see a need open an issue for this. If there were any, please link it.

## :straight_ruler: Design Decisions
Followed the previous examples' titles and gave this one a Heading 2.

### :clipboard: Tasks
Make sure you
- [X] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [X] :computer: have added unit/e2e tests (if appropriate) 
  Not appropriate.
- [X] :bookmark: targeted `develop` branch 
