### PR TITLE
Use `github-dark` to highlight fence blocks in vitepress docs

### DIFF
--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -91,7 +91,6 @@
     "prettier": "^2.7.1",
     "remark": "^14.0.2",
     "rimraf": "^3.0.2",
-    "shiki": "^0.11.1",
     "start-server-and-test": "^1.14.0",
     "typedoc": "^0.23.18",
     "typedoc-plugin-markdown": "^3.13.6",

--- a/packages/mermaid/src/docs/.vitepress/config.ts
+++ b/packages/mermaid/src/docs/.vitepress/config.ts
@@ -4,6 +4,8 @@ import { MermaidMarkdown } from 'vitepress-plugin-mermaid';
 import { defineConfig, MarkdownOptions } from 'vitepress';
 
 const allMarkdownTransformers: MarkdownOptions = {
+  // the shiki theme to highlight code blocks
+  theme: 'github-dark',
   config: async (md) => {
     await MermaidExample(md);
     MermaidMarkdown(md);

--- a/packages/mermaid/src/docs/.vitepress/mermaid-markdown-all.ts
+++ b/packages/mermaid/src/docs/.vitepress/mermaid-markdown-all.ts
@@ -1,8 +1,5 @@
 import type { MarkdownRenderer } from 'vitepress';
 
-// Note: using "import shiki from 'shiki' and then "const highlighter = await shiki.getHighlighter(...) does not work 2022-11-15
-import { getHighlighter } from 'shiki';
-
 const MermaidExample = async (md: MarkdownRenderer) => {
   const defaultRenderer = md.renderer.rules.fence;
 
@@ -10,26 +7,29 @@ const MermaidExample = async (md: MarkdownRenderer) => {
     throw new Error('defaultRenderer is undefined');
   }
 
-  const highlighter = await getHighlighter({
-    theme: 'material-palenight',
-    langs: ['mermaid'],
-  });
-
   md.renderer.rules.fence = (tokens, index, options, env, slf) => {
     const token = tokens[index];
 
     if (token.info.trim() === 'mermaid-example') {
-      const highlight = highlighter
-        .codeToHtml(token.content, { lang: 'mermaid' })
-        .replace(/<span/g, '<span v-pre')
-        .replace('#2e3440ff', 'transparent')
-        .replace('#292D3E', 'transparent');
+      if (!md.options.highlight) {
+        // this function is always created by vitepress, but we need to check it
+        // anyway to make TypeScript happy
+        throw new Error(
+          'Missing MarkdownIt highlight function (should be automatically created by vitepress'
+        );
+      }
 
+      // doing ```mermaid-example {line-numbers=5 highlight=14-17} is not supported
+      const langAttrs = '';
       return `<h5>Code:</h5>
           <div class="language-mermaid">
-          <button class="copy"></button>
-          <span class="lang">mermaid</span>
-${highlight}
+            <button class="copy"></button>
+            <span class="lang">mermaid</span>
+            ${
+              // html is pre-escaped by the highlight function
+              // (it also adds `v-pre` to ignore Vue template syntax)
+              md.options.highlight(token.content, 'mermaid', langAttrs)
+            }
           </div>
           <h5>Diagram:</h5>`;
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,9 +275,6 @@ importers:
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
-      shiki:
-        specifier: ^0.11.1
-        version: 0.11.1
       start-server-and-test:
         specifier: ^1.14.0
         version: 1.14.0


### PR DESCRIPTION
## :bookmark_tabs: Summary

Changes the theme used for highlighting code within `vitepress` to `github-dark` instead of the default `material-palenight`.

The current `material-palenight` highlighting theme only has a contrast ratio of 2.75:1 for comments, which makes it very hard to read.

`github-dark` has a contrast ratio of 4.43:1 for comments, which is technically not good enough for WCAG 2.0 level AA, as it requires a contrast ratio of at least 4.5:1 for normal text, but 4.43:1 is pretty close to it, and I don't really want to manually modify the colors within a theme.

Resolves #3800

## :straight_ruler: Design Decisions

As part of refactoring, I changed the vitepress `mermaid-example` highlighter to use the default `vitepress` highlighter instead of making our own highlighter using `shiki`.

The benefits are:
  - We don't need to directly depend on shiki
  - `mermaid-example` code-blocks will use the same highlighting as other languages (e.g. `html`/`js`).
  - We can control the theme from the global `vitepress` config.
  - Darkmode/lightmode themes are supported
  - Escaping is already handled by the default highlight function

### Themes

#### `material-palenight` (what was used before)

![image](https://user-images.githubusercontent.com/19716675/202530491-7bb2326b-bea8-45c7-99a1-9b056251ec04.png)

WCAG contrast checker result of the `#comment text` (from https://webaim.org/resources/contrastchecker/)
![image](https://user-images.githubusercontent.com/19716675/202532018-c77ca240-7f28-42bc-a009-83650f89b065.png)


#### `github-dark`

![image](https://user-images.githubusercontent.com/19716675/202530654-7cc5191f-956d-474a-9160-71cb47cd838e.png)

WCAG contrast checker result of the `#comment text` (from https://webaim.org/resources/contrastchecker/)

![image](https://user-images.githubusercontent.com/19716675/202531582-e40ef20f-a8ab-48b7-b9e9-960133f5a8a0.png)

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
  - Manually tested by looking at the CSS colours and using https://webaim.org/resources/contrastchecker/
- [x] :bookmark: targeted `develop` branch
