### PR TITLE
Fix font weight for messages in sequence diagrams

### DIFF
--- a/src/diagrams/sequence/styles.js
+++ b/src/diagrams/sequence/styles.js
@@ -45,7 +45,7 @@ const getStyles = (options) =>
 
   .messageText {
     fill: ${options.signalTextColor};
-    stroke: ${options.signalTextColor};
+    stroke: none;
   }
 
   .labelBox {


### PR DESCRIPTION
## :bookmark_tabs: Summary
Set `stroke: none` for `.messageText`.

Resolves #1976 

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [ ] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
