### PR TITLE
Add tests for C4 system context macros

### DIFF
--- a/src/diagrams/c4/parser/c4Boundary.spec.js
+++ b/src/diagrams/c4/parser/c4Boundary.spec.js
@@ -1,0 +1,45 @@
+import c4Db from '../c4Db';
+import c4 from './c4Diagram.jison';
+import { setConfig } from '../../../config';
+
+setConfig({
+  securityLevel: 'strict',
+});
+
+describe.each(['Boundary'])('parsing a C4 %s', function (macroName) {
+  beforeEach(function () {
+    c4.parser.yy = c4Db;
+    c4.parser.yy.clear();
+  });
+
+  it('should parse a C4 diagram with one Boundary correctly', function () {
+    c4.parser.parse(`C4Context
+title System Context diagram for Internet Banking System
+${macroName}(b1, "BankBoundary") {
+System(SystemAA, "Internet Banking System")
+}`);
+
+    const yy = c4.parser.yy;
+
+    const boundaries = yy.getBoundarys();
+    expect(boundaries.length).toBe(2);
+    const onlyShape = boundaries[1];
+
+    expect(onlyShape).toEqual({
+      alias: 'b1',
+      label: {
+        text: 'BankBoundary',
+      },
+      // TODO: Why are link, and tags undefined instead of not appearing at all?
+      //       Compare to Person where they don't show up.
+      link: undefined,
+      tags: undefined,
+      parentBoundary: 'global',
+      type: {
+        // TODO: Why is this `system` instead of `boundary`?
+        text: 'system',
+      },
+      wrap: false,
+    });
+  });
+});

--- a/src/diagrams/c4/parser/c4Boundary.spec.js
+++ b/src/diagrams/c4/parser/c4Boundary.spec.js
@@ -23,9 +23,9 @@ System(SystemAA, "Internet Banking System")
 
     const boundaries = yy.getBoundarys();
     expect(boundaries.length).toBe(2);
-    const onlyShape = boundaries[1];
+    const boundary = boundaries[1];
 
-    expect(onlyShape).toEqual({
+    expect(boundary).toEqual({
       alias: 'b1',
       label: {
         text: 'BankBoundary',
@@ -40,6 +40,71 @@ System(SystemAA, "Internet Banking System")
         text: 'system',
       },
       wrap: false,
+    });
+  });
+
+  it('should parse the alias', function () {
+    c4.parser.parse(`C4Context
+${macroName}(b1, "BankBoundary") {
+System(SystemAA, "Internet Banking System")
+}`);
+
+    expect(c4.parser.yy.getBoundarys()[1]).toMatchObject({
+      alias: 'b1',
+    });
+  });
+
+  it('should parse the label', function () {
+    c4.parser.parse(`C4Context
+${macroName}(b1, "BankBoundary") {
+System(SystemAA, "Internet Banking System")
+}`);
+
+    expect(c4.parser.yy.getBoundarys()[1]).toMatchObject({
+      label: {
+        text: 'BankBoundary',
+      },
+    });
+  });
+
+  it('should parse the type', function () {
+    c4.parser.parse(`C4Context
+${macroName}(b1, "", "company") {
+System(SystemAA, "Internet Banking System")
+}`);
+
+    expect(c4.parser.yy.getBoundarys()[1]).toMatchObject({
+      type: { text: 'company' },
+    });
+  });
+
+  it('should parse a link', function () {
+    c4.parser.parse(`C4Context
+${macroName}(b1, $link="https://github.com/mermaidjs") {
+System(SystemAA, "Internet Banking System")
+}`);
+
+    expect(c4.parser.yy.getBoundarys()[1]).toMatchObject({
+      label: {
+        text: {
+          link: 'https://github.com/mermaidjs',
+        },
+      },
+    });
+  });
+
+  it('should parse tags', function () {
+    c4.parser.parse(`C4Context
+${macroName}(b1, $tags="tag1,tag2") {
+System(SystemAA, "Internet Banking System")
+}`);
+
+    expect(c4.parser.yy.getBoundarys()[1]).toMatchObject({
+      label: {
+        text: {
+          tags: 'tag1,tag2',
+        },
+      },
     });
   });
 });

--- a/src/diagrams/c4/parser/c4Diagram.spec.js
+++ b/src/diagrams/c4/parser/c4Diagram.spec.js
@@ -1,23 +1,23 @@
-import flowDb from '../c4Db';
-import flow from './c4Diagram.jison';
+import c4Db from '../c4Db';
+import c4 from './c4Diagram.jison';
 import { setConfig } from '../../../config';
 
 setConfig({
   securityLevel: 'strict',
 });
 
