### PR TITLE
fix: Fix useMaxWidth option for git graph

### DIFF
--- a/packages/mermaid/src/diagrams/git/gitGraphRenderer.js
+++ b/packages/mermaid/src/diagrams/git/gitGraphRenderer.js
@@ -495,7 +495,6 @@ const drawBranches = (svg, branches) => {
  */
 export const draw = function (txt, id, ver, diagObj) {
   clear();
-  const conf = getConfig();
   const gitGraphConfig = getConfig().gitGraph;
   // try {
   log.debug('in gitgraph renderer', txt + '\n', 'id:', id, ver);
@@ -523,7 +522,7 @@ export const draw = function (txt, id, ver, diagObj) {
   drawCommits(diagram, allCommitsDict, true);
 
   // Setup the view box and size of the svg element
-  setupGraphViewbox(undefined, diagram, gitGraphConfig.diagramPadding, conf.useMaxWidth);
+  setupGraphViewbox(undefined, diagram, gitGraphConfig.diagramPadding, gitGraphConfig.useMaxWidth);
 };
 
 export default {

--- a/packages/mermaid/src/diagrams/git/gitGraphRenderer.js
+++ b/packages/mermaid/src/diagrams/git/gitGraphRenderer.js
@@ -495,7 +495,8 @@ const drawBranches = (svg, branches) => {
  */
 export const draw = function (txt, id, ver, diagObj) {
   clear();
-  const gitGraphConfig = getConfig().gitGraph;
+  const conf = getConfig();
+  const gitGraphConfig = conf.gitGraph;
   // try {
   log.debug('in gitgraph renderer', txt + '\n', 'id:', id, ver);
 
@@ -522,7 +523,12 @@ export const draw = function (txt, id, ver, diagObj) {
   drawCommits(diagram, allCommitsDict, true);
 
   // Setup the view box and size of the svg element
-  setupGraphViewbox(undefined, diagram, gitGraphConfig.diagramPadding, gitGraphConfig.useMaxWidth);
+  setupGraphViewbox(
+    undefined,
+    diagram,
+    gitGraphConfig.diagramPadding,
+    gitGraphConfig.useMaxWidth ?? conf.useMaxWidth
+  );
 };
 
 export default {


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fixed Git Graph to allow `useMaxWidth` option to be set.

Resolves #3651

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
