### PR TITLE
Feature decimal duration in second for gantt diagram

### DIFF
--- a/cypress/integration/rendering/gantt.spec.js
+++ b/cypress/integration/rendering/gantt.spec.js
@@ -175,7 +175,7 @@ describe('Gantt diagram', () => {
       Another task     :after a1, 20ms
       section Another
       Another another task      :b1, 20, 12ms
-      Another another another task     :after b1, 24ms
+      Another another another task     :after b1, 0.024s
         `,
       {}
     );

--- a/src/diagrams/gantt/ganttDb.js
+++ b/src/diagrams/gantt/ganttDb.js
@@ -231,37 +231,30 @@ const getStartDate = function (prevTime, dateFormat, str) {
 };
 
 /**
- * Parse a duration as an absolute date.
+ * Parse a string as a moment duration.
  *
- * @param durationStr A string representing a duration
- * @param relativeTime The moment when this duration starts
- * @returns The date of the end of the duration.
+ * The string have to be compound by a value and a shorthand duration unit. For example `5d`
+ * representes 5 days.
+ *
+ * Shorthand unit supported are:
+ *
+ * - `y` for years
+ * - `M` for months
+ * - `w` for weeks
+ * - `d` for days
+ * - `h` for hours
+ * - `s` for seconds
+ * - `ms` for milliseconds
+ *
+ * @param {string} str - A string representing the duration.
+ * @returns {moment.Duration} A moment duration, including an invalid moment for invalid input string.
  */
-const parseDuration = function (durationStr, relativeTime) {
-  const durationStatement = /^(\d+(?:\.\d+)?)([wdhms]|ms)$/.exec(durationStr.trim());
-  if (durationStatement !== null) {
-    switch (durationStatement[2]) {
-      case 'ms':
-        relativeTime.add(durationStatement[1], 'milliseconds');
-        break;
-      case 's':
-        relativeTime.add(durationStatement[1], 'seconds');
-        break;
-      case 'm':
-        relativeTime.add(durationStatement[1], 'minutes');
-        break;
-      case 'h':
-        relativeTime.add(durationStatement[1], 'hours');
-        break;
-      case 'd':
-        relativeTime.add(durationStatement[1], 'days');
-        break;
-      case 'w':
-        relativeTime.add(durationStatement[1], 'weeks');
-        break;
-    }
+const parseDuration = function (str) {
+  const statement = /^(\d+(?:\.\d+)?)([yMwdhms]|ms)$/.exec(str.trim());
+  if (statement !== null) {
+    return moment.duration(Number.parseFloat(statement[1]), statement[2]);
   }
-  return relativeTime.toDate();
+  return moment.duration.invalid();
 };
 
 const getEndDate = function (prevTime, dateFormat, str, inclusive) {
@@ -277,7 +270,12 @@ const getEndDate = function (prevTime, dateFormat, str, inclusive) {
     return mDate.toDate();
   }
 
-  return parseDuration(str, moment(prevTime));
+  const endTime = moment(prevTime);
+  const duration = parseDuration(str);
+  if (duration.isValid()) {
+    endTime.add(duration);
+  }
+  return endTime.toDate();
 };
 
 let taskCnt = 0;

--- a/src/diagrams/gantt/ganttDb.js
+++ b/src/diagrams/gantt/ganttDb.js
@@ -230,7 +230,15 @@ const getStartDate = function (prevTime, dateFormat, str) {
   return new Date();
 };
 
-const durationToDate = function (durationStatement, relativeTime) {
+/**
+ * Parse a duration as an absolute date.
+ *
+ * @param durationStr A string representing a duration
+ * @param relativeTime The moment when this duration starts
+ * @returns The date of the end of the duration.
+ */
+const parseDuration = function (durationStr, relativeTime) {
+  const durationStatement = /^([\d]+)([wdhms]|ms)$/.exec(durationStr.trim());
   if (durationStatement !== null) {
     switch (durationStatement[2]) {
       case 'ms':
@@ -253,7 +261,6 @@ const durationToDate = function (durationStatement, relativeTime) {
         break;
     }
   }
-  // Default date - now
   return relativeTime.toDate();
 };
 
@@ -270,7 +277,7 @@ const getEndDate = function (prevTime, dateFormat, str, inclusive) {
     return mDate.toDate();
   }
 
-  return durationToDate(/^([\d]+)([wdhms]|ms)$/.exec(str.trim()), moment(prevTime));
+  return parseDuration(str, moment(prevTime));
 };
 
 let taskCnt = 0;
@@ -666,7 +673,7 @@ export default {
   setLink,
   getLinks,
   bindFunctions,
-  durationToDate,
+  parseDuration,
   isInvalidDate,
 };
 

--- a/src/diagrams/gantt/ganttDb.js
+++ b/src/diagrams/gantt/ganttDb.js
@@ -238,7 +238,7 @@ const getStartDate = function (prevTime, dateFormat, str) {
  * @returns The date of the end of the duration.
  */
 const parseDuration = function (durationStr, relativeTime) {
-  const durationStatement = /^([\d]+)([wdhms]|ms)$/.exec(durationStr.trim());
+  const durationStatement = /^(\d+(?:\.\d+)?)([wdhms]|ms)$/.exec(durationStr.trim());
   if (durationStatement !== null) {
     switch (durationStatement[2]) {
       case 'ms':

--- a/src/diagrams/gantt/ganttDb.spec.js
+++ b/src/diagrams/gantt/ganttDb.spec.js
@@ -8,11 +8,11 @@ describe('when using the ganttDb', function () {
 
   describe('when using relative times', function () {
     it.each`
-      diff     | date                    | expected
-      ${' 1d'} | ${moment('2019-01-01')} | ${moment('2019-01-02').toDate()}
-      ${' 1w'} | ${moment('2019-01-01')} | ${moment('2019-01-08').toDate()}
+      diff    | date                    | expected
+      ${'1d'} | ${moment('2019-01-01')} | ${moment('2019-01-02').toDate()}
+      ${'1w'} | ${moment('2019-01-01')} | ${moment('2019-01-08').toDate()}
     `('should add $diff to $date resulting in $expected', ({ diff, date, expected }) => {
-      expect(ganttDb.durationToDate(diff, date)).toEqual(expected);
+      expect(ganttDb.parseDuration(diff, date)).toEqual(expected);
     });
   });
 
@@ -106,7 +106,7 @@ describe('when using the ganttDb', function () {
     ganttDb.addTask('test2', 'id2,after id1,5ms');
     ganttDb.addSection('testa2');
     ganttDb.addTask('test3', 'id3,20,10ms');
-    ganttDb.addTask('test4', 'id4,after id3,5ms');
+    ganttDb.addTask('test4', 'id4,after id3,0.005s');
 
     const tasks = ganttDb.getTasks();
 

--- a/src/diagrams/gantt/ganttDb.spec.js
+++ b/src/diagrams/gantt/ganttDb.spec.js
@@ -6,15 +6,16 @@ describe('when using the ganttDb', function () {
     ganttDb.clear();
   });
 
-  describe('when using relative times', function () {
+  describe('when using duration', function () {
     it.each`
-      diff      | date                        | expected
-      ${'1d'}   | ${moment.utc('2019-01-01')} | ${'2019-01-02T00:00:00.000Z'}
-      ${'1w'}   | ${moment.utc('2019-01-01')} | ${'2019-01-08T00:00:00.000Z'}
-      ${'1ms'}  | ${moment.utc('2019-01-01')} | ${'2019-01-01T00:00:00.001Z'}
-      ${'0.1s'} | ${moment.utc('2019-01-01')} | ${'2019-01-01T00:00:00.100Z'}
-    `('should add $diff to $date resulting in $expected', ({ diff, date, expected }) => {
-      expect(ganttDb.parseDuration(diff, date).toISOString()).toEqual(expected);
+      str       | expected
+      ${'1d'}   | ${moment.duration(1, 'd')}
+      ${'2w'}   | ${moment.duration(2, 'w')}
+      ${'1ms'}  | ${moment.duration(1, 'ms')}
+      ${'0.1s'} | ${moment.duration(100, 'ms')}
+      ${'1f'}   | ${moment.duration.invalid()}
+    `('should $str resulting in $expected duration', ({ str, expected }) => {
+      expect(ganttDb.parseDuration(str)).toEqual(expected);
     });
   });
 