-describe('parsing a flow chart', function () {
+describe('parsing a C4 diagram', function () {
   beforeEach(function () {
-    flow.parser.yy = flowDb;
-    flow.parser.yy.clear();
+    c4.parser.yy = c4Db;
+    c4.parser.yy.clear();
   });
 
   it('should parse a C4 diagram with one Person correctly', function () {
-    flow.parser.parse(`C4Context
+    c4.parser.parse(`C4Context
 title System Context diagram for Internet Banking System
 Person(customerA, "Banking Customer A", "A customer of the bank, with personal bank accounts.")`);
 
-    const yy = flow.parser.yy;
+    const yy = c4.parser.yy;
     expect(yy.getC4Type()).toBe('C4Context');
     expect(yy.getTitle()).toBe('System Context diagram for Internet Banking System');
 
@@ -43,7 +43,7 @@ Person(customerA, "Banking Customer A", "A customer of the bank, with personal b
 
   it('should handle a trailing whitespaces after statements', function () {
     const whitespace = ' ';
-    const rendered = flow.parser.parse(`C4Context${whitespace}
+    const rendered = c4.parser.parse(`C4Context${whitespace}
 title System Context diagram for Internet Banking System${whitespace}
 Person(customerA, "Banking Customer A", "A customer of the bank, with personal bank accounts.")${whitespace}`);
 
@@ -51,11 +51,11 @@ Person(customerA, "Banking Customer A", "A customer of the bank, with personal b
   });
 
   it('should handle parameter names that are keywords', function () {
-    flow.parser.parse(`C4Context
+    c4.parser.parse(`C4Context
 title title
 Person(Person, "Person", "Person")`);
 
-    const yy = flow.parser.yy;
+    const yy = c4.parser.yy;
     expect(yy.getTitle()).toBe('title');
 
     const shapes = yy.getC4ShapeArray();
@@ -68,10 +68,10 @@ Person(Person, "Person", "Person")`);
   });
 
   it('should allow default in the parameters', function () {
-    flow.parser.parse(`C4Context
+    c4.parser.parse(`C4Context
 Person(default, "default", "default")`);
 
-    const yy = flow.parser.yy;
+    const yy = c4.parser.yy;
 
     const shapes = yy.getC4ShapeArray();
     expect(shapes.length).toBe(1);

--- a/src/diagrams/c4/parser/c4Diagram.spec.js
+++ b/src/diagrams/c4/parser/c4Diagram.spec.js
@@ -12,35 +12,6 @@ describe('parsing a C4 diagram', function () {
     c4.parser.yy.clear();
   });
 
-  it('should parse a C4 diagram with one Person correctly', function () {
-    c4.parser.parse(`C4Context
-title System Context diagram for Internet Banking System
-Person(customerA, "Banking Customer A", "A customer of the bank, with personal bank accounts.")`);
-
-    const yy = c4.parser.yy;
-    expect(yy.getC4Type()).toBe('C4Context');
-    expect(yy.getTitle()).toBe('System Context diagram for Internet Banking System');
-
-    const shapes = yy.getC4ShapeArray();
-    expect(shapes.length).toBe(1);
-    const onlyShape = shapes[0];
-
-    expect(onlyShape).toEqual({
-      alias: 'customerA',
-      descr: {
-        text: 'A customer of the bank, with personal bank accounts.',
-      },
-      label: {
-        text: 'Banking Customer A',
-      },
-      parentBoundary: 'global',
-      typeC4Shape: {
-        text: 'person',
-      },
-      wrap: false,
-    });
-  });
-
   it('should handle a trailing whitespaces after statements', function () {
     const whitespace = ' ';
     const rendered = c4.parser.parse(`C4Context${whitespace}

--- a/src/diagrams/c4/parser/c4Person.spec.js
+++ b/src/diagrams/c4/parser/c4Person.spec.js
@@ -39,6 +39,17 @@ Person(customerA, "Banking Customer A", "A customer of the bank, with personal b
     });
   });
 
+  it('should parse the label', function () {
+    c4.parser.parse(`C4Context
+Person(customerA, "Banking Customer A")`);
+
+    expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
+      label: {
+        text: 'Banking Customer A',
+      },
+    });
+  });
+
   it('should parse the description', function () {
     c4.parser.parse(`C4Context
 Person(customerA, "", "A customer of the bank, with personal bank accounts.")`);

--- a/src/diagrams/c4/parser/c4Person.spec.js
+++ b/src/diagrams/c4/parser/c4Person.spec.js
@@ -51,4 +51,17 @@ Person(customerA, $sprite="users")`);
       },
     });
   });
+
+  it('should parse a link', function () {
+    c4.parser.parse(`C4Context
+Person(customerA, $link="https://github.com/mermaidjs")`);
+
+    expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
+      label: {
+        text: {
+          link: 'https://github.com/mermaidjs',
+        },
+      },
+    });
+  });
 });

--- a/src/diagrams/c4/parser/c4Person.spec.js
+++ b/src/diagrams/c4/parser/c4Person.spec.js
@@ -64,4 +64,17 @@ Person(customerA, $link="https://github.com/mermaidjs")`);
       },
     });
   });
