### PR TITLE
GitGraph: add support for branch ordering

### DIFF
--- a/src/diagrams/git/gitGraphParserV2.spec.js
+++ b/src/diagrams/git/gitGraphParserV2.spec.js
@@ -364,6 +364,46 @@ describe('when parsing a gitGraph', function () {
     expect(parser.yy.getDirection()).toBe('LR');
     expect(Object.keys(parser.yy.getBranches()).length).toBe(2);
   });
+  it('should handle new branch checkout with order', function () {
+    const str = `gitGraph:
+    commit
+    branch test1 order: 3
+    branch test2 order: 2
+    branch test3 order: 1
+    `;
+
+    parser.parse(str);
+    const commits = parser.yy.getCommits();
+    expect(Object.keys(commits).length).toBe(1);
+    expect(parser.yy.getCurrentBranch()).toBe('test3');
+    expect(Object.keys(parser.yy.getBranches()).length).toBe(4);
+    expect(parser.yy.getBranchesAsObjArray()).toStrictEqual([
+      { name: 'main' },
+      { name: 'test3' },
+      { name: 'test2' },
+      { name: 'test1' },
+    ]);
+  });
+  it('should handle new branch checkout with and without order', function () {
+    const str = `gitGraph:
+    commit
+    branch test1 order: 1
+    branch test2
+    branch test3
+    `;
+
+    parser.parse(str);
+    const commits = parser.yy.getCommits();
+    expect(Object.keys(commits).length).toBe(1);
+    expect(parser.yy.getCurrentBranch()).toBe('test3');
+    expect(Object.keys(parser.yy.getBranches()).length).toBe(4);
+    expect(parser.yy.getBranchesAsObjArray()).toStrictEqual([
+      { name: 'main' },
+      { name: 'test2' },
+      { name: 'test3' },
+      { name: 'test1' },
+    ]);
+  });
 
   it('should handle new branch checkout & commit', function () {
     const str = `gitGraph:

--- a/src/diagrams/git/parser/gitGraph.jison
+++ b/src/diagrams/git/parser/gitGraph.jison
@@ -36,6 +36,7 @@
 "HIGHLIGHT"                             return 'HIGHLIGHT';
 "tag:"                                  return 'COMMIT_TAG';
 "branch"                                return 'BRANCH';
+"order:"                                return 'ORDER';
 "merge"                                 return 'MERGE';
 // "reset"                                 return 'RESET';
 "checkout"                              return 'CHECKOUT';
@@ -49,6 +50,7 @@
 ["]                                     this.begin("string");
 <string>["]                             this.popState();
 <string>[^"]*                           return 'STR';
+[0-9]+                                  return 'NUM';
 [a-zA-Z][-_\./a-zA-Z0-9]*[-_a-zA-Z0-9]  return 'ID';
 <<EOF>>                                 return 'EOF';
 
@@ -90,9 +92,13 @@ line
 statement
     : commitStatement
     | mergeStatement
-    | BRANCH ID {yy.branch($2)}
+    | branchStatement
     | CHECKOUT ID {yy.checkout($2)}
     // | RESET reset_arg {yy.reset($2)}
+    ;
+branchStatement
+    : BRANCH ID {yy.branch($2)}
+    | BRANCH ID ORDER NUM {yy.branch($2, $4)}
     ;
 
 mergeStatement


### PR DESCRIPTION
## :bookmark_tabs: Summary
add "order: NUM" syntax to branch creation

Resolves #2937

## :straight_ruler: Design Decisions
branches are sorted by order when returned to renderer

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
