### PR TITLE
fixed Composition arrow

### DIFF
--- a/packages/mermaid/src/docs/syntax/classDiagram.md
+++ b/packages/mermaid/src/docs/syntax/classDiagram.md
@@ -172,7 +172,7 @@ There are eight different types of relations defined for classes under UML which
 | Type    | Description   |
 | ------- | ------------- |
 | `<\|--` | Inheritance   |
-| `\*--`  | Composition   |
+| `*--`   | Composition   |
 | `o--`   | Aggregation   |
 | `-->`   | Association   |
 | `--`    | Link (Solid)  |


### PR DESCRIPTION
## :bookmark_tabs: Summary

Composition arrow was displayed as `\*--` but should be `*--`

<img width="369" alt="Bildschirm­foto 2022-12-19 um 15 41 09" src="https://user-images.githubusercontent.com/53651857/208450955-306b2475-78c7-4b04-8f58-feabfbb71e39.png">

## :straight_ruler: Design Decisions

Just fixed a typo

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [x] :bookmark: targeted `develop` branch
