### PR TITLE
Fix #4195 start and end arrow have different sizes

### DIFF
--- a/packages/mermaid/src/dagre-wrapper/markers.js
+++ b/packages/mermaid/src/dagre-wrapper/markers.js
@@ -142,7 +142,7 @@ const point = (elem, type) => {
     .append('marker')
     .attr('id', type + '-pointEnd')
     .attr('class', 'marker ' + type)
-    .attr('viewBox', '0 0 12 20')
+    .attr('viewBox', '0 0 10 10')
     .attr('refX', 10)
     .attr('refY', 5)
     .attr('markerUnits', 'userSpaceOnUse')


### PR DESCRIPTION
## :bookmark_tabs: Summary

In #3938, it appears that the marker sizes for pointEnd was unintentionally changed. This reverts the change in marker size.

Resolves #4195

It is also possible that the intention was to change the viewBox size for both start and end, but I doubt this since it makes the arrows significantly smaller than other markers.

### :clipboard: Tasks

Make sure you

- [X] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [ ] :notebook: have added documentation (if appropriate)
- [X] :bookmark: targeted `develop` branch
