### PR TITLE
Cache `eslint` in pre-commit script (makes `git commit` 5x faster)

### DIFF
--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -1,5 +1,11 @@
 export default {
-  '!(docs/**/*)*.{ts,js,json,html,md,mts}': ['eslint --fix', 'prettier --write'],
+  '!(docs/**/*)*.{ts,js,json,html,md,mts}': [
+    'eslint --cache --cache-strategy content --fix',
+    // don't cache prettier yet, since we use `prettier-plugin-jsdoc`,
+    // and prettier doesn't invalidate cache on plugin updates"
+    // https://prettier.io/docs/en/cli.html#--cache
+    'prettier --write',
+  ],
   'cSpell.json': ['ts-node-esm scripts/fixCSpell.ts'],
   '**/*.jison': ['pnpm -w run lint:jison'],
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build": "pnpm run -r clean && concurrently \"pnpm build:vite\" \"pnpm build:types\"",
     "dev": "concurrently \"pnpm build:vite --watch\" \"ts-node-esm .vite/server.ts\"",
     "release": "pnpm build",
-    "lint": "eslint --cache --ignore-path .gitignore . && pnpm lint:jison && prettier --cache --check .",
+    "lint": "eslint --cache --cache-strategy content --ignore-path .gitignore . && pnpm lint:jison && prettier --cache --check .",
     "lint:fix": "eslint --fix --ignore-path .gitignore . && prettier --write . && ts-node-esm scripts/fixCSpell.ts",
     "lint:jison": "ts-node-esm ./scripts/jison/lint.mts",
     "cypress": "cypress run",


### PR DESCRIPTION
## :bookmark_tabs: Summary

Run eslint with `--cache` to speed up pre-commit scripts.

This was added to the `pnpm run lint` script in b7f9495a and doesn't seem to be causing any issues.

On my PC, this speeds up `git commit` on a single file from ~10 seconds to ~2 seconds.

Discussed in https://github.com/mermaid-js/mermaid/pull/4035#issuecomment-1407764595

## :straight_ruler: Design Decisions

### Not enabling `--cache` for prettier

I haven't enabled `--cache` for `prettier` since as of prettier 2.8.0, their cache invalidation doesn't yet work with prettier plugins.

It's not too big of a deal, since `prettier` doesn't use up much time: `prettier` takes about 0.5s on a single-file, but `eslint` takes 8.5s without `--cache` and 1.4s with `--cache`.

### Changing `eslint` to use `--cache-strategy content`

I also had to change eslint to use [`--cache-strategy content`](https://eslint.org/docs/latest/use/command-line-interface#--cache-strategy) to get it working with `lint-staged`.

By default, `eslint` uses the file metadata (e.g. modification time) to detect when the cache should be invalidated.

However, this is not efficient with `git`, since git constantly changes the modification time, e.g. running `git switch main && git switch original-branch` would not change the file contents, but would change the file `mtimes` and force `eslint` to re-lint everything.

Using the file contents is slower (~3% for me, going from `1.51s` to `1.46s`), but more resilient. However, I have a pretty fast SSD, so I imagine the slowdown would be higher on computers with a slower disk.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [ ] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
