### PR TITLE
Removed unnecessary textLength attribute.

### DIFF
--- a/src/diagrams/sequence/sequenceRenderer.js
+++ b/src/diagrams/sequence/sequenceRenderer.js
@@ -441,7 +441,6 @@ const drawMessage = function (diagram, msgModel, lineStarty) {
       .attr('font-family', 'sans-serif')
       .attr('font-size', '12px')
       .attr('text-anchor', 'middle')
-      .attr('textLength', '16px')
       .attr('class', 'sequenceNumber')
       .text(sequenceIndex);
   }


### PR DESCRIPTION
This attribute makes two digit numbers look bad.