### PR TITLE
Bug/3865 C4Context: $borderColor has no effect

### DIFF
--- a/packages/mermaid/src/diagrams/c4/svgDraw.js
+++ b/packages/mermaid/src/diagrams/c4/svgDraw.js
@@ -234,7 +234,7 @@ export const drawC4Shape = function (elem, c4Shape, conf) {
   const c4ShapeElem = elem.append('g');
   c4ShapeElem.attr('class', 'person-man');
 
-  // <rect fill="#08427B" height="119.2188" rx="2.5" ry="2.5" stroke="#073B6F" stroke-width=0.5" width="110" x="120" y="7"/>
+  // <rect fill="#08427B" height="119.2188" rx="2.5" ry="2.5" stroke="#073B6F" stroke-width="0.5" width="110" x="120" y="7"/>
   // draw rect of c4Shape
   const rect = getNoteRect();
   switch (c4Shape.typeC4Shape.text) {

--- a/packages/mermaid/src/diagrams/c4/svgDraw.js
+++ b/packages/mermaid/src/diagrams/c4/svgDraw.js
@@ -234,7 +234,7 @@ export const drawC4Shape = function (elem, c4Shape, conf) {
   const c4ShapeElem = elem.append('g');
   c4ShapeElem.attr('class', 'person-man');
 
-  // <rect fill="#08427B" height="119.2188" rx="2.5" ry="2.5" style="stroke:#073B6F;stroke-width:0.5;" width="110" x="120" y="7"/>
+  // <rect fill="#08427B" height="119.2188" rx="2.5" ry="2.5" stroke="#073B6F" stroke-width=0.5" width="110" x="120" y="7"/>
   // draw rect of c4Shape
   const rect = getNoteRect();
   switch (c4Shape.typeC4Shape.text) {
@@ -251,9 +251,10 @@ export const drawC4Shape = function (elem, c4Shape, conf) {
       rect.fill = fillColor;
       rect.width = c4Shape.width;
       rect.height = c4Shape.height;
-      rect.style = 'stroke:' + strokeColor + ';stroke-width:0.5;';
+      rect.stroke = strokeColor;
       rect.rx = 2.5;
       rect.ry = 2.5;
+      rect.attrs = { 'stroke-width': 0.5 };
       drawRect(c4ShapeElem, rect);
       break;
     case 'system_db':


### PR DESCRIPTION
## :bookmark_tabs: Summary

Resolves #3865 

```code
      C4Context
      title Border Color Test
      Person(person, "Some Person")
      Person_Ext(ex_person, "Banking Customer C", "desc")

      UpdateElementStyle(person, $bgColor="green", $fontColor="yellow", $borderColor="#fe22ff")
      UpdateElementStyle(ex_person, $bgColor="white", $fontColor="black", $borderColor="green")
```

| Before | Now |
| --- | --- |
| <img width="583" alt="image" src="https://user-images.githubusercontent.com/5371676/209714506-3b8661bc-37b7-4183-b05a-3b99db915f93.png"> | <img width="591" alt="image" src="https://user-images.githubusercontent.com/5371676/209714469-aebe6ce8-6e0a-4c44-83d6-01a71a8affc9.png"> |


## :straight_ruler: Design Decisions

I fixed the mismatch between the type of rect variable and second argment type of drawRect function.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [ ] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
