### PR TITLE
add eslint-plugin-no-only-tests plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,7 @@
     "plugin:markdown/recommended",
     "prettier"
   ],
-  "plugins": ["@typescript-eslint", "html", "jest", "jsdoc", "json"],
+  "plugins": ["@typescript-eslint", "no-only-tests", "html", "jest", "jsdoc", "json"],
   "rules": {
     "no-console": "error",
     "no-prototype-builtins": "off",
@@ -48,7 +48,13 @@
       }
     ],
     "json/*": ["error", "allowComments"],
-    "no-empty": ["error", { "allowEmptyCatch": true }]
+    "no-empty": [
+      "error",
+      {
+        "allowEmptyCatch": true
+      }
+    ],
+    "no-only-tests/no-only-tests": "error"
   },
   "overrides": [
     {

--- a/cypress/integration/rendering/erDiagram.spec.js
+++ b/cypress/integration/rendering/erDiagram.spec.js
@@ -167,7 +167,7 @@ describe('Entity Relationship Diagram', () => {
     cy.get('svg');
   });
 
-  it.only('should render entities with generic and array attributes', () => {
+  it('should render entities with generic and array attributes', () => {
     renderGraph(
       `
     erDiagram

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "eslint-plugin-jsdoc": "39.3.6",
     "eslint-plugin-json": "3.1.0",
     "eslint-plugin-markdown": "3.0.0",
+    "eslint-plugin-no-only-tests": "^3.0.0",
     "express": "4.18.2",
     "globby": "13.1.2",
     "husky": "8.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,7 @@ importers:
       eslint-plugin-jsdoc: 39.3.6
       eslint-plugin-json: 3.1.0
       eslint-plugin-markdown: 3.0.0
+      eslint-plugin-no-only-tests: ^3.0.0
       express: 4.18.2
       fast-clone: 1.5.13
       globby: 13.1.2
@@ -125,6 +126,7 @@ importers:
       eslint-plugin-jsdoc: 39.3.6_eslint@8.25.0
       eslint-plugin-json: 3.1.0
       eslint-plugin-markdown: 3.0.0_eslint@8.25.0
+      eslint-plugin-no-only-tests: 3.0.0
       express: 4.18.2
       globby: 13.1.2
       husky: 8.0.1
@@ -5713,6 +5715,11 @@ packages:
       mdast-util-from-markdown: 0.8.5
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /eslint-plugin-no-only-tests/3.0.0:
+    resolution: {integrity: sha512-I0PeXMs1vu21ap45hey4HQCJRqpcoIvGcNTPJe+UhUm8TwjQ6//mCrDqF8q0WS6LgmRDwQ4ovQej0AQsAHb5yg==}
+    engines: {node: '>=5.0.0'}
     dev: true
 
   /eslint-scope/5.1.1:


### PR DESCRIPTION
## :bookmark_tabs: Summary

add eslint-plugin-no-only-tests plugin, remove `it.only` from cypress erDaigram rendering tests (https://github.com/mermaid-js/mermaid/blob/develop/cypress/integration/rendering/erDiagram.spec.js#L170)
It's done because of this comment: https://github.com/mermaid-js/mermaid/pull/3647#issuecomment-1281163858

@sidharthv96 , FYI.

## :straight_ruler: Design Decisions

No decisions, technical PR

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
