### PR TITLE
Fix typos

### DIFF
--- a/packages/mermaid/src/docs/syntax/flowchart.md
+++ b/packages/mermaid/src/docs/syntax/flowchart.md
@@ -245,9 +245,9 @@ flowchart LR
    A == text ==> B
 ```
 
-### An invisisble link
+### An invisible link
 
-This can be a usefull tool in some instances where you want to alter the default positining of a node.
+This can be a useful tool in some instances where you want to alter the default positining of a node.
 
 ```mermaid-example
 flowchart LR


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fixes typo re-introduced by #4113 after 4d46ea9
