### PR TITLE
build: run `build:prod` on `yarn prepare`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test": "yarn lint && jest src/.*",
     "test:watch": "jest --watch src",
     "prepublishOnly": "yarn build && yarn test",
-    "prepare": "husky install",
+    "prepare": "concurrently \"husky install\" \"yarn build:prod\"",
     "pre-commit": "lint-staged"
   },
   "repository": {


### PR DESCRIPTION
## :bookmark_tabs: Summary

Adds `yarn build:prod` to the `yarn prepare` script.

For most package managers (e.g. yarn v1 and NPM), the `prepare` script is called automatically when installing from a local location/git url. It's not called when installing from NPM.

This is required because the source code doesn't contain the `dist/mermaid.min.js` file, it has to be built first.

Fixes installing mermaid via `git`, e.g. `yarn add git+https://github.com/mermaid-js/mermaid.git`

Fixes: 1549eb20dfbf0698749ab50b2cb264e63d2015b5

## :straight_ruler: Design Decisions

@sidharthv96, this undoes this line you changed in commit 1549eb20dfbf0698749ab50b2cb264e63d2015b5 https://github.com/mermaid-js/mermaid/blame/1549eb20dfbf0698749ab50b2cb264e63d2015b5/package.json#L44

I think you probably disabled it for testing and forgot to re-enable it when you commited, but I thought I'd @-you just in case you had a reason for disabling it.

I've used `concurrently` so it's a bit faster (and `&&` is only usually supported on Windows).
I've also only enabled `build:prod`, since I don't think we need `build:dev`.

### :clipboard: Tasks

Make sure you
- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md) 
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch 
