### PR TITLE
Fix failing vitest unit tests

### DIFF
--- a/packages/mermaid-example-diagram/package.json
+++ b/packages/mermaid-example-diagram/package.json
@@ -29,10 +29,6 @@
     "lint": "eslint --cache --ignore-path .gitignore . && yarn lint:jison && prettier --check .",
     "lint:fix": "eslint --fix --ignore-path .gitignore . && prettier --write .",
     "lint:jison": "ts-node-esm src/jison/lint.mts",
-    "ci": "vitest run",
-    "test": "yarn lint && vitest run",
-    "test:watch": "vitest --coverage --watch",
-    "todo-prepublishOnly": "yarn build && yarn test",
     "todo-prepare": "concurrently \"husky install ../../.husky\" \"yarn build\"",
     "todo-pre-commit": "lint-staged"
   },

--- a/packages/mermaid-mindmap/package.json
+++ b/packages/mermaid-mindmap/package.json
@@ -29,10 +29,6 @@
     "lint": "eslint --cache --ignore-path .gitignore . && yarn lint:jison && prettier --check .",
     "lint:fix": "eslint --fix --ignore-path .gitignore . && prettier --write .",
     "lint:jison": "ts-node-esm src/jison/lint.mts",
-    "ci": "vitest run",
-    "test": "yarn lint && vitest run",
-    "test:watch": "vitest --coverage --watch",
-    "todo-prepublishOnly": "yarn build && yarn test",
     "todo-prepare": "concurrently \"husky install ../../.husky\" \"yarn build\"",
     "todo-pre-commit": "lint-staged"
   },

--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -41,10 +41,6 @@
     "cypress": "cypress run",
     "cypress:open": "cypress open",
     "e2e": "start-server-and-test dev http://localhost:9000/ cypress",
-    "ci": "vitest run",
-    "test": "yarn lint && vitest run",
-    "test:watch": "vitest --coverage --watch",
-    "prepublishOnly": "yarn build && yarn test",
     "todo-prepare": "concurrently \"husky install\" \"yarn build\"",
     "pre-commit": "lint-staged"
   },
@@ -92,8 +88,6 @@
     "@types/stylis": "^4.0.2",
     "@typescript-eslint/eslint-plugin": "^5.37.0",
     "@typescript-eslint/parser": "^5.37.0",
-    "@vitest/coverage-c8": "^0.23.2",
-    "@vitest/ui": "^0.23.2",
     "concurrently": "^7.4.0",
     "coveralls": "^3.1.1",
     "cypress": "^10.0.0",
@@ -125,8 +119,7 @@
     "start-server-and-test": "^1.12.6",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.3",
