### PR TITLE
Support `lazyLoadedDiagrams` when calling `initThrowsErrors`

### DIFF
--- a/packages/mermaid/src/mermaid.spec.ts
+++ b/packages/mermaid/src/mermaid.spec.ts
@@ -48,10 +48,31 @@ describe('when using mermaid and ', function () {
       const node = document.createElement('div');
       node.appendChild(document.createTextNode('graph TD;\na;'));
 
-      mermaid.initThrowsErrors(undefined, node);
+      await mermaid.initThrowsErrors(undefined, node);
       // mermaidAPI.render function has been mocked, since it doesn't yet work
       // in Node.JS (only works in browser)
       expect(mermaidAPI.render).toHaveBeenCalled();
+    });
+    it('should throw error (but still render) if lazyLoadedDiagram fails', async () => {
+      const node = document.createElement('div');
+      node.appendChild(document.createTextNode('graph TD;\na;'));
+
+      mermaidAPI.setConfig({
+        lazyLoadedDiagrams: ['this-file-does-not-exist.mjs'],
+      });
+      await expect(mermaid.initThrowsErrors(undefined, node)).rejects.toThrowError(
+        // this error message is probably different on every platform
+        // this one is just for vite-note (node/jest/browser may be different)
+        'Failed to load this-file-does-not-exist.mjs'
+      );
+
+      // should still render, even if lazyLoadedDiagrams fails
+      expect(mermaidAPI.render).toHaveBeenCalled();
+    });
+
+    afterEach(() => {
+      // we modify mermaid config in some tests, so we need to make sure to reset them
+      mermaidAPI.reset();
     });
   });
 

--- a/packages/mermaid/src/mermaid.ts
+++ b/packages/mermaid/src/mermaid.ts
@@ -57,6 +57,18 @@ const init = async function (
   }
 };
 
+/**
+ * Equivalent to {@link init()}, except an error will be thrown on error.
+ *
+ * @param config - **Deprecated** Mermaid sequenceConfig.
+ * @param nodes - One of:
+ * - A DOM Node
+ * - An array of DOM nodes (as would come from a jQuery selector)
+ * - A W3C selector, a la `.mermaid` (default)
+ * @param callback - Function that is called with the id of each generated mermaid diagram.
+ *
+ * @returns Resolves on success, otherwise the {@link Promise} will be rejected with an Error.
+ */
 const initThrowsErrors = async function (
   config?: MermaidConfig,
   // eslint-disable-next-line no-undef

--- a/packages/mermaid/src/mermaid.ts
+++ b/packages/mermaid/src/mermaid.ts
@@ -45,16 +45,6 @@ const init = async function (
   callback?: Function
 ) {
   try {
-    const conf = mermaidAPI.getConfig();
-    if (conf?.lazyLoadedDiagrams && conf.lazyLoadedDiagrams.length > 0) {
-      // Load all lazy loaded diagrams in parallel
-      await Promise.allSettled(
-        conf.lazyLoadedDiagrams.map(async (diagram: string) => {
-          const { id, detector, loadDiagram } = await import(diagram);
-          addDetector(id, detector, loadDiagram);
-        })
-      );
-    }
     await initThrowsErrors(config, nodes, callback);
   } catch (e) {
     log.warn('Syntax Error rendering');
@@ -80,6 +70,16 @@ const initThrowsErrors = async function (
     // This is a legacy way of setting config. It is not documented and should be removed in the future.
     // @ts-ignore: TODO Fix ts errors
     mermaid.sequenceConfig = config;
+  }
+
+  if (conf?.lazyLoadedDiagrams && conf.lazyLoadedDiagrams.length > 0) {
+    // Load all lazy loaded diagrams in parallel
+    await Promise.allSettled(
+      conf.lazyLoadedDiagrams.map(async (diagram: string) => {
+        const { id, detector, loadDiagram } = await import(diagram);
+        addDetector(id, detector, loadDiagram);
+      })
+    );
   }
 
   // if last argument is a function this is the callback function


### PR DESCRIPTION
## :bookmark_tabs: Summary

Adds support for calling `lazyLoadedDiagrams` in `mermaid.initThrowsErrors`.

If there is an error when trying to dynamically load a module from `lazyLoadedDiagrams`, this is now thrown. (Rendering is still performed!!)

Partially gets https://github.com/mermaid-js/mermaid-cli/pull/406 working
(not 100%, puppeteer is throwing some Content-Security-Policy errors, but at least now we can see the errors).

## :straight_ruler: Design Decisions

I've made sure that rendering is still performed, even if there is an error when lazily loading a diagram. This is so if a user has 10 diagrams, but only one relies on a plugin diagram, at least the other 9 diagrams will render properly.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [ ] :bookmark: targeted `develop` branch
  - Currently targeting the `[release_9.2.0_buggfixes](https://github.com/mermaid-js/mermaid/tree/release_9.2.0_buggfixes)` branch, however, this PR should also be compatible with the `develop` branch (my PR is based of a commit before these two branches diverged)
