### PR TITLE
fix: vertex property `props` is overwritten instead of being merged w…

### DIFF
--- a/packages/mermaid/src/diagrams/flowchart/flowDb.js
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.js
@@ -119,7 +119,11 @@ export const addVertex = function (_id, text, type, style, classes, dir, props =
   if (typeof dir !== 'undefined') {
     vertices[id].dir = dir;
   }
-  vertices[id].props = props;
+  if (typeof vertices[id].props === 'undefined') {
+    vertices[id].props = props;
+  } else if (typeof props !== 'undefined') {
+    Object.assign(vertices[id].props, props);
+  }
 };
 
 /**


### PR DESCRIPTION
## :bookmark_tabs: Summary

Resolves #3263

I've added the property `props` to vertices in [this](https://github.com/mermaid-js/mermaid/pull/2389) PR that added support for data flow diagrams. As pointed out in #3263, the borders (passed as `props` in `addVertex`, see file `flowDB.js`) are not woking if the node is used after its declaration, e.g.

```
1 | flowchart LR
2 |   datastore[|borders:tb|Datastore]
3 |   process((System))
4 |   entity[Customer]
5 | 
6 |   datastore -->|input| process -->|output| entity
```

In the example above, the node `datastore` is declared in line 2 and used again in line 6. Thereby, `addVertex` is called twice. The first time (declaration), the borders are passed as `props` (`{borders: 'tb'}`). The second time (usage), no properties (`{}`) are passed as `props`. The `props` are stored in `vertices[id]`. Since they where always assigned to this object, the second call assigned its value (no properties) at last (overwritting the properies (borders) of the first call). This is a bug. The borders should have been maintained. Therefore, the properties get merged now using `Object.assign`.