### PR TITLE
prevent-inherited-lineheights-on-edgeterminal-4083

### DIFF
--- a/packages/mermaid/src/diagrams/class/styles.js
+++ b/packages/mermaid/src/diagrams/class/styles.js
@@ -146,6 +146,7 @@ g.classGroup line {
 
 .edgeTerminals {
   font-size: 11px;
+  line-height: initial;
 }
 
 .classTitleText {


### PR DESCRIPTION
## :bookmark_tabs: Summary

A small css fix to prevent line-height from being inherited onto the edgeterminal label.
Preventing labels from appearing trimmed from having a higher line-height than intended.

Resolves #4083

## :straight_ruler: Design Decisions

line-height: initial sets the value back to the default, and has no effect if nothing is written.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/docs/community/development.md#3-update-documentation) is used for all new features.
- [x] :bookmark: targeted `develop` branch
