### PR TITLE
Fix broken cherry-pick parsing in gitgraph

### DIFF
--- a/src/diagrams/git/gitGraphParserV2.spec.js
+++ b/src/diagrams/git/gitGraphParserV2.spec.js
@@ -611,6 +611,22 @@ describe('when parsing a gitGraph', function () {
     ]);
   });
 
+  it('should support cherry-picking commits', function () {
+    const str = `gitGraph
+    commit id: "ZERO"
+    branch develop
+    commit id:"A"
+    checkout main
+    cherry-pick id:"A"
+    `;
+
+    parser.parse(str);
+    const commits = parser.yy.getCommits();
+    const cherryPickCommitID = Object.keys(commits)[2];
+    expect(commits[cherryPickCommitID].tag).toBe('cherry-pick:A');
+    expect(commits[cherryPickCommitID].branch).toBe('main');
+  });
+
   it('should throw error when try to branch existing branch: main', function () {
     const str = `gitGraph
     commit

--- a/src/diagrams/git/parser/gitGraph.jison
+++ b/src/diagrams/git/parser/gitGraph.jison
@@ -47,7 +47,7 @@ commit(?=\s|$)                          return 'COMMIT';
 branch(?=\s|$)                          return 'BRANCH';
 "order:"                                return 'ORDER';
 merge(?=\s|$)                           return 'MERGE';
-cherry-pick(?=\s|$)                     return 'CHERRY_PICK';
+cherry\-pick(?=\s|$)                    return 'CHERRY_PICK';
 // "reset"                                 return 'RESET';
 checkout(?=\s|$)                        return 'CHECKOUT';
 "LR"                                    return 'DIR';


### PR DESCRIPTION
## :bookmark_tabs: Summary

Using `cherry-pick` in git graphs is currently broken.

That's my fault, I forgot to escape the `-` character in the regex in https://github.com/mermaid-js/mermaid/commit/152795666932cf92af33635d2f98dcbe93e911ba.

Since we didn't having unit tests for `cherry-pick`, I didn't catch the error.

We do have cypress e2e tests for `cherry-pick`, but they didn't throw an error, they just showed 
![image](https://user-images.githubusercontent.com/19716675/190888241-e8bd57d9-ae1f-43f9-9257-fb4aad33273f.png)

## :straight_ruler: Design Decisions

I've added unit tests so this shouldn't happen again!

In the long term, we probably want to modify the cypress e2e tests to throw a an error if Mermaid ever fails.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
