### PR TITLE
Remove inline-specifiers pnpm option from `.npmrc` file to avoid merge conflicts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
 auto-install-peers=true
 strict-peer-dependencies=false
-use-inline-specifiers-lockfile-format=true


### PR DESCRIPTION
## :bookmark_tabs: Summary

Remove the `use-inline-specifiers-lockfile-format=true` pnpm option from our `.npmrc` file.

This was added in [PNPM version v7.7.0](https://github.com/pnpm/pnpm/releases/tag/v7.7.0) and should make our `pnpm-lock.yaml` file much nicer, but unfortunately, renovate doesn't seem to support it (unsure why?).

This means that whenever we do a `pnpm install` locally, the lock-file gets changed, and whenever renovate makes a PR, it changes the lock-file back. This causes a lot of unnecessary merge conflicts.

Resolves the constant extensive changes that renovate makes in the `pnpm-lock.yaml` file, see https://github.com/mermaid-js/mermaid/blob/8b37ceffe1a4c182f3e0bbf06c6b35622a0fccb1/pnpm-lock.yaml.

## :straight_ruler: Design Decisions

It's possible that some renovate option might be able to fix this, but `pnpm` version 8 might get this option `true` by default (see https://github.com/orgs/pnpm/discussions/4967#discussioncomment-3541548), so hopefully soon it will be enabled by default.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [ ] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
