### PR TITLE
docs(sequenceDiagram): subvert prettification of arrow types

### DIFF
--- a/packages/mermaid/src/docs/syntax/sequenceDiagram.md
+++ b/packages/mermaid/src/docs/syntax/sequenceDiagram.md
@@ -68,16 +68,16 @@ Messages can be of two displayed either solid or with a dotted line.
 
 There are six types of arrows currently supported:
 
-| Type | Description                                      |
-| ---- | ------------------------------------------------ |
-| ->   | Solid line without arrow                         |
-| -->  | Dotted line without arrow                        |
-| ->>  | Solid line with arrowhead                        |
-| -->> | Dotted line with arrowhead                       |
-| -x   | Solid line with a cross at the end               |
-| --x  | Dotted line with a cross at the end.             |
-| -)   | Solid line with an open arrow at the end (async) |
-| --)  | Dotted line with a open arrow at the end (async) |
+| Type   | Description                                      |
+| ------ | ------------------------------------------------ |
+| `->`   | Solid line without arrow                         |
+| `-->`  | Dotted line without arrow                        |
+| `->>`  | Solid line with arrowhead                        |
+| `-->>` | Dotted line with arrowhead                       |
+| `-x`   | Solid line with a cross at the end               |
+| `--x`  | Dotted line with a cross at the end.             |
+| `-)`   | Solid line with an open arrow at the end (async) |
+| `--)`  | Dotted line with a open arrow at the end (async) |
 
 ## Activations
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

The rendering of the arrows becomes prettified using some sort of font library on mermaid.js.org . Here: https://mermaid.js.org/syntax/sequenceDiagram.html#messages

<img width="507" alt="image" src="https://user-images.githubusercontent.com/4025945/212367062-67b23fb8-f3e6-4b83-ad0f-ff3b66d00fcb.png">

Let's quote in backticks to indicate these are code and should be displayed as is!

## :straight_ruler: Design Decisions

_Oh wow, it's not that grand._

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate) 🤔 ... **n/a**
- [x] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
