### PR TITLE
Feat/3208 backwards arrow direction

### DIFF
--- a/packages/mermaid/src/diagrams/flowchart/flowDb.js
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.js
@@ -155,6 +155,7 @@ export const addSingleLink = function (_start, _end, type, linkText) {
     edge.type = type.type;
     edge.stroke = type.stroke;
     edge.length = type.length;
+    edge.reversed = type.reversed;
   }
   edges.push(edge);
 };
@@ -670,6 +671,11 @@ const destructEndLink = (_str) => {
   let stroke = 'normal';
   let length = line.length - 1;
 
+  const reversed = line.includes('\\');
+  if (reversed) {
+    length = length - 1;
+  }
+
   if (line[0] === '=') {
     stroke = 'thick';
   }
@@ -681,7 +687,7 @@ const destructEndLink = (_str) => {
     length = dots;
   }
 
-  return { type, stroke, length };
+  return { type, stroke, length, reversed };
 };
 
 export const destructLink = (_str, _startStr) => {
@@ -710,6 +716,7 @@ export const destructLink = (_str, _startStr) => {
       startInfo.type = 'double_arrow_point';
     }
 
+    startInfo.reversed = info.reversed;
     startInfo.length = info.length;
     return startInfo;
   }

--- a/packages/mermaid/src/diagrams/flowchart/flowRenderer-v2.js
+++ b/packages/mermaid/src/diagrams/flowchart/flowRenderer-v2.js
@@ -255,6 +255,13 @@ export const addEdges = function (edges, g, diagObj) {
         break;
     }
 
