### PR TITLE
Added grammar to skip comment in attribute block

### DIFF
--- a/packages/mermaid/src/diagrams/er/parser/erDiagram.jison
+++ b/packages/mermaid/src/diagrams/er/parser/erDiagram.jison
@@ -35,6 +35,8 @@ accDescr\s*"{"\s*                                { this.begin("acc_descr_multili
 <block>[A-Za-z_][A-Za-z0-9\-_\[\]\(\)]*  return 'ATTRIBUTE_WORD'
 <block>\"[^"]*\"                return 'COMMENT';
 <block>[\n]+                    /* nothing */
+<block>\%%(?!\{)[^\n]*          /* skip comments in attribute block */
+<block>[^\}]\%\%[^\n]*          /* skip comments in attribute block */
 <block>"}"                      { this.popState(); return 'BLOCK_STOP'; }
 <block>.                        return yytext[0];
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

Added changes in grammar for erDiagram.jison to skip comments that are added in attribute block.

Resolves #3949 

The code sample given in the bug does not give error and is rendered correctly.

![Screenshot from 2023-02-22 08-30-52](https://user-images.githubusercontent.com/122204126/220513890-b6efadd2-83f7-474c-a266-8de37a0b017a.png)

![Screenshot from 2023-02-22 08-30-13](https://user-images.githubusercontent.com/122204126/220513901-aa3900a6-442d-4def-89fe-9697bfb1dbe7.png)



### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
