### PR TITLE
Feature/1768 sequencediagram custom grouping

### DIFF
--- a/packages/mermaid/src/diagrams/sequence/sequenceDb.js
+++ b/packages/mermaid/src/diagrams/sequence/sequenceDb.js
@@ -299,6 +299,8 @@ export const LINETYPE = {
   BREAK_START: 30,
   BREAK_END: 31,
   PAR_OVER_START: 32,
+  GROUP_START: 33,
+  GROUP_END: 34,
 };
 
 export const ARROWTYPE = {
@@ -591,6 +593,12 @@ export const apply = function (param) {
         break;
       case 'breakEnd':
         addSignal(undefined, undefined, undefined, param.signalType);
+        break;
+      case 'groupStart':
+        addSignal(undefined, undefined, param.groupText, param.signalType);
+        break;
+      case 'groupEnd':
+        addSignal(undefined, undefined, param.groupLabel, param.signalType);
         break;
     }
   }

--- a/packages/mermaid/src/diagrams/sequence/sequenceDiagram.spec.js
+++ b/packages/mermaid/src/diagrams/sequence/sequenceDiagram.spec.js
@@ -1099,6 +1099,32 @@ sequenceDiagram
     expect(messages[4].type).toBe(diagram.db.LINETYPE.BREAK_END);
     expect(messages[5].from).toBe('API');
   });
+  it('should handle group statements', async () => {
+    const str = `
+sequenceDiagram
+    Alice-->Bob: I have a secret
+    Bob-->Alice: What is it?
+    group:Whisper So nobody hears
+        Alice-->Bob: I love you
+    end
+    Bob-->Alice: AAAAAAHHhhh!!!`;
+
+    await mermaidAPI.parse(str);
+    const actors = diagram.db.getActors();
+
+    expect(actors.Consumer.description).toBe('Consumer');
+    expect(actors.API.description).toBe('API');
+
+    const messages = diagram.db.getMessages();
+
+    expect(messages.length).toBe(6);
+    expect(messages[0].from).toBe('Alice');
+    expect(messages[1].from).toBe('Bob');
+    expect(messages[2].type).toBe(diagram.db.LINETYPE.GROUP_START);
+    expect(messages[3].from).toBe('API');
+    expect(messages[4].type).toBe(diagram.db.LINETYPE.GROUP_END);
+    expect(messages[5].from).toBe('API');
+  });
   it('should handle par statements a sequenceDiagram', async () => {
     const str = `
 sequenceDiagram

--- a/packages/mermaid/src/diagrams/sequence/sequenceRenderer.ts
+++ b/packages/mermaid/src/diagrams/sequence/sequenceRenderer.ts
@@ -991,6 +991,22 @@ export const draw = function (_text: string, id: string, _version: string, diagO
         bounds.bumpVerticalPos(loopModel.stopy - bounds.getVerticalPos());
         bounds.models.addLoop(loopModel);
         break;
+      case diagObj.db.LINETYPE.GROUP_START:
+        adjustLoopHeightForWrap(
+          loopWidths,
+          msg,
+          conf.boxMargin,
+          conf.boxMargin + conf.boxTextMargin,
+          (message) => bounds.newLoop(message)
+        );
+        break;
+      case diagObj.db.LINETYPE.GROUP_END:
+        loopModel = bounds.endLoop();
+        conf.labelBoxWidth = msg.message.length * 10;
+        svgDraw.drawLoop(diagram, loopModel, msg.message, conf);
+        bounds.bumpVerticalPos(loopModel.stopy - bounds.getVerticalPos());
+        bounds.models.addLoop(loopModel);
+        break;
       default:
         try {
           msgModel = msg.msgModel;
@@ -1467,6 +1483,15 @@ const calculateLoopBounds = function (messages, actors, _maxWidthPerActor, diagO
           width: 0,
         });
         break;
+      case diagObj.db.LINETYPE.GROUP_START:
+        stack.push({
+          id: msg.id,
+          msg: msg.message,
+          from: Number.MAX_SAFE_INTEGER,
+          to: Number.MIN_SAFE_INTEGER,
+          width: 0,
+        });
+        break;
       case diagObj.db.LINETYPE.ALT_ELSE:
       case diagObj.db.LINETYPE.PAR_AND:
       case diagObj.db.LINETYPE.CRITICAL_OPTION:
@@ -1483,6 +1508,10 @@ const calculateLoopBounds = function (messages, actors, _maxWidthPerActor, diagO
       case diagObj.db.LINETYPE.PAR_END:
       case diagObj.db.LINETYPE.CRITICAL_END:
       case diagObj.db.LINETYPE.BREAK_END:
+        current = stack.pop();
+        loops[current.id] = current;
+        break;
+      case diagObj.db.LINETYPE.GROUP_END:
         current = stack.pop();
         loops[current.id] = current;
         break;

--- a/packages/mermaid/src/docs/syntax/sequenceDiagram.md
+++ b/packages/mermaid/src/docs/syntax/sequenceDiagram.md
@@ -369,6 +369,30 @@ sequenceDiagram
     API-->BillingService: Start billing process
 ```
 
+## Custom Grouping
+
+It is possible to create a group of actions similar to those described above, but with a custom label.
+
+This is done by the notation
+
+```
+group:label [description]
+... statements ...
+end
+```
+
+See the example below:
+
+```
+sequenceDiagram
+    Alice-->Bob: I have a secret
+    Bob-->Alice: What is it?
+    group:Whisper So nobody hears
+        Alice-->Bob: I love you
+    end
+    Bob-->Alice: AAAAAAHHhhh!!!
+```
+
 ## Background Highlighting
 
 It is possible to highlight flows by providing colored background rects. This is done by the notation


### PR DESCRIPTION
## :bookmark_tabs: Summary

Adds method for creating a grouping of actions (similar to loop, alt, break), but with a custom label.

Resolves #<your issue id here>

## :straight_ruler: Design Decisions

Syntax uses "group" as a keyword, followed by a colon, followed by the custom label.  White space around the colon is optional.

Example:

group:label [description]
... statements ...
end

### :clipboard: Tasks

Make sure you

- [ ] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/docs/community/development.md#3-update-documentation) is used for all new features.
- [ ] :bookmark: targeted `develop` branch
