### PR TITLE
Change fill attribute to style

### DIFF
--- a/packages/mermaid/src/diagrams/er/erRenderer.js
+++ b/packages/mermaid/src/diagrams/er/erRenderer.js
@@ -357,7 +357,7 @@ const drawEntities = function (svgNode, entities, graph) {
     const rectNode = groupNode
       .insert('rect', '#' + textId)
       .attr('class', 'er entityBox')
-      .attr('fill', conf.fill)
+      .style('fill', conf.fill)
       .attr('fill-opacity', '100%')
       .attr('stroke', conf.stroke)
       .attr('x', 0)


### PR DESCRIPTION
## :bookmark_tabs: Summary

Tiny fix to demonstrate the resolution of the issue. Other declarations of attributes will have to be changed to styles to standardize this if it's preferable. According to the [SVG specification](https://www.w3.org/TR/SVG/styling.html#PresentationAttributes) it's preferable to use `style` for styling rather than attributes.

Resolves #3711.