### PR TITLE
Restore classes on edges for elk

### DIFF
--- a/cypress/integration/rendering/flowchart-elk.spec.js
+++ b/cypress/integration/rendering/flowchart-elk.spec.js
@@ -684,6 +684,20 @@ A --> B
       { titleTopMargin: 0 }
     );
   });
+  it('elk: should include classes on the edges', () => {
+    renderGraph(
+      `flowchart-elk TD
+      A --> B --> C --> D
+      `,
+      {}
+    );
+    cy.get('svg').should((svg) => {
+      const edges = svg.querySelectorAll('.edges > path');
+      edges.forEach((edge) => {
+        expect(edge).to.have.class('flowchart-link');
+      });
+    });
+  });
   describe('Markdown strings flowchart-elk (#4220)', () => {
     describe('html labels', () => {
       it('With styling and classes', () => {

--- a/packages/mermaid/src/diagrams/flowchart/elk/flowRenderer-elk.js
+++ b/packages/mermaid/src/diagrams/flowchart/elk/flowRenderer-elk.js
@@ -717,7 +717,7 @@ const insertEdge = function (edgesEl, edge, edgeData, diagObj, parentLookupDb) {
   const edgePath = edgesEl
     .insert('path')
     .attr('d', curve(points))
-    .attr('class', 'path')
+    .attr('class', 'path ' + edgeData.classes)
     .attr('fill', 'none');
   const edgeG = edgesEl.insert('g').attr('class', 'edgeLabel');
   const edgeWithLabel = select(edgeG.node().appendChild(edge.labelEl));


### PR DESCRIPTION
## :bookmark_tabs: Summary

For SVGs generated using the `flowchart` graph, the edges has helper classes:
```html
<path d="...." id="L-SOURCE-DEST-0" class=" edge-thickness-normal edge-pattern-solid flowchart-link LS-SOURCE LE-DEST" ....></path>
```
However, when using `flowchart-elk`, the edges no longer has those classes, only "path".

This CR fixes this issue by adding them.

## :straight_ruler: Design Decisions

In [`addEdges`](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/diagrams/flowchart/elk/flowRenderer-elk.js#L527), `edgeData.classes` is initiated with the relevant classes, but it is never used. The CR modify `addEdge` to append them to the end of `classes`.

About tests: I wrote the most simple test, since I'm not really familiar with the project. It checks only for `flowchart-link`.

### :clipboard: Tasks

Make sure you

- [X] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [X] :computer: have added unit/e2e tests (if appropriate)
- [X] :notebook: have added documentation (if appropriate)
- [X] :bookmark: targeted `develop` branch
