### PR TITLE
Add tests for C4 parser

### DIFF
--- a/src/diagrams/c4/parser/flow.spec.js
+++ b/src/diagrams/c4/parser/flow.spec.js
@@ -49,4 +49,21 @@ Person(customerA, "Banking Customer A", "A customer of the bank, with personal b
 
     expect(rendered).toBe(true);
   });
+
+  it('should handle parameter names that are keywords', function () {
+    flow.parser.parse(`C4Context
+title title
+Person(Person, "Person", "Person")`);
+
+    const yy = flow.parser.yy;
+    expect(yy.getTitle()).toBe('title');
+
+    const shapes = yy.getC4ShapeArray();
+    expect(shapes.length).toBe(1);
+    const onlyShape = shapes[0];
+
+    expect(onlyShape.alias).toBe('Person');
+    expect(onlyShape.descr.text).toBe('Person');
+    expect(onlyShape.label.text).toBe('Person');
+  });
 });

--- a/src/diagrams/c4/parser/flow.spec.js
+++ b/src/diagrams/c4/parser/flow.spec.js
@@ -40,4 +40,13 @@ Person(customerA, "Banking Customer A", "A customer of the bank, with personal b
       wrap: false,
     });
   });
+
+  it('should handle a trailing whitespaces after statements', function () {
+    const whitespace = ' ';
+    const rendered = flow.parser.parse(`C4Context${whitespace}
+title System Context diagram for Internet Banking System${whitespace}
+Person(customerA, "Banking Customer A", "A customer of the bank, with personal bank accounts.")${whitespace}`);
+
+    expect(rendered).toBe(true);
+  });
 });

--- a/src/diagrams/c4/parser/flow.spec.js
+++ b/src/diagrams/c4/parser/flow.spec.js
@@ -66,4 +66,19 @@ Person(Person, "Person", "Person")`);
     expect(onlyShape.descr.text).toBe('Person');
     expect(onlyShape.label.text).toBe('Person');
   });
+
+  it('should allow default in the parameters', function () {
+    flow.parser.parse(`C4Context
+Person(default, "default", "default")`);
+
+    const yy = flow.parser.yy;
+
+    const shapes = yy.getC4ShapeArray();
+    expect(shapes.length).toBe(1);
+    const onlyShape = shapes[0];
+
+    expect(onlyShape.alias).toBe('default');
+    expect(onlyShape.descr.text).toBe('default');
+    expect(onlyShape.label.text).toBe('default');
+  });
 });

--- a/src/diagrams/c4/parser/flow.spec.js
+++ b/src/diagrams/c4/parser/flow.spec.js
@@ -1,0 +1,43 @@
+import flowDb from '../c4Db';
+import flow from './c4Diagram.jison';
+import { setConfig } from '../../../config';
+
+setConfig({
+  securityLevel: 'strict',
+});
+
+describe('parsing a flow chart', function () {
+  beforeEach(function () {
+    flow.parser.yy = flowDb;
+    flow.parser.yy.clear();
+  });
+
+  it('should parse a C4 diagram with one Person correctly', function () {
+    flow.parser.parse(`C4Context
+title System Context diagram for Internet Banking System
+Person(customerA, "Banking Customer A", "A customer of the bank, with personal bank accounts.")`);
+
+    const yy = flow.parser.yy;
+    expect(yy.getC4Type()).toBe('C4Context');
+    expect(yy.getTitle()).toBe('System Context diagram for Internet Banking System');
+
+    const shapes = yy.getC4ShapeArray();
+    expect(shapes.length).toBe(1);
+    const onlyShape = shapes[0];
+
+    expect(onlyShape).toEqual({
+      alias: 'customerA',
+      descr: {
+        text: 'A customer of the bank, with personal bank accounts.',
+      },
+      label: {
+        text: 'Banking Customer A',
+      },
+      parentBoundary: 'global',
+      typeC4Shape: {
+        text: 'person',
+      },
+      wrap: false,
+    });
+  });
+});


### PR DESCRIPTION
## :bookmark_tabs: Summary
This adds tests for the new C4 diagram type, specifically for the parser. This PR will not contain any changes to the actual production code.

It is based on [the following discussion](https://github.com/mermaid-js/mermaid/pull/3151#issuecomment-1174676087).

For now, it's a work in progress, but will always be in a mergeable state so that if a reviewer sees it, they are encouraged to review and merge right away. This way, the first tests will be available as soon as a reviewer has time to review, and units of review can be kept small.

## :straight_ruler: Design Decisions

Tests are similar to the tests for the flowchart parser.

### :clipboard: Tasks
Make sure you
- [X] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [X] :computer: have added unit/e2e tests (if appropriate) 
- [X] :bookmark: targeted `develop` branch 
