### PR TITLE
CI(e2e): Skip caching in `actions/setup-node`, as `cypress-io/github-action` already caches for us

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,11 +21,7 @@ jobs:
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
-        # Need to skip setup if Cypress run is skipped, otherwise an error
-        # is thrown since the pnpm cache step fails
-        if: ${{ ( env.CYPRESS_RECORD_KEY != '' ) || ( matrix.containers == 1 ) }}
         with:
-          cache: pnpm
           node-version: ${{ matrix.node-version }}
 
       # Install NPM dependencies, cache them correctly


### PR DESCRIPTION
## :bookmark_tabs: Summary

Skip caching `pnpm` in `actions/setup-node`, because the `cypress-io/github-action` natively supports caching `pnpm`, as of [cypress-io/github-action@v4.2.0][1].

[1]: https://github.com/cypress-io/github-action/releases/tag/v4.2.0

This seems to fix the failing e2e CI action on the `develop` branch, see https://github.com/mermaid-js/mermaid/actions/runs/4343424589/jobs/7597285754, but I don't know if that's just random chance. Maybe the issue is that both `cypress-io/github-action` and `actions/setup-node` cache the same things with the same key?

## :straight_ruler: Design Decisions

N/A

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [ ] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
