### PR TITLE
ci(release-drafter): add more release notes categories

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,14 +1,27 @@
 name-template: '$NEXT_PATCH_VERSION'
 tag-template: '$NEXT_PATCH_VERSION'
 categories:
+  - title: '🚨 **Breaking Changes**'
+    labels:
+      - 'Breaking Change'
   - title: '🚀 Features'
     labels:
       - 'Type: Enhancement'
+      - 'feature' # deprecated, new PRs shouldn't have this
   - title: '🐛 Bug Fixes'
     labels:
       - 'Type: Bug / Error'
+      - 'fix' # deprecated, new PRs shouldn't have this
   - title: '🧰 Maintenance'
-    label: 'Type: Other'
+    labels:
+      - 'Type: Other'
+      - 'chore' # deprecated, new PRs shouldn't have this
+  - title: '⚡️ Performance'
+    labels:
+      - 'Type: Performance'
+  - title: '📚 Documentation'
+    labels:
+      - 'Area: Documentation'
 change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
 sort-by: title
 sort-direction: ascending


### PR DESCRIPTION
## :bookmark_tabs: Summary

Add the following new categories to the release notes:
  - **BREAKING CHANGES**
  - Performance
  - Documentation

I've also made the `feature`, `fix`, and `chore` label point to their appropriate section.

This should make it a bit easier for @sidharthv96 and/or @knsv to make the release notes!

## :straight_ruler: Design Decisions

Although the `feature`/`fix`/`chore` labels shouldn't be used on new PRs, some PRs still have those labels, due to an old PR labeler configuration, so I've kept them in for backwards compatibility.

I've picked the emoji to use for each section from https://github.com/favoloso/conventional-changelog-emoji.

At some point, I'd also like to somehow move [@renovate[bot]](https://github.com/renovatebot/renovate) PRs into their own section, maybe by automatically labeling them with the **dependencies** label, and using that? But that would be a bit more work, so it's something I can do in a future PR.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/docs/community/development.md#3-update-documentation) is used for all new features.
- [x] :bookmark: targeted `develop` branch
