### PR TITLE
Fix user-journey leaking css

### DIFF
--- a/src/diagrams/user-journey/styles.js
+++ b/src/diagrams/user-journey/styles.js
@@ -132,8 +132,6 @@ const getStyles = (options) =>
   .actor-5 {
     ${options.actor5 ? `fill: ${options.actor5}` : ''};
   }
-
-  }
 `;
 
 export default getStyles;


### PR DESCRIPTION
## :bookmark_tabs: Summary

This fixes a CSS syntax error that causes the CSS parser to soft-fail, which leads to the later CSS (custom styles) to not properly append the `#id` to them, leaking them out to the global document.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
