### PR TITLE
GitGraph. Support tags for merge commits 

### DIFF
--- a/src/diagrams/git/gitGraphAst.js
+++ b/src/diagrams/git/gitGraphAst.js
@@ -136,7 +136,7 @@ export const branch = function (name) {
   }
 };
 
-export const merge = function (otherBranch) {
+export const merge = function (otherBranch, tag) {
   otherBranch = common.sanitizeText(otherBranch, configApi.getConfig());
   const currentCommit = commits[branches[curBranch]];
   const otherCommit = commits[branches[otherBranch]];
@@ -213,6 +213,7 @@ export const merge = function (otherBranch) {
     parents: [head == null ? null : head.id, branches[otherBranch]],
     branch: curBranch,
     type: commitType.MERGE,
+    tag: tag ? tag : '',
   };
   head = commit;
   commits[commit.id] = commit;

--- a/src/diagrams/git/gitGraphParserV2.spec.js
+++ b/src/diagrams/git/gitGraphParserV2.spec.js
@@ -255,7 +255,7 @@ describe('when parsing a gitGraph', function () {
   it('should handle a gitGraph commit with custom  type,tag, msg, commit id,', function () {
     const str = `gitGraph:
     commit type:REVERSE tag: "test tag" msg: "test msg" id: "1111"
-    
+
     `;
 
     parser.parse(str);
@@ -405,6 +405,41 @@ describe('when parsing a gitGraph', function () {
     expect(commits[commit3].parents).toStrictEqual([commits[commit2].id]);
     expect(commits[commit4].branch).toBe('main');
     expect(commits[commit4].parents).toStrictEqual([commits[commit1].id, commits[commit3].id]);
+    expect(parser.yy.getBranchesAsObjArray()).toStrictEqual([
+      { name: 'main' },
+      { name: 'testBranch' },
+    ]);
+  });
+
+  it('should handle merge tags', function () {
+    const str = `gitGraph:
+    commit
+    branch testBranch
+    checkout testBranch
+    commit
+    checkout main
+    merge testBranch tag: "merge-tag"
+    `;
+
+    parser.parse(str);
+    const commits = parser.yy.getCommits();
+    expect(Object.keys(commits).length).toBe(3);
+    expect(parser.yy.getCurrentBranch()).toBe('main');
+    expect(parser.yy.getDirection()).toBe('LR');
+    expect(Object.keys(parser.yy.getBranches()).length).toBe(2);
+    const commit1 = Object.keys(commits)[0];
+    const commit2 = Object.keys(commits)[1];
+    const commit3 = Object.keys(commits)[2];
+
+    expect(commits[commit1].branch).toBe('main');
+    expect(commits[commit1].parents).toStrictEqual([]);
+
+    expect(commits[commit2].branch).toBe('testBranch');
+    expect(commits[commit2].parents).toStrictEqual([commits[commit1].id]);
+
+    expect(commits[commit3].branch).toBe('main');
+    expect(commits[commit3].parents).toStrictEqual([commits[commit1].id, commits[commit2].id]);
+    expect(commits[commit3].tag).toBe('merge-tag');
     expect(parser.yy.getBranchesAsObjArray()).toStrictEqual([
       { name: 'main' },
       { name: 'testBranch' },

--- a/src/diagrams/git/parser/gitGraph.jison
+++ b/src/diagrams/git/parser/gitGraph.jison
@@ -89,11 +89,17 @@ line
 
 statement
     : commitStatement
+    | mergeStatement
     | BRANCH ID {yy.branch($2)}
     | CHECKOUT ID {yy.checkout($2)}
-    | MERGE ID {yy.merge($2)}
     // | RESET reset_arg {yy.reset($2)}
     ;
+
+mergeStatement
+    : MERGE ID {yy.merge($2)}
+    | MERGE ID COMMIT_TAG STR {yy.merge($2, $4)}
+    ;
+
 commitStatement
     : COMMIT commit_arg {yy.commit($2)}
     | COMMIT COMMIT_TAG STR {yy.commit('','',yy.commitType.NORMAL,$3)}


### PR DESCRIPTION
## :bookmark_tabs: Summary
Support adding tags to merge commits

Resolves #2934 

## :straight_ruler: Design Decisions
Currently only tags are added, as this is what looks like the most requested option.
Adding all options the "commit" supports would require too much code duplication. 
At this moment I don't know how to reuse all options present on "commit" to make more elegant.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
