### PR TITLE
build: add eslint --cache file to speed up commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ Gemfile.lock
 
 cypress/screenshots/
 cypress/snapshots/
+
+# eslint --cache file
+.eslintcache

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "postbuild": "documentation build src/mermaidAPI.js src/config.js src/defaultConfig.js --shallow -f md --markdown-toc false > docs/Setup.md",
     "build:watch": "yarn build:development --watch",
     "release": "yarn build",
-    "lint": "eslint ./ --ext .js,.json,.html,.md",
+    "lint": "eslint --cache ./ --ext .js,.json,.html,.md",
     "lint:fix": "yarn lint --fix",
     "e2e:depr": "yarn lint && jest e2e --config e2e/jest.config.js",
     "cypress": "cypress run",


### PR DESCRIPTION
## :bookmark_tabs: Summary

Doing a `git commit` is a bit low, as eslint runs before the commit. On my PC (and I have a fairly high-end system), `git commit` currently is `Done in 12.24s.`

Adding an `eslint --cache` makes it slightly faster; `git commit` is `Done in 7.54s.`, so about 1.6x faster.

This doesn't sound like that much, but if you're `git rebase`-ing a lot of commits, it feels a lot faster.

## :straight_ruler: Design Decisions

This shouldn't cause any issues. The eslint cache uses `mtime`/`size` by default, so the cache should almost never be wrong (except maybe for leap seconds), but even if it doesn't work, the [lint.yml](https://github.com/mermaid-js/mermaid/actions/workflows/lint.yml) action should catch it.

### :clipboard: Tasks

Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 

I'm sure why, but the label `'Type: Other'` didn't get automatically applied. You may want to manually apply it to this PR.
