### PR TITLE
chore: fix cSpell word entry misspelling "mermiad" -> "mermaid"

### DIFF
--- a/cSpell.json
+++ b/cSpell.json
@@ -6,7 +6,7 @@
     "customizability",
     "Gantt",
     "jison",
-    "mermiad",
+    "mermaid",
     "mindmap",
     "Mindmaps",
     "mitigations",

--- a/packages/mermaid/src/Diagram.ts
+++ b/packages/mermaid/src/Diagram.ts
@@ -55,7 +55,7 @@ export class Diagram {
   }
 
   handleError(error: unknown, parseError?: ParseErrorFunction) {
-    // Is this the correct way to access mermiad's parseError()
+    // Is this the correct way to access mermaid's parseError()
     // method ? (or global.mermaid.parseError()) ?
 
     if (parseError === undefined) {


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fix incorrectly spelled word in cSpell.json. Correct code where misspelled word was passing

Resolves #3750 
## :straight_ruler: Design Decisions


### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
