### PR TITLE
chore: fix JSDOC @param, @returns lint errors

### DIFF
--- a/src/assignWithDepth.js
+++ b/src/assignWithDepth.js
@@ -17,15 +17,6 @@
  *   Traditional Object.assign would have clobbered foo in config_0 with foo in config_1. If src is a
  *   destructured array of objects and dst is not an array, assignWithDepth will apply each element
  *   of src to dst in order.
- * @param dst
- * @param src
- * @param config
- * @param dst
- * @param src
- * @param config
- * @param dst
- * @param src
- * @param config
  * @param {any} dst - The destination of the merge
  * @param {any} src - The source object(s) to merge into destination
  * @param {{ depth: number; clobber: boolean }} [config={ depth: 2, clobber: false }] - Depth: depth

--- a/src/dagre-wrapper/mermaid-graphlib.js
+++ b/src/dagre-wrapper/mermaid-graphlib.js
@@ -163,9 +163,9 @@ export const validate = (graph) => {
 };
 
 /**
- * Finds a child that is not a cluster. When faking a edge between a node and a cluster.
+ * Finds a child that is not a cluster. When faking an edge between a node and a cluster.
  *
- * @param {Finds a} id
+ * @param id
  * @param {any} graph
  */
 export const findNonClusterChild = (id, graph) => {
@@ -235,7 +235,7 @@ export const adjustClustersAndEdges = (graph, depth) => {
       edges.forEach((edge) => {
         // log.debug('Edge, decendants: ', edge, decendants[id]);
 
-        // Check if any edge leaves the cluster (not the actual cluster, thats a link from the box)
+        // Check if any edge leaves the cluster (not the actual cluster, that's a link from the box)
         if (edge.v !== id && edge.w !== id) {
           // Any edge where either the one of the nodes is decending to the cluster but not the other
           // if (decendants[id].indexOf(edge.v) < 0 && decendants[id].indexOf(edge.w) < 0) {

--- a/src/diagrams/c4/c4Renderer.js
+++ b/src/diagrams/c4/c4Renderer.js
@@ -568,10 +568,9 @@ function drawInsideBoundary(diagram, parentBoundaryAlias, parentBounds, currentB
 /**
  * Draws a sequenceDiagram in the tag with id: id based on the graph definition in text.
  *
- * @param {any} text
- * @param _text
+ * @param {any} _text
  * @param {any} id
- * @param _version
+ * @param {any} _version
  * @param diagObj
  */
 export const draw = function (_text, id, _version, diagObj) {

--- a/src/diagrams/class/classRenderer.js
+++ b/src/diagrams/class/classRenderer.js
@@ -142,8 +142,7 @@ const insertMarkers = function (elem) {
  *
  * @param {string} text
  * @param {string} id
- * @param version
- * @param _version
+ * @param {any} _version
  * @param diagObj
  */
 export const draw = function (text, id, _version, diagObj) {

--- a/src/diagrams/er/erRenderer.js
+++ b/src/diagrams/er/erRenderer.js
@@ -32,7 +32,7 @@ export const setConf = function (cnf) {
  * @param groupNode The svg group node for the entity
  * @param entityTextNode The svg node for the entity label text
  * @param attributes An array of attributes defined for the entity (each attribute has a type and a name)
- * @returns The bounding box of the entity, after attributes have been added
+ * @returns {object} The bounding box of the entity, after attributes have been added. The bounding box has a .width and .height
  */
 const drawAttributes = (groupNode, entityTextNode, attributes) => {
   const heightPadding = conf.entityPadding / 3; // Padding internal to attribute boxes
@@ -307,7 +307,7 @@ const drawAttributes = (groupNode, entityTextNode, attributes) => {
  * @param svgNode The svg node that contains the diagram
  * @param entities The entities to be drawn
  * @param graph The graph that contains the vertex and edge definitions post-layout
- * @returns The first entity that was inserted
+ * @returns {object} The first entity that was inserted
  */
 const drawEntities = function (svgNode, entities, graph) {
   const keys = Object.keys(entities);
@@ -545,7 +545,6 @@ const drawRelationshipFromLayout = function (svg, rel, g, insert, diagObj) {
  * @param text The text of the diagram
  * @param id The unique id of the DOM node that contains the diagram
  * @param _version
- * @param diag
  * @param diagObj
  */
 export const draw = function (text, id, _version, diagObj) {

--- a/src/diagrams/flowchart/flowRenderer.js
+++ b/src/diagrams/flowchart/flowRenderer.js
@@ -25,7 +25,6 @@ export const setConf = function (cnf) {
  * @param g The graph that is to be drawn.
  * @param svgId
  * @param root
- * @param doc
  * @param _doc
  * @param diagObj
  */

--- a/src/diagrams/git/gitGraphRenderer.js
+++ b/src/diagrams/git/gitGraphRenderer.js
@@ -290,13 +290,13 @@ const drawCommits = (svg, commits, modifyGraph) => {
 };
 
 /**
- * Detect if there are other commits between commit1s x-position and commit2s x-position on the same
+ * Detect if there are other commits between commit1's x-position and commit2's x-position on the same
  * branch as commit2.
  *
  * @param {any} commit1
  * @param {any} commit2
  * @param allCommits
- * @returns
+ * @returns {boolean} if there are commits between commit1's x-position and commit2's x-position
  */
 const hasOverlappingCommits = (commit1, commit2, allCommits) => {
   const commit1Pos = commitPos[commit2.id];
@@ -322,7 +322,7 @@ const hasOverlappingCommits = (commit1, commit2, allCommits) => {
  * @param {any} y1
  * @param {any} y2
  * @param {any} _depth
- * @returns
+ * @returns {number} y value between y1 and y2
  */
 const findLane = (y1, y2, _depth) => {
   const depth = _depth || 0;
@@ -347,7 +347,7 @@ const findLane = (y1, y2, _depth) => {
 };
 
 /**
- * This function draw the lines between the commits. They were arrows initially.
+ * Draw the lines between the commits. They were arrows initially.
  *
  * @param {any} svg
  * @param {any} commit1
@@ -453,12 +453,10 @@ const drawArrows = (svg, commits) => {
 };
 
 /**
- * This function adds the branches and the branches' labels to the svg.
+ * Adds the branches and the branches' labels to the svg.
  *
  * @param svg
- * @param commitid
  * @param branches
- * @param direction
  */
 const drawBranches = (svg, branches) => {
   const gitGraphConfig = getConfig().gitGraph;
@@ -510,10 +508,6 @@ const drawBranches = (svg, branches) => {
 };
 
 /**
- * @param svg
- * @param commit
- * @param direction
- * @param branchColor
  * @param txt
  * @param id
  * @param ver

--- a/src/diagrams/mindmap/mindmapRenderer.js
+++ b/src/diagrams/mindmap/mindmapRenderer.js
@@ -22,7 +22,6 @@ function drawNodes(svg, mindmap, section, conf) {
 }
 
 /**
- * @param {any} svg The svg element to draw the diagram onto
  * @param edgesElem
  * @param mindmap
  * @param parent
@@ -149,8 +148,6 @@ const mergeTrees = (node, trees) => {
 
 /**
  * @param node
- * @param isRoot
- * @param parent
  * @param conf
  */
 function layoutMindmap(node, conf) {
@@ -201,7 +198,6 @@ function layoutMindmap(node, conf) {
 }
 /**
  * @param node
- * @param isRoot
  * @param conf
  */
 function positionNodes(node, conf) {

--- a/src/diagrams/sequence/sequenceRenderer.js
+++ b/src/diagrams/sequence/sequenceRenderer.js
@@ -326,7 +326,7 @@ const boundMessage = function (diagram, msgModel) {
  *
  * @param {any} diagram - The parent of the message element
  * @param {any} msgModel - The model containing fields describing a message
- * @param {float} lineStarty - The Y coordinate at which the message line starts
+ * @param {number} lineStarty - The Y coordinate at which the message line starts
  * @param diagObj
  */
 const drawMessage = function (diagram, msgModel, lineStarty, diagObj) {
@@ -582,8 +582,7 @@ function adjustLoopHeightForWrap(loopWidths, msg, preMargin, postMargin, addLoop
 /**
  * Draws a sequenceDiagram in the tag with id: id based on the graph definition in text.
  *
- * @param {any} text The text of the diagram
- * @param _text
+ * @param {any} _text The text of the diagram
  * @param {any} id The id of the diagram which will be used as a DOM element id¨
  * @param {any} _version Mermaid version from package.json
  * @param {any} diagObj A stanard diagram containing the db and the text and type etc of the diagram

--- a/src/diagrams/state/shapes.js
+++ b/src/diagrams/state/shapes.js
@@ -66,9 +66,9 @@ export const drawSimpleState = (g, stateDef) => {
 /**
  * Draws a state with descriptions
  *
- * @param {any} g
+ * @param {any} g The d3 svg object to add the state to
  * @param {any} stateDef
- * @returns
+ * @returns {any} The d3 svg state
  */
 export const drawDescrState = (g, stateDef) => {
   const addTspan = function (textEl, txt, isFirst) {

--- a/src/setupGraphViewbox.js
+++ b/src/setupGraphViewbox.js
@@ -37,8 +37,6 @@ export const calculateSvgSizeAttrs = function (height, width, useMaxWidth) {
  * @param {SVGSVGElement} svgElem The SVG Element to configure
  * @param {number} height The height of the SVG
  * @param {number} width The width of the SVG
- * @param tx
- * @param ty
  * @param {boolean} useMaxWidth Whether or not to use max-width and set width to 100%
  */
 export const configureSvgSize = function (svgElem, height, width, useMaxWidth) {


### PR DESCRIPTION
## :bookmark_tabs: Summary

No code was changed. All changes were within comment blocks.

- Fixed JSDOC errors:  missing @returns types, duplicate @params  
- fixed a few minor typos I saw in the comments while fixing above

Resolves #3421

I started the PR branch name with `chore/`  That is the preferred convention for many projects. Is that the convention for this one?

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :bookmark: targeted `develop` branch
