### PR TITLE
bug: change shiki getHighlighter import

### DIFF
--- a/packages/mermaid/src/docs/.vitepress/mermaid-markdown-all.ts
+++ b/packages/mermaid/src/docs/.vitepress/mermaid-markdown-all.ts
@@ -1,5 +1,7 @@
 import type { MarkdownRenderer } from 'vitepress';
-import shiki from 'shiki';
+
+// Note: using "import shiki from 'shiki' and then "const highlighter = await shiki.getHighlighter(...) does not work 2022-11-15
+import { getHighlighter } from 'shiki';
 
 const MermaidExample = async (md: MarkdownRenderer) => {
   const defaultRenderer = md.renderer.rules.fence;
@@ -8,7 +10,7 @@ const MermaidExample = async (md: MarkdownRenderer) => {
     throw new Error('defaultRenderer is undefined');
   }
 
-  const highlighter = await shiki.getHighlighter({
+  const highlighter = await getHighlighter({
     theme: 'material-palenight',
     langs: ['mermaid'],
   });


### PR DESCRIPTION
## :bookmark_tabs: Summary

change how shiki getHighlighter is imported in .vitepress/mermaid-markdown-all.ts

Resolves #3803 

## :straight_ruler: Design Decisions

Used solution found on stack overflow: https://stackoverflow.com/questions/71335258/nuxt-content-shiki-plugin-returns-error-home-not-found

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
