### PR TITLE
fix(docs): remove duplicate section

### DIFF
--- a/packages/mermaid/src/docs/syntax/classDiagram.md
+++ b/packages/mermaid/src/docs/syntax/classDiagram.md
@@ -141,10 +141,6 @@ Square : +setMessages(List~string~ messages)
 Square : +getMessages() List~string~
 ```
 
-#### Return Type
-
-Optionally you can end the method/function definition with the data type that will be returned.
-
 #### Visibility
 
 To describe the visibility (or encapsulation) of an attribute or method/function that is a part of a class (i.e. a class member), optional notation may be placed before that members' name:


### PR DESCRIPTION
## :bookmark_tabs: Summary

Remove duplicate `Return Type` section.
The full section can be found on [line 110](https://github.com/mermaid-js/mermaid/blob/a975c8c9cdd92b49445aeb950cb7b6f13ea0dc61/packages/mermaid/src/docs/syntax/classDiagram.md?plain=1#L110).

### :clipboard: Tasks

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
