### PR TITLE
fix(git): support unusual prefixes in branch name

### DIFF
--- a/src/diagrams/git/gitGraphParserV2.spec.js
+++ b/src/diagrams/git/gitGraphParserV2.spec.js
@@ -363,6 +363,34 @@ describe('when parsing a gitGraph', function () {
     expect(Object.keys(parser.yy.getBranches()).length).toBe(2);
   });
 
+  it('should allow branch names starting with unusual prefixes', function () {
+    const str = `gitGraph:
+    commit
+    %% branch names starting with numbers are not recommended, but are supported by git
+    branch branch01
+    branch checkout02
+    branch cherry-pick03
+    branch branch/example-branch
+    branch merge/test_merge
+    `;
+
+    parser.parse(str);
+    const commits = parser.yy.getCommits();
+    expect(Object.keys(commits).length).toBe(1);
+    expect(parser.yy.getCurrentBranch()).toBe('merge/test_merge');
+    expect(parser.yy.getDirection()).toBe('LR');
+    expect(Object.keys(parser.yy.getBranches()).length).toBe(6);
+    expect(Object.keys(parser.yy.getBranches())).toEqual(
+      expect.arrayContaining([
+        'branch01',
+        'checkout02',
+        'cherry-pick03',
+        'branch/example-branch',
+        'merge/test_merge',
+      ])
+    );
+  });
+
   it('should handle new branch checkout', function () {
     const str = `gitGraph:
     commit

--- a/src/diagrams/git/parser/gitGraph.jison
+++ b/src/diagrams/git/parser/gitGraph.jison
@@ -36,7 +36,7 @@ accDescr\s*"{"\s*                                               { this.begin("ac
 \#[^\n]*                               /* skip comments */
 \%%[^\n]*                              /* skip comments */
 "gitGraph"                              return 'GG';
-"commit"                                return 'COMMIT';
+commit(?=\s|$)                          return 'COMMIT';
 "id:"                                   return 'COMMIT_ID';
 "type:"                                 return 'COMMIT_TYPE';
 "msg:"                                  return 'COMMIT_MSG';
@@ -44,12 +44,12 @@ accDescr\s*"{"\s*                                               { this.begin("ac
 "REVERSE"                               return 'REVERSE';
 "HIGHLIGHT"                             return 'HIGHLIGHT';
 "tag:"                                  return 'COMMIT_TAG';
-"branch"                                return 'BRANCH';
+branch(?=\s|$)                          return 'BRANCH';
 "order:"                                return 'ORDER';
-"merge"                                 return 'MERGE';
-"cherry-pick"                           return 'CHERRY_PICK';
+merge(?=\s|$)                           return 'MERGE';
+cherry-pick(?=\s|$)                     return 'CHERRY_PICK';
 // "reset"                                 return 'RESET';
-"checkout"                              return 'CHECKOUT';
+checkout(?=\s|$)                        return 'CHECKOUT';
 "LR"                                    return 'DIR';
 "BT"                                    return 'DIR';
 ":"                                     return ':';


### PR DESCRIPTION
## :bookmark_tabs: Summary

The gitgraph jison throws an error if a branch name starts with an unusual prefix.

For example, a branch named `branch/test-branch` will throw a parse error, since jison thinks it's a `branch` command, and not a branch id.

````markdown
```mermaid
gitGraph
  commit
  branch branch/test-branch
```
````

```mermaid
gitGraph
  commit
  branch branch/test-branch
```

An easy fix is to use the `(?=\s|$)` regex to ensure that only 'branch ' or 'branch\n' will be parsed as the branch command.

Resolves https://github.com/mermaid-js/mermaid/issues/3362

## :straight_ruler: Design Decisions

I've only added unit tests, since I didn't feel like it was worth slowing down `e2e` tests by adding another test case, and I felt this PR wouldn't change anything on the rendering side.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
  - Is it worth me adding `e2e` tests?
- [x] :bookmark: targeted `develop` branch
