### PR TITLE
fix #3019 Add word boundary to FK&PK.

### DIFF
--- a/src/diagrams/er/parser/erDiagram.jison
+++ b/src/diagrams/er/parser/erDiagram.jison
@@ -28,7 +28,7 @@ accDescr\s*"{"\s*                                { this.begin("acc_descr_multili
 "erDiagram"                     return 'ER_DIAGRAM';
 "{"                             { this.begin("block"); return 'BLOCK_START'; }
 <block>\s+                      /* skip whitespace in block */
-<block>(?:PK)|(?:FK)            return 'ATTRIBUTE_KEY'
+<block>\b((?:PK)|(?:FK))\b      return 'ATTRIBUTE_KEY'
 <block>[A-Za-z][A-Za-z0-9\-_]*  return 'ATTRIBUTE_WORD'
 <block>\"[^"]*\"                return 'COMMENT';
 <block>[\n]+                    /* nothing */

--- a/src/diagrams/er/parser/erDiagram.spec.js
+++ b/src/diagrams/er/parser/erDiagram.spec.js
@@ -72,6 +72,19 @@ describe('when parsing ER diagram it...', function () {
     expect(entities[entity].attributes.length).toBe(1);
   });
 
+  it('should allow an entity with attribute starting with fk or pk and a comment', function () {
+    const entity = 'BOOK';
+    const attribute1 = 'int fk_title FK';
+    const attribute2 = 'string pk_author PK';
+    const attribute3 = 'float pk_price PK "comment"';
+
+    erDiagram.parser.parse(
+      `erDiagram\n${entity} {\n${attribute1} \n\n${attribute2}\n${attribute3}\n}`
+    );
+    const entities = erDb.getEntities();
+    expect(entities[entity].attributes.length).toBe(3);
+  });
+
   it('should allow an entity with multiple attributes to be defined', function () {
     const entity = 'BOOK';
     const attribute1 = 'string title';


### PR DESCRIPTION
## :bookmark_tabs: Summary
Fix error when entities had fk/pk as prefix in ER Diagrams.

Resolves #3019
Resolves #3146

## :straight_ruler: Design Decisions
I feel like there is a more correct way to achive this with bison, but I don't have enough experience in bison to figure it out. This works and all the tests pass. 


### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
