### PR TITLE
(chore) Docs: add tag to produce only a diagram, not code example

### DIFF
--- a/packages/mermaid/src/docs.spec.ts
+++ b/packages/mermaid/src/docs.spec.ts
@@ -1,0 +1,115 @@
+import { transformBlocks, transformToBlockQuote } from './docs.mjs';
+
+import { remark } from 'remark'; // import it this way so we can mock it
+vi.mock('remark');
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('docs.mts', () => {
+  describe('transformBlocks', () => {
+    it('uses remark.parse to create the AST for the file ', () => {
+      const remarkParseSpy = vi
+        .spyOn(remark, 'parse')
+        .mockReturnValue({ type: 'root', children: [] });
+      const contents = 'Markdown file contents';
+      transformBlocks(contents);
+      expect(remarkParseSpy).toHaveBeenCalledWith(contents);
+    });
+    describe('checks each AST node', () => {
+      it('does no transformation if there are no code blocks', async () => {
+        const contents = 'Markdown file contents\n';
+        const result = transformBlocks(contents);
+        expect(result).toEqual(contents);
+      });
+
+      describe('is a code block', () => {
+        const beforeCodeLine = 'test\n';
+        const diagram_text = 'graph\n A --> B\n';
+
+        describe('language = "mermaid-nocode"', () => {
+          const lang_keyword = 'mermaid-nocode';
+          const contents = beforeCodeLine + '```' + lang_keyword + '\n' + diagram_text + '\n```\n';
+
+          it('changes the language to "mermaid"', () => {
+            const result = transformBlocks(contents);
+            expect(result).toEqual(
+              beforeCodeLine + '\n' + '```' + 'mermaid' + '\n' + diagram_text + '\n```\n'
+            );
+          });
+        });
+
+        describe('language = "mermaid" | "mmd" | "mermaid-example"', () => {
+          const mermaid_keywords = ['mermaid', 'mmd', 'mermaid-example'];
+
+          mermaid_keywords.forEach((lang_keyword) => {
+            const contents =
+              beforeCodeLine + '```' + lang_keyword + '\n' + diagram_text + '\n```\n';
+
+            it('changes the language to "mermaid-example" and adds a copy of the code block with language = "mermaid"', () => {
+              const result = transformBlocks(contents);
+              expect(result).toEqual(
+                beforeCodeLine +
+                  '\n' +
+                  '```mermaid-example\n' +
+                  diagram_text +
+                  '\n```\n' +
+                  '\n```mermaid\n' +
+                  diagram_text +
+                  '\n```\n'
+              );
+            });
+          });
+        });
+
+        it('calls transformToBlockQuote with the node information', () => {
+          const lang_keyword = 'note';
+          const contents =
+            beforeCodeLine + '```' + lang_keyword + '\n' + 'This is the text\n' + '```\n';
+
+          const result = transformBlocks(contents);
+          expect(result).toEqual(beforeCodeLine + '\n> **Note**\n' + '> This is the text\n');
+        });
+      });
+    });
+  });
+
+  describe('transformToBlockQuote', () => {
+    // TODO Is there a way to test this with --vitepress given as a process argument?
+
+    describe('vitepress is not given as an argument', () => {
+      it('everything starts with "> " (= block quote)', () => {
+        const result = transformToBlockQuote('first line\n\n\nfourth line', 'blorfType');
+        expect(result).toMatch(/> (.)*\n> first line(?:\n> ){3}fourth line/);
+      });
+
+      it('includes an icon if there is one for the type', () => {
+        const result = transformToBlockQuote(
+          'first line\n\n\nfourth line',
+          'danger',
+          'Custom Title'
+        );
+        expect(result).toMatch(/> \*\*‼️ Custom Title\*\* /);
+      });
+
+      describe('a custom title is given', () => {
+        it('custom title is surrounded in spaces, in bold', () => {
+          const result = transformToBlockQuote(
+            'first line\n\n\nfourth line',
+            'blorfType',
+            'Custom Title'
+          );
+          expect(result).toMatch(/> \*\*Custom Title\*\* /);
+        });
+      });
+
+      describe.skip('no custom title is given', () => {
+        it('title is the icon and the capitalized type, in bold', () => {
+          const result = transformToBlockQuote('first line\n\n\nfourth line', 'blorf type');
+          expect(result).toMatch(/> \*\*Blorf Type\*\* /);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :bookmark_tabs: Summary

Create a tag that is used only during Mermaid documentation preprocessing (the docs.mts file) so that a mermaid diagram is rendered but the code is not also added.

Resolves #3922 

## :straight_ruler: Design Decisions

I chose the tag `mermaid-nocode` but am open to other suggestions

- I refactored the logic to transform _code blocks_ into its own function (`transformBlocks`)
- I created some simple tests for docs.mts.  I didn't do a lot because it wasn't clear to me how to mock specific functions (and not others) in`docs.mts`.  I also don't know how to create the context to test when `--vitepress` has been passed in to the process (tho I didn't spend much time investigating this)

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
