### PR TITLE
Fix incorrect linting arguments

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,4 @@
-dist/**
+**/dist/**
 .github/**
 docs/Setup.md
 cypress.config.js


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fixes `/dist` folders in `packages` subdirectories being considered when linting, causing linting to take longer than necessary.

## :straight_ruler: Design Decisions

The `dist/**` pattern in `.eslintignore`  only affects the root `dist` directory, but `packages/mermaid/dist/*` and `mermaid-example-diagram/dist/*` files are still considered.

I changed the pattern to `**/dist` to also catch dist directories in subdirectories. This could be updated to just target `dist`, `packages/mermaid/dist` and `packages/mermaid-example-diagram/dist` if that makes more sense.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
