### PR TITLE
fix(git): support single character branch names

### DIFF
--- a/src/diagrams/git/gitGraphParserV2.spec.js
+++ b/src/diagrams/git/gitGraphParserV2.spec.js
@@ -372,14 +372,16 @@ describe('when parsing a gitGraph', function () {
     branch cherry-pick03
     branch branch/example-branch
     branch merge/test_merge
+    %% single character branch name
+    branch A
     `;
 
     parser.parse(str);
     const commits = parser.yy.getCommits();
     expect(Object.keys(commits).length).toBe(1);
-    expect(parser.yy.getCurrentBranch()).toBe('merge/test_merge');
+    expect(parser.yy.getCurrentBranch()).toBe('A');
     expect(parser.yy.getDirection()).toBe('LR');
-    expect(Object.keys(parser.yy.getBranches()).length).toBe(6);
+    expect(Object.keys(parser.yy.getBranches()).length).toBe(7);
     expect(Object.keys(parser.yy.getBranches())).toEqual(
       expect.arrayContaining([
         'branch01',
@@ -387,6 +389,7 @@ describe('when parsing a gitGraph', function () {
         'cherry-pick03',
         'branch/example-branch',
         'merge/test_merge',
+        'A',
       ])
     );
   });

--- a/src/diagrams/git/parser/gitGraph.jison
+++ b/src/diagrams/git/parser/gitGraph.jison
@@ -61,7 +61,7 @@ checkout(?=\s|$)                        return 'CHECKOUT';
 <string>["]                             this.popState();
 <string>[^"]*                           return 'STR';
 [0-9]+(?=\s|$)                          return 'NUM';
-\w[-\./\w]*[-\w]                        return 'ID'; // only a subset of https://git-scm.com/docs/git-check-ref-format
+\w([-\./\w]*[-\w])?                     return 'ID'; // only a subset of https://git-scm.com/docs/git-check-ref-format
 <<EOF>>                                 return 'EOF';
 \s+                                    /* skip all whitespace */ // lowest priority so we can use lookaheads in earlier regex
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

In gitGraph, add support for branch names that only have a single character.

The branch regex is checking for a starting character, and an ending character, so it currently needs at least two characters.

Resolves #3463

## :straight_ruler: Design Decisions

I've wrapped everything except the first character in a `()?` to fix this.

There are some really complicated regexes that do match what valid git branches are (see https://stackoverflow.com/a/12093994), but I'm reluctant to add them in, since it will be a pain to test all the different edge-cases.

Hopefully https://github.com/mermaid-js/mermaid/pull/3432 might be used in the future to make a better gitgraph parser!

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
