### PR TITLE
feat(git): cherry-pick keyword supports tag attribute

### DIFF
--- a/cypress/integration/rendering/gitGraph.spec.js
+++ b/cypress/integration/rendering/gitGraph.spec.js
@@ -180,7 +180,27 @@ describe('Git Graph diagram', () => {
       {}
     );
   });
-
+  it('11: should render a gitgraph with cherry pick commit with custom tag', () => {
+    imgSnapshotTest(
+      `
+    gitGraph
+       commit id: "ZERO"
+       branch develop
+       commit id:"A"
+       checkout main
+       commit id:"ONE"
+       checkout develop
+       commit id:"B"
+       checkout main
+       commit id:"TWO"
+       cherry-pick id:"A" tag: "snapshot"
+       commit id:"THREE"
+       checkout develop
+       commit id:"C"
+      `,
+      {}
+    );
+  });
   it('11: should render a simple gitgraph with two cherry pick commit', () => {
     imgSnapshotTest(
       `
@@ -207,7 +227,6 @@ describe('Git Graph diagram', () => {
       {}
     );
   });
-
   it('12: should render commits for more than 8 branches', () => {
     imgSnapshotTest(
       `

--- a/cypress/integration/rendering/gitGraph.spec.js
+++ b/cypress/integration/rendering/gitGraph.spec.js
@@ -201,6 +201,27 @@ describe('Git Graph diagram', () => {
       {}
     );
   });
+  it('11: should render a gitgraph with cherry pick commit with no tag', () => {
+    imgSnapshotTest(
+      `
+    gitGraph
+       commit id: "ZERO"
+       branch develop
+       commit id:"A"
+       checkout main
+       commit id:"ONE"
+       checkout develop
+       commit id:"B"
+       checkout main
+       commit id:"TWO"
+       cherry-pick id:"A" tag: ""
+       commit id:"THREE"
+       checkout develop
+       commit id:"C"
+      `,
+      {}
+    );
+  });
   it('11: should render a simple gitgraph with two cherry pick commit', () => {
     imgSnapshotTest(
       `

--- a/docs/gitgraph.md
+++ b/docs/gitgraph.md
@@ -429,6 +429,8 @@ By default, the cherry-picked commit from commit with id `A` will be labeled `ch
        commit id:"C"
 ```
 
+To suppress the tag entirely, use `tag:""` (empty string).
+
 ## Gitgraph specific configuration options
 
 In Mermaid, you have the option to configure the gitgraph diagram. You can configure the following options:

--- a/docs/gitgraph.md
+++ b/docs/gitgraph.md
@@ -393,6 +393,42 @@ Let see an example:
        commit id:"C"
 ```
 
+By default, the cherry-picked commit from commit with id `A` will be labeled `cherry-pick:A`. You can provide your own custom tag instead to override this behavior, using the same syntax as the `commit` keyword:
+
+```mermaid-example
+    gitGraph
+       commit id: "ZERO"
+       branch develop
+       commit id:"A"
+       checkout main
+       commit id:"ONE"
+       checkout develop
+       commit id:"B"
+       checkout main
+       commit id:"TWO"
+       cherry-pick id:"A" tag:"fix"
+       commit id:"THREE"
+       checkout develop
+       commit id:"C"
+```
+
+```mermaid
+    gitGraph
+       commit id: "ZERO"
+       branch develop
+       commit id:"A"
+       checkout main
+       commit id:"ONE"
+       checkout develop
+       commit id:"B"
+       checkout main
+       commit id:"TWO"
+       cherry-pick id:"A" tag:"fix"
+       commit id:"THREE"
+       checkout develop
+       commit id:"C"
+```
+
 ## Gitgraph specific configuration options
 
 In Mermaid, you have the option to configure the gitgraph diagram. You can configure the following options:

--- a/src/diagrams/git/gitGraphAst.js
+++ b/src/diagrams/git/gitGraphAst.js
@@ -262,10 +262,6 @@ export const cherryPick = function (sourceId, targetId, tag) {
   log.debug('Entering cherryPick:', sourceId, targetId, tag);
   sourceId = common.sanitizeText(sourceId, configApi.getConfig());
   targetId = common.sanitizeText(targetId, configApi.getConfig());
-
-  if (tag === 'cherry-pick:<id>') {
-    tag = 'cherry-pick:' + sourceCommit.id;
-  }
   tag = common.sanitizeText(tag, configApi.getConfig());
 
   if (!sourceId || typeof commits[sourceId] === 'undefined') {
@@ -334,7 +330,7 @@ export const cherryPick = function (sourceId, targetId, tag) {
       parents: [head == null ? null : head.id, sourceCommit.id],
       branch: curBranch,
       type: commitType.CHERRY_PICK,
-      tag: tag,
+      tag: tag ?? 'cherry-pick:' + sourceCommit.id,
     };
     head = commit;
     commits[commit.id] = commit;

--- a/src/diagrams/git/gitGraphAst.js
+++ b/src/diagrams/git/gitGraphAst.js
@@ -262,6 +262,10 @@ export const cherryPick = function (sourceId, targetId, tag) {
   log.debug('Entering cherryPick:', sourceId, targetId, tag);
   sourceId = common.sanitizeText(sourceId, configApi.getConfig());
   targetId = common.sanitizeText(targetId, configApi.getConfig());
+
+  if (tag === 'cherry-pick:<id>') {
+    tag = 'cherry-pick:' + sourceCommit.id;
+  }
   tag = common.sanitizeText(tag, configApi.getConfig());
 
   if (!sourceId || typeof commits[sourceId] === 'undefined') {
@@ -330,7 +334,7 @@ export const cherryPick = function (sourceId, targetId, tag) {
       parents: [head == null ? null : head.id, sourceCommit.id],
       branch: curBranch,
       type: commitType.CHERRY_PICK,
-      tag: tag ? tag : 'cherry-pick:' + sourceCommit.id,
+      tag: tag,
     };
     head = commit;
     commits[commit.id] = commit;

--- a/src/diagrams/git/gitGraphAst.js
+++ b/src/diagrams/git/gitGraphAst.js
@@ -258,9 +258,11 @@ export const merge = function (otherBranch, custom_id, override_type, custom_tag
   log.debug('in mergeBranch');
 };
 
-export const cherryPick = function (sourceId, targetId) {
+export const cherryPick = function (sourceId, targetId, tag) {
+  log.debug('Entering cherryPick:', sourceId, targetId, tag);
   sourceId = common.sanitizeText(sourceId, configApi.getConfig());
   targetId = common.sanitizeText(targetId, configApi.getConfig());
+  tag = common.sanitizeText(tag, configApi.getConfig());
 
   if (!sourceId || typeof commits[sourceId] === 'undefined') {
     let error = new Error(
@@ -328,13 +330,13 @@ export const cherryPick = function (sourceId, targetId) {
       parents: [head == null ? null : head.id, sourceCommit.id],
       branch: curBranch,
       type: commitType.CHERRY_PICK,
-      tag: 'cherry-pick:' + sourceCommit.id,
+      tag: tag ? tag : 'cherry-pick:' + sourceCommit.id,
     };
     head = commit;
     commits[commit.id] = commit;
     branches[curBranch] = commit.id;
     log.debug(branches);
-    log.debug('in cheeryPick');
+    log.debug('in cherryPick');
   }
 };
 export const checkout = function (branch) {

--- a/src/diagrams/git/gitGraphParserV2.spec.js
+++ b/src/diagrams/git/gitGraphParserV2.spec.js
@@ -627,6 +627,38 @@ describe('when parsing a gitGraph', function () {
     expect(commits[cherryPickCommitID].branch).toBe('main');
   });
 
+  it('should support cherry-picking commits with custom tag', function () {
+    const str = `gitGraph
+    commit id: "ZERO"
+    branch develop
+    commit id:"A"
+    checkout main
+    cherry-pick id:"A" tag:"MyTag"
+    `;
+
+    parser.parse(str);
+    const commits = parser.yy.getCommits();
+    const cherryPickCommitID = Object.keys(commits)[2];
+    expect(commits[cherryPickCommitID].tag).toBe('MyTag');
+    expect(commits[cherryPickCommitID].branch).toBe('main');
+  });
+
+  it('should support cherry-picking commits with no tag', function () {
+    const str = `gitGraph
+    commit id: "ZERO"
+    branch develop
+    commit id:"A"
+    checkout main
+    cherry-pick id:"A" tag:""
+    `;
+
+    parser.parse(str);
+    const commits = parser.yy.getCommits();
+    const cherryPickCommitID = Object.keys(commits)[2];
+    expect(commits[cherryPickCommitID].tag).toBe('');
+    expect(commits[cherryPickCommitID].branch).toBe('main');
+  });
+
   it('should throw error when try to branch existing branch: main', function () {
     const str = `gitGraph
     commit

--- a/src/diagrams/git/parser/gitGraph.jison
+++ b/src/diagrams/git/parser/gitGraph.jison
@@ -117,7 +117,7 @@ branchStatement
     ;
 
 cherryPickStatement
-    : CHERRY_PICK COMMIT_ID STR {yy.cherryPick($3, '', '')}
+    : CHERRY_PICK COMMIT_ID STR {yy.cherryPick($3, '', 'cherry-pick:<id>')}
     | CHERRY_PICK COMMIT_ID STR COMMIT_TAG STR {yy.cherryPick($3, '', $5)}
     | CHERRY_PICK COMMIT_TAG STR COMMIT_ID STR {yy.cherryPick($5, '', $3)}
     ;

--- a/src/diagrams/git/parser/gitGraph.jison
+++ b/src/diagrams/git/parser/gitGraph.jison
@@ -117,7 +117,7 @@ branchStatement
     ;
 
 cherryPickStatement
-    : CHERRY_PICK COMMIT_ID STR {yy.cherryPick($3, '', 'cherry-pick:<id>')}
+    : CHERRY_PICK COMMIT_ID STR {yy.cherryPick($3, '', undefined)}
     | CHERRY_PICK COMMIT_ID STR COMMIT_TAG STR {yy.cherryPick($3, '', $5)}
     | CHERRY_PICK COMMIT_TAG STR COMMIT_ID STR {yy.cherryPick($5, '', $3)}
     ;

--- a/src/diagrams/git/parser/gitGraph.jison
+++ b/src/diagrams/git/parser/gitGraph.jison
@@ -117,7 +117,9 @@ branchStatement
     ;
 
 cherryPickStatement
-    : CHERRY_PICK COMMIT_ID STR {yy.cherryPick($3)}
+    : CHERRY_PICK COMMIT_ID STR {yy.cherryPick($3, '')}
+    | CHERRY_PICK COMMIT_ID STR COMMIT_TAG STR {yy.cherryPick($3, $4)}
+    | CHERRY_PICK COMMIT_TAG STR COMMIT_ID STR {yy.cherryPick($4, $3)}
     ;
 
 mergeStatement

--- a/src/diagrams/git/parser/gitGraph.jison
+++ b/src/diagrams/git/parser/gitGraph.jison
@@ -57,6 +57,7 @@ checkout(?=\s|$)                        return 'CHECKOUT';
 "options"\r?\n                          this.begin("options"); //
 <options>[ \r\n\t]+"end"                this.popState();       // not used anymore in the renderer, fixed for backward compatibility
 <options>[\s\S]+(?=[ \r\n\t]+"end")     return 'OPT';          //
+["]["]                                  return 'EMPTYSTR';
 ["]                                     this.begin("string");
 <string>["]                             this.popState();
 <string>[^"]*                           return 'STR';
@@ -119,7 +120,9 @@ branchStatement
 cherryPickStatement
     : CHERRY_PICK COMMIT_ID STR {yy.cherryPick($3, '', undefined)}
     | CHERRY_PICK COMMIT_ID STR COMMIT_TAG STR {yy.cherryPick($3, '', $5)}
+    | CHERRY_PICK COMMIT_ID STR COMMIT_TAG EMPTYSTR {yy.cherryPick($3, '', '')}
     | CHERRY_PICK COMMIT_TAG STR COMMIT_ID STR {yy.cherryPick($5, '', $3)}
+    | CHERRY_PICK COMMIT_TAG EMPTYSTR COMMIT_ID STR {yy.cherryPick($3, '', '')}
     ;
 
 mergeStatement

--- a/src/diagrams/git/parser/gitGraph.jison
+++ b/src/diagrams/git/parser/gitGraph.jison
@@ -117,9 +117,9 @@ branchStatement
     ;
 
 cherryPickStatement
-    : CHERRY_PICK COMMIT_ID STR {yy.cherryPick($3, '')}
-    | CHERRY_PICK COMMIT_ID STR COMMIT_TAG STR {yy.cherryPick($3, $4)}
-    | CHERRY_PICK COMMIT_TAG STR COMMIT_ID STR {yy.cherryPick($4, $3)}
+    : CHERRY_PICK COMMIT_ID STR {yy.cherryPick($3, '', '')}
+    | CHERRY_PICK COMMIT_ID STR COMMIT_TAG STR {yy.cherryPick($3, '', $5)}
+    | CHERRY_PICK COMMIT_TAG STR COMMIT_ID STR {yy.cherryPick($5, '', $3)}
     ;
 
 mergeStatement


### PR DESCRIPTION
## :bookmark_tabs: Summary

Cherry-picked commits are commits as well, and might be tagged (especially if you are cherry-picking commits into a release branch from a trunk branch). So it makes sense to support the `tag` attribute in the `cherry-pick` keyword.

Resolves #<your issue id here>

## :straight_ruler: Design Decisions

For syntax, the most straightforward implementation is to copy from the `commit` keyword.

For display, we are currently already rendering the tag `cherry-pick:<ID>` for a cherry-pick. Here, I think the most flexible change is to allow the `tag` attribute to override this default tag and completely replace it, which allows the user to choose to extend it (e.g. `cherry-pick:A snapshot`) or to use alternate text (e.g. `bug fixed`).

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
