### PR TITLE
Add Slab to the list of integrations

### DIFF
--- a/docs/ecosystem/integrations.md
+++ b/docs/ecosystem/integrations.md
@@ -23,6 +23,7 @@ They also serve as proof of concept, for the variety of things that can be built
 - [Mermaid Flow Visual Editor](https://www.mermaidflow.app) (**Native support**)
 - [Deepdwn](https://billiam.itch.io/deepdwn) (**Native support**)
 - [Joplin](https://joplinapp.org) (**Native support**)
+- [Slab](https://slab.com) (**Native support**)
 - [Swimm](https://swimm.io) (**Native support**)
 - [Notion](https://notion.so) (**Native support**)
 - [Observable](https://observablehq.com/@observablehq/mermaid) (**Native support**)

--- a/packages/mermaid/src/docs/ecosystem/integrations.md
+++ b/packages/mermaid/src/docs/ecosystem/integrations.md
@@ -17,6 +17,7 @@ They also serve as proof of concept, for the variety of things that can be built
 - [Mermaid Flow Visual Editor](https://www.mermaidflow.app) (**Native support**)
 - [Deepdwn](https://billiam.itch.io/deepdwn) (**Native support**)
 - [Joplin](https://joplinapp.org) (**Native support**)
+- [Slab](https://slab.com) (**Native support**)
 - [Swimm](https://swimm.io) (**Native support**)
 - [Notion](https://notion.so) (**Native support**)
 - [Observable](https://observablehq.com/@observablehq/mermaid) (**Native support**)


### PR DESCRIPTION
## :bookmark_tabs: Summary

Added Slab to the list of integrations: https://twitter.com/SLAB/status/1623702592454025222.

Here's a quick screencast demonstrating how to add a Mermaid block on a Slab post:

https://user-images.githubusercontent.com/635902/229554719-46703ebe-3df5-4756-a540-7a626830c531.mp4



### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
