### PR TITLE
Fix typo in quadrant chart documentation

### DIFF
--- a/packages/mermaid/src/docs/syntax/quadrantChart.md
+++ b/packages/mermaid/src/docs/syntax/quadrantChart.md
@@ -133,6 +133,6 @@ quadrantChart
   y-axis Not Important --> "Important ❤"
   quadrant-1 Plan
   quadrant-2 Do
-  quadrant-3 Deligate
+  quadrant-3 Delegate
   quadrant-4 Delete
 ```


### PR DESCRIPTION
## :bookmark_tabs: Summary

This is just a typo fix.

## :straight_ruler: Design Decisions

N/A

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
