### PR TITLE
docs: fix c4 layout doc not supported yet

### DIFF
--- a/docs/syntax/c4c.md
+++ b/docs/syntax/c4c.md
@@ -122,11 +122,11 @@ updateElementStyle and UpdateElementStyle are written in the diagram last part. 
 The layout does not use a fully automated layout algorithm. The position of shapes is adjusted by changing the order in which statements are written. So there is no plan to support the following Layout statements.
 The number of shapes per row and the number of boundaries can be adjusted using UpdateLayoutConfig.
 
-- Layout
-- - Lay_U, Lay_Up
-- - Lay_D, Lay_Down
-- - Lay_L, Lay_Left
-- - Lay_R, Lay_Right
+- [ ] Layout
+- - [ ] Lay_U, Lay_Up
+- - [ ] Lay_D, Lay_Down
+- - [ ] Lay_L, Lay_Left
+- - [ ] Lay_R, Lay_Right
 
 The following unfinished features are not supported in the short term.
 

--- a/packages/mermaid/src/docs/syntax/c4c.md
+++ b/packages/mermaid/src/docs/syntax/c4c.md
@@ -69,11 +69,11 @@ updateElementStyle and UpdateElementStyle are written in the diagram last part. 
 The layout does not use a fully automated layout algorithm. The position of shapes is adjusted by changing the order in which statements are written. So there is no plan to support the following Layout statements.
 The number of shapes per row and the number of boundaries can be adjusted using UpdateLayoutConfig.
 
-- Layout
-- - Lay_U, Lay_Up
-- - Lay_D, Lay_Down
-- - Lay_L, Lay_Left
-- - Lay_R, Lay_Right
+- [ ] Layout
+- - [ ] Lay_U, Lay_Up
+- - [ ] Lay_D, Lay_Down
+- - [ ] Lay_L, Lay_Left
+- - [ ] Lay_R, Lay_Right
 
 The following unfinished features are not supported in the short term.
 


### PR DESCRIPTION
- fix c4 layout doc not supported yet

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [ ] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
