### PR TITLE
Fix link to CSS classes

### DIFF
--- a/docs/syntax/gantt.md
+++ b/docs/syntax/gantt.md
@@ -280,7 +280,7 @@ gantt
 
 ## Styling
 
-Styling of the a gantt diagram is done by defining a number of css classes. During rendering, these classes are extracted from the file located at src/themes/gantt.scss
+Styling of the Gantt diagram is done by defining a number of CSS classes. During rendering, these classes are extracted from the file located at src/diagrams/gantt/styles.js
 
 ### Classes used
 

--- a/packages/mermaid/src/docs/syntax/gantt.md
+++ b/packages/mermaid/src/docs/syntax/gantt.md
@@ -210,7 +210,7 @@ gantt
 
 ## Styling
 
-Styling of the a gantt diagram is done by defining a number of css classes. During rendering, these classes are extracted from the file located at src/themes/gantt.scss
+Styling of the Gantt diagram is done by defining a number of CSS classes. During rendering, these classes are extracted from the file located at src/diagrams/gantt/styles.js
 
 ### Classes used
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

There is no `src/themes/gantt.scss` file. Instead point to https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/diagrams/gantt/styles.js.

Also fix some typos.

## :straight_ruler: Design Decisions

n/a

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [n/a] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
