### PR TITLE
Fix: add require entry in package.json

### DIFF
--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -7,6 +7,7 @@
   "types": "./dist/mermaid.d.ts",
   "exports": {
     ".": {
+      "require": "./dist/mermaid.esm.mjs",
       "types": "./dist/mermaid.d.ts",
       "import": "./dist/mermaid.core.mjs"
     },

--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -7,9 +7,9 @@
   "types": "./dist/mermaid.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/mermaid.esm.mjs",
       "types": "./dist/mermaid.d.ts",
-      "import": "./dist/mermaid.core.mjs"
+      "import": "./dist/mermaid.core.mjs",
+      "default": "./dist/mermaid.core.mjs"
     },
     "./*": "./*"
   },


### PR DESCRIPTION
## :bookmark_tabs: Summary

This PR adds `require` entry in `package.json` in order to allow the package to be exported.

Resolves #4161

## :straight_ruler: Design Decisions

Jest wasn't able to find the package, as it didn't have the `require` entry.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: ~have added unit/e2e tests (if appropriate)~
- [ ] :notebook: ~have added documentation (if appropriate)~
- [x] :bookmark: targeted `develop` branch
