### PR TITLE
[sequenceDiagrams] Support dashes in participant names

### DIFF
--- a/src/diagrams/sequence/parser/sequenceDiagram.jison
+++ b/src/diagrams/sequence/parser/sequenceDiagram.jison
@@ -37,7 +37,7 @@
 [0-9]+(?=[ \n]+)       											return 'NUM';
 "participant"                                                   { this.begin('ID'); return 'participant'; }
 "actor"                                                   	{ this.begin('ID'); return 'participant_actor'; }
-<ID>[^\->:\n,;]+?(?=((?!\n)\s)+"as"(?!\n)\s|[#\n;]|$)           { yytext = yytext.trim(); this.begin('ALIAS'); return 'ACTOR'; }
+<ID>[^\->:\n,;]+?([\-]*[^\->:\n,;]+?)*?(?=((?!\n)\s)+"as"(?!\n)\s|[#\n;]|$)     { yytext = yytext.trim(); this.begin('ALIAS'); return 'ACTOR'; }
 <ALIAS>"as"                                                     { this.popState(); this.popState(); this.begin('LINE'); return 'AS'; }
 <ALIAS>(?:)                                                     { this.popState(); this.popState(); return 'NEWLINE'; }
 "loop"                                                          { this.begin('LINE'); return 'loop'; }

--- a/src/diagrams/sequence/sequenceDiagram.spec.js
+++ b/src/diagrams/sequence/sequenceDiagram.spec.js
@@ -249,7 +249,7 @@ Bob-->Alice-in-Wonderland:I am good thanks!`;
     mermaidAPI.parse(str);
     const actors = diagram.db.getActors();
     expect(actors['Alice-in-Wonderland'].description).toBe('Alice-in-Wonderland');
-    actors.Bob.description = 'Bob';
+    expect(actors.Bob.description).toBe('Bob');
 
     const messages = diagram.db.getMessages();
 

--- a/src/diagrams/sequence/sequenceDiagram.spec.js
+++ b/src/diagrams/sequence/sequenceDiagram.spec.js
@@ -257,6 +257,28 @@ Bob-->Alice-in-Wonderland:I am good thanks!`;
     expect(messages[0].from).toBe('Alice-in-Wonderland');
     expect(messages[1].from).toBe('Bob');
   });
+
+  it('should handle dashes in participant names', function () {
+    const str = `
+sequenceDiagram
+participant Alice-in-Wonderland
+participant Bob
+Alice-in-Wonderland->Bob:Hello Bob, how are - you?
+Bob-->Alice-in-Wonderland:I am good thanks!`;
+
+    mermaidAPI.parse(str);
+    const actors = diagram.db.getActors();
+    expect(Object.keys(actors)).toEqual(['Alice-in-Wonderland', 'Bob']);
+    expect(actors['Alice-in-Wonderland'].description).toBe('Alice-in-Wonderland');
+    expect(actors.Bob.description).toBe('Bob');
+
+    const messages = diagram.db.getMessages();
+
+    expect(messages.length).toBe(2);
+    expect(messages[0].from).toBe('Alice-in-Wonderland');
+    expect(messages[1].from).toBe('Bob');
+  });
+
   it('should alias participants', function () {
     const str = `
 sequenceDiagram


### PR DESCRIPTION
## :bookmark_tabs: Summary
Add support for hyphens `-` in the `participant` name definition

Currently the following syntax: 

```mermaid
sequenceDiagram
    participant Joe as joe-with-dashes
    participant Bob
    participant Alice-In-Wonderland
```

Will produce an error:
```
"Lexical error on line 3. Unrecognized text.
...Bob    participant Alice-In-Wonderland
----------------------^"
```

Resolves #3078 

## :straight_ruler: Design Decisions

This is based off the prior work in PR https://github.com/mermaid-js/mermaid/pull/1574

Tried to use the same logic as much as possible for this one. All tests pass, I believe this is working as expected. Let me know if you can think of any edge cases that might need to be accounted for. The key appears to be the lazy quantifiers in this query.

I fixed what I think is a minor bug in the tests from the previous PR.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
