### PR TITLE
[9.2] fix(mermaid): default mermaid back to CommonJS

### DIFF
--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -2,10 +2,10 @@
   "name": "mermaid",
   "version": "9.2.0",
   "description": "Markdownish syntax for generating flowcharts, sequence diagrams, class diagrams, gantt charts and git graphs.",
-  "main": "./dist/mermaid.core.mjs",
+  "main": "./dist/mermaid.min.js",
   "module": "./dist/mermaid.core.mjs",
   "types": "./dist/mermaid.d.ts",
-  "type": "module",
+  "type": "commonjs",
   "exports": {
     ".": {
       "require": "./dist/mermaid.min.js",


### PR DESCRIPTION
## :bookmark_tabs: Summary

Default mermaid back to being a CommonJS module.

Improrting Mermaid as CommonJS (e.g. using `require("mermaid")`) is normally broken (since v8), due to it's dependency on d3, which is now ESM only. See https://github.com/mermaid-js/mermaid/issues/2559.

However, it looks like some software (e.g. TypeScript, in the docusaurus project) could still handle the CommonJS version of Mermaid.

This commit now means that older versions of Node/build-tools should now default to using the CommonJS version of Mermaid, which is the same behavior as v9.1.7, see https://github.com/mermaid-js/mermaid/blob/0c0468123fa1ca08baf69716eeca0b8872075b5e/package.json#L3-L11

There should be **no change** for newer tools, since they should still see that the `"module"` field points to ESM, or use the `exports["."]["import"]` field to load ESM.

Fixes: https://github.com/mermaid-js/mermaid/issues/3747

This may also fix https://github.com/mermaid-js/mermaid/issues/3754, but I'm not 100% sure. I've only tested this with the Docusaurus repo that uses TypeScript.

## :straight_ruler: Design Decisions

I'm not 100% why TypeScript was having an issue with the old syntax.

According to the official TypeScript docs at https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing, using `"type": "module"` and a `"exports": { ".": { "require": "..."` should mean that mermaid is both an ESM/CJS module. Maybe docusaurus is using an older version of TypeScript though.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [ ] :bookmark: targeted `develop` branch
  - This targets a `release_9.2.1_bugfixes` branch that I just created of the `release/9.2.0` tag.
    @sidharthv96 or @knsv, should we instead make a `release/9.2.1` branch instead?
