### PR TITLE
pie diagram mermaid module import fix

### DIFF
--- a/demos/pie.html
+++ b/demos/pie.html
@@ -38,7 +38,7 @@
     </pre>
 
     <script type="module">
-      import mermaid from '../packages/mermaid/src/mermaid';
+      import mermaid from './mermaid.esm.mjs';
       mermaid.initialize({
         theme: 'forest',
         // themeCSS: '.node rect { fill: red; }',


### PR DESCRIPTION
## :bookmark_tabs: Summary

Brief description about the content of your PR.

Running the repo locally, the demo file pie.html doesn't render the pie diagram on port 9000 due to the mermaid library import issue inside the script tag.
Fixed that in this pr

Before import fix

<img width="1440" alt="Screenshot 2023-04-19 at 11 23 33 AM" src="https://user-images.githubusercontent.com/35917821/232980331-3418dce6-78e5-486d-bca4-359d11d89c98.png">

After import fix

<img width="1440" alt="Screenshot 2023-04-19 at 11 24 43 AM" src="https://user-images.githubusercontent.com/35917821/232980358-fb05473a-6a1b-46e3-9385-9a137b2aebdf.png">


### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
