### PR TITLE
feat(git): allow custom merge commit ids

### DIFF
--- a/cypress/integration/rendering/gitGraph.spec.js
+++ b/cypress/integration/rendering/gitGraph.spec.js
@@ -74,7 +74,7 @@ describe('Git Graph diagram', () => {
       {}
     );
   });
-  it('7: should render a simple gitgraph with three branches and merge commit', () => {
+  it('7: should render a simple gitgraph with three branches and tagged merge commit', () => {
     imgSnapshotTest(
       `gitGraph
        commit id: "1"
@@ -93,7 +93,7 @@ describe('Git Graph diagram', () => {
        checkout nice_feature
        commit id: "7"
        checkout main
-       merge nice_feature
+       merge nice_feature id: "12345" tag: "my merge commit"
        checkout very_nice_feature
        commit id: "8"
        checkout main

--- a/docs/gitgraph.md
+++ b/docs/gitgraph.md
@@ -182,6 +182,8 @@ After this we made use of the `checkout` keyword to set the current branch as `m
 After this we merge the `develop` branch onto the current branch `main`, resulting in a merge commit.
 Since the current branch at this point is still `main`, the last two commits are registered against that.
 
+Additionally, you may add a tag to the merge commit, or override the default id: `merge branch id:"1234" tag:"v1.0.0"`
+
 ### Cherry Pick commit from another branch
 Similar to how 'git' allows you to cherry-pick a commit from **another branch** onto the **current** branch, Mermaid also supports this functionality. You can also cherry-pick a commit from another branch using the `cherry-pick` keyword.
 

--- a/src/diagrams/git/gitGraphAst.js
+++ b/src/diagrams/git/gitGraphAst.js
@@ -148,8 +148,17 @@ export const branch = function (name, order) {
   }
 };
 
-export const merge = function (otherBranch, tag) {
+/**
+ * Creates a merge commit.
+ *
+ * @param {string} otherBranch - Target branch to merge to.
+ * @param {string} [tag] - Git tag to use on this merge commit.
+ * @param {string} [id] - Git commit id.
+ */
+export const merge = function (otherBranch, tag, id) {
   otherBranch = common.sanitizeText(otherBranch, configApi.getConfig());
+  id = common.sanitizeText(id, configApi.getConfig());
+
   const currentCommit = commits[branches[curBranch]];
   const otherCommit = commits[branches[otherBranch]];
   if (curBranch === otherBranch) {
@@ -219,7 +228,7 @@ export const merge = function (otherBranch, tag) {
   // } else {
   // create merge commit
   const commit = {
-    id: seq + '-' + getId(),
+    id: id || seq + '-' + getId(),
     message: 'merged branch ' + otherBranch + ' into ' + curBranch,
     seq: seq++,
     parents: [head == null ? null : head.id, branches[otherBranch]],

--- a/src/diagrams/git/gitGraphParserV2.spec.js
+++ b/src/diagrams/git/gitGraphParserV2.spec.js
@@ -496,6 +496,76 @@ describe('when parsing a gitGraph', function () {
     ]);
   });
 
+  it('should handle merge ids', function () {
+    const str = `gitGraph:
+      commit
+      branch testBranch
+      checkout testBranch
+      commit
+      checkout main
+      %% Merge Tag and ID
+      merge testBranch tag: "merge-tag" id: "2-222"
+      branch testBranch2
+      checkout testBranch2
+      commit
+      checkout main
+      %% Merge ID and Tag (reverse order)
+      merge testBranch2 id: "4-444" tag: "merge-tag2"
+      branch testBranch3
+      checkout testBranch3
+      commit
+      checkout main
+      %% just Merge ID
+      merge testBranch3 id: "6-666"
+    `;
+
+    parser.parse(str);
+    const commits = parser.yy.getCommits();
+    expect(Object.keys(commits).length).toBe(7);
+    expect(parser.yy.getCurrentBranch()).toBe('main');
+    expect(parser.yy.getDirection()).toBe('LR');
+
+    // The order of these commits is in alphabetical order of IDs
+    const [
+      mainCommit,
+      testBranchCommit,
+      testBranchMerge,
+      testBranch2Commit,
+      testBranch2Merge,
+      testBranch3Commit,
+      testBranch3Merge,
+    ] = Object.values(commits);
+
+    console.log(Object.keys(commits));
+
+    expect(mainCommit.branch).toBe('main');
+    expect(mainCommit.parents).toStrictEqual([]);
+
+    expect(testBranchCommit.branch).toBe('testBranch');
+    expect(testBranchCommit.parents).toStrictEqual([mainCommit.id]);
+
+    expect(testBranchMerge.branch).toBe('main');
+    expect(testBranchMerge.parents).toStrictEqual([mainCommit.id, testBranchCommit.id]);
+    expect(testBranchMerge.tag).toBe('merge-tag');
+    expect(testBranchMerge.id).toBe('2-222');
+
+    expect(testBranch2Merge.branch).toBe('main');
+    expect(testBranch2Merge.parents).toStrictEqual([testBranchMerge.id, testBranch2Commit.id]);
+    expect(testBranch2Merge.tag).toBe('merge-tag2');
+    expect(testBranch2Merge.id).toBe('4-444');
+
+    expect(testBranch3Merge.branch).toBe('main');
+    expect(testBranch3Merge.parents).toStrictEqual([testBranch2Merge.id, testBranch3Commit.id]);
+    expect(testBranch3Merge.id).toBe('6-666');
+
+    expect(parser.yy.getBranchesAsObjArray()).toStrictEqual([
+      { name: 'main' },
+      { name: 'testBranch' },
+      { name: 'testBranch2' },
+      { name: 'testBranch3' },
+    ]);
+  });
+
   it('should throw error when try to branch existing branch: main', function () {
     const str = `gitGraph
     commit

--- a/src/diagrams/git/gitGraphRenderer.js
+++ b/src/diagrams/git/gitGraphRenderer.js
@@ -215,11 +215,7 @@ const drawCommits = (svg, commits, modifyGraph) => {
       const px = 4;
       const py = 2;
       // Draw the commit label
-      if (
-        commit.type !== commitType.CHERRY_PICK &&
-        commit.type !== commitType.MERGE &&
-        gitGraphConfig.showCommitLabel
-      ) {
+      if (commit.type !== commitType.CHERRY_PICK && gitGraphConfig.showCommitLabel) {
         const wrapper = gLabels.append('g');
         const labelBkg = wrapper.insert('rect').attr('class', 'commit-label-bkg');
 

--- a/src/diagrams/git/parser/gitGraph.jison
+++ b/src/diagrams/git/parser/gitGraph.jison
@@ -123,6 +123,9 @@ cherryPickStatement
 mergeStatement
     : MERGE ID {yy.merge($2)}
     | MERGE ID COMMIT_TAG STR {yy.merge($2, $4)}
+    | MERGE ID COMMIT_ID STR {yy.merge($2, '', $4)}
+    | MERGE ID COMMIT_TAG STR COMMIT_ID STR {yy.merge($2, $4, $6)}
+    | MERGE ID COMMIT_ID STR COMMIT_TAG STR {yy.merge($2, $6, $4)}
     ;
 
 commitStatement


### PR DESCRIPTION
## :bookmark_tabs: Summary

Currently, merge commits can have a git tag, but they cannot have a custom git commit ID.

This commit allows modifying the default merge commit id.

Resolves #3356

Partially resolves issue #3238 (most of the discussion there is talking about merge commit IDs, but technically the issue is asking for all merge commits to have all the same options as base commits).

## :straight_ruler: Design Decisions

In order to view the custom merge commit ids, I've undone commit https://github.com/mermaid-js/mermaid/commit/3ccf027f4285ba89bba13de62d05d0ce58ac79b5.

**This means that all merge commits have their IDs displayed, including auto-generated commit IDs.** Personally, I think this is okay, since it's how git works, but it does add a bit of clutter to the git graphs.

If you want, I could hide merge commits labels behind a config option `gitGraphConfig.showMergeCommitLabel`.

I've also made a commit (https://github.com/aloisklink/mermaid/commit/954bf9e1607afc0bcff5166199d5a85b537e5acc), where I update some ```mermaid-examples``` diagrams in the docs, but they're not included in this PR, since the docs currently only use v9.1.5 of mermaid: https://github.com/mermaid-js/mermaid/blob/cde3a7cf70cbf6f33406ebb4e83e58d7af9feb7d/docs/index.html#L21-L22

### Example changes:

```mermaid-example
%%{init: { 'logLevel': 'debug', 'theme': 'forest' } }%%
      gitGraph
        commit
        branch hotfix
        checkout hotfix
        commit
        branch develop
        checkout develop
        commit id:"ash" tag:"abc"
        branch featureB
        checkout featureB
        commit type:HIGHLIGHT
        checkout main
        checkout hotfix
        commit type:NORMAL
        checkout develop
        commit type:REVERSE
        checkout featureB
        commit
        checkout main
        merge hotfix
        checkout featureB
        commit
        checkout develop
        branch featureA
        commit
        checkout develop
        %% ID added here
        merge hotfix id: "bca"
        checkout featureA
        commit
        checkout featureB
        commit
        checkout develop
        %% Tag added here (already working before)
        merge featureA tag: "v1.1.0-rc1"
        branch release
        checkout release
        commit
        checkout main
        commit
        checkout release
        merge main
        checkout develop
        merge release
```

![image](https://user-images.githubusercontent.com/19716675/186782650-548918ff-c29c-44e4-a44f-1b6747c3e29c.png)


### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
