### PR TITLE
ci: disable checking twitter links

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -9,5 +9,8 @@ https://mkdocs.org/
 https://osawards.com/javascript/#nominees
 https://osawards.com/javascript/2019
 
+# Timeout error, maybe Twitter has anti-bot defences against GitHub's CI servers?
+https://twitter.com/mermaidjs_
+
 # Don't check files that are generated during the build via `pnpm docs:code`
 packages/mermaid/src/docs/config/setup/*


### PR DESCRIPTION
## :bookmark_tabs: Summary

The [lycheeverse/lychee-action][1] GitHub action keeps timing out when trying to check any of the links from twitter.com

My guess is maybe Twitter has anti-bot measures active against GitHub's CI servers.

[1]: https://github.com/lycheeverse/lychee-action

Ignoring <https://twitter.com/mermaidjs_> resolves failing CI, e.g.:

> ## Summary
> 
> | Status        | Count |
> |---------------|-------|
> | 🔍 Total      | 463   |
> | ✅ Successful | 445   |
> | ⏳ Timeouts   | 3     |
> | 🔀 Redirected | 0     |
> | 👻 Excluded   | 15    |
> | ❓ Unknown    | 0     |
> | 🚫 Errors     | 0     |
> 
> ## Errors per input
> 
> ### Errors in README.md
> 
> * [TIMEOUT] [https://twitter.com/mermaidjs_](https://twitter.com/mermaidjs_) | Timeout
> 
> ### Errors in packages/mermaid/src/docs/intro/index.md
> 
> * [TIMEOUT] [https://twitter.com/mermaidjs_](https://twitter.com/mermaidjs_) | Timeout
> 
> ### Errors in README.zh-CN.md
> 
> * [TIMEOUT] [https://twitter.com/mermaidjs_](https://twitter.com/mermaidjs_) | Timeout
> 
> _Taken from https://github.com/mermaid-js/mermaid/actions/runs/3864431087/attempts/1#summary-10503683950_

## :straight_ruler: Design Decisions

N/A

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [ ] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