+
+  it('should parse tags', function () {
+    c4.parser.parse(`C4Context
+Person(customerA, $tags="tag1,tag2")`);
+
+    expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
+      label: {
+        text: {
+          tags: 'tag1,tag2',
+        },
+      },
+    });
+  });
 });

--- a/src/diagrams/c4/parser/c4Person.spec.js
+++ b/src/diagrams/c4/parser/c4Person.spec.js
@@ -39,6 +39,17 @@ Person(customerA, "Banking Customer A", "A customer of the bank, with personal b
     });
   });
 
+  it('should parse the description', function () {
+    c4.parser.parse(`C4Context
+Person(customerA, "", "A customer of the bank, with personal bank accounts.")`);
+
+    expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
+      descr: {
+        text: 'A customer of the bank, with personal bank accounts.',
+      },
+    });
+  });
+
   it('should parse a sprite', function () {
     c4.parser.parse(`C4Context
 Person(customerA, $sprite="users")`);

--- a/src/diagrams/c4/parser/c4Person.spec.js
+++ b/src/diagrams/c4/parser/c4Person.spec.js
@@ -38,4 +38,17 @@ Person(customerA, "Banking Customer A", "A customer of the bank, with personal b
       wrap: false,
     });
   });
+
+  it('should parse a sprite', function () {
+    c4.parser.parse(`C4Context
+Person(customerA, $sprite="users")`);
+
+    expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
+      label: {
+        text: {
+          sprite: 'users',
+        },
+      },
+    });
+  });
 });

--- a/src/diagrams/c4/parser/c4Person.spec.js
+++ b/src/diagrams/c4/parser/c4Person.spec.js
@@ -6,7 +6,7 @@ setConfig({
   securityLevel: 'strict',
 });
 
