### PR TITLE
comments in states are skipped now

### DIFF
--- a/packages/mermaid/src/diagrams/state/parser/state-style.spec.js
+++ b/packages/mermaid/src/diagrams/state/parser/state-style.spec.js
@@ -184,6 +184,27 @@ describe('ClassDefs and classes when parsing a State diagram', () => {
           });
         });
       });
+
+      describe('comments parsing', () => {
+        it('working inside states', function () {
+          let diagram = '';
+          diagram += 'stateDiagram-v2\n\n';
+          diagram += '[*] --> Moving\n';
+          diagram += 'Moving --> Still\n';
+          diagram += 'Moving --> Crash\n';
+          diagram += 'state Moving {\n';
+          diagram += '%% comment inside state\n';
+          diagram += 'slow  --> fast\n';
+          diagram += '}\n';
+
+          stateDiagram.parser.parse(diagram);
+          stateDiagram.parser.yy.extract(stateDiagram.parser.yy.getRootDocV2());
+
+          const states = stateDiagram.parser.yy.getStates();
+
+          expect(states['Moving'].doc.length).toEqual(1);
+        });
+      });
     });
   });
 });

--- a/packages/mermaid/src/diagrams/state/parser/stateDiagram.jison
+++ b/packages/mermaid/src/diagrams/state/parser/stateDiagram.jison
@@ -109,6 +109,7 @@ accDescr\s*"{"\s*                                { this.begin("acc_descr_multili
 <STATE>[^\n\s\{]+      {/*console.log('COMPOSIT_STATE', yytext);*/return 'COMPOSIT_STATE';}
 <STATE>\n      {this.popState();}
 <INITIAL,STATE>\{               {this.popState();this.pushState('struct'); /*console.log('begin struct', yytext);*/return 'STRUCT_START';}
+<struct>\%\%(?!\{)[^\n]*                                       /* skip comments inside state*/
 <struct>\}           { /*console.log('Ending struct');*/ this.popState(); return 'STRUCT_STOP';}}
 <struct>[\n]              /* nothing */
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

Added rules to ignore comments inside `state` struct. When we start parsing the `state` struct, the existing comment rules don't apply. So added one rule for ignoring comments specifically inside `state` struct. 

Resolves #[3728](https://github.com/mermaid-js/mermaid/issues/3728)


Make sure you

- [x ] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x ] :computer: have added unit/e2e tests (if appropriate)
- [x ] :bookmark: targeted `develop` branch
