### PR TITLE
Fix broken Gantt  `todayMarker` tests

### DIFF
--- a/cypress/integration/rendering/gantt.spec.js
+++ b/cypress/integration/rendering/gantt.spec.js
@@ -133,6 +133,24 @@ describe('Gantt diagram', () => {
     );
   });
 
+  it('should default to showing today marker', () => {
+    // This test only works if the environment thinks today is 1010-10-10
+    imgSnapshotTest(
+      `
+      gantt
+        title Show today marker (vertical line should be visible)
+        dateFormat YYYY-MM-DD
+        axisFormat %d
+        %% Should default to being on
+        %% todayMarker on
+        section Section1
+         Yesterday: 1010-10-09, 1d
+         Today: 1010-10-10, 1d
+      `,
+      {}
+    );
+  });
+
   it('should hide today marker', () => {
     imgSnapshotTest(
       `
@@ -142,7 +160,8 @@ describe('Gantt diagram', () => {
         axisFormat %d
         todayMarker off
         section Section1
-         Today: 1, -1h
+         Yesterday: 1010-10-09, 1d
+         Today: 1010-10-10, 1d
       `,
       {}
     );
@@ -157,7 +176,8 @@ describe('Gantt diagram', () => {
       axisFormat %d
       todayMarker stroke-width:5px,stroke:#00f,opacity:0.5
       section Section1
-       Today: 1, -1h
+       Yesterday: 1010-10-09, 1d
+       Today: 1010-10-10, 1d
       `,
       {}
     );


### PR DESCRIPTION
## :bookmark_tabs: Summary

The gantt diagram that were supposed to test whether `todayMarker off` works wasn't working properly, because `todayMarker on` wasn't working (i.e. the test never failed).

I've fixed this issue, and added a test that checks whether `todayMarker on` works.

Resolves https://github.com/mermaid-js/mermaid/issues/4198

## :straight_ruler: Design Decisions

By the way, the reason why I used `1010-10-10` [^1] as the date in the diagrams is because that's what we've set the current date in Cypress to:

https://github.com/mermaid-js/mermaid/blob/155e7297222a658d3173f2e58c67fc6d51202a95/cypress/integration/rendering/gantt.spec.js#L4-L6

[^1]: Apparently JavaScript dates are still accurate to +/-7μs in the year 1010 (calculated via `new Date(new Date('1010-10-10').getTime()) * Number.EPSILON`!), so it's unlikely we get any weird floating-point issues in diagrams at that time.

### New snapshot

`cypress/snapshots/rendering/gantt.spec.js/Gantt-diagram-should-default-to-showing-today-marker.snap.png`:

![image](https://user-images.githubusercontent.com/19716675/224132568-048d7441-23b6-4f9d-874e-377229acdd5a.png)

### Changed snapshots

`cypress/snapshots/rendering/gantt.spec.js/Gantt-diagram-should-hide-today-marker.snap.png`:

![image](https://user-images.githubusercontent.com/19716675/224132644-a6af5bff-aaac-4045-9229-a70ce736eec4.png)

`cypress/snapshots/rendering/gantt.spec.js/Gantt-diagram-should-style-today-marker.snap.png`:

![image](https://user-images.githubusercontent.com/19716675/224132688-9e55eee5-23f1-4740-b6bd-1548ec7a7d58.png)

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
  - I've only added tests.
- [ ] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
