### PR TITLE
docs(flowchart): duplicated hexagon node example

### DIFF
--- a/docs/syntax/flowchart.md
+++ b/docs/syntax/flowchart.md
@@ -183,20 +183,6 @@ flowchart LR
 
 ### A hexagon node
 
-Code:
-
-```mermaid-example
-flowchart LR
-    id1{{This is the text in the box}}
-```
-
-```mermaid
-flowchart LR
-    id1{{This is the text in the box}}
-```
-
-Render:
-
 ```mermaid-example
 flowchart LR
     id1{{This is the text in the box}}


### PR DESCRIPTION
## :bookmark_tabs: Summary

The hexagon node example is duplicated in the documentation (see screenshot below)

<img width="688" alt="Capture d’écran 2023-02-18 à 22 30 16" src="https://user-images.githubusercontent.com/2571084/219900383-a5048fcf-9d3d-4572-ac7f-27948d62950b.png">

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
