### PR TITLE
Make gitgraph snapshots consistent in E2E tests

### DIFF
--- a/cypress/integration/rendering/gitGraph.spec.js
+++ b/cypress/integration/rendering/gitGraph.spec.js
@@ -328,7 +328,7 @@ describe('Git Graph diagram', () => {
 title: simple gitGraph
 ---
 gitGraph
-  commit
+  commit id: "1-abcdefg"
 `,
       {}
     );


### PR DESCRIPTION
## :bookmark_tabs: Summary

Add a commit id to 'should render a simple gitgraph with a title', as otherwise the gitgraph renderer picks a random commit ID, and so image snapshots will be different.

Without this change, we'll always get something like the following, when running `pnpm run e2e`:

![Git-Graph-diagram-1433-should-render-a-simple-gitgraph-with-a-title diff](https://user-images.githubusercontent.com/19716675/204154798-06462be6-5bdd-4a42-911d-db396a7bb5a3.png)

Maybe it's worth adding an option for deterministic commit hashes in Git graph, although I'm not 100% sure how that would work.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
