### PR TITLE
Make initThrowsErrors available to clients

### DIFF
--- a/src/mermaid.js
+++ b/src/mermaid.js
@@ -215,6 +215,7 @@ const mermaid = {
   render: mermaidAPI != undefined ? mermaidAPI.render : null,
 
   init,
+  initThrowsErrors,
   initialize,
 
   contentLoaded,


### PR DESCRIPTION
Missing piece for https://github.com/mermaid-js/mermaid/pull/2379

Otherwise I cannot call the function in mermaid-cli