### PR TITLE
Update docs: Added Nextra to Blogs category on integrations page

### DIFF
--- a/packages/mermaid/src/docs/ecosystem/integrations.md
+++ b/packages/mermaid/src/docs/ecosystem/integrations.md
@@ -53,6 +53,8 @@ They also serve as proof of concept, for the variety of things that can be built
   - [hexo-filter-mermaid-diagrams](https://github.com/webappdevelp/hexo-filter-mermaid-diagrams)
   - [hexo-tag-mermaid](https://github.com/JameChou/hexo-tag-mermaid)
   - [hexo-mermaid-diagrams](https://github.com/mslxl/hexo-mermaid-diagrams)
+- [Nextra](https://nextra.site/)
+  - [Mermaid](https://nextra.site/docs/guide/mermaid)
 
 ## CMS
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

This PR adds Nextra to the Blogs category on the integrations page. This change allows users to easily access Nextra's integration documentation directly from the Mermaid website, enhancing the ecosystem's reach and making it easier for users to find resources related to Mermaid.

## :straight_ruler: Design Decisions

Added the Nextra entry in the Blogs section following the existing format and maintaining alphabetical order. This decision was made to keep consistency in the design and layout of the page.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [x] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
