### PR TITLE
docs: replace `yarn` with `pnpm` in dev guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,8 @@ Here are a few things to know to get you started on the right path.
 ```bash
 git clone git@github.com:mermaid-js/mermaid.git
 cd mermaid
-yarn
-yarn test
+pnpm install
+pnpm test
 ```
 
 ## Committing code
@@ -103,7 +103,7 @@ This is important so that, if someone else does a change to the grammar that doe
 
 This tests the rendering and visual appearance of the diagram. This ensures that the rendering of that feature in the e2e will be reviewed in the release process going forward. Less chance that it breaks!
 
-To start working with the e2e tests, run `yarn dev` to start the dev server, after that start cypress by running `cypress open` in the mermaid folder. (Make sure you have path to cypress in order, the binary is located in node_modules/.bin).
+To start working with the e2e tests, run `pnpm run dev` to start the dev server, after that start cypress by running `pnpm exec cypress open` in the mermaid folder.
 
 The rendering tests are very straightforward to create. There is a function imgSnapshotTest. This function takes a diagram in text form, the mermaid options and renders that diagram in cypress.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -72,9 +72,8 @@ This tests the rendering and visual appearance of the diagrams. This ensures tha
 
 To start working with the e2e tests:
 
-1.  Run `yarn dev` to start the dev server
-2.  Start **Cypress** by running `cypress open` in the **mermaid** folder.
-    (Make sure you have path to Cypress in order, the binary is located in `node_modules/.bin`).
+1.  Run `pnpm run dev` to start the dev server
+2.  Start **Cypress** by running `pnpm exec cypress open` in the **mermaid** folder.
 
 The rendering tests are very straightforward to create. There is a function `imgSnapshotTest`, which takes a diagram in text form and the mermaid options, and it renders that diagram in Cypress.
 

--- a/packages/mermaid/src/docs/development.md
+++ b/packages/mermaid/src/docs/development.md
@@ -70,9 +70,8 @@ This tests the rendering and visual appearance of the diagrams. This ensures tha
 
 To start working with the e2e tests:
 
-1. Run `yarn dev` to start the dev server
-2. Start **Cypress** by running `cypress open` in the **mermaid** folder.
-   (Make sure you have path to Cypress in order, the binary is located in `node_modules/.bin`).
+1. Run `pnpm run dev` to start the dev server
+2. Start **Cypress** by running `pnpm exec cypress open` in the **mermaid** folder.
 
 The rendering tests are very straightforward to create. There is a function `imgSnapshotTest`, which takes a diagram in text form and the mermaid options, and it renders that diagram in Cypress.
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

With the new mono-repo move (PR #3531), development must be done with `pnpm`.

Using `memaid` can still be done with `yarn`/`npm` however.

## :straight_ruler: Design Decisions

I've manually updated the `docs/development.md` file since the `pnpm run docs:verify` and `pnpm run docs:build` scripts are currently broken (see #3534).

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
