### PR TITLE
doc: remove links from atom.io; add note Atom has been archived

### DIFF
--- a/docs/misc/integrations.md
+++ b/docs/misc/integrations.md
@@ -110,9 +110,9 @@ They also serve as proof of concept, for the variety of things that can be built
   - [markdown-it-mermaid-fence-new](https://github.com/Revomatico/markdown-it-mermaid-fence-new)
   - [markdown-it-mermaid-less](https://github.com/searKing/markdown-it-mermaid-less)
 - Atom _(Atom has been [archived.](https://github.blog/2022-06-08-sunsetting-atom/))_
-  - Markdown Preview Enhanced
+  - [Markdown Preview Enhanced](https://github.com/shd101wyy/markdown-preview-enhanced)
   - [Atom Mermaid](https://github.com/y-takey/atom-mermaid)
-  - Language Mermaid Syntax Highlighter
+  - [Language Mermaid Syntax Highlighter](https://github.com/ytisf/language-mermaid)
 - [Sublime Text 3](https://sublimetext.com)
   - [Mermaid Package](https://packagecontrol.io/packages/Mermaid)
 - [Astah](https://astah.net)

--- a/docs/misc/integrations.md
+++ b/docs/misc/integrations.md
@@ -109,10 +109,10 @@ They also serve as proof of concept, for the variety of things that can be built
   - [md-it-mermaid](https://github.com/iamcco/md-it-mermaid)
   - [markdown-it-mermaid-fence-new](https://github.com/Revomatico/markdown-it-mermaid-fence-new)
   - [markdown-it-mermaid-less](https://github.com/searKing/markdown-it-mermaid-less)
-- [Atom](https://atom.io)
-  - [Markdown Preview Enhanced](https://atom.io/packages/markdown-preview-enhanced)
-  - [Atom Mermaid](https://atom.io/packages/atom-mermaid)
-  - [Language Mermaid Syntax Highlighter](https://atom.io/packages/language-mermaid)
+- Atom _(Atom has been [archived.](https://github.blog/2022-06-08-sunsetting-atom/))_
+  - Markdown Preview Enhanced
+  - [Atom Mermaid](https://github.com/y-takey/atom-mermaid)
+  - Language Mermaid Syntax Highlighter
 - [Sublime Text 3](https://sublimetext.com)
   - [Mermaid Package](https://packagecontrol.io/packages/Mermaid)
 - [Astah](https://astah.net)

--- a/packages/mermaid/src/docs/misc/integrations.md
+++ b/packages/mermaid/src/docs/misc/integrations.md
@@ -103,10 +103,10 @@ They also serve as proof of concept, for the variety of things that can be built
   - [md-it-mermaid](https://github.com/iamcco/md-it-mermaid)
   - [markdown-it-mermaid-fence-new](https://github.com/Revomatico/markdown-it-mermaid-fence-new)
   - [markdown-it-mermaid-less](https://github.com/searKing/markdown-it-mermaid-less)
-- [Atom](https://atom.io)
-  - [Markdown Preview Enhanced](https://atom.io/packages/markdown-preview-enhanced)
-  - [Atom Mermaid](https://atom.io/packages/atom-mermaid)
-  - [Language Mermaid Syntax Highlighter](https://atom.io/packages/language-mermaid)
+- Atom _(Atom has been [archived.](https://github.blog/2022-06-08-sunsetting-atom/))_
+  - Markdown Preview Enhanced
+  - [Atom Mermaid](https://github.com/y-takey/atom-mermaid)
+  - Language Mermaid Syntax Highlighter
 - [Sublime Text 3](https://sublimetext.com)
   - [Mermaid Package](https://packagecontrol.io/packages/Mermaid)
 - [Astah](https://astah.net)

--- a/packages/mermaid/src/docs/misc/integrations.md
+++ b/packages/mermaid/src/docs/misc/integrations.md
@@ -104,9 +104,9 @@ They also serve as proof of concept, for the variety of things that can be built
   - [markdown-it-mermaid-fence-new](https://github.com/Revomatico/markdown-it-mermaid-fence-new)
   - [markdown-it-mermaid-less](https://github.com/searKing/markdown-it-mermaid-less)
 - Atom _(Atom has been [archived.](https://github.blog/2022-06-08-sunsetting-atom/))_
-  - Markdown Preview Enhanced
+  - [Markdown Preview Enhanced](https://github.com/shd101wyy/markdown-preview-enhanced)
   - [Atom Mermaid](https://github.com/y-takey/atom-mermaid)
-  - Language Mermaid Syntax Highlighter
+  - [Language Mermaid Syntax Highlighter](https://github.com/ytisf/language-mermaid)
 - [Sublime Text 3](https://sublimetext.com)
   - [Mermaid Package](https://packagecontrol.io/packages/Mermaid)
 - [Astah](https://astah.net)


### PR DESCRIPTION
## :bookmark_tabs: Summary

Remove links from atom.io in the **Integrations** section

Resolves problem with broken/intermittent link with atom.io.  The project will be archived (sunsetted) soon. 

See [this comment](https://github.com/mermaid-js/mermaid/pull/3897#pullrequestreview-1210716394) in PR #3897 

## :straight_ruler: Design Decisions

Added a note saying the project **has been** archived.  It's a few days before it actually will be archived, but I thought it'd be ok.  Happy to change it and make an issue to change it again in a few days.


### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
