### PR TITLE
Added mermerd to integrations documentation

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -31,6 +31,7 @@ They also serve as proof of concept, for the variety of things that can be built
   - [redmine-mermaid](https://github.com/styz/redmine_mermaid)
   - [markdown-for-mermaid-plugin](https://github.com/jamieh-mongolian/markdown-for-mermaid-plugin)
 - [Jetsbrain IDE eg Pycharm](https://www.jetbrains.com/go/guide/tips/mermaid-js-support-in-markdown/)
+- [mermerd](https://github.com/KarnerTh/mermerd) 
 
 ## CRM/ERP/Similar
 


### PR DESCRIPTION
## :bookmark_tabs: Summary
I created a small cli called [mermerd](https://github.com/KarnerTh/mermerd) that lets you generate mermaid-js ERDs from your existing database.
As discussed in #2859 I would like to add it to the website under "Use-Case and Integrations"

Resolves #2859 

## :straight_ruler: Design Decisions
Added the link in the markdown documentation

### :clipboard: Tasks
Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate) 
- [x] :bookmark: targeted `develop` branch 
