### PR TITLE
fix: add font-awesome css to docsify index.html

### DIFF
--- a/docs/flowchart.md
+++ b/docs/flowchart.md
@@ -612,7 +612,7 @@ The icons are accessed via the syntax fa:#icon class name#.
 
 ```mermaid-example
 flowchart TD
-    B["fa:fa-twitter for peace"]
+    B["fab:fa-twitter for peace"]
     B-->C[fa:fa-ban forbidden]
     B-->D(fa:fa-spinner);
     B-->E(A fa:fa-camera-retro perhaps?)

--- a/docs/flowchart.md
+++ b/docs/flowchart.md
@@ -618,6 +618,8 @@ flowchart TD
     B-->E(A fa:fa-camera-retro perhaps?)
 ```
 
+?> Mermaid is now only compatible with Font Awesome versions 4 and 5. Check that you are using the correct version of Font Awesome.
+
 
 ## Graph declarations with spaces between vertices and link and without semicolon
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
     />
     <!-- <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css"> -->
     <link rel="stylesheet" href="theme.css" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.9.0/css/all.min.css">
     <script src="//cdn.jsdelivr.net/npm/mermaid@9.1.3/dist/mermaid.min.js"></script>
     <!-- <script src="http://localhost:9000/mermaid.js"></script> -->
     <script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,6 +17,7 @@
     />
     <!-- <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css"> -->
     <link rel="stylesheet" href="theme.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
     <script src="//cdn.jsdelivr.net/npm/mermaid@9.1.3/dist/mermaid.min.js"></script>
     <!-- <script src="http://localhost:9000/mermaid.js"></script> -->
     <script>


### PR DESCRIPTION
## :bookmark_tabs: Summary
Because docsify `index.html` does not have font-awesome CSS file setup yet. Thus, Docsify can not render the font-awesome icon in any example pages.

This PR is adding `font-awesome.min.css` in version 5.9.0 and also adding statement to the document that Mermaid now only support font-awesome version 4 and 5 only. The reason explained on :straight_ruler: Design Decisions

Resolves #3190

## :straight_ruler: Design Decisions
This PR is adding `font-awesome.min.css` in version 5.9.0 (Latest Version: 6.1.2) because Mermaid's font-awesome seems supported only old syntax.

For example,
- ([Twitter icon](https://fontawesome.com/v6/search?q=twitter&s=solid%2Cbrands)) in version 6 is using `fa-brands` prefix instead of `fab`, such as `<i class="fa-brands fa-twitter"></i>` 
- ([Car icon](https://fontawesome.com/v6/icons/car?s=solid)) in version is also using `fa-solid` as well, such as `<i class="fa-solid fa-car"></i>`

We should update the [font-awesome extractor](https://github.com/mermaid-js/mermaid/blob/1675174b2a2f80869cba7fa65702a8b9e8709d1d/src/diagrams/flowchart/flowRenderer.js#L62-L64) to support the version 6 as well. 

But it should not included in this PR as it out of scope of the issue. We need to update regex to extract the right `fa` class and write a unit test to make sure every versions (v4, v5, and v6) are working properly.

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [ ] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 

🚨 The unit test fail because of latest commit on `develop` branch. https://github.com/mermaid-js/mermaid/commit/8681e78e50ca48462cfe8677551455ea1e397d41
