### PR TITLE
Doc (typo): remove duplicate "be"

### DIFF
--- a/packages/mermaid/src/docs/syntax/sequenceDiagram.md
+++ b/packages/mermaid/src/docs/syntax/sequenceDiagram.md
@@ -418,7 +418,7 @@ It is possible to get a sequence number attached to each arrow in a sequence dia
 </script>
 ```
 
-It can also be be turned on via the diagram code as in the diagram:
+It can also be turned on via the diagram code as in the diagram:
 
 ```mermaid-example
 sequenceDiagram


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fixes a small typo in the docs.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: ~~have added unit/e2e tests (if appropriate)~~
- [x] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
