### PR TITLE
build(lint:fix): cache eslint in pnpm run lint:fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dev": "concurrently \"pnpm build:vite --watch\" \"ts-node-esm .vite/server.ts\"",
     "release": "pnpm build",
     "lint": "eslint --cache --cache-strategy content --ignore-path .gitignore . && pnpm lint:jison && prettier --cache --check .",
-    "lint:fix": "eslint --fix --ignore-path .gitignore . && prettier --write . && ts-node-esm scripts/fixCSpell.ts",
+    "lint:fix": "eslint --cache --cache-strategy content --fix --ignore-path .gitignore . && prettier --write . && ts-node-esm scripts/fixCSpell.ts",
     "lint:jison": "ts-node-esm ./scripts/jison/lint.mts",
     "cypress": "cypress run",
     "cypress:open": "cypress open",


### PR DESCRIPTION
## :bookmark_tabs: Summary

Cache eslint in `pnpm run lint:fix`.

This was added to the `pnpm run lint` script in b7f9495a1434e620ff475d46b6c98834ce34bc77, but we didn't add it to `pnpm run lint:fix` due to worries about cache invalidation.

However, we switched to using `--cache-strategy content` in b3e509b7d4548a7f440b0cabbb1459e1ab0c3ff2, which should avoid any caching issues.

Suggested by @sidharthv96 in (I've added them as a co-author) https://github.com/mermaid-js/mermaid/pull/4057#discussion_r1096808215

### Performance increase

`pnpm run lint:fix` seems to now take 25s for me, compared to 40s earlier, so it's a ~1.6x speedup.

## :straight_ruler: Design Decisions

As discussed in https://github.com/mermaid-js/mermaid/pull/4057, I haven't added `--cache` to prettier, since I'm a bit worried about prettier plugins not invalidating the cache.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [ ] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
