### PR TITLE
Fix hexagon node flowchart code example in docs

### DIFF
--- a/docs/syntax/flowchart.md
+++ b/docs/syntax/flowchart.md
@@ -183,8 +183,6 @@ flowchart LR
 
 ### A hexagon node
 
-Code:
-
 ```mermaid-example
 flowchart LR
     id1{{This is the text in the box}}

--- a/packages/mermaid/src/docs/syntax/flowchart.md
+++ b/packages/mermaid/src/docs/syntax/flowchart.md
@@ -122,9 +122,7 @@ flowchart LR
 
 ### A hexagon node
 
-Code:
-
-```mmd
+```mermaid-example
 flowchart LR
     id1{{This is the text in the box}}
 ```


### PR DESCRIPTION
The preview on the site was broken/duplicated because of this

![image](https://user-images.githubusercontent.com/16529503/227635920-88052a43-b0cb-48c7-83ed-4a03de98b707.png)
