### PR TITLE
Fill inheritance arrow with background color

### DIFF
--- a/packages/mermaid/src/diagrams/class/styles.js
+++ b/packages/mermaid/src/diagrams/class/styles.js
@@ -105,13 +105,13 @@ g.classGroup line {
 }
 
 #extensionStart, .extension {
-  fill: ${options.lineColor} !important;
+  fill: ${options.mainBkg} !important;
   stroke: ${options.lineColor} !important;
   stroke-width: 1;
 }
 
 #extensionEnd, .extension {
-  fill: ${options.lineColor} !important;
+  fill: ${options.mainBkg} !important;
   stroke: ${options.lineColor} !important;
   stroke-width: 1;
 }


### PR DESCRIPTION
## :bookmark_tabs: Summary

Replace the inheritance arrow from the class diagram with an unfilled triangle.

This is to match the UML specification:
![image](https://user-images.githubusercontent.com/7579321/193468948-2d005efd-a319-4b2a-9b1a-cce14be56a6b.png)

Here is how it was displayed:
![image](https://user-images.githubusercontent.com/7579321/194721633-b16787cc-459e-445c-9064-40453d11f455.png)

Here is how it is now displayed:
![image](https://user-images.githubusercontent.com/7579321/194721588-e451dfbf-c468-48fb-81a9-404c3a599171.png)


Resolves #3527

## :straight_ruler: Design Decisions

Was implemented based on the unfilled diamond already used by Mermaid.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
