### PR TITLE
Quadrant chart unicode arrows

### DIFF
--- a/packages/mermaid/src/diagrams/quadrant-chart/parser/quadrant.jison
+++ b/packages/mermaid/src/diagrams/quadrant-chart/parser/quadrant.jison
@@ -119,10 +119,10 @@ points
 
 axisDetails
   : X-AXIS text AXIS-TEXT-DELIMITER text {yy.setXAxisLeftText($2); yy.setXAxisRightText($4);}
-  | X-AXIS text AXIS-TEXT-DELIMITER {$2.text += " ⭢ "; yy.setXAxisLeftText($2);}
+  | X-AXIS text AXIS-TEXT-DELIMITER {$2.text += " ⟶ "; yy.setXAxisLeftText($2);}
   | X-AXIS text {yy.setXAxisLeftText($2);}
   | Y-AXIS text AXIS-TEXT-DELIMITER text {yy.setYAxisBottomText($2); yy.setYAxisTopText($4);}
-  | Y-AXIS text AXIS-TEXT-DELIMITER {$2.text += " ⭢ "; yy.setYAxisBottomText($2);}
+  | Y-AXIS text AXIS-TEXT-DELIMITER {$2.text += " ⟶ "; yy.setYAxisBottomText($2);}
   | Y-AXIS text {yy.setYAxisBottomText($2);}
   ;
 

--- a/packages/mermaid/src/diagrams/quadrant-chart/parser/quadrant.jison
+++ b/packages/mermaid/src/diagrams/quadrant-chart/parser/quadrant.jison
@@ -119,10 +119,10 @@ points
 
 axisDetails
   : X-AXIS text AXIS-TEXT-DELIMITER text {yy.setXAxisLeftText($2); yy.setXAxisRightText($4);}
-  | X-AXIS text AXIS-TEXT-DELIMITER {$2.text += $3; yy.setXAxisLeftText($2);}
+  | X-AXIS text AXIS-TEXT-DELIMITER {$2.text += " ⭢ "; yy.setXAxisLeftText($2);}
   | X-AXIS text {yy.setXAxisLeftText($2);}
   | Y-AXIS text AXIS-TEXT-DELIMITER text {yy.setYAxisBottomText($2); yy.setYAxisTopText($4);}
-  | Y-AXIS text AXIS-TEXT-DELIMITER {$2.text += $3; yy.setYAxisBottomText($2);}
+  | Y-AXIS text AXIS-TEXT-DELIMITER {$2.text += " ⭢ "; yy.setYAxisBottomText($2);}
   | Y-AXIS text {yy.setYAxisBottomText($2);}
   ;
 

--- a/packages/mermaid/src/diagrams/quadrant-chart/parser/quadrant.jison.spec.ts
+++ b/packages/mermaid/src/diagrams/quadrant-chart/parser/quadrant.jison.spec.ts
@@ -93,7 +93,7 @@ describe('Testing quadrantChart jison file', () => {
     str = 'quadrantChart\n       x-AxIs         "Urgent(* +=[❤"  --> ';
     expect(parserFnConstructor(str)).not.toThrow();
     expect(mockDB.setXAxisLeftText).toHaveBeenCalledWith({
-      text: 'Urgent(* +=[❤ ⭢ ',
+      text: 'Urgent(* +=[❤ ⟶ ',
       type: 'text',
     });
     expect(mockDB.setXAxisRightText).not.toHaveBeenCalled();
@@ -131,7 +131,7 @@ describe('Testing quadrantChart jison file', () => {
     str = 'quadrantChart\n       y-AxIs         "Urgent(* +=[❤"  --> ';
     expect(parserFnConstructor(str)).not.toThrow();
     expect(mockDB.setYAxisBottomText).toHaveBeenCalledWith({
-      text: 'Urgent(* +=[❤ ⭢ ',
+      text: 'Urgent(* +=[❤ ⟶ ',
       type: 'text',
     });
     expect(mockDB.setYAxisTopText).not.toHaveBeenCalled();

--- a/packages/mermaid/src/diagrams/quadrant-chart/parser/quadrant.jison.spec.ts
+++ b/packages/mermaid/src/diagrams/quadrant-chart/parser/quadrant.jison.spec.ts
@@ -93,7 +93,7 @@ describe('Testing quadrantChart jison file', () => {
     str = 'quadrantChart\n       x-AxIs         "Urgent(* +=[❤"  --> ';
     expect(parserFnConstructor(str)).not.toThrow();
     expect(mockDB.setXAxisLeftText).toHaveBeenCalledWith({
-      text: 'Urgent(* +=[❤  --> ',
+      text: 'Urgent(* +=[❤ ⭢ ',
       type: 'text',
     });
     expect(mockDB.setXAxisRightText).not.toHaveBeenCalled();
@@ -131,7 +131,7 @@ describe('Testing quadrantChart jison file', () => {
     str = 'quadrantChart\n       y-AxIs         "Urgent(* +=[❤"  --> ';
     expect(parserFnConstructor(str)).not.toThrow();
     expect(mockDB.setYAxisBottomText).toHaveBeenCalledWith({
-      text: 'Urgent(* +=[❤  --> ',
+      text: 'Urgent(* +=[❤ ⭢ ',
       type: 'text',
     });
     expect(mockDB.setYAxisTopText).not.toHaveBeenCalled();


### PR DESCRIPTION
## :bookmark_tabs: Summary

Uses unicode arrows in quadrant chart axis.

Resolves #<your issue id here>

## :straight_ruler: Design Decisions

<img width="283" alt="image" src="https://github.com/mermaid-js/mermaid/assets/10703445/e3e41d42-daef-4bea-822e-1c87bfeea9cf">
<img width="280" alt="image" src="https://github.com/mermaid-js/mermaid/assets/10703445/9f5870cf-602c-47d9-8d8e-f320fdbd8e80">


### :clipboard: Tasks

Make sure you

- [ ] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [ ] :notebook: have added documentation (if appropriate)
- [ ] :bookmark: targeted `develop` branch
