### PR TITLE
Bug/4592 fix new line padding class diagram

### DIFF
--- a/cypress/integration/rendering/classDiagram.spec.js
+++ b/cypress/integration/rendering/classDiagram.spec.js
@@ -1,7 +1,7 @@
 import { imgSnapshotTest, renderGraph } from '../../helpers/util.js';
 
 describe('Class diagram', () => {
-  it('1: should render a simple class diagram', () => {
+  it('should render a simple class diagram', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -35,7 +35,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('2: should render a simple class diagrams with cardinality', () => {
+  it('should render a simple class diagrams with cardinality', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -64,7 +64,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('3: should render a simple class diagram with different visibilities', () => {
+  it('should render a simple class diagram with different visibilities', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -82,7 +82,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('4: should render a simple class diagram with comments', () => {
+  it('should render a simple class diagram with comments', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -112,7 +112,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('5: should render a simple class diagram with abstract method', () => {
+  it('should render a simple class diagram with abstract method', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -124,7 +124,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('6: should render a simple class diagram with static method', () => {
+  it('should render a simple class diagram with static method', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -136,7 +136,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('7: should render a simple class diagram with Generic class', () => {
+  it('should render a simple class diagram with Generic class', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -156,7 +156,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('8: should render a simple class diagram with Generic class and relations', () => {
+  it('should render a simple class diagram with Generic class and relations', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -177,7 +177,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('9: should render a simple class diagram with clickable link', () => {
+  it('should render a simple class diagram with clickable link', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -199,7 +199,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('10: should render a simple class diagram with clickable callback', () => {
+  it('should render a simple class diagram with clickable callback', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -221,7 +221,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('11: should render a simple class diagram with return type on method', () => {
+  it('should render a simple class diagram with return type on method', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -236,7 +236,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('12: should render a simple class diagram with generic types', () => {
+  it('should render a simple class diagram with generic types', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -252,7 +252,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('13: should render a simple class diagram with css classes applied', () => {
+  it('should render a simple class diagram with css classes applied', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -270,7 +270,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('14: should render a simple class diagram with css classes applied directly', () => {
+  it('should render a simple class diagram with css classes applied directly', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -286,7 +286,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('15: should render a simple class diagram with css classes applied to multiple classes', () => {
+  it('should render a simple class diagram with css classes applied to multiple classes', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -301,7 +301,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('16: should render multiple class diagrams', () => {
+  it('should render multiple class diagrams', () => {
     imgSnapshotTest(
       [
         `
@@ -354,7 +354,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  // it('17: should render a class diagram when useMaxWidth is true (default)', () => {
+  // it('should render a class diagram when useMaxWidth is true (default)', () => {
   //   renderGraph(
   //     `
   //   classDiagram
@@ -382,7 +382,7 @@ describe('Class diagram', () => {
   //     });
   // });
 
-  // it('18: should render a class diagram when useMaxWidth is false', () => {
+  // it('should render a class diagram when useMaxWidth is false', () => {
   //   renderGraph(
   //     `
   //   classDiagram
@@ -408,7 +408,7 @@ describe('Class diagram', () => {
   //     });
   // });
 
-  it('19: should render a simple class diagram with notes', () => {
+  it('should render a simple class diagram with notes', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -424,7 +424,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('20: should render class diagram with newlines in title', () => {
+  it('should render class diagram with newlines in title', () => {
     imgSnapshotTest(`
       classDiagram
         Animal <|-- \`Du\nck\`
@@ -442,7 +442,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('21: should render class diagram with many newlines in title', () => {
+  it('should render class diagram with many newlines in title', () => {
     imgSnapshotTest(`
     classDiagram
       class \`This\nTitle\nHas\nMany\nNewlines\` {
@@ -456,7 +456,7 @@ describe('Class diagram', () => {
     `);
   });
 
-  it('22: should render with newlines in title and an annotation', () => {
+  it('should render with newlines in title and an annotation', () => {
     imgSnapshotTest(`
     classDiagram
       class \`This\nTitle\nHas\nMany\nNewlines\` {
@@ -467,11 +467,11 @@ describe('Class diagram', () => {
         -Many()
         #Methods()
       }
-      &lt;&lt;Interface&gt;&gt; \`This\nTitle\nHas\nMany\nNewlines\`  
+      &lt;&lt;Interface&gt;&gt; \`This\nTitle\nHas\nMany\nNewlines\`
     `);
   });
 
-  it('23: should handle newline title in namespace', () => {
+  it('should handle newline title in namespace', () => {
     imgSnapshotTest(`
     classDiagram
       namespace testingNamespace {

--- a/cypress/integration/rendering/classDiagram.spec.js
+++ b/cypress/integration/rendering/classDiagram.spec.js
@@ -486,4 +486,19 @@ describe('Class diagram', () => {
     }
     `);
   });
+
+  it('should handle newline in string label', () => {
+    imgSnapshotTest(`
+      classDiagram
+        class A["This has\na newline!"] {
+          +String boop
+          -Int beep
+          #double bop
+        }
+
+        class B["This title also has\na newline"]
+        B : +with(more)
+        B : -methods()
+      `);
+  });
 });

--- a/cypress/integration/rendering/classDiagram.spec.js
+++ b/cypress/integration/rendering/classDiagram.spec.js
@@ -424,7 +424,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('20: should render class diagram with newlines in title', () => {
+  it('should render class diagram with newlines in title', () => {
     imgSnapshotTest(`
       classDiagram
         Animal <|-- \`Du\nck\`
@@ -442,7 +442,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('21: should render class diagram with many newlines in title', () => {
+  it('should render class diagram with many newlines in title', () => {
     imgSnapshotTest(`
     classDiagram
       class \`This\nTitle\nHas\nMany\nNewlines\` {
@@ -456,7 +456,7 @@ describe('Class diagram', () => {
     `);
   });
 
-  it('22: should render with newlines in title and an annotation', () => {
+  it('should render with newlines in title and an annotation', () => {
     imgSnapshotTest(`
     classDiagram
       class \`This\nTitle\nHas\nMany\nNewlines\` {
@@ -471,7 +471,7 @@ describe('Class diagram', () => {
     `);
   });
 
-  it('23: should handle newline title in namespace', () => {
+  it('should handle newline title in namespace', () => {
     imgSnapshotTest(`
     classDiagram
       namespace testingNamespace {

--- a/cypress/integration/rendering/classDiagram.spec.js
+++ b/cypress/integration/rendering/classDiagram.spec.js
@@ -1,7 +1,7 @@
 import { imgSnapshotTest, renderGraph } from '../../helpers/util.js';
 
 describe('Class diagram', () => {
-  it('should render a simple class diagram', () => {
+  it('1: should render a simple class diagram', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -35,7 +35,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('should render a simple class diagrams with cardinality', () => {
+  it('2: should render a simple class diagrams with cardinality', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -64,7 +64,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('should render a simple class diagram with different visibilities', () => {
+  it('3: should render a simple class diagram with different visibilities', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -82,7 +82,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('should render a simple class diagram with comments', () => {
+  it('4: should render a simple class diagram with comments', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -112,7 +112,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('should render a simple class diagram with abstract method', () => {
+  it('5: should render a simple class diagram with abstract method', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -124,7 +124,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('should render a simple class diagram with static method', () => {
+  it('6: should render a simple class diagram with static method', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -136,7 +136,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('should render a simple class diagram with Generic class', () => {
+  it('7: should render a simple class diagram with Generic class', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -156,7 +156,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('should render a simple class diagram with Generic class and relations', () => {
+  it('8: should render a simple class diagram with Generic class and relations', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -177,7 +177,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('should render a simple class diagram with clickable link', () => {
+  it('9: should render a simple class diagram with clickable link', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -199,7 +199,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('should render a simple class diagram with clickable callback', () => {
+  it('10: should render a simple class diagram with clickable callback', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -221,7 +221,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('should render a simple class diagram with return type on method', () => {
+  it('11: should render a simple class diagram with return type on method', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -236,7 +236,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('should render a simple class diagram with generic types', () => {
+  it('12: should render a simple class diagram with generic types', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -252,7 +252,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('should render a simple class diagram with css classes applied', () => {
+  it('13: should render a simple class diagram with css classes applied', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -270,7 +270,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('should render a simple class diagram with css classes applied directly', () => {
+  it('14: should render a simple class diagram with css classes applied directly', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -286,7 +286,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('should render a simple class diagram with css classes applied to multiple classes', () => {
+  it('15: should render a simple class diagram with css classes applied to multiple classes', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -301,7 +301,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('should render multiple class diagrams', () => {
+  it('16: should render multiple class diagrams', () => {
     imgSnapshotTest(
       [
         `
@@ -354,7 +354,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  // it('should render a class diagram when useMaxWidth is true (default)', () => {
+  // it('17: should render a class diagram when useMaxWidth is true (default)', () => {
   //   renderGraph(
   //     `
   //   classDiagram
@@ -382,7 +382,7 @@ describe('Class diagram', () => {
   //     });
   // });
 
-  // it('should render a class diagram when useMaxWidth is false', () => {
+  // it('18: should render a class diagram when useMaxWidth is false', () => {
   //   renderGraph(
   //     `
   //   classDiagram
@@ -408,7 +408,7 @@ describe('Class diagram', () => {
   //     });
   // });
 
-  it('should render a simple class diagram with notes', () => {
+  it('19: should render a simple class diagram with notes', () => {
     imgSnapshotTest(
       `
     classDiagram
@@ -424,7 +424,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('should render class diagram with newlines in title', () => {
+  it('20: should render class diagram with newlines in title', () => {
     imgSnapshotTest(`
       classDiagram
         Animal <|-- \`Du\nck\`
@@ -442,7 +442,7 @@ describe('Class diagram', () => {
     cy.get('svg');
   });
 
-  it('should render class diagram with many newlines in title', () => {
+  it('21: should render class diagram with many newlines in title', () => {
     imgSnapshotTest(`
     classDiagram
       class \`This\nTitle\nHas\nMany\nNewlines\` {
@@ -456,7 +456,7 @@ describe('Class diagram', () => {
     `);
   });
 
-  it('should render with newlines in title and an annotation', () => {
+  it('22: should render with newlines in title and an annotation', () => {
     imgSnapshotTest(`
     classDiagram
       class \`This\nTitle\nHas\nMany\nNewlines\` {
@@ -467,11 +467,11 @@ describe('Class diagram', () => {
         -Many()
         #Methods()
       }
-      &lt;&lt;Interface&gt;&gt; \`This\nTitle\nHas\nMany\nNewlines\`
+      &lt;&lt;Interface&gt;&gt; \`This\nTitle\nHas\nMany\nNewlines\`  
     `);
   });
 
-  it('should handle newline title in namespace', () => {
+  it('23: should handle newline title in namespace', () => {
     imgSnapshotTest(`
     classDiagram
       namespace testingNamespace {

--- a/cypress/integration/rendering/classDiagram.spec.js
+++ b/cypress/integration/rendering/classDiagram.spec.js
@@ -423,4 +423,67 @@ describe('Class diagram', () => {
     );
     cy.get('svg');
   });
+
+  it('20: should render class diagram with newlines in title', () => {
+    imgSnapshotTest(`
+      classDiagram
+        Animal <|-- \`Du\nck\`
+        Animal : +int age
+        Animal : +String gender
+        Animal: +isMammal()
+        Animal: +mate()
+        class \`Du\nck\` {
+          +String beakColor
+          +String featherColor
+          +swim()
+          +quack()
+        }
+      `);
+    cy.get('svg');
+  });
+
+  it('21: should render class diagram with many newlines in title', () => {
+    imgSnapshotTest(`
+    classDiagram
+      class \`This\nTitle\nHas\nMany\nNewlines\` {
+        +String Also
+        -Stirng Many
+        #int Members
+        +And()
+        -Many()
+        #Methods()
+      }
+    `);
+  });
+
+  it('22: should render with newlines in title and an annotation', () => {
+    imgSnapshotTest(`
+    classDiagram
+      class \`This\nTitle\nHas\nMany\nNewlines\` {
+        +String Also
+        -Stirng Many
+        #int Members
+        +And()
+        -Many()
+        #Methods()
+      }
+      &lt;&lt;Interface&gt;&gt; \`This\nTitle\nHas\nMany\nNewlines\`  
+    `);
+  });
+
+  it('23: should handle newline title in namespace', () => {
+    imgSnapshotTest(`
+    classDiagram
+      namespace testingNamespace {
+      class \`This\nTitle\nHas\nMany\nNewlines\` {
+        +String Also
+        -Stirng Many
+        #int Members
+        +And()
+        -Many()
+        #Methods()
+      }
+    }
+    `);
+  });
 });

--- a/packages/mermaid/src/dagre-wrapper/nodes.js
+++ b/packages/mermaid/src/dagre-wrapper/nodes.js
@@ -937,8 +937,8 @@ const class_box = (parent, node) => {
       'transform',
       'translate( ' + -maxWidth / 2 + ', ' + ((-1 * maxHeight) / 2 + verticalPos) + ')'
     );
-    const methodBBox = lbl ? lbl.getBBox() : null;
-    verticalPos += (methodBBox.height ?? 0) + rowPadding;
+    const memberBBox = lbl?.getBBox();
+    verticalPos += (memberBBox?.height ?? 0) + rowPadding;
   });
 
   rect

--- a/packages/mermaid/src/dagre-wrapper/nodes.js
+++ b/packages/mermaid/src/dagre-wrapper/nodes.js
@@ -917,7 +917,9 @@ const class_box = (parent, node) => {
         ((-1 * maxHeight) / 2 + verticalPos + lineHeight / 2) +
         ')'
     );
-    verticalPos += classTitleBBox.height + rowPadding;
+    //get the height of the bounding box of each member if exists
+    const memberBBox = lbl ? lbl.getBBox() : null;
+    verticalPos += (memberBBox.height ?? 0) + rowPadding;
   });
 
   verticalPos += lineHeight;
@@ -935,7 +937,8 @@ const class_box = (parent, node) => {
       'transform',
       'translate( ' + -maxWidth / 2 + ', ' + ((-1 * maxHeight) / 2 + verticalPos) + ')'
     );
-    verticalPos += classTitleBBox.height + rowPadding;
+    const methodBBox = lbl ? lbl.getBBox() : null;
+    verticalPos += (methodBBox.height ?? 0) + rowPadding;
   });
 
   rect

--- a/packages/mermaid/src/dagre-wrapper/nodes.js
+++ b/packages/mermaid/src/dagre-wrapper/nodes.js
@@ -918,8 +918,8 @@ const class_box = (parent, node) => {
         ')'
     );
     //get the height of the bounding box of each member if exists
-    const memberBBox = lbl ? lbl.getBBox() : null;
-    verticalPos += (memberBBox.height ?? 0) + rowPadding;
+    const memberBBox = lbl?.getBBox();
+    verticalPos += (memberBBox?.height ?? 0) + rowPadding;
   });
 
   verticalPos += lineHeight;


### PR DESCRIPTION
## :bookmark_tabs: Summary

Changes how class member height adds to class diagram overall height

Resolves #4592 

## :straight_ruler: Design Decisions

Previously, for each class member the title height was added assuming the titleHeight was a single line. Now, we calculate the height of each member's Bounding Box and add it to the vertical position to render the class properly

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added unit/e2e tests (if appropriate)
- [ ] :notebook: have added documentation (if appropriate)
- [x] :bookmark: targeted `develop` branch
