### PR TITLE
💄 section width now covers all tasks

### DIFF
--- a/packages/mermaid/src/diagrams/user-journey/journeyRenderer.ts
+++ b/packages/mermaid/src/diagrams/user-journey/journeyRenderer.ts
@@ -224,6 +224,17 @@ export const drawTasks = function (diagram, tasks, verticalPos) {
       num = sectionNumber % fills.length;
       colour = textColours[sectionNumber % textColours.length];
 
+      // count how many consecutive tasks have the same section
+      let taskInSectionCount = 0;
+      const currentSection = task.section;
+      for (let taskIndex = i; taskIndex < tasks.length; taskIndex++) {
+        if (tasks[taskIndex].section == currentSection) {
+          taskInSectionCount = taskInSectionCount + 1;
+        } else {
+          break;
+        }
+      }
+
       const section = {
         x: i * conf.taskMargin + i * conf.width + LEFT_MARGIN,
         y: 50,
@@ -231,6 +242,7 @@ export const drawTasks = function (diagram, tasks, verticalPos) {
         fill,
         num,
         colour,
+        taskCount: taskInSectionCount,
       };
 
       svgDraw.drawSection(diagram, section, conf);

--- a/packages/mermaid/src/diagrams/user-journey/svgDraw.js
+++ b/packages/mermaid/src/diagrams/user-journey/svgDraw.js
@@ -196,7 +196,10 @@ export const drawSection = function (elem, section, conf) {
   rect.x = section.x;
   rect.y = section.y;
   rect.fill = section.fill;
-  rect.width = conf.width;
+  // section width covers all nested tasks
+  rect.width =
+    conf.width * section.taskCount + // width of the tasks
+    conf.diagramMarginX * (section.taskCount - 1); // width of space between tasks
   rect.height = conf.height;
   rect.class = 'journey-section section-type-' + section.num;
   rect.rx = 3;


### PR DESCRIPTION
## :bookmark_tabs: Summary

Brief description about the content of your PR.
Before:

<img width="1262" alt="image" src="https://user-images.githubusercontent.com/12746550/217715119-26bb031e-deda-4f19-9808-a5b769218af9.png">

After: the section encompasses all its tasks

<img width="1250" alt="image" src="https://user-images.githubusercontent.com/12746550/217715162-7fcf395b-c14f-45b4-a16a-264e7b3043d4.png">

More consistent with what I could observe in user journey produced by designers where the sections are umbrellas to all contained tasks.

## :straight_ruler: Design Decisions

Code is counting the number of tasks with the same section title.

Another option that would be more intrusive would be to completely change the underlying journeyDb and to have a structure with a list of sections, each section containing tasks. Right now tasks are flat and a section attribute is set on them as a text property

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
