### PR TITLE
feat: make `parseError` function more type-safe

### DIFF
--- a/packages/mermaid/src/Diagram.ts
+++ b/packages/mermaid/src/Diagram.ts
@@ -2,9 +2,9 @@ import * as configApi from './config';
 import { log } from './logger';
 import { getDiagram, registerDiagram } from './diagram-api/diagramAPI';
 import { detectType, getDiagramLoader } from './diagram-api/detectType';
-import { isDetailedError } from './utils';
+import { isDetailedError, type DetailedError } from './utils';
 
-export type ParseErrorFunction = (str: string, hash?: any) => void;
+export type ParseErrorFunction = (err: string | DetailedError, hash?: any) => void;
 
 export class Diagram {
   type = 'graph';

--- a/packages/mermaid/src/__mocks__/mermaidAPI.ts
+++ b/packages/mermaid/src/__mocks__/mermaidAPI.ts
@@ -6,7 +6,7 @@
 import * as configApi from '../config';
 import { vi } from 'vitest';
 import { addDiagrams } from '../diagram-api/diagram-orchestration';
-import Diagram from '../Diagram';
+import Diagram, { type ParseErrorFunction } from '../Diagram';
 
 // Normally, we could just do the following to get the original `parse()`
 // implementation, however, requireActual returns a promise and it's not documented how to use withing mock file.
@@ -15,8 +15,7 @@ import Diagram from '../Diagram';
  * @param text
  * @param parseError
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
-function parse(text: string, parseError?: Function): boolean {
+function parse(text: string, parseError?: ParseErrorFunction): boolean {
   addDiagrams();
   const diagram = new Diagram(text, parseError);
   return diagram.parse(text, parseError);

--- a/packages/mermaid/src/mermaid.ts
+++ b/packages/mermaid/src/mermaid.ts
@@ -8,7 +8,7 @@ import utils from './utils';
 import { mermaidAPI } from './mermaidAPI';
 import { addDetector } from './diagram-api/detectType';
 import { isDetailedError } from './utils';
-import { ParseErrorFunction } from './Diagram';
+import type { ParseErrorFunction } from './Diagram';
 
 /**
  * ## init

--- a/packages/mermaid/src/mermaid.ts
+++ b/packages/mermaid/src/mermaid.ts
@@ -8,6 +8,7 @@ import utils from './utils';
 import { mermaidAPI } from './mermaidAPI';
 import { addDetector } from './diagram-api/detectType';
 import { isDetailedError } from './utils';
+import { ParseErrorFunction } from './Diagram';
 
 /**
  * ## init
@@ -62,7 +63,7 @@ const init = async function (
       log.warn(e.str);
     }
     if (mermaid.parseError) {
-      mermaid.parseError(e);
+      mermaid.parseError(e as string);
     }
   }
 };
@@ -212,8 +213,7 @@ const parse = (txt: string) => {
 const mermaid: {
   startOnLoad: boolean;
   diagrams: any;
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  parseError?: Function;
+  parseError?: ParseErrorFunction;
   mermaidAPI: typeof mermaidAPI;
   parse: typeof parse;
   render: typeof mermaidAPI.render;

--- a/packages/mermaid/src/mermaidAPI.ts
+++ b/packages/mermaid/src/mermaidAPI.ts
@@ -22,7 +22,7 @@ import classDb from './diagrams/class/classDb';
 import flowDb from './diagrams/flowchart/flowDb';
 import flowRenderer from './diagrams/flowchart/flowRenderer';
 import ganttDb from './diagrams/gantt/ganttDb';
-import Diagram, { getDiagramFromText } from './Diagram';
+import Diagram, { getDiagramFromText, type ParseErrorFunction } from './Diagram';
 import errorRenderer from './diagrams/error/errorRenderer';
 import { attachFunctions } from './interactionDb';
 import { log, setLogLevel } from './logger';
@@ -37,8 +37,7 @@ import { evaluate } from './diagrams/common/common';
  * @param text
  * @param parseError
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
-function parse(text: string, parseError?: Function): boolean {
+function parse(text: string, parseError?: ParseErrorFunction): boolean {
   addDiagrams();
   const diagram = new Diagram(text, parseError);
   return diagram.parse(text, parseError);


### PR DESCRIPTION
## :bookmark_tabs: Summary

This PR makes the `parseError` handler more type-safe by introducing a new type alias: `ParseErrorFunction`.

## :straight_ruler: Design Decisions

The new `ParseErrorFunction` type alias simply encodes the `parseError` interface in TypeScript.

```ts
export type ParseErrorFunction = (str: string | DetailedError, hash?: any) => void;
```

This allows us to remove several disabled lints in `Diagram.ts`—namely `@typescript-eslint/ban-types`, which I assume comes from the usage of the less type-safe `Function` type.

I must warn that this may break code that relies on the arbitrary `Function` type. I believe that this is a non-issue, however, because the documentation explicitly states the exact interface that a `parseError` handler adheres to.

### :clipboard: Tasks

Make sure you...

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
