### PR TITLE
protect config.js from attempting to use invalid theme name (which corrupted mermaid use until reset())

### DIFF
--- a/docs/8.6.0_docs.md
+++ b/docs/8.6.0_docs.md
@@ -7,7 +7,7 @@
 With version 8.6.0 comes the release of directives for mermaid, a new system for modifying configurations, with the aim of establishing centralized, sane defaults and simple implementation.
 
 `directives` allow for a single-use overwriting of `config`, as it has been discussed in [Configurations](./Setup.md).
-This allows site Diagram Authors to instantiate temporary modifications to `config` through the use of [Directives](), which are parsed before rendering diagram definitions. This allows the Diagram Authors to alter the appearance of the diagrams. 
+This allows site Diagram Authors to instantiate temporary modifications to `config` through the use of [Directives](), which are parsed before rendering diagram definitions. This allows the Diagram Authors to alter the appearance of the diagrams.
 
 **A likely application for this is in the creation of diagrams/charts inside company/organizational webpages, that rely on mermaid for diagram and chart rendering.**
 
@@ -65,7 +65,7 @@ init would be an argument-directive: `%%{init: { **insert argument here**}}%%`
 The json object that is passed as {**argument** } must be valid, quoted json or it will be ignored.
     **for example**:
 
-`%%{init: {"theme": default, "logLevel": 1 }}%%`
+`%%{init: {"theme": "default", "logLevel": 1 }}%%`
 
 Configurations that are passed through init cannot change the parameters in secure arrays of higher levels. In the event of a conflict, mermaid will give priority to secure arrays and parse the request, without changing the values of the parameters in conflict.
 

--- a/src/config.js
+++ b/src/config.js
@@ -27,7 +27,7 @@ export const updateCurrentConfig = (siteCfg, _directives) => {
 
   cfg = assignWithDepth(cfg, sumOfDirectives);
 
-  if (sumOfDirectives.theme) {
+  if (sumOfDirectives.theme && theme[sumOfDirectives.theme]) {
     const tmpConfigFromInitialize = assignWithDepth({}, configFromInitialize);
     const themeVariables = assignWithDepth(
       tmpConfigFromInitialize.themeVariables || {},
@@ -59,7 +59,7 @@ export const setSiteConfig = (conf) => {
   siteConfig = assignWithDepth({}, defaultConfig);
   siteConfig = assignWithDepth(siteConfig, conf);
 
-  if (conf.theme) {
+  if (conf.theme && theme[conf.theme]) {
     siteConfig.themeVariables = theme[conf.theme].getThemeVariables(conf.themeVariables);
   }
 


### PR DESCRIPTION
This protects the use of invalid theme names the same way they are protected in MermaidAPI.js.

The situation that led to finding this bug was a mistyped:
`%%{init: {"theme": "neutrl" }}%%`

This led to the directive array getting corrupted with a `theme:'neutrl'` value, which in turn prevented all future use of the library entirely until reset() was called.  (any attempt to call anything but reset() causes exception again)
Calls to setConfig() or initialize() also failed because the code in config.js would exception out because the invalid theme name was being use to index into theme[] and causing an exception.

This change simply protects from the use of invalid theme names:
(please refer to changes for more context)

`if (sumOfDirectives.theme) {`
becomes:
`if (sumOfDirectives.theme && theme[sumOfDirectives.theme]) {`

(and for good measure, but not where exception was)
`if (conf.theme) {`
becomes
`if (conf.theme && theme[conf.theme]) {`

again this is identical to how MermaidAPI.js protects against using invalid theme names.