### PR TITLE
Wait for `marker_unique_id.html` E2E test to render before taking a screenshot

### DIFF
--- a/cypress/platform/marker_unique_id.html
+++ b/cypress/platform/marker_unique_id.html
@@ -42,7 +42,8 @@
     </pre>
     <script type="module">
       import mermaid from './mermaid.esm.mjs';
-      mermaid.initialize({ startOnLoad: true, logLevel: 0 });
+      mermaid.initialize({ startOnLoad: false, logLevel: 0 });
+      await mermaid.run();
 
       if (window.Cypress) {
         window.rendered = true;


### PR DESCRIPTION
## :bookmark_tabs: Summary

Sometimes, Cypress takes the screenshot for [`cypress/platform/marker_unique_id.html`](https://github.com/mermaid-js/mermaid/blob/4201e4775d9206a5fc44006a2e26747cfc10ef78/cypress/platform/marker_unique_id.html) early, before mermaid has finished rendering the diagrams. This results in the following error when running `pnpm run e2e`:

```
  Running:  marker_unique_id.spec.js                                                        (1 of 1)


  Marker Unique IDs Per Diagram
    1) should render a blue arrow tip in second digram


  0 passing (4s)
  1 failing

  1) Marker Unique IDs Per Diagram
       should render a blue arrow tip in second digram:
     Error: Image size (1000x688) different than saved snapshot size (1000x854).
See diff for details: /mermaid/cypress/snapshots/marker_unique_id.spec.js/__diff_output__/Marker-Unique-IDs-Per-Diagram-should-render-a-blue-arrow-tip-in-second-digram.diff.png
      at Context.eval (webpack:///./node_modules/.pnpm/cypress-image-snapshot@4.0.1_cypress@12.10.0_jest@29.5.0/node_modules/cypress-image-snapshot/command.js:51:0)
```

![Marker-Unique-IDs-Per-Diagram-should-render-a-blue-arrow-tip-in-second-digram diff](https://github.com/mermaid-js/mermaid/assets/19716675/55f7045a-8766-4313-a4ff-8ebdd3406364)

Fixes: 924c9e913b665f22f9a3401dbf31857579833ca4 and bceae92d3021498543f6eb90aff0c5755b0f3117 (from PR https://github.com/mermaid-js/mermaid/pull/4825)

## :straight_ruler: Design Decision

Instead of taking a screenshot instantly, I've told Cypress to wait until it can see 4 SVGs on the given HTML page.

Because this is just a test change, I've labelled this PR as **Skip changelog**, since there's no point in putting it in the release notes.

Requesting a review from @sidharthv96, as they helped write these Cypress E2E tests a few days ago in https://github.com/mermaid-js/mermaid/pull/4825 :smile:.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/docs/community/development.md#3-update-documentation) is used for all new features.
- [x] :bookmark: targeted `develop` branch
