### PR TITLE
fix(git): support numeric branch names

### DIFF
--- a/src/diagrams/git/gitGraphParserV2.spec.js
+++ b/src/diagrams/git/gitGraphParserV2.spec.js
@@ -348,6 +348,21 @@ describe('when parsing a gitGraph', function () {
     expect(Object.keys(parser.yy.getBranches()).length).toBe(2);
   });
 
+  it('should allow branch names starting with numbers', function () {
+    const str = `gitGraph:
+    commit
+    %% branch names starting with numbers are not recommended, but are supported by git
+    branch 1.0.1
+    `;
+
+    parser.parse(str);
+    const commits = parser.yy.getCommits();
+    expect(Object.keys(commits).length).toBe(1);
+    expect(parser.yy.getCurrentBranch()).toBe('1.0.1');
+    expect(parser.yy.getDirection()).toBe('LR');
+    expect(Object.keys(parser.yy.getBranches()).length).toBe(2);
+  });
+
   it('should handle new branch checkout', function () {
     const str = `gitGraph:
     commit

--- a/src/diagrams/git/parser/gitGraph.jison
+++ b/src/diagrams/git/parser/gitGraph.jison
@@ -33,7 +33,6 @@ accDescr\s*"{"\s*                                               { this.begin("ac
 <acc_descr_multiline>[\}]                                       { this.popState(); }
 <acc_descr_multiline>[^\}]*                                     return "acc_descr_multiline_value";
 (\r?\n)+                               /*{console.log('New line');return 'NL';}*/ return 'NL';
-\s+                                    /* skip all whitespace */
 \#[^\n]*                               /* skip comments */
 \%%[^\n]*                              /* skip comments */
 "gitGraph"                              return 'GG';
@@ -61,9 +60,10 @@ accDescr\s*"{"\s*                                               { this.begin("ac
 ["]                                     this.begin("string");
 <string>["]                             this.popState();
 <string>[^"]*                           return 'STR';
-[0-9]+                                  return 'NUM';
-[a-zA-Z][-_\./a-zA-Z0-9]*[-_a-zA-Z0-9]  return 'ID';
+[0-9]+(?=\s|$)                          return 'NUM';
+\w[-\./\w]*[-\w]                        return 'ID'; // only a subset of https://git-scm.com/docs/git-check-ref-format
 <<EOF>>                                 return 'EOF';
+\s+                                    /* skip all whitespace */ // lowest priority so we can use lookaheads in earlier regex
 
 /lex
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

gitGraph does not support branch names that start with a number, because the gitGraph.jison file parses these as NUM (number) instead.

Although [most people don't recommend having branches that start with numbers](https://docs.github.com/en/get-started/using-git/dealing-with-special-characters-in-branch-and-tag-names#naming-branches-and-tags), it is supported by git, and occasionally used by people with maintenance branches (https://github.com/mermaid-js/mermaid/issues/3347).

To fix this, I've changed the NUM parser to only accept strings that end with whitespace, using the regex [`(?=)` positive lookahead assertion](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Assertions). For example, 1234 is a NUM, but 1234abc is not a NUM.

The ID parser now accepts strings starting with any `\w` character (aka `[A-Za-z0-9_]`). This is still a subset of all supported git branch names (see https://git-scm.com/docs/git-check-ref-format), but those rules are pretty complicated, so it's probably not worth supporting all of them, unless people ask for it.

Resolves #3347

## :straight_ruler: Design Decisions

To do this, I had to move the "skip all whitespace" step to the end of the parser, but this doesn't seem to have caused any issues, so it's probably fine. **However, I'm not an expert in jison, so it's probably worth somebody else double-checking this bit.**

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
