### PR TITLE
Mention obsidian has native support for mermaid

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -19,6 +19,7 @@ They also serve as proof of concept, for the variety of things that can be built
 - [Joplin](https://joplinapp.org) (**Native support**)
 - [Notion](https://notion.so) (**Native support**)
 - [Observable](https://observablehq.com/@observablehq/mermaid) (**Native support**)
+- [Obsidian](https://help.obsidian.md/How+to/Format+your+notes#Diagram) (**Native support**)
 - [GitBook](https://gitbook.com)
   - [Mermaid Plugin](https://github.com/JozoVilcek/gitbook-plugin-mermaid)
   - [Markdown with Mermaid CLI](https://github.com/miao1007/gitbook-plugin-mermaid-cli)

--- a/src/docs/integrations.md
+++ b/src/docs/integrations.md
@@ -17,6 +17,7 @@ They also serve as proof of concept, for the variety of things that can be built
 - [Joplin](https://joplinapp.org) (**Native support**)
 - [Notion](https://notion.so) (**Native support**)
 - [Observable](https://observablehq.com/@observablehq/mermaid) (**Native support**)
+- [Obsidian](https://help.obsidian.md/How+to/Format+your+notes#Diagram) (**Native support**)
 - [GitBook](https://gitbook.com)
   - [Mermaid Plugin](https://github.com/JozoVilcek/gitbook-plugin-mermaid)
   - [Markdown with Mermaid CLI](https://github.com/miao1007/gitbook-plugin-mermaid-cli)


### PR DESCRIPTION
## :bookmark_tabs: Summary

Add "Obsidian" app as having native support for Mermaid to the Integrations documentation page.

Resolves (N/A - no issue)

## :straight_ruler: Design Decisions

Updated documentation.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] ~~:computer: have added unit/e2e tests (if appropriate)~~
- [x] :bookmark: targeted `develop` branch
