### PR TITLE
Update duplicate copy pasted directive description

### DIFF
--- a/docs/directives.md
+++ b/docs/directives.md
@@ -144,7 +144,7 @@ A --> C[End]
 
 ### Changing fontFamily via directive
 
-The following code snippet changes theme to forest:
+The following code snippet changes fontFamily to rebuchet MS, Verdana, Arial, Sans-Serif:
 
 `%%{init: { "fontFamily": "Trebuchet MS, Verdana, Arial, Sans-Serif" } }%%`
 
@@ -176,7 +176,7 @@ A --> C[End]
 
 ### Changing logLevel via directive
 
-The following code snippet changes theme to forest:
+The following code snippet changes logLevel to 2:
 
 `%%{init: { "logLevel": 2 } }%%`
 

--- a/src/docs/directives.md
+++ b/src/docs/directives.md
@@ -132,7 +132,7 @@ A --> C[End]
 
 ### Changing fontFamily via directive
 
-The following code snippet changes theme to forest:
+The following code snippet changes fontFamily to rebuchet MS, Verdana, Arial, Sans-Serif:
 
 `%%{init: { "fontFamily": "Trebuchet MS, Verdana, Arial, Sans-Serif" } }%%`
 
@@ -152,7 +152,7 @@ A --> C[End]
 
 ### Changing logLevel via directive
 
-The following code snippet changes theme to forest:
+The following code snippet changes logLevel to 2:
 
 `%%{init: { "logLevel": 2 } }%%`
 


### PR DESCRIPTION
Looked like the description for changing the theme via a directive had been copied to a couple of other use cases.

## :bookmark_tabs: Summary

I’ve updated a couple of lines in the docs for directives which seemed to have incorrect copy-pasted text.

I haven’t raised an issue for this.

## :straight_ruler: Design Decisions

No functional changes

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