-describe('parsing a C4 diagram', function () {
+describe('parsing a C4 Person', function () {
   beforeEach(function () {
     c4.parser.yy = c4Db;
     c4.parser.yy.clear();

--- a/src/diagrams/c4/parser/c4Person.spec.js
+++ b/src/diagrams/c4/parser/c4Person.spec.js
@@ -39,6 +39,15 @@ Person(customerA, "Banking Customer A", "A customer of the bank, with personal b
     });
   });
 
+  it('should parse the alias', function () {
+    c4.parser.parse(`C4Context
+Person(customerA, "Banking Customer A")`);
+
+    expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
+      alias: 'customerA',
+    });
+  });
+
   it('should parse the label', function () {
     c4.parser.parse(`C4Context
 Person(customerA, "Banking Customer A")`);

--- a/src/diagrams/c4/parser/c4Person.spec.js
+++ b/src/diagrams/c4/parser/c4Person.spec.js
@@ -1,0 +1,41 @@
+import c4Db from '../c4Db';
+import c4 from './c4Diagram.jison';
+import { setConfig } from '../../../config';
+
+setConfig({
+  securityLevel: 'strict',
+});
+
+describe('parsing a C4 diagram', function () {
+  beforeEach(function () {
+    c4.parser.yy = c4Db;
+    c4.parser.yy.clear();
+  });
+
+  it('should parse a C4 diagram with one Person correctly', function () {
+    c4.parser.parse(`C4Context
+title System Context diagram for Internet Banking System
+Person(customerA, "Banking Customer A", "A customer of the bank, with personal bank accounts.")`);
+
+    const yy = c4.parser.yy;
+
+    const shapes = yy.getC4ShapeArray();
+    expect(shapes.length).toBe(1);
+    const onlyShape = shapes[0];
+
+    expect(onlyShape).toEqual({
+      alias: 'customerA',
+      descr: {
+        text: 'A customer of the bank, with personal bank accounts.',
+      },
+      label: {
+        text: 'Banking Customer A',
+      },
+      parentBoundary: 'global',
+      typeC4Shape: {
+        text: 'person',
+      },
+      wrap: false,
+    });
+  });
+});

--- a/src/diagrams/c4/parser/c4PersonExt.spec.js
+++ b/src/diagrams/c4/parser/c4PersonExt.spec.js
@@ -1,0 +1,44 @@
+import c4Db from '../c4Db';
+import c4 from './c4Diagram.jison';
+import { setConfig } from '../../../config';
+
+setConfig({
+  securityLevel: 'strict',
+});
+
+describe('parsing a C4 diagram', function () {
+  beforeEach(function () {
+    c4.parser.yy = c4Db;
+    c4.parser.yy.clear();
+  });
+
+  it('should parse a C4 diagram with one Person_Ext correctly', function () {
+    c4.parser.parse(`C4Context
+title System Context diagram for Internet Banking System
+Person_Ext(customerA, "Banking Customer A", "A customer of the bank, with personal bank accounts.")`);
+
+    const yy = c4.parser.yy;
+
+    const shapes = yy.getC4ShapeArray();
+    expect(shapes.length).toBe(1);
+    const onlyShape = shapes[0];
+
+    expect(onlyShape).toEqual({
+      alias: 'customerA',
+      descr: {
+        text: 'A customer of the bank, with personal bank accounts.',
+      },
+      label: {
+        text: 'Banking Customer A',
+      },
+      link: undefined,
+      sprite: undefined,
+      tags: undefined,
+      parentBoundary: 'global',
+      typeC4Shape: {
+        text: 'external_person',
+      },
+      wrap: false,
+    });
+  });
+});

--- a/src/diagrams/c4/parser/c4PersonExt.spec.js
+++ b/src/diagrams/c4/parser/c4PersonExt.spec.js
@@ -43,4 +43,17 @@ Person_Ext(customerA, "Banking Customer A", "A customer of the bank, with person
       wrap: false,
     });
   });
+
+  it('should parse a link', function () {
+    c4.parser.parse(`C4Context
+Person_Ext(customerA, $link="https://github.com/mermaidjs")`);
+
+    expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
+      label: {
+        text: {
+          link: 'https://github.com/mermaidjs',
+        },
+      },
+    });
+  });
 });

--- a/src/diagrams/c4/parser/c4PersonExt.spec.js
+++ b/src/diagrams/c4/parser/c4PersonExt.spec.js
@@ -44,6 +44,50 @@ Person_Ext(customerA, "Banking Customer A", "A customer of the bank, with person
     });
   });
 