--- a/src/diagrams/gantt/ganttDb.spec.js
+++ b/src/diagrams/gantt/ganttDb.spec.js
@@ -8,11 +8,13 @@ describe('when using the ganttDb', function () {
 
   describe('when using relative times', function () {
     it.each`
-      diff    | date                    | expected
-      ${'1d'} | ${moment('2019-01-01')} | ${moment('2019-01-02').toDate()}
-      ${'1w'} | ${moment('2019-01-01')} | ${moment('2019-01-08').toDate()}
+      diff      | date                        | expected
+      ${'1d'}   | ${moment.utc('2019-01-01')} | ${'2019-01-02T00:00:00.000Z'}
+      ${'1w'}   | ${moment.utc('2019-01-01')} | ${'2019-01-08T00:00:00.000Z'}
+      ${'1ms'}  | ${moment.utc('2019-01-01')} | ${'2019-01-01T00:00:00.001Z'}
+      ${'0.1s'} | ${moment.utc('2019-01-01')} | ${'2019-01-01T00:00:00.100Z'}
     `('should add $diff to $date resulting in $expected', ({ diff, date, expected }) => {
-      expect(ganttDb.parseDuration(diff, date)).toEqual(expected);
+      expect(ganttDb.parseDuration(diff, date).toISOString()).toEqual(expected);
     });
   });
 


### PR DESCRIPTION
## :bookmark_tabs: Summary
Hi, following #3355 this PR feature a duration in second in decimal (`0.1s`).

```
   gantt
      title A Gantt Diagram
      dateFormat x
      axisFormat %L
      section Section
      A task           :a1, 0, 0.3s
      Another task     :after a1, 0.2s
```

Plus some clean up.

Resolves #3028

## :straight_ruler: Design Decisions

Previously:

- The duration parsing was done at 2 different places (regex in one side, transformation of the regex result at another place)
- `durationToDate` was using input in `moment`, output in `Date` (which is kind of inconsistent)

Changes:

- `durationToDate` was replaced by `parseDuration` which is now a pure function for parsing (easier to test)
     - `parseDuration` now also supports years (`y`) and months (`M`)
     - invalid duration string are parsed as invalid duration
     - regex was updated to support decimal values including dot (`0.1`)
- `getEndDate` handle the business logic with the parsing result
     - an invalid duration is considered as a duration of 0d, like before (but could be handled in a different way)

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
