### PR TITLE
enable auto rerender

### DIFF
--- a/packages/mermaid/src/docs/.vitepress/theme/Mermaid.vue
+++ b/packages/mermaid/src/docs/.vitepress/theme/Mermaid.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script setup>
-import { onMounted, onUnmounted, ref } from 'vue';
+import { onMounted, onUnmounted, ref, watch } from 'vue';
 import { render } from './mermaid';
 
 const props = defineProps({
@@ -69,4 +69,6 @@ const renderChart = async () => {
   const salt = Math.random().toString(36).substring(7);
   svg.value = `${svgCode} <span style="display: none">${salt}</span>`;
 };
+
+watch(props, renderChart);
 </script>


### PR DESCRIPTION
## :bookmark_tabs: Summary

Enable auto rerender when `pnpm run docs:dev`. And other projects may also be inspired about how to integrate `mermaid` into `vitepress`.

## :straight_ruler: Design Decisions

According to <https://vuejs.org/guide/essentials/watchers.html>, `watch` track `props`, and will call `renderChar` when `props` changes.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
