### PR TITLE
bug: #4905 change shiki theme to github-light

### DIFF
--- a/packages/mermaid/src/docs/.vitepress/config.ts
+++ b/packages/mermaid/src/docs/.vitepress/config.ts
@@ -4,7 +4,7 @@ import { defineConfig, MarkdownOptions } from 'vitepress';
 
 const allMarkdownTransformers: MarkdownOptions = {
   // the shiki theme to highlight code blocks
-  theme: 'github-dark',
+  theme: 'github-light',
   config: async (md) => {
     await MermaidExample(md);
   },

--- a/packages/mermaid/src/docs/.vitepress/config.ts
+++ b/packages/mermaid/src/docs/.vitepress/config.ts
@@ -6,7 +6,7 @@ const allMarkdownTransformers: MarkdownOptions = {
   // the shiki theme to highlight code blocks
   theme: {
     light: 'github-light',
-    dark: 'github-dark'
+    dark: 'github-dark',
   },
   config: async (md) => {
     await MermaidExample(md);

--- a/packages/mermaid/src/docs/.vitepress/config.ts
+++ b/packages/mermaid/src/docs/.vitepress/config.ts
@@ -4,7 +4,10 @@ import { defineConfig, MarkdownOptions } from 'vitepress';
 
 const allMarkdownTransformers: MarkdownOptions = {
   // the shiki theme to highlight code blocks
-  theme: 'github-light',
+  theme: {
+    light: 'github-light',
+    dark: 'github-dark'
+  },
   config: async (md) => {
     await MermaidExample(md);
   },


### PR DESCRIPTION
## :bookmark_tabs: Summary

Changes the theme of shiki to github-light in order to propertly show all text with the light background
another way around could be to change the code block background to a darker one,
please let me know if you prefer it that way.

Resolves #4905

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

before / after
![image](https://github.com/mermaid-js/mermaid/assets/2723336/da8da43b-f79c-4f96-81d3-b3659e6e524a)


### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/docs/community/development.md#3-update-documentation) is used for all new features.
- [x] :bookmark: targeted `develop` branch
