### PR TITLE
Updated DokuWiki plugin for Mermaid integration

### DIFF
--- a/packages/mermaid/src/docs/ecosystem/integrations.md
+++ b/packages/mermaid/src/docs/ecosystem/integrations.md
@@ -83,7 +83,7 @@ They also serve as proof of concept, for the variety of things that can be built
 - [FosWiki](https://foswiki.org)
   - [Mermaid Plugin](https://foswiki.org/Extensions/MermaidPlugin)
 - [DokuWiki](https://dokuwiki.org)
-  - [Flowcharts](https://www.dokuwiki.org/plugin:flowcharts?s[]=mermaid)
+  - [Mermaid Plugin](https://www.dokuwiki.org/plugin:mermaid)
   - [ComboStrap](https://combostrap.com/mermaid)
 - [TiddlyWiki](https://tiddlywiki.com/)
   - [mermaid-tw5: full js library](https://github.com/efurlanm/mermaid-tw5)


### PR DESCRIPTION
Update of the documentation of Mermaid integrations. The currently mentioned plugin flowcharts for DokuWiki has not been updated for over 2 years. Replace it with the plugin Mermaid instead.