+  it('should parse the alias', function () {
+    c4.parser.parse(`C4Context
+Person_Ext(customerA, "Banking Customer A")`);
+
+    expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
+      alias: 'customerA',
+    });
+  });
+
+  it('should parse the label', function () {
+    c4.parser.parse(`C4Context
+Person_Ext(customerA, "Banking Customer A")`);
+
+    expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
+      label: {
+        text: 'Banking Customer A',
+      },
+    });
+  });
+
+  it('should parse the description', function () {
+    c4.parser.parse(`C4Context
+Person_Ext(customerA, "", "A customer of the bank, with personal bank accounts.")`);
+
+    expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
+      descr: {
+        text: 'A customer of the bank, with personal bank accounts.',
+      },
+    });
+  });
+
+  it('should parse a sprite', function () {
+    c4.parser.parse(`C4Context
+Person_Ext(customerA, $sprite="users")`);
+
+    expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
+      label: {
+        text: {
+          sprite: 'users',
+        },
+      },
+    });
+  });
+
   it('should parse a link', function () {
     c4.parser.parse(`C4Context
 Person_Ext(customerA, $link="https://github.com/mermaidjs")`);
@@ -52,6 +96,19 @@ Person_Ext(customerA, $link="https://github.com/mermaidjs")`);
       label: {
         text: {
           link: 'https://github.com/mermaidjs',
+        },
+      },
+    });
+  });
+
+  it('should parse tags', function () {
+    c4.parser.parse(`C4Context
+Person_Ext(customerA, $tags="tag1,tag2")`);
+
+    expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
+      label: {
+        text: {
+          tags: 'tag1,tag2',
         },
       },
     });

--- a/src/diagrams/c4/parser/c4PersonExt.spec.js
+++ b/src/diagrams/c4/parser/c4PersonExt.spec.js
@@ -31,6 +31,8 @@ Person_Ext(customerA, "Banking Customer A", "A customer of the bank, with person
       label: {
         text: 'Banking Customer A',
       },
+      // TODO: Why are link, sprite, and tags undefined instead of not appearing at all?
+      //       Compare to Person where they don't show up.
       link: undefined,
       sprite: undefined,
       tags: undefined,

--- a/src/diagrams/c4/parser/c4PersonExt.spec.js
+++ b/src/diagrams/c4/parser/c4PersonExt.spec.js
@@ -6,7 +6,7 @@ setConfig({
   securityLevel: 'strict',
 });
 
-describe('parsing a C4 diagram', function () {
+describe('parsing a C4 Person_Ext', function () {
   beforeEach(function () {
     c4.parser.yy = c4Db;
     c4.parser.yy.clear();

--- a/src/diagrams/c4/parser/c4System.spec.js
+++ b/src/diagrams/c4/parser/c4System.spec.js
@@ -6,7 +6,7 @@ setConfig({
   securityLevel: 'strict',
 });
 
-describe('parsing a C4 System', function () {
+describe.each([['System', 'system']])('parsing a C4 %s', function (macroName, elementName) {
   beforeEach(function () {
     c4.parser.yy = c4Db;
     c4.parser.yy.clear();
@@ -15,7 +15,7 @@ describe('parsing a C4 System', function () {
   it('should parse a C4 diagram with one System correctly', function () {
     c4.parser.parse(`C4Context
 title System Context diagram for Internet Banking System
-System(SystemAA, "Internet Banking System", "Allows customers to view information about their bank accounts, and make payments.")`);
+${macroName}(SystemAA, "Internet Banking System", "Allows customers to view information about their bank accounts, and make payments.")`);
 
     const yy = c4.parser.yy;
 
@@ -38,7 +38,7 @@ System(SystemAA, "Internet Banking System", "Allows customers to view informatio
       tags: undefined,
       parentBoundary: 'global',
       typeC4Shape: {
-        text: 'system',
+        text: elementName,
       },
       wrap: false,
     });
