### PR TITLE
Add nested test for parseGenericTypes

### DIFF
--- a/src/diagrams/class/svgDraw.js
+++ b/src/diagrams/class/svgDraw.js
@@ -345,10 +345,9 @@ const buildMethodDisplay = function (parsedText) {
 };
 
 const buildLegacyDisplay = function (text) {
-  // if for some reason we dont have any match, use old format to parse text
+  // if for some reason we don't have any match, use old format to parse text
   let displayText = '';
   let cssStyle = '';
-  let memberText = '';
   let returnType = '';
   let methodStart = text.indexOf('(');
   let methodEnd = text.indexOf(')');
@@ -368,26 +367,27 @@ const buildLegacyDisplay = function (text) {
       methodName = text.substring(1, methodStart).trim();
     }
 
-    let parameters = text.substring(methodStart + 1, methodEnd);
-    let classifier = text.substring(methodEnd + 1, 1);
+    const parameters = text.substring(methodStart + 1, methodEnd);
+    const classifier = text.substring(methodEnd + 1, methodEnd + 2);
     cssStyle = parseClassifier(classifier);
 
     displayText = visibility + methodName + '(' + parseGenericTypes(parameters.trim()) + ')';
 
-    if (methodEnd < memberText.length) {
+    if (methodEnd <= text.length) {
       returnType = text.substring(methodEnd + 2).trim();
       if (returnType !== '') {
         returnType = ' : ' + parseGenericTypes(returnType);
+        displayText += returnType;
       }
+    } else {
+      // finally - if all else fails, just send the text back as written (other than parsing for generic types)
+      displayText = parseGenericTypes(text);
     }
-  } else {
-    // finally - if all else fails, just send the text back as written (other than parsing for generic types)
-    displayText = parseGenericTypes(text);
   }
 
   return {
-    displayText: displayText,
-    cssStyle: cssStyle,
+    displayText,
+    cssStyle,
   };
 };
 

--- a/src/diagrams/class/svgDraw.spec.js
+++ b/src/diagrams/class/svgDraw.spec.js
@@ -137,6 +137,14 @@ describe('class member Renderer, ', function () {
       expect(actual.displayText).toBe('+foo(List<int> ids) : List<Item>');
       expect(actual.cssStyle).toBe('font-style:italic;');
     });
+
+    it('should handle method declaration with nested markup', function () {
+      const str = '+foo (  List~List~int~~ ids  )* List~List~Item~~';
+      let actual = svgDraw.parseMember(str);
+
+      expect(actual.displayText).toBe('+foo(List<List<int>> ids) : List<List<Item>>');
+      expect(actual.cssStyle).toBe('font-style:italic;');
+    });
   });
 
   describe('when parsing text to build field display string', function () {

--- a/src/diagrams/common/common.js
+++ b/src/diagrams/common/common.js
@@ -197,7 +197,7 @@ export const parseGenericTypes = function (text) {
 
   if (text.indexOf('~') != -1) {
     cleanedText = cleanedText.replace(/~([^~].*)/, '<$1');
-    cleanedText = cleanedText.replace(/~([^~]*)$/, '$1>');
+    cleanedText = cleanedText.replace(/~([^~]*)$/, '>$1');
 
     return parseGenericTypes(cleanedText);
   } else {

--- a/src/diagrams/common/common.js
+++ b/src/diagrams/common/common.js
@@ -196,8 +196,8 @@ export const parseGenericTypes = function (text) {
   let cleanedText = text;
 
   if (text.indexOf('~') != -1) {
-    cleanedText = cleanedText.replace('~', '<');
-    cleanedText = cleanedText.replace('~', '>');
+    cleanedText = cleanedText.replace(/~([^~].*)/, '<$1');
+    cleanedText = cleanedText.replace(/~([^~]*)$/, '$1>');
 
     return parseGenericTypes(cleanedText);
   } else {

--- a/src/diagrams/common/common.spec.js
+++ b/src/diagrams/common/common.spec.js
@@ -108,5 +108,11 @@ describe('generic parser', function () {
   it('should parse generic types', function () {
     expect(parseGenericTypes('test~T~')).toEqual('test<T>');
     expect(parseGenericTypes('test~Array~Array~string~~~')).toEqual('test<Array<Array<string>>>');
+    expect(parseGenericTypes('test~Array~Array~string[]~~~')).toEqual(
+      'test<Array<Array<string[]>>>'
+    );
+    expect(parseGenericTypes('test ~Array~Array~string[]~~~')).toEqual(
+      'test <Array<Array<string[]>>>'
+    );
   });
 });

--- a/src/diagrams/common/common.spec.js
+++ b/src/diagrams/common/common.spec.js
@@ -106,7 +106,7 @@ describe('Sanitize text', function () {
 
 describe('generic parser', function () {
   it('should parse generic types', function () {
-    const result = parseGenericTypes('test~T~');
-    expect(result).toEqual('test<T>');
+    expect(parseGenericTypes('test~T~')).toEqual('test<T>');
+    expect(parseGenericTypes('test~Array~Array~string~~~')).toEqual('test<Array<Array<string>>>');
   });
 });


### PR DESCRIPTION
## :bookmark_tabs: Summary
Add testcase for parseGenericTypes

@FlorianWoelki, the case mentioned in the doc seems to fail when added as a unit test.

```
// returns "Array<Array<string>>"
 *   parseGenericTypes('Array~Array~string~~');
```

```
    Expected: "test<Array<Array<string>>>"
    Received: "test<Array>Array<string><>"
```

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
