### PR TITLE
ci(e2e): fix e2e action when running from fork

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,11 +37,16 @@ jobs:
       # and run all Cypress tests
       - name: Cypress run
         uses: cypress-io/github-action@v3
+        # If CYPRESS_RECORD_KEY is set, run in parallel on all containers
+        # Otherwise (e.g. if running from fork), we run on a single container only
+        if: ${{ ( env.CYPRESS_RECORD_KEY != '' ) || ( matrix.containers == 1 ) }}
         with:
           start: yarn dev
           wait-on: 'http://localhost:9000'
-          record: true
+          # Disable recording if we don't have an API key
+          # e.g. if this action was run from a fork
+          record: ${{ secrets.CYPRESS_RECORD_KEY != '' }}
+          parallel: ${{ secrets.CYPRESS_RECORD_KEY != '' }}
           headless: true
-          parallel: true
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}


### PR DESCRIPTION
## :bookmark_tabs: Summary

PRs from forks don't have access to the `secrets.CYPRESS_RECORD_KEY`. Because of this, we need to disable `recording`/`parallel` Cypress builds.

## :straight_ruler: Design Decisions

See comments. Essentially we skip running Cypress on containers 2-4 if `secrets.CYPRESS_RECORD_KEY` is empty.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