+    if (edge.reversed) {
+      [edgeData.arrowTypeStart, edgeData.arrowTypeEnd] = [
+        edgeData.arrowTypeEnd,
+        edgeData.arrowTypeStart,
+      ];
+    }
+
     let style = '';
     let labelStyle = '';
 

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow-arrows.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow-arrows.spec.js
@@ -24,6 +24,7 @@ describe('[Arrows] when parsing', () => {
     expect(edges[0].start).toBe('A');
     expect(edges[0].end).toBe('B');
     expect(edges[0].type).toBe('arrow_point');
+    expect(edges[0].reversed).toBe(false);
     expect(edges[0].text).toBe('');
     expect(edges[0].stroke).toBe('normal');
     expect(edges[0].length).toBe(1);
@@ -44,6 +45,7 @@ describe('[Arrows] when parsing', () => {
     expect(edges[0].start).toBe('A');
     expect(edges[0].end).toBe('B');
     expect(edges[0].type).toBe('arrow_point');
+    expect(edges[0].reversed).toBe(false);
     expect(edges[0].text).toBe('');
     expect(edges[0].stroke).toBe('normal');
     expect(edges[0].length).toBe(1);
@@ -64,6 +66,7 @@ describe('[Arrows] when parsing', () => {
     expect(edges[0].start).toBe('A');
     expect(edges[0].end).toBe('B');
     expect(edges[0].type).toBe('arrow_point');
+    expect(edges[0].reversed).toBe(false);
     expect(edges[0].text).toBe('');
     expect(edges[0].stroke).toBe('normal');
     expect(edges[0].length).toBe(1);
@@ -85,6 +88,7 @@ describe('[Arrows] when parsing', () => {
     expect(edges[0].end).toBe('B');
     expect(edges[0].length).toBe(1);
     expect(edges[0].type).toBe('arrow_point');
+    expect(edges[0].reversed).toBe(false);
     expect(edges[0].text).toBe('');
     expect(edges[0].stroke).toBe('normal');
     expect(edges[0].length).toBe(1);
@@ -105,6 +109,7 @@ describe('[Arrows] when parsing', () => {
     expect(edges[0].start).toBe('A');
     expect(edges[0].end).toBe('B');
     expect(edges[0].type).toBe('arrow_point');
+    expect(edges[0].reversed).toBe(false);
     expect(edges[0].text).toBe('');
     expect(edges[0].stroke).toBe('normal');
     expect(edges[0].length).toBe(1);
@@ -122,6 +127,7 @@ describe('[Arrows] when parsing', () => {
     expect(edges[0].start).toBe('A');
     expect(edges[0].end).toBe('B');
     expect(edges[0].type).toBe('arrow_point');
+    expect(edges[0].reversed).toBe(false);
     expect(edges[0].text).toBe('');
     expect(edges[0].stroke).toBe('normal');
     expect(edges[0].length).toBe(1);
@@ -139,6 +145,7 @@ describe('[Arrows] when parsing', () => {
     expect(edges[0].start).toBe('A');
     expect(edges[0].end).toBe('B');
     expect(edges[0].type).toBe('arrow_point');
+    expect(edges[0].reversed).toBe(false);
     expect(edges[0].text).toBe('');
     expect(edges[0].stroke).toBe('normal');
     expect(edges[0].length).toBe(1);
@@ -156,6 +163,7 @@ describe('[Arrows] when parsing', () => {
     expect(edges[1].start).toBe('B');
     expect(edges[1].end).toBe('C');
     expect(edges[0].type).toBe('arrow_point');
+    expect(edges[0].reversed).toBe(false);
     expect(edges[0].text).toBe('');
     expect(edges[0].stroke).toBe('normal');
     expect(edges[0].length).toBe(1);
@@ -175,6 +183,7 @@ describe('[Arrows] when parsing', () => {
         expect(edges[0].start).toBe('A');
         expect(edges[0].end).toBe('B');
         expect(edges[0].type).toBe('double_arrow_point');
+        expect(edges[0].reversed).toBe(false);
         expect(edges[0].text).toBe('');
         expect(edges[0].stroke).toBe('normal');
         expect(edges[0].length).toBe(1);
@@ -192,6 +201,7 @@ describe('[Arrows] when parsing', () => {
         expect(edges[0].start).toBe('A');
         expect(edges[0].end).toBe('B');
         expect(edges[0].type).toBe('double_arrow_point');
+        expect(edges[0].reversed).toBe(false);
         expect(edges[0].text).toBe('text');
         expect(edges[0].stroke).toBe('normal');
         expect(edges[0].length).toBe(1);
@@ -209,6 +219,7 @@ describe('[Arrows] when parsing', () => {
         expect(edges[0].start).toBe('A');
         expect(edges[0].end).toBe('B');
         expect(edges[0].type).toBe('double_arrow_point');
+        expect(edges[0].reversed).toBe(false);
         expect(edges[0].text).toBe('');
         expect(edges[0].stroke).toBe('thick');
         expect(edges[0].length).toBe(1);
@@ -226,6 +237,7 @@ describe('[Arrows] when parsing', () => {
         expect(edges[0].start).toBe('A');
         expect(edges[0].end).toBe('B');
         expect(edges[0].type).toBe('double_arrow_point');
+        expect(edges[0].reversed).toBe(false);
         expect(edges[0].text).toBe('text');
         expect(edges[0].stroke).toBe('thick');
         expect(edges[0].length).toBe(1);
@@ -243,6 +255,7 @@ describe('[Arrows] when parsing', () => {
         expect(edges[0].start).toBe('A');
         expect(edges[0].end).toBe('B');
         expect(edges[0].type).toBe('double_arrow_point');
+        expect(edges[0].reversed).toBe(false);
         expect(edges[0].text).toBe('');
         expect(edges[0].stroke).toBe('dotted');
         expect(edges[0].length).toBe(1);
@@ -260,6 +273,7 @@ describe('[Arrows] when parsing', () => {
         expect(edges[0].start).toBe('A');
         expect(edges[0].end).toBe('B');
         expect(edges[0].type).toBe('double_arrow_point');
+        expect(edges[0].reversed).toBe(false);
         expect(edges[0].text).toBe('text');
         expect(edges[0].stroke).toBe('dotted');
         expect(edges[0].length).toBe(1);

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow-arrows.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow-arrows.spec.js
@@ -266,4 +266,225 @@ describe('[Arrows] when parsing', () => {
       });
     });
   });
+
+  describe('it should handle reversed arrows', function () {
+    describe('should handle arrow type variations', function () {
+      it('should handle reversed point arrow', function () {
+        const res = flow.parser.parse('graph TD;\nA-\\->B;');
+
+        const vert = flow.parser.yy.getVertices();
+        const edges = flow.parser.yy.getEdges();
+
+        expect(vert['A'].id).toBe('A');
+        expect(vert['B'].id).toBe('B');
+        expect(edges.length).toBe(1);
+        expect(edges[0].start).toBe('A');
+        expect(edges[0].end).toBe('B');
+        expect(edges[0].type).toBe('arrow_point');
+        expect(edges[0].reversed).toBe(true);
+        expect(edges[0].text).toBe('');
+        expect(edges[0].stroke).toBe('normal');
+        expect(edges[0].length).toBe(1);
+      });
+
+      it('should handle reversed point arrow with text', function () {
+        const res = flow.parser.parse('graph TD;\nA-- text -\\->B;');
+
+        const vert = flow.parser.yy.getVertices();
+        const edges = flow.parser.yy.getEdges();
+
+        expect(vert['A'].id).toBe('A');
+        expect(vert['B'].id).toBe('B');
+        expect(edges.length).toBe(1);
+        expect(edges[0].start).toBe('A');
+        expect(edges[0].end).toBe('B');
+        expect(edges[0].type).toBe('arrow_point');
+        expect(edges[0].reversed).toBe(true);
+        expect(edges[0].text).toBe('text');
+        expect(edges[0].stroke).toBe('normal');
+        expect(edges[0].length).toBe(1);
+      });
+
+      it('should handle reversed cross arrows', function () {
+        const res = flow.parser.parse('graph TD;\nA-\\-xB;');
+
+        const vert = flow.parser.yy.getVertices();
+        const edges = flow.parser.yy.getEdges();
+
+        expect(vert['A'].id).toBe('A');
+        expect(vert['B'].id).toBe('B');
+        expect(edges.length).toBe(1);
+        expect(edges[0].start).toBe('A');
+        expect(edges[0].end).toBe('B');
+        expect(edges[0].type).toBe('arrow_cross');
+        expect(edges[0].reversed).toBe(true);
+        expect(edges[0].text).toBe('');
+        expect(edges[0].stroke).toBe('normal');
+        expect(edges[0].length).toBe(1);
+      });
+
+      it('should handle reversed cross arrows with text', function () {
+        const res = flow.parser.parse('graph TD;\nA-- text -\\-xB;');
+
+        const vert = flow.parser.yy.getVertices();
+        const edges = flow.parser.yy.getEdges();
+
+        expect(vert['A'].id).toBe('A');
+        expect(vert['B'].id).toBe('B');
+        expect(edges.length).toBe(1);
+        expect(edges[0].start).toBe('A');
+        expect(edges[0].end).toBe('B');
+        expect(edges[0].type).toBe('arrow_cross');
+        expect(edges[0].reversed).toBe(true);
+        expect(edges[0].text).toBe('text');
+        expect(edges[0].stroke).toBe('normal');
+        expect(edges[0].length).toBe(1);
+      });
+
+      it('should handle reversed circle arrow', function () {
+        const res = flow.parser.parse('graph TD;\nA-\\-oB;');
+
+        const vert = flow.parser.yy.getVertices();
+        const edges = flow.parser.yy.getEdges();
+
+        expect(vert['A'].id).toBe('A');
+        expect(vert['B'].id).toBe('B');
+        expect(edges.length).toBe(1);
+        expect(edges[0].start).toBe('A');
+        expect(edges[0].end).toBe('B');
+        expect(edges[0].type).toBe('arrow_circle');
+        expect(edges[0].reversed).toBe(true);
+        expect(edges[0].text).toBe('');
+        expect(edges[0].stroke).toBe('normal');
+        expect(edges[0].length).toBe(1);
+      });
+
+      it('should handle reversed circle arrow with text', function () {
+        const res = flow.parser.parse('graph TD;\nA-- text -\\-oB;');
+
+        const vert = flow.parser.yy.getVertices();
+        const edges = flow.parser.yy.getEdges();
+
+        expect(vert['A'].id).toBe('A');
+        expect(vert['B'].id).toBe('B');
+        expect(edges.length).toBe(1);
+        expect(edges[0].start).toBe('A');
+        expect(edges[0].end).toBe('B');
+        expect(edges[0].type).toBe('arrow_circle');
+        expect(edges[0].reversed).toBe(true);
+        expect(edges[0].text).toBe('text');
+        expect(edges[0].stroke).toBe('normal');
+        expect(edges[0].length).toBe(1);
+      });
+    });
+    describe('should handle stroke variations', function () {
+      it('should handle reversed simple arrow', function () {
+        const res = flow.parser.parse('graph TD;\nA-\\->B;');
+
+        const vert = flow.parser.yy.getVertices();
+        const edges = flow.parser.yy.getEdges();
+
+        expect(vert['A'].id).toBe('A');
+        expect(vert['B'].id).toBe('B');
+        expect(edges.length).toBe(1);
+        expect(edges[0].start).toBe('A');
+        expect(edges[0].end).toBe('B');
+        expect(edges[0].type).toBe('arrow_point');
+        expect(edges[0].reversed).toBe(true);
+        expect(edges[0].text).toBe('');
+        expect(edges[0].stroke).toBe('normal');
+        expect(edges[0].length).toBe(1);
+      });
+
+      it('should handle reversed double edged nodes with text', function () {
+        const res = flow.parser.parse('graph TD;\nA-- text -\\->B;');
+
+        const vert = flow.parser.yy.getVertices();
+        const edges = flow.parser.yy.getEdges();
+
+        expect(vert['A'].id).toBe('A');
+        expect(vert['B'].id).toBe('B');
+        expect(edges.length).toBe(1);
+        expect(edges[0].start).toBe('A');
+        expect(edges[0].end).toBe('B');
+        expect(edges[0].type).toBe('arrow_point');
+        expect(edges[0].reversed).toBe(true);
+        expect(edges[0].text).toBe('text');
+        expect(edges[0].stroke).toBe('normal');
+        expect(edges[0].length).toBe(1);
+      });
+
+      it('should handle reversed thick arrows', function () {
+        const res = flow.parser.parse('graph TD;\nA=\\=>B;');
+
+        const vert = flow.parser.yy.getVertices();
+        const edges = flow.parser.yy.getEdges();
+
+        expect(vert['A'].id).toBe('A');
+        expect(vert['B'].id).toBe('B');
+        expect(edges.length).toBe(1);
+        expect(edges[0].start).toBe('A');
+        expect(edges[0].end).toBe('B');
+        expect(edges[0].type).toBe('arrow_point');
+        expect(edges[0].reversed).toBe(true);
+        expect(edges[0].text).toBe('');
+        expect(edges[0].stroke).toBe('thick');
+        expect(edges[0].length).toBe(1);
+      });
+
+      it('should handle reversed thick arrows with text', function () {
+        const res = flow.parser.parse('graph TD;\nA== text =\\=>B;');
+
+        const vert = flow.parser.yy.getVertices();
+        const edges = flow.parser.yy.getEdges();
+
+        expect(vert['A'].id).toBe('A');
+        expect(vert['B'].id).toBe('B');
+        expect(edges.length).toBe(1);
+        expect(edges[0].start).toBe('A');
+        expect(edges[0].end).toBe('B');
+        expect(edges[0].type).toBe('arrow_point');
+        expect(edges[0].reversed).toBe(true);
+        expect(edges[0].text).toBe('text');
+        expect(edges[0].stroke).toBe('thick');
+        expect(edges[0].length).toBe(1);
+      });
+
+      it('should handle reversed dotted arrow', function () {
+        const res = flow.parser.parse('graph TD;\nA.\\->B;');
+
+        const vert = flow.parser.yy.getVertices();
+        const edges = flow.parser.yy.getEdges();
+
+        expect(vert['A'].id).toBe('A');
+        expect(vert['B'].id).toBe('B');
+        expect(edges.length).toBe(1);
+        expect(edges[0].start).toBe('A');
+        expect(edges[0].end).toBe('B');
+        expect(edges[0].type).toBe('arrow_point');
+        expect(edges[0].reversed).toBe(true);
+        expect(edges[0].text).toBe('');
+        expect(edges[0].stroke).toBe('dotted');
+        expect(edges[0].length).toBe(1);
+      });
+
+      it('should handle reversed dotted arrow with text', function () {
+        const res = flow.parser.parse('graph TD;\nA-. text .\\->B;');
+
+        const vert = flow.parser.yy.getVertices();
+        const edges = flow.parser.yy.getEdges();
+
+        expect(vert['A'].id).toBe('A');
+        expect(vert['B'].id).toBe('B');
+        expect(edges.length).toBe(1);
+        expect(edges[0].start).toBe('A');
+        expect(edges[0].end).toBe('B');
+        expect(edges[0].type).toBe('arrow_point');
+        expect(edges[0].reversed).toBe(true);
+        expect(edges[0].text).toBe('text');
+        expect(edges[0].stroke).toBe('dotted');
+        expect(edges[0].length).toBe(1);
+      });
+    });
+  });
 });

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
@@ -118,9 +118,9 @@ that id.
 ";"                   return 'SEMI';
 ","                   return 'COMMA';
 "*"                   return 'MULT';
-\s*[xo<]?\-\-+[-xo>]\s*     return 'LINK';
-\s*[xo<]?\=\=+[=xo>]\s*     return 'LINK';
-\s*[xo<]?\-?\.+\-[xo>]?\s*  return 'LINK';
+\s*[xo<]?\-\\?\-+[-xo>]\s*     return 'LINK';
+\s*[xo<]?\=\\?\=+[=xo>]\s*     return 'LINK';
+\s*[xo<]?\-?\.+\\?\-[xo>]?\s*  return 'LINK';
 \s*[xo<]?\-\-\s*            return 'START_LINK';
 \s*[xo<]?\=\=\s*            return 'START_LINK';
 \s*[xo<]?\-\.\s*            return 'START_LINK';
@@ -420,11 +420,11 @@ link: linkStatement arrowText
     | linkStatement
     {$$ = $1;}
     | START_LINK text LINK
-        {var inf = yy.destructLink($3, $1); $$ = {"type":inf.type,"stroke":inf.stroke,"length":inf.length,"text":$2};}
+        {var inf = yy.destructLink($3, $1); $$ = {"type":inf.type,"stroke":inf.stroke,"length":inf.length,"text":$2,"reversed":inf.reversed};}
     ;
 
 linkStatement: LINK
-        {var inf = yy.destructLink($1);$$ = {"type":inf.type,"stroke":inf.stroke,"length":inf.length};}
+        {var inf = yy.destructLink($1);$$ = {"type":inf.type,"stroke":inf.stroke,"length":inf.length,"reversed":inf.reversed};}
         ;
 
 arrowText:


### PR DESCRIPTION
## :bookmark_tabs: Summary

Add backward arrows to flowchart

Resolves #3208 

This pr is not ready to merge yet, and I wanted to confirm the syntax/direction with the maintainers before I add documentation and e2e tests

## :straight_ruler: Design Decisions

For backward arrow syntax, I've decided to go with a separator `\` that marks a link as being reversed:
```
A1 -\-> B1 --> C1
```

![image](https://user-images.githubusercontent.com/43521033/213843067-0d1aa1bf-6175-4fe2-b14c-13c9ab6a6821.png)

I chose this syntax because using  `<--` creates an inconsistency with the existing double arrow syntax. For example,

```
A1 --> B1 --> C1 // existing syntax that creates three nodes
A2 <-- B2 --> C2 // existing syntax to create two nodes and set 'B2' as a label. 
```
If backward arrow is implemented as `<--`, from a user's perspective, in cases like `A2 <-- B2 --> C2`, I would expect it to create three nodes, similar to `A1 --> B1 --> C1`. I've provided more details about this in the #3208, fell free to check it out!

Is the syntax that I chose ok for this issue? Alternatively, I can try to keep the `<--` syntax, and prioritize the existing behaviour when possible for backward compatibility. For example,
```
A1 <-- B --> A2 // B is text

A1 <-- B
B --> A2 // B is a vertex
```

Thanks!
### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [ ] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
