### PR TITLE
fix: gantt demo diagrams (#3655)

### DIFF
--- a/demos/gantt.html
+++ b/demos/gantt.html
@@ -74,22 +74,22 @@
     <pre class="mermaid">
     gantt
     title Hide today marker (vertical line should not be visible)
-    dateFormat YYYY-MM-DD
-    axisFormat %d
+    dateFormat Z
+    axisFormat %d/%m
     todayMarker off
     section Section1
-    Today: 1, -1h
+    Today: 1, -01:00, 5min
     </pre>
     <hr />
 
     <pre class="mermaid">
     gantt
     title Style today marker (vertical line should be 5px wide and half-transparent blue)
-    dateFormat YYYY-MM-DD
-    axisFormat %d
+    dateFormat Z
+    axisFormat %d/%m
     todayMarker stroke-width:5px,stroke:#00f,opacity:0.5
     section Section1
-    Today: 1, -1h
+    Today: 1, -01:00, 5min
     </pre>
     <hr />
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fix for issues regarding gantt demo diagrams in Firefox 105.0.3.

Resolves #3655

## :straight_ruler: Design Decisions

When dateFormat is changed to Z and start value is set to something like -01:00, graphs are rendered.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
