### PR TITLE
Fix gitGraph findLane function error

### DIFF
--- a/src/diagrams/git/gitGraphRenderer.js
+++ b/src/diagrams/git/gitGraphRenderer.js
@@ -336,7 +336,7 @@ const findLane = (y1, y2, _depth) => {
     return candidate;
   }
   const diff = Math.abs(y1 - y2);
-  return findLane(y1, y2 - diff / 5, depth);
+  return findLane(y1, y2 - diff / 5, depth + 1);
 };
 
 /**


### PR DESCRIPTION
## :bookmark_tabs: Summary
`findLane` function may infinite loop after recursive call, then cause `RangeError: Maximum call stack size exceeded`.


### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [ ] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
