### PR TITLE
Fix husky `pre-commit` rules

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn pre-commit
+pnpm run pre-commit

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,6 +1,6 @@
 {
-  "src/docs/**": ["pnpm run docs:build --git"],
-  "src/docs.mts": ["pnpm run docs:build --git"],
+  "packages/mermaid/src/docs/**": ["pnpm run docs:build --git"],
+  "packages/mermaid/src/docs.mts": ["pnpm run docs:build --git"],
   "*.{ts,js,json,html,md,mts}": ["eslint --fix", "prettier --write"],
   "*.jison": ["pnpm run lint:jison"]
 }

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,6 +1,6 @@
 {
-  "src/docs/**": ["yarn docs:build --git"],
-  "src/docs.mts": ["yarn docs:build --git"],
+  "src/docs/**": ["pnpm run docs:build --git"],
+  "src/docs.mts": ["pnpm run docs:build --git"],
   "*.{ts,js,json,html,md,mts}": ["eslint --fix", "prettier --write"],
-  "*.jison": ["yarn lint:jison"]
+  "*.jison": ["pnpm run lint:jison"]
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test": "pnpm lint && vitest run",
     "test:watch": "vitest --coverage --watch",
     "prepublishOnly": "pnpm build && pnpm test",
-    "todo-prepare": "concurrently \"husky install\" \"pnpm build\"",
+    "prepare": "concurrently \"husky install\" \"pnpm build\"",
     "pre-commit": "lint-staged"
   },
   "repository": {


### PR DESCRIPTION
## :bookmark_tabs: Summary

Currently, the husky rules that used to automatically run before `git commit` are broken.
This PR fixes the pre-commit rules with the following changes:

- [build: update pre-commit rules to use pnpm](https://github.com/mermaid-js/mermaid/commit/9513e0e2d56786adced7465f6dc804c6f942c34f)
  Update husky and lint-staged to use `pnpm` instead of `yarn`.
- [build: re-enable prepare script for husky setup](https://github.com/mermaid-js/mermaid/commit/1cdb0ff72c5b9f2f1fabc6f0ef7f7b52efcb41d4)
  Re-enables the `pnpm run prepare` script.

  The prepare script is automatically run when running `pnpm install` locally.

  It both:
  - Sets up husky/git pre-commit scripts
  - Builds the `packages/mermaid/dist` folder.
- [build: lint-staged docs in packages/mermaid/src/…](https://github.com/mermaid-js/mermaid/commit/1f3a02559c2dff01248dca79c47a9b6cff86913c)
  When running lint-staged during git pre-commit scripts, search for docs in the `packages/mermaid/src/docs` folder instead of the original `src/docs` folder.
  > **Warning**
  >
  > `pnpm run docs:build` currently does nothing until #3534 is merged.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
