### PR TITLE
Changed C4 stereotype braces to «»

### DIFF
--- a/packages/mermaid/src/diagrams/c4/c4Renderer.js
+++ b/packages/mermaid/src/diagrams/c4/c4Renderer.js
@@ -220,7 +220,7 @@ export const drawC4ShapeArray = function (currentBounds, diagram, c4ShapeArray, 
     let c4ShapeTypeConf = c4ShapeFont(conf, c4Shape.typeC4Shape.text);
     c4ShapeTypeConf.fontSize = c4ShapeTypeConf.fontSize - 2;
     c4Shape.typeC4Shape.width = calculateTextWidth(
-      '<<' + c4Shape.typeC4Shape.text + '>>',
+      '«' + c4Shape.typeC4Shape.text + '»',
       c4ShapeTypeConf
     );
     c4Shape.typeC4Shape.height = c4ShapeTypeConf.fontSize + 2;
@@ -665,13 +665,13 @@ export const draw = function (_text, id, _version, diagObj) {
   diagram.attr(
     'viewBox',
     box.startx -
-      conf.diagramMarginX +
-      ' -' +
-      (conf.diagramMarginY + extraVertForTitle) +
-      ' ' +
-      width +
-      ' ' +
-      (height + extraVertForTitle)
+    conf.diagramMarginX +
+    ' -' +
+    (conf.diagramMarginY + extraVertForTitle) +
+    ' ' +
+    width +
+    ' ' +
+    (height + extraVertForTitle)
   );
 
   log.debug(`models:`, box);


### PR DESCRIPTION
## :bookmark_tabs: Summary

Changed C4 stereotype braces to `«` and `»` which in my opinion make for neater stereotype braces

No issue raised regarding this suggestion

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

There is no specification for the precise character used to brace a stereotype in UML, but some tools choose to use Unicode Character 'LEFT-POINTING DOUBLE ANGLE QUOTATION MARK' (U+00AB) and Unicode Character 'RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK' (U+00BB), such as Rational Software Architect and uml-diagrams.org.
The use of `<<` and `>>` is typically due to simplicity of entering these characters on a western alphabet keyboard.

### :clipboard: Tasks

Make sure you

- [X] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [X] :notebook: have added documentation (if appropriate)
- [X] :bookmark: targeted `develop` branch
