### PR TITLE
Example of spaces in stateDiagram

### DIFF
--- a/docs/stateDiagram.md
+++ b/docs/stateDiagram.md
@@ -249,3 +249,13 @@ stateDiagram-v2
 ## Styling
 
 Styling of the a state diagram is done by defining a number of css classes.  During rendering these classes are extracted from the file located at src/themes/state.scss
+
+## Spaces in state names
+
+Spaces can be added to a state by defining it at the top and referencing the acronym later.
+
+```mermaid-example
+stateDiagram-v2
+    Yswsii: Your state with spaces in it
+    [*] --> Yswsii
+```


### PR DESCRIPTION
## :bookmark_tabs: Summary
Update the documentation on how to add spaces to states in a state diagram.

## :straight_ruler: Design Decisions
This example was originally shown by https://github.com/aleneum in https://github.com/mermaid-js/mermaid/issues/1342.

### :clipboard: Tasks
Make sure you
- [X] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [X] :computer: have added unit/e2e tests (if appropriate) 
- [X] :bookmark: targeted `develop` branch 
