### PR TITLE
(chore) remove console stmt in pieDetector

### DIFF
--- a/packages/mermaid/src/diagrams/pie/pieDetector.ts
+++ b/packages/mermaid/src/diagrams/pie/pieDetector.ts
@@ -2,6 +2,5 @@ import type { DiagramDetector } from '../../diagram-api/types';
 
 export const pieDetector: DiagramDetector = (txt) => {
   const logOutput = txt.match(/^\s*pie/) !== null || txt.match(/^\s*bar/) !== null;
-  console.log(logOutput);
   return logOutput;
 };


### PR DESCRIPTION
## :bookmark_tabs: Summary

deleted the line in pieDetector.ts

lint started failing because pieDetector had a console.log statement

The statement was committed on 4 November.

Weird that it wasn't caught before.  Is that because es-lint wasn't really catching it before?  Or did something change with the lint script?  

### :clipboard: Tasks

Make sure you

- [ ] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [ ] :bookmark: targeted `develop` branch
