### PR TITLE
Added 'ms' duration to gantt diagram

### DIFF
--- a/cypress/integration/rendering/gantt.spec.js
+++ b/cypress/integration/rendering/gantt.spec.js
@@ -163,6 +163,24 @@ describe('Gantt diagram', () => {
     );
   });
 
+  it('should handle milliseconds', () => {
+    imgSnapshotTest(
+      `
+    gantt
+      title A Gantt Diagram
+      dateFormat x
+      axisFormat %L
+      section Section
+      A task           :a1, 0, 30ms
+      Another task     :after a1, 20ms
+      section Another
+      Another another task      :b1, 20, 12ms
+      Another another another task     :after b1, 24ms
+        `,
+      {}
+    );
+  });
+
   it('should render a gantt diagram when useMaxWidth is true (default)', () => {
     renderGraph(
       `

--- a/src/diagrams/gantt/ganttDb.js
+++ b/src/diagrams/gantt/ganttDb.js
@@ -233,6 +233,9 @@ const getStartDate = function (prevTime, dateFormat, str) {
 const durationToDate = function (durationStatement, relativeTime) {
   if (durationStatement !== null) {
     switch (durationStatement[2]) {
+      case 'ms':
+        relativeTime.add(durationStatement[1], 'milliseconds');
+        break;
       case 's':
         relativeTime.add(durationStatement[1], 'seconds');
         break;
@@ -267,7 +270,7 @@ const getEndDate = function (prevTime, dateFormat, str, inclusive) {
     return mDate.toDate();
   }
 
-  return durationToDate(/^([\d]+)([wdhms])/.exec(str.trim()), moment(prevTime));
+  return durationToDate(/^([\d]+)([wdhms]|ms)$/.exec(str.trim()), moment(prevTime));
 };
 
 let taskCnt = 0;

--- a/src/diagrams/gantt/ganttDb.spec.js
+++ b/src/diagrams/gantt/ganttDb.spec.js
@@ -99,6 +99,27 @@ describe('when using the ganttDb', function () {
     }
   );
 
+  it('should handle milliseconds', function () {
+    ganttDb.setDateFormat('x');
+    ganttDb.addSection('testa1');
+    ganttDb.addTask('test1', 'id1,0,20ms');
+    ganttDb.addTask('test2', 'id2,after id1,5ms');
+    ganttDb.addSection('testa2');
+    ganttDb.addTask('test3', 'id3,20,10ms');
+    ganttDb.addTask('test4', 'id4,after id3,5ms');
+
+    const tasks = ganttDb.getTasks();
+
+    expect(tasks[0].startTime.toISOString()).toEqual('1970-01-01T00:00:00.000Z');
+    expect(tasks[0].endTime.toISOString()).toEqual('1970-01-01T00:00:00.020Z');
+    expect(tasks[1].startTime.toISOString()).toEqual('1970-01-01T00:00:00.020Z');
+    expect(tasks[1].endTime.toISOString()).toEqual('1970-01-01T00:00:00.025Z');
+    expect(tasks[2].startTime.toISOString()).toEqual('1970-01-01T00:00:00.020Z');
+    expect(tasks[2].endTime.toISOString()).toEqual('1970-01-01T00:00:00.030Z');
+    expect(tasks[3].startTime.toISOString()).toEqual('1970-01-01T00:00:00.030Z');
+    expect(tasks[3].endTime.toISOString()).toEqual('1970-01-01T00:00:00.035Z');
+  });
+
   it('should handle relative start date based on id regardless of sections', function () {
     ganttDb.setDateFormat('YYYY-MM-DD');
     ganttDb.addSection('testa1');


### PR DESCRIPTION
## :bookmark_tabs: Summary
Hi. This PR features task duration in milliseconds.

Resolves #3028 

![image](https://user-images.githubusercontent.com/7579321/186518575-03005b1c-81ac-4635-a6d1-575274ee3bf6.png)

```
    gantt
      title A Gantt Diagram
      dateFormat x
      axisFormat %L
      section Section
      A task           :a1, 0, 30ms
      Another task     :after a1, 20ms
      section Another
      Another another task      :b1, 20, 12ms
      Another another another task     :after b1, 24ms
```

## :straight_ruler: Design Decisions

No crazy things

- Fix the regex to match multi character including `ms`
    - Previously the string was not matched until the end -> `10ms` was matched as `10 minutes`
    - The side effect is now a duration like `10mhj` will probably not be matched anymore -> which is IMO better
- Use `ms` to properly convert the duration in millisecond

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
