### PR TITLE
Fix link to Tutorials from n00b-overview page

### DIFF
--- a/docs/community/n00b-overview.md
+++ b/docs/community/n00b-overview.md
@@ -69,6 +69,6 @@ In fact one can pick up the syntax for it quite easily from the examples given a
 
 ## Mermaid is for everyone.
 
-Video [Tutorials](https://mermaid-js.github.io/mermaid/#/../config/Tutorials) are also available for the mermaid [live editor](https://mermaid.live/).
+Video [Tutorials](https://mermaid-js.github.io/mermaid/#/./Tutorials) are also available for the mermaid [live editor](https://mermaid.live/).
 
 Alternatively you can use Mermaid [Plug-Ins](https://mermaid-js.github.io/mermaid/#/./integrations), with tools you already use, like Google Docs.

--- a/docs/community/n00b-overview.md
+++ b/docs/community/n00b-overview.md
@@ -69,6 +69,6 @@ In fact one can pick up the syntax for it quite easily from the examples given a
 
 ## Mermaid is for everyone.
 
-Video [Tutorials](https://mermaid-js.github.io/mermaid/#/./Tutorials) are also available for the mermaid [live editor](https://mermaid.live/).
+Video [Tutorials](https://mermaid.js.org/config/Tutorials.html) are also available for the mermaid [live editor](https://mermaid.live/).
 
 Alternatively you can use Mermaid [Plug-Ins](https://mermaid-js.github.io/mermaid/#/./integrations), with tools you already use, like Google Docs.

--- a/packages/mermaid/src/docs/community/n00b-overview.md
+++ b/packages/mermaid/src/docs/community/n00b-overview.md
@@ -63,6 +63,6 @@ In fact one can pick up the syntax for it quite easily from the examples given a
 
 ## Mermaid is for everyone.
 
-Video [Tutorials](https://mermaid-js.github.io/mermaid/#/./Tutorials) are also available for the mermaid [live editor](https://mermaid.live/).
+Video [Tutorials](https://mermaid.js.org/config/Tutorials.html) are also available for the mermaid [live editor](https://mermaid.live/).
 
 Alternatively you can use Mermaid [Plug-Ins](https://mermaid-js.github.io/mermaid/#/./integrations), with tools you already use, like Google Docs.

--- a/packages/mermaid/src/docs/community/n00b-overview.md
+++ b/packages/mermaid/src/docs/community/n00b-overview.md
@@ -63,6 +63,6 @@ In fact one can pick up the syntax for it quite easily from the examples given a
 
 ## Mermaid is for everyone.
 
-Video [Tutorials](https://mermaid-js.github.io/mermaid/#/../config/Tutorials) are also available for the mermaid [live editor](https://mermaid.live/).
+Video [Tutorials](https://mermaid-js.github.io/mermaid/#/./Tutorials) are also available for the mermaid [live editor](https://mermaid.live/).
 
 Alternatively you can use Mermaid [Plug-Ins](https://mermaid-js.github.io/mermaid/#/./integrations), with tools you already use, like Google Docs.


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fix link to Tutorials from n00b-overview page. Currently clicking on the link navigates you to the homepage rather than the "Tutorials" page.

Tested with new link `https://mermaid.js.org/#/./Tutorials` and was redirected correctly to Tutorials page.

Resolves (no issue)

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests (if appropriate)
- [x] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
