### PR TITLE
GitGraph: add support for "pathed" branches. fix #2936 

### DIFF
--- a/src/diagrams/git/gitGraphParserV2.spec.js
+++ b/src/diagrams/git/gitGraphParserV2.spec.js
@@ -336,6 +336,20 @@ describe('when parsing a gitGraph', function () {
     expect(Object.keys(parser.yy.getBranches()).length).toBe(2);
   });
 
+  it('should allow _-./ characters in branch names', function () {
+    const str = `gitGraph:
+    commit
+    branch azAZ_-./test
+    `;
+
+    parser.parse(str);
+    const commits = parser.yy.getCommits();
+    expect(Object.keys(commits).length).toBe(1);
+    expect(parser.yy.getCurrentBranch()).toBe('azAZ_-./test');
+    expect(parser.yy.getDirection()).toBe('LR');
+    expect(Object.keys(parser.yy.getBranches()).length).toBe(2);
+  });
+
   it('should handle new branch checkout', function () {
     const str = `gitGraph:
     commit

--- a/src/diagrams/git/parser/gitGraph.jison
+++ b/src/diagrams/git/parser/gitGraph.jison
@@ -26,31 +26,31 @@
 \s+                                    /* skip all whitespace */
 \#[^\n]*                               /* skip comments */
 \%%[^\n]*                              /* skip comments */
-"gitGraph"                             return 'GG';
-"commit"                               return 'COMMIT';
-"id:"                                  return 'COMMIT_ID';
-"type:"                                return 'COMMIT_TYPE';
-"msg:"                                 return 'COMMIT_MSG';
-"NORMAL"                               return 'NORMAL';
-"REVERSE"                              return 'REVERSE';
-"HIGHLIGHT"                            return 'HIGHLIGHT';
-"tag:"                                 return 'COMMIT_TAG';
-"branch"                               return 'BRANCH';
-"merge"                                return 'MERGE';
-// "reset"                                return 'RESET';
-"checkout"                             return 'CHECKOUT';
-"LR"                                   return 'DIR';
-"BT"                                   return 'DIR';
-":"                                    return ':';
-"^"                                    return 'CARET'
-"options"\r?\n                         this.begin("options");
-<options>"end"\r?\n                    this.popState();
-<options>[^\n]+\r?\n                   return 'OPT';
-["]                                    this.begin("string");
-<string>["]                            this.popState();
-<string>[^"]*                          return 'STR';
-[a-zA-Z][-_\.a-zA-Z0-9]*[-_a-zA-Z0-9]  return 'ID';
-<<EOF>>                                return 'EOF';
+"gitGraph"                              return 'GG';
+"commit"                                return 'COMMIT';
+"id:"                                   return 'COMMIT_ID';
+"type:"                                 return 'COMMIT_TYPE';
+"msg:"                                  return 'COMMIT_MSG';
+"NORMAL"                                return 'NORMAL';
+"REVERSE"                               return 'REVERSE';
+"HIGHLIGHT"                             return 'HIGHLIGHT';
+"tag:"                                  return 'COMMIT_TAG';
+"branch"                                return 'BRANCH';
+"merge"                                 return 'MERGE';
+// "reset"                                 return 'RESET';
+"checkout"                              return 'CHECKOUT';
+"LR"                                    return 'DIR';
+"BT"                                    return 'DIR';
+":"                                     return ':';
+"^"                                     return 'CARET'
+"options"\r?\n                          this.begin("options");
+<options>"end"\r?\n                     this.popState();
+<options>[^\n]+\r?\n                    return 'OPT';
+["]                                     this.begin("string");
+<string>["]                             this.popState();
+<string>[^"]*                           return 'STR';
+[a-zA-Z][-_\./a-zA-Z0-9]*[-_a-zA-Z0-9]  return 'ID';
+<<EOF>>                                 return 'EOF';
 
 /lex
 


### PR DESCRIPTION
## :bookmark_tabs: Summary
allow "/" in branch names

Resolves #2936 

## :straight_ruler: Design Decisions
Extend regex in JISON to allow "/" inside branch name

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
