### PR TITLE
test: fix classDiagramGrammer unit test

### DIFF
--- a/packages/mermaid/src/diagrams/class/classDiagramGrammar.spec.ts
+++ b/packages/mermaid/src/diagrams/class/classDiagramGrammar.spec.ts
@@ -1,10 +1,10 @@
 import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 // @ts-ignore - no types
 import { LALRGenerator } from 'jison';
-import path from 'path';
 
 const getAbsolutePath = (relativePath: string) => {
-  return new URL(path.join(__dirname, relativePath)).pathname;
+  return fileURLToPath(new URL(relativePath, import.meta.url));
 };
 
 describe('class diagram grammar', function () {


### PR DESCRIPTION

## :bookmark_tabs: Summary

The `classDiagramGrammer.spec.ts` unit test had some bad filepath manipulation that fails on UNIX platforms. This is causing the unit tests to fail in the `develop` branch, and people making PRs are a bit confused!

I think this was caused by @jgreywolf accidentally pushing 221640aa258c9e8f97e8113a15a52097cb2d1cf8 to `develop`! We might want to push up the priority of enabling **GitHub Merge Queues** and **GitHub Required Checks** on the `develop` branch, see https://github.com/mermaid-js/mermaid/issues/4075#issuecomment-1424646015, since this does seem to happen quite often! Having all changes go through PRs will confirm that everything works, and @mermaid-js collaborators could always just make a PR and merge without waiting for a review for minor/documentation fixes.

Fixes: 221640aa258c9e8f97e8113a15a52097cb2d1cf8

## :straight_ruler: Design Decisions

I've mainly just copied the recommended method from the Node.JS documentation, see https://nodejs.org/api/esm.html#importmetaurl:

> This enables useful patterns such as relative file loading:
>
> ```js
> import { readFileSync } from 'node:fs';
> const buffer = readFileSync(new URL('./data.proto', import.meta.url)); 
> ```

I have also used a call to [`url.fileURLToPath`](https://nodejs.org/api/url.html#urlfileurltopathurl) to match what this function originally returned, even though we don't need it since the [`node:fs` module has supported `file://` URLs since Node v8](https://nodejs.org/api/fs.html#file-url-paths)

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [x] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