-    "unist-util-flatmap": "^1.0.0",
-    "vitest": "^0.23.1"
+    "unist-util-flatmap": "^1.0.0"
   },
   "resolutions": {
     "d3": "^7.0.0"

--- a/packages/mermaid/src/diagrams/gantt/ganttDb.spec.ts
+++ b/packages/mermaid/src/diagrams/gantt/ganttDb.spec.ts
@@ -1,7 +1,6 @@
 // @ts-nocheck TODO: Fix TS
 import moment from 'moment-mini';
 import ganttDb from './ganttDb';
-import { it, describe } from 'vitest';
 import { convert } from '../../tests/util';
 
 describe('when using the ganttDb', function () {

--- a/packages/mermaid/src/mermaid.spec.ts
+++ b/packages/mermaid/src/mermaid.spec.ts
@@ -1,7 +1,6 @@
 import mermaid from './mermaid';
 import { mermaidAPI } from './mermaidAPI';
 import './diagram-api/diagram-orchestration';
-import { vi, describe, it, beforeEach, afterEach, expect } from 'vitest';
 const spyOn = vi.spyOn;
 
 vi.mock('./mermaidAPI');

--- a/packages/mermaid/src/utils.spec.js
+++ b/packages/mermaid/src/utils.spec.js
@@ -1,4 +1,4 @@
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi } from 'vitest';
 import utils from './utils';
 import assignWithDepth from './assignWithDepth';
 import { detectType } from './diagram-api/detectType';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,8 +164,6 @@ importers:
       '@types/stylis': ^4.0.2
       '@typescript-eslint/eslint-plugin': ^5.37.0
       '@typescript-eslint/parser': ^5.37.0
-      '@vitest/coverage-c8': ^0.23.2
-      '@vitest/ui': ^0.23.2
       concurrently: ^7.4.0
       coveralls: ^3.1.1
       cypress: ^10.0.0
@@ -209,7 +207,6 @@ importers:
       ts-node: ^10.9.1
       typescript: ^4.8.3
       unist-util-flatmap: ^1.0.0
-      vitest: ^0.23.1
     dependencies:
       '@braintree/sanitize-url': 6.0.0
       d3: 7.6.1
@@ -237,8 +234,6 @@ importers:
       '@types/stylis': 4.0.2
       '@typescript-eslint/eslint-plugin': 5.38.0_wsb62dxj2oqwgas4kadjymcmry
       '@typescript-eslint/parser': 5.38.0_irgkl5vooow2ydyo6aokmferha
-      '@vitest/coverage-c8': 0.23.4_y2hohvmcqnhseytaw4yjcnsnkm
-      '@vitest/ui': 0.23.4
       concurrently: 7.4.0
       coveralls: 3.1.1
       cypress: 10.8.0
@@ -271,7 +266,6 @@ importers:
       ts-node: 10.9.1_typescript@4.8.3
       typescript: 4.8.3
       unist-util-flatmap: 1.0.0
-      vitest: 0.23.4_y2hohvmcqnhseytaw4yjcnsnkm
 
   packages/mermaid-example-diagram:
     specifiers:
@@ -3569,24 +3563,6 @@ packages:
     dependencies:
       c8: 7.12.0
       vitest: 0.23.4_gkhtrnfwk72a2xpsvrk7h3dcna
-    transitivePeerDependencies:
-      - '@edge-runtime/vm'
-      - '@vitest/browser'
-      - '@vitest/ui'
-      - happy-dom
-      - jsdom
-      - less
-      - sass
-      - stylus
-      - supports-color
-      - terser
-    dev: true
-
-  /@vitest/coverage-c8/0.23.4_y2hohvmcqnhseytaw4yjcnsnkm:
-    resolution: {integrity: sha512-jmD00a5DQH9gu9K+YdvVhcMuv2CzHvU4gCnySS40Ec5hKlXtlCzRfNHl00VnhfuBeaQUmaQYe60BLT413HyDdg==}
-    dependencies:
-      c8: 7.12.0
-      vitest: 0.23.4_y2hohvmcqnhseytaw4yjcnsnkm
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@vitest/browser'
@@ -13173,49 +13149,6 @@ packages:
       chai: 4.3.6
       debug: 4.3.4
       jsdom: 20.0.1
-      local-pkg: 0.4.2
-      strip-literal: 0.4.2
-      tinybench: 2.1.5
-      tinypool: 0.3.0
-      tinyspy: 1.0.2
-      vite: 3.1.3
-    transitivePeerDependencies:
-      - less
-      - sass
-      - stylus
-      - supports-color
-      - terser
-    dev: true
-
-  /vitest/0.23.4_y2hohvmcqnhseytaw4yjcnsnkm:
-    resolution: {integrity: sha512-iukBNWqQAv8EKDBUNntspLp9SfpaVFbmzmM0sNcnTxASQZMzRw3PsM6DMlsHiI+I6GeO5/sYDg3ecpC+SNFLrQ==}
-    engines: {node: '>=v14.16.0'}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@vitest/browser': '*'
-      '@vitest/ui': '*'
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-    dependencies:
-      '@types/chai': 4.3.3
-      '@types/chai-subset': 1.3.3
-      '@types/node': 18.7.21
-      '@vitest/ui': 0.23.4
-      chai: 4.3.6
-      debug: 4.3.4
-      jsdom: 20.0.0
       local-pkg: 0.4.2
       strip-literal: 0.4.2
       tinybench: 2.1.5


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fix the failing vitest unit tests.

I think this was broken by https://github.com/mermaid-js/mermaid/pull/3557

It looks like dependabot doesn't support `pnpm`, and because of that, it's PRs don't work very well, see https://github.com/dependabot/dependabot-core/issues/1736

Maybe it's worth switching to use `npm` workspaces instead? It'll probably be slower, but it will mean we won't get dependabot issues.

## :straight_ruler: Design Decisions

Removes vitest from all subpackages so that vitest/`pnpm run test` are only in the root mono-repo.

This is required, because otherwise the root vitest and the subpackage vitest versions can be slightly different, which causes issues when running unit tests:

```Error: Snapshot cannot be used outside of test```

#### Potential future improvement

In the future, we may want to consider moving package specific tests into `packages/*/test`, and instead running these tests with `pnpm run --recursive`, so that tests are run in each package by their own version of vitest. This is the way that most projects do things (e.g. https://github.com/vitest-dev/vitest).

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
