### PR TITLE
Wait for `theme-directives.html` E2E test to render before taking a screenshot

### DIFF
--- a/cypress/integration/rendering/conf-and-directives.spec.js
+++ b/cypress/integration/rendering/conf-and-directives.spec.js
@@ -1,4 +1,4 @@
-import { imgSnapshotTest } from '../../helpers/util.ts';
+import { imgSnapshotTest, urlSnapshotTest } from '../../helpers/util.ts';
 
 describe('Configuration and directives - nodes should be light blue', () => {
   it('No config - use default', () => {
@@ -206,8 +206,7 @@ graph TD
   describe('when rendering several diagrams', () => {
     it('diagrams should not taint later diagrams', () => {
       const url = 'http://localhost:9000/theme-directives.html';
-      cy.visit(url);
-      cy.matchImageSnapshot('conf-and-directives.spec-when-rendering-several-diagrams-diagram-1');
+      urlSnapshotTest(url, {});
     });
   });
 });

--- a/cypress/platform/theme-directives.html
+++ b/cypress/platform/theme-directives.html
@@ -1,15 +1,6 @@
 <html>
   <head>
-    <link href="https://fonts.googleapis.com/css?family=Montserrat&display=swap" rel="stylesheet" />
     <link href="https://unpkg.com/tailwindcss@^1.0/dist/tailwind.min.css" rel="stylesheet" />
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"
-    />
-    <link
-      href="https://fonts.googleapis.com/css?family=Noto+Sans+SC&display=swap"
-      rel="stylesheet"
-    />
     <style>
       body {
         /* background: rgb(221, 208, 208); */
@@ -122,27 +113,15 @@
 
     <script type="module">
       import mermaid from './mermaid.esm.mjs';
-      mermaid.parseError = function (err, hash) {
-        // console.error('Mermaid error: ', err);
-      };
+
       mermaid.initialize({
-        // theme: 'dark',
-        // theme: 'dark',
-        // arrowMarkerAbsolute: true,
-        // themeCSS: '.edgePath .path {stroke: red;} .arrowheadPath {fill: red;}',
         logLevel: 0,
-        // flowchart: { useMaxWidth: true },
         graph: { curve: 'cardinal', htmlLabels: false },
-        // gantt: { axisFormat: '%m/%d/%Y' },
         sequence: { actorMargin: 50, showSequenceNumbers: true },
-        // sequenceDiagram: { actorMargin: 300 } // deprecated
         fontFamily: '"arial", sans-serif',
         curve: 'cardinal',
         securityLevel: 'strict',
       });
-      function callback() {
-        alert('It worked');
-      }
     </script>
   </body>
 </html>

--- a/cypress/platform/theme-directives.html
+++ b/cypress/platform/theme-directives.html
@@ -121,7 +121,14 @@
         fontFamily: '"arial", sans-serif',
         curve: 'cardinal',
         securityLevel: 'strict',
+        startOnLoad: false,
       });
+
+      await mermaid.run();
+
+      if (window.Cypress) {
+        window.rendered = true;
+      }
     </script>
   </body>
 </html>


### PR DESCRIPTION
## :bookmark_tabs: Summary

The `theme-directives.html` test currently sometimes takes a screenshot before all of the Mermaid diagrams have completed rendering.

This can result in the following error message when running `pnpm run e2e`:

```
1) Configuration and directives - nodes should be light blue
when rendering several diagrams
  diagrams should not taint later diagrams:
Error: Image was 23.384242424242423% different from saved snapshot with 154336 different pixels.
See diff for details: /mermaid/cypress/snapshots/rendering/conf-and-directives.spec.js/__diff_output__/conf-and-directives.spec-when-rendering-several-diagrams-diagram-1.diff.png
at Context.eval (webpack:///./node_modules/.pnpm/cypress-image-snapshot@4.0.1_cypress@12.10.0_jest@29.5.0/node_modules/cypress-image-snapshot/command.js:51:0)
```

![conf-and-directives spec-when-rendering-several-diagrams-diagram-1 diff](https://github.com/mermaid-js/mermaid/assets/19716675/5f6d9f5f-956b-47d5-a837-f81725ef58ba)

## Notes to reviewer

I'm not sure why we're only detecting this issue now in our E2E tests. Maybe https://github.com/mermaid-js/mermaid/pull/4759 changed some performance parameters, and that made the race-condition occur on my PC. Who knows, it could also just be because one of our dependencies updated, or now my PC is overheating and is running slightly slower :laughing:

Also, because this is just a test change, I've labelled this PR as **Skip changelog**, since there's no point in putting it in the release notes.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/docs/community/development.md#3-update-documentation) is used for all new features.
- [x] :bookmark: targeted `develop` branch
