### PR TITLE
fix(Diagram): fix persisted data due to db not being cleared before parsing

### DIFF
--- a/src/Diagram.js
+++ b/src/Diagram.js
@@ -18,6 +18,8 @@ class Diagram {
     // console.log('this.type', this.type, diagrams[this.type]);
     // Setup diagram
     this.db = diagrams[this.type].db;
+    this.db.clear();
+
     this.renderer = diagrams[this.type].renderer;
     this.parser = diagrams[this.type].parser;
     this.parser.parser.yy = this.db;

--- a/src/Diagram.js
+++ b/src/Diagram.js
@@ -18,7 +18,7 @@ class Diagram {
     // console.log('this.type', this.type, diagrams[this.type]);
     // Setup diagram
     this.db = diagrams[this.type].db;
-    this.db.clear();
+    this.db.clear?.();
 
     this.renderer = diagrams[this.type].renderer;
     this.parser = diagrams[this.type].parser;

--- a/src/diagrams/sequence/sequenceDiagram.spec.js
+++ b/src/diagrams/sequence/sequenceDiagram.spec.js
@@ -22,6 +22,81 @@ function addConf(conf, key, value) {
 // const parser = sequence.parser;
 let diagram;
 
+describe('more than one sequence diagram', () => {
+  it('should not have duplicated messages', () => {
+    const diagram1 = new Diagram(`
+        sequenceDiagram
+        Alice->Bob:Hello Bob, how are you?
+        Bob-->Alice: I am good thanks!`);
+    expect(diagram1.db.getMessages()).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "from": "Alice",
+          "message": "Hello Bob, how are you?",
+          "to": "Bob",
+          "type": 5,
+          "wrap": false,
+        },
+        Object {
+          "from": "Bob",
+          "message": "I am good thanks!",
+          "to": "Alice",
+          "type": 6,
+          "wrap": false,
+        },
+      ]
+    `);
+    const diagram2 = new Diagram(`
+        sequenceDiagram
+        Alice->Bob:Hello Bob, how are you?
+        Bob-->Alice: I am good thanks!`);
+
+    expect(diagram2.db.getMessages()).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "from": "Alice",
+          "message": "Hello Bob, how are you?",
+          "to": "Bob",
+          "type": 5,
+          "wrap": false,
+        },
+        Object {
+          "from": "Bob",
+          "message": "I am good thanks!",
+          "to": "Alice",
+          "type": 6,
+          "wrap": false,
+        },
+      ]
+    `);
+
+    // Add John actor
+    const diagram3 = new Diagram(`
+        sequenceDiagram
+        Alice->John:Hello John, how are you?
+        John-->Alice: I am good thanks!`);
+
+    expect(diagram3.db.getMessages()).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "from": "Alice",
+          "message": "Hello John, how are you?",
+          "to": "John",
+          "type": 5,
+          "wrap": false,
+        },
+        Object {
+          "from": "John",
+          "message": "I am good thanks!",
+          "to": "Alice",
+          "type": 6,
+          "wrap": false,
+        },
+      ]
+    `);
+  });
+});
+
 describe('when parsing a sequenceDiagram', function () {
   beforeEach(function () {
     // diagram.db = sequenceDb;


### PR DESCRIPTION
## :bookmark_tabs: Summary
Data was being persisted to subsequent newer mermaid Diagrams called via `new`.

Resolves #3305

## :straight_ruler: Design Decisions

I noticed that the `this.db` was not cleared after each call to `new Diagram(...)`. Since the `db` for each diagram type is a singleton, we need to to call clear. 

Otherwise, subsequent calls of the same type will persist the data to the next diagram created.


### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
