### PR TITLE
Esbuild: backwards-compatible `mermaid.core.mjs`

### DIFF
--- a/.esbuild/esbuild.cjs
+++ b/.esbuild/esbuild.cjs
@@ -1,4 +1,4 @@
-const { esmBuild, iifeBuild } = require('./util.cjs');
+const { esmBuild, esmCoreBuild, iifeBuild } = require('./util.cjs');
 const { build } = require('esbuild');
 
 const handler = (e) => {
@@ -12,10 +12,9 @@ build(iifeBuild({ minify: false, watch })).catch(handler);
 // mermaid.esm.mjs
 build(esmBuild({ minify: false, watch })).catch(handler);
 
-// mermaid.core.js
-build(iifeBuild({ minify: false, core: true })).catch(handler);
-
 // mermaid.min.js
 build(esmBuild()).catch(handler);
 // mermaid.esm.min.mjs
 build(iifeBuild()).catch(handler);
+// mermaid.core.mjs (node_modules unbundled)
+build(esmCoreBuild()).catch(handler);

--- a/.esbuild/util.cjs
+++ b/.esbuild/util.cjs
@@ -61,7 +61,9 @@ const jisonPlugin = {
     build.onLoad({ filter: /\.jison$/ }, async (args) => {
       // Load the file from the file system
       const source = await fs.promises.readFile(args.path, 'utf8');
-      const contents = new Generator(source, { 'token-stack': true }).generate();
+      const contents = new Generator(source, { 'token-stack': true }).generate({
+        moduleMain: '() => {}', // disable moduleMain (default one requires Node.JS modules)
+      });
       return { contents, warnings: [] };
     });
   },

--- a/.esbuild/util.cjs
+++ b/.esbuild/util.cjs
@@ -47,7 +47,7 @@ exports.esmBuild = (override = { minify: true }) => {
  * Build options for mermaid.core.* build.
  *
  * This build does not bundle `./node_modules/`, as it is designed to be used
- * with Webpack/ESBuild to merge webpack into a website.
+ * with Webpack/ESBuild/Vite to use mermaid inside an app/website.
  *
  * @param {Options} override - Override options.
  * @returns {Options} ESBuild build options.

--- a/cypress/platform/bundle-test.js
+++ b/cypress/platform/bundle-test.js
@@ -1,4 +1,4 @@
-import mermaid from '../../dist/mermaid';
+import mermaid from '../../dist/mermaid.core.mjs';
 
 let code = `flowchart LR
 Power_Supply --> Transmitter_A

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "mermaid",
   "version": "9.1.6",
   "description": "Markdownish syntax for generating flowcharts, sequence diagrams, class diagrams, gantt charts and git graphs.",
-  "main": "dist/mermaid.min.js",
-  "module": "dist/mermaid.esm.min.mjs",
+  "main": "dist/mermaid.core.mjs",
+  "module": "dist/mermaid.core.mjs",
   "types": "dist/mermaid.d.ts",
   "exports": {
     ".": {
       "require": "./dist/mermaid.min.js",
-      "import": "./dist/mermaid.esm.min.mjs",
+      "import": "./dist/mermaid.core.mjs",
       "types": "./dist/mermaid.d.ts"
     },
     "./*": "./*"


### PR DESCRIPTION
## :bookmark_tabs: Summary

**Note: This PR targets `sidv/esbuild`, aka PR #3386**

The `mermaid.core.js` build was previously a UMD build that did not have `node_modules` bundled.

This was designed for users to add `mermaid` to their own apps, then bundle with Webpack/ESBuild. Hence the bundle test in `cypress/platform/bundle-test.js`.

After this PR, there will be three different types of files in the `dist/` folder:
  - `mermaid{.min}.js` - Minified Bundled IIFE - For use in browsers from a CDN that don't support ESM yet.
  - `mermaid.esm{.min}.mjs` - Minified Bundled ESM - For use in browsers from a CDN that do support ESM.
  - `mermaid.core.mjs` - Minified unbundled ESM. For use when creating your own apps using `NPM`/`yarn`. Does **not bundle** `node_modules/`, as your Webpack/ESBuild/vite should bundle them.

## :straight_ruler: Design Decisions

I had to slightly modify the `.jison` parser, as by default it adds an unused `main()` that has a `require("fs");`. As this `main()` function is never used, I've just overrode it with an empty function.

### Possible breaking change (low risk)

As ESBuild does not support UMD, I've switched the `mermaid.core.js` to instead use ESM at `mermaid.core.mjs`, as Mermaid now requires ESM (due to d3 requiring ESM).

The switch from UMD to ESM shouldn't break anybody's configuration, because since Mermaid 8.12.0, ESM has been required due to d3 requiring ESM (see https://github.com/mermaid-js/mermaid/issues/2677).

Switching from `.core.js` to `.core.mjs` _probably_ won't cause any issues, since most people would use `import mermaid from "mermaid"`, and their bundler would automatically find the file by looking at the `package.json` file.
  - A quick code search of `mermaid.core.js`: https://github.com/search?p=1&q=mermaid.core.js&type=Code
    - Everything I can see there is just auto-generated files, so I don't think this will cause any issues.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
  - Tested in `cypress/platform/bundle-test.js`
  - I've also tested this with https://github.com/mermaid-js/mermaid-live-editor
    I've confirmed that `yarn dev` works after running `yarn add git+https://github.com/aloisklink/mermaid.git#esbuild-backwards-compatible-core-js`.
- [ ] :bookmark: ~targeted `develop` branch~
  - I've targeted `sidv/esbuild`, aka PR #3386 