### PR TITLE
Remove all TypeScript enums and forbid them in ESLint

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -123,6 +123,14 @@ module.exports = {
       files: ['*.{ts,tsx}'],
       plugins: ['tsdoc'],
       rules: {
+        'no-restricted-syntax': [
+          'error',
+          {
+            selector: 'TSEnumDeclaration',
+            message:
+              'Prefer using TypeScript union types over TypeScript enum, since TypeScript enums have a bunch of issues, see https://dev.to/dvddpl/whats-the-problem-with-typescript-enums-2okj',
+          },
+        ],
         'tsdoc/syntax': 'error',
       },
     },

--- a/packages/mermaid/src/config.ts
+++ b/packages/mermaid/src/config.ts
@@ -226,9 +226,11 @@ export const reset = (config = siteConfig): void => {
   updateCurrentConfig(config, directives);
 };
 
-enum ConfigWarning {
-  'LAZY_LOAD_DEPRECATED' = 'The configuration options lazyLoadedDiagrams and loadExternalDiagramsAtStartup are deprecated. Please use registerExternalDiagrams instead.',
-}
+const ConfigWarning = {
+  LAZY_LOAD_DEPRECATED:
+    'The configuration options lazyLoadedDiagrams and loadExternalDiagramsAtStartup are deprecated. Please use registerExternalDiagrams instead.',
+} as const;
+
 type ConfigWarningStrings = keyof typeof ConfigWarning;
 const issuedWarnings: { [key in ConfigWarningStrings]?: boolean } = {};
 const issueWarning = (warning: ConfigWarningStrings) => {

--- a/packages/mermaid/src/config.type.ts
+++ b/packages/mermaid/src/config.type.ts
@@ -412,18 +412,8 @@ export interface FlowchartDiagramConfig extends BaseDiagramConfig {
   wrappingWidth?: number;
 }
 
-export enum SankeyLinkColor {
-  source = 'source',
-  target = 'target',
-  gradient = 'gradient',
-}
-
-export enum SankeyNodeAlignment {
-  left = 'left',
-  right = 'right',
-  center = 'center',
-  justify = 'justify',
-}
+export type SankeyLinkColor = 'source' | 'target' | 'gradient';
+export type SankeyNodeAlignment = 'left' | 'right' | 'center' | 'justify';
 
 export interface SankeyDiagramConfig extends BaseDiagramConfig {
   width?: number;

--- a/packages/mermaid/src/defaultConfig.ts
+++ b/packages/mermaid/src/defaultConfig.ts
@@ -1,5 +1,5 @@
 import theme from './themes/index.js';
-import { MermaidConfig, SankeyLinkColor, SankeyNodeAlignment } from './config.type.js';
+import { type MermaidConfig } from './config.type.js';
 /**
  * **Configuration methods in Mermaid version 8.6.0 have been updated, to learn more[[click
  * here](8.6.0_docs.md)].**
@@ -2273,8 +2273,8 @@ const config: Partial<MermaidConfig> = {
   sankey: {
     width: 800,
     height: 400,
-    linkColor: SankeyLinkColor.gradient,
-    nodeAlignment: SankeyNodeAlignment.justify,
+    linkColor: 'gradient',
+    nodeAlignment: 'justify',
     useMaxWidth: false,
   },
   fontSize: 16,

--- a/packages/mermaid/src/diagrams/sankey/sankeyRenderer.ts
+++ b/packages/mermaid/src/diagrams/sankey/sankeyRenderer.ts
@@ -18,17 +18,17 @@ import {
 } from 'd3-sankey';
 import { configureSvgSize } from '../../setupGraphViewbox.js';
 import { Uid } from '../../rendering-util/uid.js';
-import { SankeyLinkColor, SankeyNodeAlignment } from '../../config.type.js';
+import type { SankeyLinkColor, SankeyNodeAlignment } from '../../config.type.js';
 
 // Map config options to alignment functions
 const alignmentsMap: Record<
   SankeyNodeAlignment,
   (node: d3SankeyNode<object, object>, n: number) => number
 > = {
-  [SankeyNodeAlignment.left]: d3SankeyLeft,
-  [SankeyNodeAlignment.right]: d3SankeyRight,
-  [SankeyNodeAlignment.center]: d3SankeyCenter,
-  [SankeyNodeAlignment.justify]: d3SankeyJustify,
+  left: d3SankeyLeft,
+  right: d3SankeyRight,
+  center: d3SankeyCenter,
+  justify: d3SankeyJustify,
 };
 
 /**
@@ -157,9 +157,9 @@ export const draw = function (text: string, id: string, _version: string, diagOb
     .attr('class', 'link')
     .style('mix-blend-mode', 'multiply');
 
-  const linkColor = conf?.linkColor || SankeyLinkColor.gradient;
+  const linkColor = conf?.linkColor || 'gradient';
 
-  if (linkColor === SankeyLinkColor.gradient) {
+  if (linkColor === 'gradient') {
     const gradient = link
       .append('linearGradient')
       .attr('id', (d: any) => (d.uid = Uid.next('linearGradient-')).id)
@@ -180,13 +180,13 @@ export const draw = function (text: string, id: string, _version: string, diagOb
 
   let coloring: any;
   switch (linkColor) {
-    case SankeyLinkColor.gradient:
+    case 'gradient':
       coloring = (d: any) => d.uid;
       break;
-    case SankeyLinkColor.source:
+    case 'source':
       coloring = (d: any) => colorScheme(d.source.id);
       break;
-    case SankeyLinkColor.target:
+    case 'target':
       coloring = (d: any) => colorScheme(d.target.id);
       break;
     default:


### PR DESCRIPTION
## :bookmark_tabs: Summary

[TypeScript enums][1] are an unusual TypeScript feature, because it's one of the only features that is "not a type-level extension of JavaScript".

This means TypeScript generates custom code for enums, which can cause a bunch of issues, especially as this custom code can be built differently depending on which bundler you use, and because of this, many people discourage the use of enums:

- [The Dangers of TypeScript Enums][2]
- [Tidy TypeScript: Prefer union types over enums][3]
- [TypeScript: Handbook - Enums # Objects vs Enums][4]

In fact, even the official TypeScript handbook says:

> Enums are a feature added to JavaScript by TypeScript which allows for describing a value which could be one of a set of possible named constants. Unlike most TypeScript features, this is _not_ a type-level addition to JavaScript but something added to the language and runtime. Because of this, it’s a feature which you should know exists, but maybe hold off on using unless you are sure.
>
> Taken from https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#enums, used under the [CC BY 4.0 License](https://github.com/microsoft/TypeScript-Website/blob/d27c2d4f44beeb5578d4d5efbcd7f070da44ab5e/LICENSE).

I've also added an ESLint rule to ban TypeScript enums, using the [`no-restricted-syntax` ESLint rule](https://github.com/typescript-eslint/typescript-eslint/blob/dbb70ee41600760b64521bcc63528aa5c30fca85/docs/getting-started/linting/FAQ.md#how-can-i-ban-specific-language-feature).

### Better alternatives for TypeScript enums

For public APIs (e.g. that non-Mermaid users will use), it's better to use string literals, e.g.:

```ts
export type MyValue = "a" | "b" | "c";
```

For internal use, [`const` assertions where added in TypeScript 3.4](https://devblogs.microsoft.com/typescript/announcing-typescript-3-4/#const-assertions) and can be used to create enum-like objects in plain JavaScript, that act like TypeScript enums, but has none of the downsides of TypeScript enums.

Using a JavaScript object and `as const` performs pretty much exactly the same as a TypeScript enum, without the downsides of a TypeScript enum:

```ts
const MyEnum = {
  ABC: "my-string-val",
  DEF: "my-other-enum-val",
} as const;
```

[1]: https://www.typescriptlang.org/docs/handbook/enums.html#string-enums
[2]: https://dev.to/azure/the-dangers-of-typescript-enums-55pd
[3]: https://fettblog.eu/tidy-typescript-avoid-enums/
[4]: https://www.typescriptlang.org/docs/handbook/enums.html#objects-vs-enums

## :straight_ruler: Design Decisions

**Important**: This is a breaking change to the MermaidConfig Sankey diagram type. However, since the Sankey diagram PR was only merged yesterday (see https://github.com/mermaid-js/mermaid/pull/4502), as long as this PR is merged before the next Mermaid release, this change will be fine.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
  - ESLint rule added.
- [x] :notebook: have added documentation (if appropriate)
  - Warning added to ESLint rule.
- [x] :bookmark: targeted `develop` branch
