### PR TITLE
fix(flowchart): apply style on doublecircle

### DIFF
--- a/packages/mermaid/src/dagre-wrapper/nodes.js
+++ b/packages/mermaid/src/dagre-wrapper/nodes.js
@@ -602,6 +602,8 @@ const doublecircle = async (parent, node) => {
   const outerCircle = circleGroup.insert('circle');
   const innerCircle = circleGroup.insert('circle');
 
+  circleGroup.attr('class', node.class);
+
   // center the circle around its coordinate
   outerCircle
     .attr('style', node.style)


### PR DESCRIPTION
## :bookmark_tabs: Summary

Correctly apply CSS through classes on double circle shape

Resolves #4536 

## :straight_ruler: Design Decisions

Double circles are two `circle` svg tags inside a `g` tag that group them.
It looks like this:

```svg
<g class="myClass defaultClasses">
    <g>
        <circle></circle>
        <circle></circle>
    </g>
    <g class="label">...</g>
</g>
```

Generated CSS rules will be `myClass > * {...}` and `myClass span {...}` because of this line
https://github.com/mermaid-js/mermaid/blob/2fe5750be1a4f482229e875fd30b380da92f72a1/packages/mermaid/src/mermaidAPI.ts#L210

Our two `circle` tags won't be directly targeted by these CSS rules, so other rules (such as the ones provided by a theme) can override CSS defined in `classDef`.

To fix it,  we add the classes to the `g` tag that is the parent of the two `circle` tags:
```svg
<g class="myClass defaultClasses">
    <g class="myClass">
        <circle></circle>
        <circle></circle>
    </g>
    <g class="label">...</g>
</g>
```

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added unit/e2e tests -> not appropriate
- [ ] :notebook: have added documentation -> not appropriate
- [x] :bookmark: targeted `develop` branch
