### PR TITLE
Fix exceptions for empty lines

### DIFF
--- a/cypress/integration/rendering/sequencediagram.spec.js
+++ b/cypress/integration/rendering/sequencediagram.spec.js
@@ -93,7 +93,7 @@ context('Sequence diagram', () => {
       `
       sequenceDiagram
       Alice->>John: Hello John<br/>
-      John-->>Alice: Great!
+      John-->>Alice: Great<br/><br/>day!
     `,
       {}
     );

--- a/cypress/integration/rendering/sequencediagram.spec.js
+++ b/cypress/integration/rendering/sequencediagram.spec.js
@@ -88,6 +88,16 @@ context('Sequence diagram', () => {
       {}
     );
   });
+  it('should handle empty lines', () => {
+    imgSnapshotTest(
+      `
+      sequenceDiagram
+      Alice->>John: Hello John<br/>
+      John-->>Alice: Great!
+    `,
+      {}
+    );
+  });
   it('should handle line breaks and wrap annotations', () => {
     imgSnapshotTest(
       `

--- a/packages/mermaid/src/diagrams/sequence/svgDraw.js
+++ b/packages/mermaid/src/diagrams/sequence/svgDraw.js
@@ -1,7 +1,7 @@
 import common from '../common/common.js';
 import * as svgDrawCommon from '../common/svgDrawCommon';
 import { addFunction } from '../../interactionDb.js';
-import { parseFontSize } from '../../utils.js';
+import { ZERO_WIDTH_SPACE, parseFontSize } from '../../utils.js';
 import { sanitizeUrl } from '@braintree/sanitize-url';
 
 export const drawRect = function (elem, rectData) {
@@ -224,15 +224,16 @@ export const drawText = function (elem, textData) {
       textElem.attr('dy', dy);
     }
 
+    const text = line || ZERO_WIDTH_SPACE;
     if (textData.tspan) {
       const span = textElem.append('tspan');
       span.attr('x', textData.x);
       if (textData.fill !== undefined) {
         span.attr('fill', textData.fill);
       }
-      span.text(line);
+      span.text(text);
     } else {
-      textElem.text(line);
+      textElem.text(text);
     }
     if (
       textData.valign !== undefined &&

--- a/packages/mermaid/src/utils.ts
+++ b/packages/mermaid/src/utils.ts
@@ -32,6 +32,8 @@ import assignWithDepth from './assignWithDepth.js';
 import { MermaidConfig } from './config.type.js';
 import memoize from 'lodash-es/memoize.js';
 
+export const ZERO_WIDTH_SPACE = '\u200b';
+
 // Effectively an enum of the supported curve types, accessible by name
 const d3CurveTypes = {
   curveBasis: curveBasis,
@@ -764,11 +766,8 @@ export const calculateTextDimensions: (
       let cheight = 0;
       const dim = { width: 0, height: 0, lineHeight: 0 };
       for (const line of lines) {
-        if (!line) {
-          continue;
-        }
         const textObj = getTextObj();
-        textObj.text = line;
+        textObj.text = line || ZERO_WIDTH_SPACE;
         const textElem = drawSimpleText(g, textObj)
           .style('font-size', _fontSizePx)
           .style('font-weight', fontWeight)

--- a/packages/mermaid/src/utils.ts
+++ b/packages/mermaid/src/utils.ts
@@ -764,6 +764,9 @@ export const calculateTextDimensions: (
       let cheight = 0;
       const dim = { width: 0, height: 0, lineHeight: 0 };
       for (const line of lines) {
+        if (!line) {
+          continue;
+        }
         const textObj = getTextObj();
         textObj.text = line;
         const textElem = drawSimpleText(g, textObj)


### PR DESCRIPTION
## :bookmark_tabs: Summary

Ignore empty lines when calculating text dimensions. In https://github.com/mermaid-js/mermaid/issues/4180, we threw an exception when the text dimension is 0. However, besides the two reasons given in the ticket description, another cause is the text is empty.

Resolves #4280, #4298, #4293

## :straight_ruler: Design Decisions

This PR ignores empty lines. We already ignores empty text, but we didn't handle empty lines.

### :clipboard: Tasks

Make sure you

- [X] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [X] :computer: have added unit/e2e tests (if appropriate)
- [X] :notebook: have added documentation (if appropriate)
- [X] :bookmark: targeted `develop` branch