@@ -46,7 +46,7 @@ System(SystemAA, "Internet Banking System", "Allows customers to view informatio
 
   it('should parse the alias', function () {
     c4.parser.parse(`C4Context
-System(SystemAA, "Internet Banking System")`);
+${macroName}(SystemAA, "Internet Banking System")`);
 
     expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
       alias: 'SystemAA',
@@ -55,7 +55,7 @@ System(SystemAA, "Internet Banking System")`);
 
   it('should parse the label', function () {
     c4.parser.parse(`C4Context
-System(SystemAA, "Internet Banking System")`);
+${macroName}(SystemAA, "Internet Banking System")`);
 
     expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
       label: {
@@ -66,7 +66,7 @@ System(SystemAA, "Internet Banking System")`);
 
   it('should parse the description', function () {
     c4.parser.parse(`C4Context
-System(SystemAA, "", "Allows customers to view information about their bank accounts, and make payments.")`);
+${macroName}(SystemAA, "", "Allows customers to view information about their bank accounts, and make payments.")`);
 
     expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
       descr: {
@@ -77,7 +77,7 @@ System(SystemAA, "", "Allows customers to view information about their bank acco
 
   it('should parse a sprite', function () {
     c4.parser.parse(`C4Context
-System(SystemAA, $sprite="users")`);
+${macroName}(SystemAA, $sprite="users")`);
 
     expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
       label: {
@@ -90,7 +90,7 @@ System(SystemAA, $sprite="users")`);
 
   it('should parse a link', function () {
     c4.parser.parse(`C4Context
-System(SystemAA, $link="https://github.com/mermaidjs")`);
+${macroName}(SystemAA, $link="https://github.com/mermaidjs")`);
 
     expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
       label: {
@@ -103,7 +103,7 @@ System(SystemAA, $link="https://github.com/mermaidjs")`);
 
   it('should parse tags', function () {
     c4.parser.parse(`C4Context
-System(SystemAA, $tags="tag1,tag2")`);
+${macroName}(SystemAA, $tags="tag1,tag2")`);
 
     expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
       label: {

--- a/src/diagrams/c4/parser/c4System.spec.js
+++ b/src/diagrams/c4/parser/c4System.spec.js
@@ -1,0 +1,116 @@
+import c4Db from '../c4Db';
+import c4 from './c4Diagram.jison';
+import { setConfig } from '../../../config';
+
+setConfig({
+  securityLevel: 'strict',
+});
+
+describe('parsing a C4 System', function () {
+  beforeEach(function () {
+    c4.parser.yy = c4Db;
+    c4.parser.yy.clear();
+  });
+
+  it('should parse a C4 diagram with one System correctly', function () {
+    c4.parser.parse(`C4Context
+title System Context diagram for Internet Banking System
+System(SystemAA, "Internet Banking System", "Allows customers to view information about their bank accounts, and make payments.")`);
+
+    const yy = c4.parser.yy;
+
+    const shapes = yy.getC4ShapeArray();
+    expect(shapes.length).toBe(1);
+    const onlyShape = shapes[0];
+
+    expect(onlyShape).toEqual({
+      alias: 'SystemAA',
+      descr: {
+        text: 'Allows customers to view information about their bank accounts, and make payments.',
+      },
+      label: {
+        text: 'Internet Banking System',
+      },
+      // TODO: Why are link, sprite, and tags undefined instead of not appearing at all?
+      //       Compare to Person where they don't show up.
+      link: undefined,
+      sprite: undefined,
+      tags: undefined,
+      parentBoundary: 'global',
+      typeC4Shape: {
+        text: 'system',
+      },
+      wrap: false,
+    });
+  });
+
+  it('should parse the alias', function () {
+    c4.parser.parse(`C4Context
+System(SystemAA, "Internet Banking System")`);
+
+    expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
+      alias: 'SystemAA',
+    });
+  });
+
+  it('should parse the label', function () {
+    c4.parser.parse(`C4Context
+System(SystemAA, "Internet Banking System")`);
+
+    expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
+      label: {
+        text: 'Internet Banking System',
+      },
+    });
+  });
+
+  it('should parse the description', function () {
+    c4.parser.parse(`C4Context
+System(SystemAA, "", "Allows customers to view information about their bank accounts, and make payments.")`);
+
+    expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
+      descr: {
+        text: 'Allows customers to view information about their bank accounts, and make payments.',
+      },
+    });
+  });
+
+  it('should parse a sprite', function () {
+    c4.parser.parse(`C4Context
+System(SystemAA, $sprite="users")`);
+
+    expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
+      label: {
+        text: {
+          sprite: 'users',
+        },
+      },
+    });
+  });
+
+  it('should parse a link', function () {
+    c4.parser.parse(`C4Context
+System(SystemAA, $link="https://github.com/mermaidjs")`);
+
+    expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
+      label: {
+        text: {
+          link: 'https://github.com/mermaidjs',
+        },
+      },
+    });
+  });
+
+  it('should parse tags', function () {
+    c4.parser.parse(`C4Context
+System(SystemAA, $tags="tag1,tag2")`);
+
+    expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
+      label: {
+        text: {
+          tags: 'tag1,tag2',
+        },
+      },
+    });
+  });
+});

--- a/src/diagrams/c4/parser/c4System.spec.js
+++ b/src/diagrams/c4/parser/c4System.spec.js
@@ -6,7 +6,14 @@ setConfig({
   securityLevel: 'strict',
 });
 
-describe.each([['System', 'system']])('parsing a C4 %s', function (macroName, elementName) {
+describe.each([
+  ['System', 'system'],
+  ['SystemDb', 'system_db'],
+  ['SystemQueue', 'system_queue'],
+  ['System_Ext', 'external_system'],
+  ['SystemDb_Ext', 'external_system_db'],
+  ['SystemQueue_Ext', 'external_system_queue'],
+])('parsing a C4 %s', function (macroName, elementName) {
   beforeEach(function () {
     c4.parser.yy = c4Db;
     c4.parser.yy.clear();


### PR DESCRIPTION
## :bookmark_tabs: Summary
This PR only adds tests without any changes to production code, plus a small documentation typo and style fix. It adds tests for the following C4 macros:
- Person
- Person_Ext
- System
- SystemDb
- SystemQueue
- System_Ext
- SystemDb_Ext
- SystemQueue_Ext
- Boundary

There are also some TODO comments in the test, where the tests test for the current behavior of the C4 parser, but the current behavior might be unwanted.

This is a continuation of #3349 and it is based [on this discussion](https://github.com/mermaid-js/mermaid/pull/3151#issuecomment-1174676087).

## :straight_ruler: Design Decisions
Tests are similar to the tests for the flowchart parser.

### :clipboard: Tasks
Make sure you
- [X] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [X] :computer: have added unit/e2e tests (if appropriate) 
- [X] :bookmark: targeted `develop` branch 
