### PR TITLE
Documentation fix for 8.6.0 readme - add missing quotes to example theme default

### DIFF
--- a/docs/8.6.0_docs.md
+++ b/docs/8.6.0_docs.md
@@ -7,7 +7,7 @@
 With version 8.6.0 comes the release of directives for mermaid, a new system for modifying configurations, with the aim of establishing centralized, sane defaults and simple implementation.
 
 `directives` allow for a single-use overwriting of `config`, as it has been discussed in [Configurations](./Setup.md).
-This allows site Diagram Authors to instantiate temporary modifications to `config` through the use of [Directives](), which are parsed before rendering diagram definitions. This allows the Diagram Authors to alter the appearance of the diagrams. 
+This allows site Diagram Authors to instantiate temporary modifications to `config` through the use of [Directives](), which are parsed before rendering diagram definitions. This allows the Diagram Authors to alter the appearance of the diagrams.
 
 **A likely application for this is in the creation of diagrams/charts inside company/organizational webpages, that rely on mermaid for diagram and chart rendering.**
 
@@ -65,7 +65,7 @@ init would be an argument-directive: `%%{init: { **insert argument here**}}%%`
 The json object that is passed as {**argument** } must be valid, quoted json or it will be ignored.
     **for example**:
 
-`%%{init: {"theme": default, "logLevel": 1 }}%%`
+`%%{init: {"theme": "default", "logLevel": 1 }}%%`
 
 Configurations that are passed through init cannot change the parameters in secure arrays of higher levels. In the event of a conflict, mermaid will give priority to secure arrays and parse the request, without changing the values of the parameters in conflict.
 


### PR DESCRIPTION
simple documentation fix so that the example code works - the "default" was missing quotes so did not work in when example was used in a diagram.
