### PR TITLE
chore(deps): unpin the dompurify dependency

### DIFF
--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -67,7 +67,7 @@
     "d3-sankey": "^0.12.3",
     "dagre-d3-es": "7.0.10",
     "dayjs": "^1.11.7",
-    "dompurify": "3.0.5",
+    "dompurify": "^3.0.5",
     "elkjs": "^0.8.2",
     "khroma": "^2.0.0",
     "lodash-es": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,7 +218,7 @@ importers:
         specifier: ^1.11.7
         version: 1.11.7
       dompurify:
-        specifier: 3.0.5
+        specifier: ^3.0.5
         version: 3.0.5
       elkjs:
         specifier: ^0.8.2


### PR DESCRIPTION
## :bookmark_tabs: Summary

Unpins the `DOMPurify` dependency. Resolves concerns at https://github.com/mermaid-js/mermaid/pull/3735

## Why

This is because:

1. The consumers of Mermaid end up with a specific version of `DOMPurify` pulled in, and to de-duplicate that they'd need to use sort of resolutions or overrides.

2. As `DOMPurify` is a security library, it'd benefit to get regular updates and keep things secure by default.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/docs/community/development.md#3-update-documentation) is used for all new features.
- [x] :bookmark: targeted `develop` branch
