### PR TITLE
Disable Testomatio for forks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,6 +12,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     name: check tests
+    if: github.repository_owner == 'mermaid'
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Fix for #3164.
Don't think there is an easy & secure workaround for this permission issue.