### PR TITLE
docs: make contributing to docs a bit clearer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,8 @@ The documentation is written in **Markdown**. For more information about Markdow
 The source files for the project documentation are located in the [`/packages/mermaid/src/docs`](packages/mermaid/src/docs) directory. This is where you should make changes.
 The files under `/packages/mermaid/src/docs` are processed to generate the published documentation, and the resulting files are put into the `/docs` directory.
 
+After editing files in the [`/packages/mermaid/src/docs`](packages/mermaid/src/docs) directory, be sure to run `pnpm install` and `pnpm run --filter mermaid docs:build` locally to build the `/docs` directory.
+
 ```mermaid
 flowchart LR
   classDef default fill:#fff,color:black,stroke:black


### PR DESCRIPTION
## :bookmark_tabs: Summary

It wasn't clear to me whether docs would be generated and committed in ci or should be built locally.

Related to #4184 


### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
