### PR TITLE
fix(er): switch to deterministic UUIDs in ER

### DIFF
--- a/packages/mermaid/src/diagrams/er/erRenderer.js
+++ b/packages/mermaid/src/diagrams/er/erRenderer.js
@@ -7,7 +7,7 @@ import utils from '../../utils';
 import erMarkers from './erMarkers';
 import { configureSvgSize } from '../../setupGraphViewbox';
 import { parseGenericTypes } from '../common/common';
-import { v4 as uuid4 } from 'uuid';
+import { v5 as uuid5 } from 'uuid';
 
 /** Regex used to remove chars from the entity name so the result can be used in an id */
 const BAD_ID_CHARS_REGEXP = /[^\dA-Za-z](\W)*/g;
@@ -643,9 +643,15 @@ export const draw = function (text, id, _version, diagObj) {
   svg.attr('viewBox', `${svgBounds.x - padding} ${svgBounds.y - padding} ${width} ${height}`);
 }; // draw
 
+/** UUID namespace for ER diagram IDs */
+const MERMAID_ERDIAGRAM_UUID = uuid5(
+  'https://mermaid-js.github.io/mermaid/syntax/entityRelationshipDiagram.html',
+  uuid5.URL
+);
+
 /**
  * Return a unique id based on the given string. Start with the prefix, then a hyphen, then the
- * simplified str, then a hyphen, then a unique uuid. (Hyphens are only included if needed.)
+ * simplified str, then a hyphen, then a unique uuid based on the str. (Hyphens are only included if needed.)
  * Although the official XML standard for ids says that many more characters are valid in the id,
  * this keeps things simple by accepting only A-Za-z0-9.
  *
@@ -656,7 +662,11 @@ export const draw = function (text, id, _version, diagObj) {
  */
 export function generateId(str = '', prefix = '') {
   const simplifiedStr = str.replace(BAD_ID_CHARS_REGEXP, '');
-  return `${strWithHyphen(prefix)}${strWithHyphen(simplifiedStr)}${uuid4()}`;
+  // we use `uuid v5` so that UUIDs are consistent given a string.
+  return `${strWithHyphen(prefix)}${strWithHyphen(simplifiedStr)}${uuid5(
+    str,
+    MERMAID_ERDIAGRAM_UUID
+  )}`;
 }
 
 /**

--- a/packages/mermaid/src/diagrams/er/erRenderer.spec.ts
+++ b/packages/mermaid/src/diagrams/er/erRenderer.spec.ts
@@ -1,0 +1,12 @@
+import { generateId } from './erRenderer';
+
+describe('erRenderer', () => {
+  describe('generateId', () => {
+    it('should be deterministic', () => {
+      const id1 = generateId('hello world', 'my-prefix');
+      const id2 = generateId('hello world', 'my-prefix');
+
+      expect(id1).toBe(id2);
+    });
+  });
+});


### PR DESCRIPTION
## :bookmark_tabs: Summary

Switch to deterministic UUIDs in the entity relation diagram.

The entity relation diagram uses UUID v4, which is randomly generated.

UUID v5 uses a SHA-1 hash, which makes the UUID deterministic (e.g. given the same string input, it will always create the same UUID).

The input strings are unique per diagram (they're created from `Object.keys()`), so this should be okay.

Fixes the issue encountered by @nhooyr when trying to make deterministic mermaid diagrams:  https://github.com/terrastruct/text-to-diagram-site/issues/34#issuecomment-1352160744 

## :straight_ruler: Design Decisions

@weedySeaDragon, any chance you want to review this! You were the one to add UUID v4 in https://github.com/mermaid-js/mermaid/commit/91091c614f78ce3a92f2cadc1fe30ec50a1b0857, so I'd love to have your feedback, in case I'm doing anything wrong :)

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
