### PR TITLE
fix(doc): Link to Obsidian doc/integration

### DIFF
--- a/packages/mermaid/src/docs/ecosystem/integrations.md
+++ b/packages/mermaid/src/docs/ecosystem/integrations.md
@@ -21,7 +21,7 @@ They also serve as proof of concept, for the variety of things that can be built
 - [Swimm](https://swimm.io) (**Native support**)
 - [Notion](https://notion.so) (**Native support**)
 - [Observable](https://observablehq.com/@observablehq/mermaid) (**Native support**)
-- [Obsidian](https://help.obsidian.md/How+to/Format+your+notes#Diagram) (**Native support**)
+- [Obsidian](https://help.obsidian.md/Editing+and+formatting/Advanced+formatting+syntax#Diagram) (**Native support**)
 - [GitBook](https://gitbook.com)
   - [Mermaid Plugin](https://github.com/JozoVilcek/gitbook-plugin-mermaid)
   - [Markdown with Mermaid CLI](https://github.com/miao1007/gitbook-plugin-mermaid-cli)


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fixing the URL of the link to the Obsidian documentation in the `integrations` page

~~Resolves #<your issue id here>~~

## :straight_ruler: Design Decisions

It's just an URL fix; nothing fancy.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
~~- [ ] :computer: have added unit/e2e tests (if appropriate)~~
~~- [ ] :notebook: have added documentation (if appropriate)~~
- [x] :bookmark: targeted `develop` branch
