### PR TITLE
Updated render to remove comments from text

### DIFF
--- a/docs/config/setup/modules/mermaidAPI.md
+++ b/docs/config/setup/modules/mermaidAPI.md
@@ -95,7 +95,7 @@ mermaid.initialize(config);
 
 #### Defined in
 
-[mermaidAPI.ts:659](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/mermaidAPI.ts#L659)
+[mermaidAPI.ts:661](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/mermaidAPI.ts#L661)
 
 ## Functions
 

--- a/docs/config/setup/modules/mermaidAPI.md
+++ b/docs/config/setup/modules/mermaidAPI.md
@@ -95,7 +95,7 @@ mermaid.initialize(config);
 
 #### Defined in
 
-[mermaidAPI.ts:661](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/mermaidAPI.ts#L661)
+[mermaidAPI.ts:662](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/mermaidAPI.ts#L662)
 
 ## Functions
 

--- a/packages/mermaid/src/mermaidAPI.ts
+++ b/packages/mermaid/src/mermaidAPI.ts
@@ -399,7 +399,8 @@ const render = async function (
   // clean up text CRLFs
   text = text.replace(/\r\n?/g, '\n'); // parser problems on CRLF ignore all CR and leave LF;;
 
-  text = text.replace(/\s*%%.*\n/gm, '\n'); // remove comments from text to avoid issues with parser
+  // eslint-disable-next-line unicorn/better-regex
+  text = text.replace(/\s*%%[^{\ninit].*\n/gm, '\n'); // remove comments from text to avoid issues with parser
 
   const idSelector = '#' + id;
   const iFrameID = 'i' + id;

--- a/packages/mermaid/src/mermaidAPI.ts
+++ b/packages/mermaid/src/mermaidAPI.ts
@@ -399,6 +399,8 @@ const render = async function (
   // clean up text CRLFs
   text = text.replace(/\r\n?/g, '\n'); // parser problems on CRLF ignore all CR and leave LF;;
 
+  text = text.replace(/\s*%%.*\n/gm, '\n'); // remove comments from text to avoid issues with parser
+
   const idSelector = '#' + id;
   const iFrameID = 'i' + id;
   const iFrameID_selector = '#' + iFrameID;


### PR DESCRIPTION
## :bookmark_tabs: Summary

Updated render function in mermaid API to remove comments from text before rendering diagram. This resolves the issue with parsers of all diagrams to remove comments and render diagrams without errors.

Resolves #4137 

![Screenshot from 2023-03-25 14-24-10](https://user-images.githubusercontent.com/122204126/227720602-02a6d7f6-b31c-44a3-88ea-a00be53a4f87.png)

![Screenshot from 2023-03-25 14-24-36](https://user-images.githubusercontent.com/122204126/227720608-6fea4e75-d907-40f3-9447-2573b3589898.png)

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
