### PR TITLE
docs(flowchart): wrap br tag by codeblock

### DIFF
--- a/docs/syntax/flowchart.md
+++ b/docs/syntax/flowchart.md
@@ -742,9 +742,9 @@ end
 
 Formatting:
 
-- For bold text, use double asterisks \*\* before and after the text.
-- For italics, use single asterisks \* before and after the text.
-- With traditional strings, you needed to add <br> tags for text to wrap in nodes. However, markdown strings automatically wrap text when it becomes too long and allows you to start a new line by simply using a newline character instead of a <br> tag.
+- For bold text, use double asterisks (`**`) before and after the text.
+- For italics, use single asterisks (`*`) before and after the text.
+- With traditional strings, you needed to add `<br>` tags for text to wrap in nodes. However, markdown strings automatically wrap text when it becomes too long and allows you to start a new line by simply using a newline character instead of a `<br>` tag.
 
 This feature is applicable to node labels, edge labels, and subgraph labels.
 

--- a/packages/mermaid/src/docs/syntax/flowchart.md
+++ b/packages/mermaid/src/docs/syntax/flowchart.md
@@ -465,9 +465,9 @@ end
 
 Formatting:
 
-- For bold text, use double asterisks \*\* before and after the text.
-- For italics, use single asterisks \* before and after the text.
-- With traditional strings, you needed to add <br> tags for text to wrap in nodes. However, markdown strings automatically wrap text when it becomes too long and allows you to start a new line by simply using a newline character instead of a <br> tag.
+- For bold text, use double asterisks (`**`) before and after the text.
+- For italics, use single asterisks (`*`) before and after the text.
+- With traditional strings, you needed to add `<br>` tags for text to wrap in nodes. However, markdown strings automatically wrap text when it becomes too long and allows you to start a new line by simply using a newline character instead of a `<br>` tag.
 
 This feature is applicable to node labels, edge labels, and subgraph labels.
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

So that it can render `<br>` text on doc correctly, they were rendered as newlines before. I also wrap the asterisks by codeblock for consistency so that it's more clear that they are raw text of markdown.

You can find original doc [here](https://mermaid.js.org/syntax/flowchart.html#markdown-strings).

### Screenshots

before:

![original doc](https://user-images.githubusercontent.com/16890663/232756305-003b2fc7-bbd7-4f0b-8965-3c2a6dba5517.png)

after:

![image](https://user-images.githubusercontent.com/16890663/232756460-e7689d1c-04b4-4cb9-a703-2df0679c1032.png)

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [ ] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
