### PR TITLE
build(lint): cache prettier on `pnpm run lint`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,20 @@ jobs:
           CYPRESS_CACHE_FOLDER: .cache/Cypress
 
       - name: Run Linting
-        run: pnpm run lint
+        shell: bash
+        run: |
+          if ! pnpm run lint; then
+              # print a nice error message on lint failure
+              ERROR_MESSAGE='Running `pnpm run lint` failed.'
+              ERROR_MESSAGE+=' Running `pnpm run lint:fix` may fix this issue. '
+              ERROR_MESSAGE+=" If this error doesn't occur on your local machine,"
+              ERROR_MESSAGE+=' make sure your packages are up-to-date by running `pnpm install`.'
+              ERROR_MESSAGE+=' You may also need to delete your prettier cache by running'
+              ERROR_MESSAGE+=' `rm ./node_modules/.cache/prettier/.prettier-cache`.'
+              echo "::error title=Lint failure::${ERROR_MESSAGE}"
+              # make sure to return an error exitcode so that GitHub actions shows a red-cross
+              exit 1
+          fi
 
       - name: Verify Docs
         id: verifyDocs

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build": "pnpm run -r clean && concurrently \"pnpm build:vite\" \"pnpm build:types\"",
     "dev": "concurrently \"pnpm build:vite --watch\" \"ts-node-esm .vite/server.ts\"",
     "release": "pnpm build",
-    "lint": "eslint --cache --ignore-path .gitignore . && pnpm lint:jison && prettier --check .",
+    "lint": "eslint --cache --ignore-path .gitignore . && pnpm lint:jison && prettier --cache --check .",
     "lint:fix": "eslint --fix --ignore-path .gitignore . && prettier --write . && ts-node-esm scripts/fixCSpell.ts",
     "lint:jison": "ts-node-esm ./scripts/jison/lint.mts",
     "cypress": "cypress run",


### PR DESCRIPTION
## :bookmark_tabs: Summary

[Prettier 2.7.0](https://prettier.io/blog/2022/06/14/2.7.0.html) added a `--cache` CLI option to greatly speed up subsequent prettier runs.

By default, the cache is stored in `./node_modules/.cache/prettier/.prettier-cache` and uses an `md5` checksum of the contents as the cache-key.

On my PC, running `pnpm run lint` used to take 13.9 seconds, but now it only takes 6 seconds.

### Before

```console
me@me:~/mermaid (develop) $ time pnpm run lint
...
Checking formatting...
All matched files use Prettier code style!

real	0m13.898s
user	0m27.236s
sys	0m0.763s
```

### After

```console
me@me:~/mermaid (chore/cache-prettier) $ time pnpm run lint
...
Checking formatting...
All matched files use Prettier code style!

real	0m5.975s
user	0m10.047s
sys	0m0.547s
```

Potential issues
----------------

Although updating Node.JS/Prettier will invalidate the cache, **updating or changing prettier plugins won't invalidate the cache.** (see https://prettier.io/docs/en/cli.html#--cache)

Since we do use `prettier-plugin-jsdoc` in Mermaid, this might cause a minor issue, but CI should catch it. If you think this might cause issues, we can either:
  - a) print a warning in the CI lint action telling the user to delete their `./node_modules/.cache/prettier/.prettier-cache` if `pnpm run lint` has a different response locally compared to CI
  - b) don't merge this PR until `prettier` adds plugins to their cache key.

## Comments for reviewers

Maybe we should also add `--cache` to both eslint and prettier in our `pre-commit` hooks in

https://github.com/mermaid-js/mermaid/blob/c51f6df82ccd16b74f54b3a5a99e09c2604cac38/.lintstagedrc.mjs#L2

If I'm cleaning up my commits before making a PR, and I do `git rebase`, it takes forever!!

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [ ] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
