### PR TITLE
Fix for GitGraphs not working for Mermaid Live Editor

### DIFF
--- a/src/mermaidAPI.js
+++ b/src/mermaidAPI.js
@@ -41,7 +41,7 @@ import assignWithDepth from './assignWithDepth';
 import DOMPurify from 'dompurify';
 import mermaid from './mermaid';
 
-addDiagrams();
+let hasLoadedDiagrams = false;
 
 /**
  * @param text
@@ -49,7 +49,12 @@ addDiagrams();
  * @returns {any}
  */
 function parse(text, dia) {
+  if (!hasLoadedDiagrams) {
+    addDiagrams();
+    hasLoadedDiagrams = true;
+  }
   var parseEncounteredException = false;
+
   try {
     const diag = dia ? dia : new Diagram(text);
     diag.db.clear();
@@ -515,6 +520,10 @@ function initialize(options) {
 
   updateRendererConfigs(config);
   setLogLevel(config.logLevel);
+  if (!hasLoadedDiagrams) {
+    addDiagrams();
+    hasLoadedDiagrams = true;
+  }
 }
 
 const mermaidAPI = Object.freeze({

--- a/src/mermaidAPI.js
+++ b/src/mermaidAPI.js
@@ -40,6 +40,9 @@ import utils, { directiveSanitizer } from './utils';
 import assignWithDepth from './assignWithDepth';
 import DOMPurify from 'dompurify';
 import mermaid from './mermaid';
+
+addDiagrams();
+
 /**
  * @param text
  * @param dia
@@ -512,7 +515,6 @@ function initialize(options) {
 
   updateRendererConfigs(config);
   setLogLevel(config.logLevel);
-  addDiagrams();
 }
 
 const mermaidAPI = Object.freeze({


### PR DESCRIPTION
## :bookmark_tabs: Summary
Fixes broken gitGraph for Mermaid Live Editor. 

Resolves #3306 

## :straight_ruler: Design Decisions
Moved the diagram registration logic out of initialize function, as Mermaid Live Editor used the parse function in the edit mode and initialize and renders later. Now diagram registration is independent of initialize() and hence fixes the issue. 

### :clipboard: Tasks
Make sure you
- [X] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [X] :computer: have added unit/e2e tests (if appropriate) 
- [X] :bookmark: targeted `develop` branch 
