### PR TITLE
Fix for build by revering jsdoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "moment": "^2.23.0",
     "path-browserify": "^1.0.1",
     "prettier": "^2.3.2",
-    "prettier-plugin-jsdoc": "^0.4.1",
+    "prettier-plugin-jsdoc": "^0.3.30",
     "start-server-and-test": "^1.12.6",
     "terser-webpack-plugin": "^5.2.4",
     "webpack": "^5.53.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9340,10 +9340,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier-plugin-jsdoc@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-jsdoc/-/prettier-plugin-jsdoc-0.4.1.tgz#3ab15b8c50203b4ff3287e3df6a7034387aebede"
-  integrity sha512-wWs43HdlGoOAqD/LZQ6SpXujRkZ7YzoFC5bCfClBdrlTesZBGBB1cTAUS6ofJnkfNQyiNXNnRAo6Rl56uBTxnQ==
+prettier-plugin-jsdoc@^0.3.30:
+  version "0.3.38"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-jsdoc/-/prettier-plugin-jsdoc-0.3.38.tgz#b8adbe9efc1dc11f3cc5ff0b07e0233a0fdf533d"
+  integrity sha512-h81ZV/nFk5gr3fzWMWzWoz/M/8FneAZxscT7DVSy+5jMIuWYnBFZfSswVKYZyTaZ5r6+6k4hpFTDWhRp85C1tg==
   dependencies:
     binary-searching "^2.0.5"
     comment-parser "^1.3.1"


### PR DESCRIPTION
## :bookmark_tabs: Summary
Switches to a version of jsdoc that works.
