### PR TITLE
ci(e2e-applitols): add applitools CI action

### DIFF
--- a/.github/workflows/e2e-applitools.yml
+++ b/.github/workflows/e2e-applitools.yml
@@ -1,0 +1,73 @@
+name: E2E (Applitools)
+
+on:
+  workflow_dispatch:
+    # Because we want to limit Applitools usage, so we only want to start this
+    # workflow on rare occasions/manually.
+    inputs:
+      parent_branch:
+        required: true
+        type: string
+        default: master
+        description: 'Parent branch to use for PRs'
+
+permissions:
+  contents: read
+
+env:
+  # on PRs from forks, this secret will always be empty, for security reasons
+  USE_APPLI: ${{ secrets.APPLITOOLS_API_KEY && 'true' || '' }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
+    steps:
+      - if: ${{ ! env.USE_APPLI }}
+        name: Warn if not using Applitools
+        run: |
+          echo "::error,title=Not using Applitols::APPLITOOLS_API_KEY is empty, disabling Applitools for this run."
+      - uses: actions/checkout@v3
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          cache: yarn
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install Yarn
+        run: npm i yarn --global
+
+      - name: Install Packages
+        run: |
+          yarn install --frozen-lockfile
+        env:
+          CYPRESS_CACHE_FOLDER: .cache/Cypress
+
+      - name: Run Build
+        run: yarn build
+
+      - if: ${{ env.USE_APPLI }}
+        name: Notify applitools of new batch
+        # Copied from docs https://applitools.com/docs/topics/integrations/github-integration-ci-setup.html
+        run: curl -L -d '' -X POST "$APPLITOOLS_SERVER_URL/api/externals/github/push?apiKey=$APPLITOOLS_API_KEY&CommitSha=$GITHUB_SHA&BranchName=${APPLITOOLS_BRANCH}$&ParentBranchName=$APPLITOOLS_PARENT_BRANCH"
+        env:
+          # e.g. mermaid-js/mermaid/my-branch
+          APPLITOOLS_BRANCH: ${{ github.repository }}/${{ github.ref_name }}
+          APPLITOOLS_PARENT_BRANCH: ${{ github.inputs.parent_branch }}
+          APPLITOOLS_API_KEY: ${{ secrets.APPLITOOLS_API_KEY }}
+          APPLITOOLS_SERVER_URL: 'https://eyesapi.applitools.com'
+
+      - name: Run E2E Tests
+        run: yarn e2e
+        env:
+          CYPRESS_CACHE_FOLDER: .cache/Cypress
+          # Mermaid applitools.config.js uses this to pick batch name.
+          APPLI_BRANCH: ${{ github.ref_name }}
+          APPLITOOLS_BATCH_ID: ${{ github.sha }}
+          # e.g. mermaid-js/mermaid/my-branch
+          APPLITOOLS_BRANCH: ${{ github.repository }}/${{ github.ref_name }}
+          APPLITOOLS_PARENT_BRANCH: ${{ github.inputs.parent_branch }}
+          APPLITOOLS_API_KEY: ${{ secrets.APPLITOOLS_API_KEY }}
+          APPLITOOLS_SERVER_URL: 'https://eyesapi.applitools.com'


### PR DESCRIPTION
## :bookmark_tabs: Summary

Adds a [`workflow_dispatch`][1] GitHub Actions CI workflow that performs an E2E Cypress rendering test with Applitools integration, as discussed in https://github.com/mermaid-js/mermaid/pull/3459

[1]: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow

## :straight_ruler: Design Decisions

If the `APPLITOOLS_API_KEY` secret is not set (an @mermaid-js admin will have to set this using https://docs.github.com/en/actions/security-guides/encrypted-secrets), this action fallsback to just doing a normal E2E Cypress test without Applitools support.

This way, the action still works even if you're running from a fork.

### Example of how to start a run manually

The **Parent branch** argument should be used as the baseline for Cypress (not tested since my free Applitools key doesn't have this feature). I've set this to default to `master`, for the release flow (as discussed in https://github.com/mermaid-js/mermaid/pull/3459#discussion_r972645458), but for PRs to `develop`, we can override this with `develop`.

![image](https://user-images.githubusercontent.com/19716675/190931945-58adb516-079d-40fd-9966-61eb6a2ac7be.png)

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
  - I've tested this on my `aloisklink/mermaid` fork (see https://github.com/aloisklink/mermaid/actions/workflows/e2e-applitools.yml), but unfortunately my `APPLITOOLS_API_KEY` has run out of credits, so I'm not 100% sure this will work, only 95% sure.
- [x] :bookmark: targeted `develop` branch
