### PR TITLE
bug/#3251_linkStyle-can't-specify-ids Fixed

### DIFF
--- a/packages/mermaid/src/diagrams/flowchart/flowDb.js
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.js
@@ -194,7 +194,7 @@ export const updateLink = function (positions, style) {
   positions.forEach(function (pos) {
     if (pos >= edges.length) {
       let error = new Error(
-        `Incorrect index ${pos} of linkStyle. (Help: Index must be from 0 to ${edges.length - 1})`
+        `The index for linkStyle is out of bounds. (Help: Ensure that the index is within the range of existing edges.)`
       );
       throw error;
     }

--- a/packages/mermaid/src/diagrams/flowchart/flowDb.js
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.js
@@ -192,6 +192,12 @@ export const updateLinkInterpolate = function (positions, interp) {
  */
 export const updateLink = function (positions, style) {
   positions.forEach(function (pos) {
+    if (pos >= edges.length) {
+      let error = new Error(
+        `Incorrect index ${pos} of linkStyle. (Help: Index must be from 0 to ${edges.length - 1})`
+      );
+      throw error;
+    }
     if (pos === 'default') {
       edges.defaultStyle = style;
     } else {

--- a/packages/mermaid/src/diagrams/flowchart/flowDb.js
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.js
@@ -193,10 +193,11 @@ export const updateLinkInterpolate = function (positions, interp) {
 export const updateLink = function (positions, style) {
   positions.forEach(function (pos) {
     if (pos >= edges.length) {
-      let error = new Error(
-        `The index for linkStyle is out of bounds. (Help: Ensure that the index is within the range of existing edges.)`
+      throw new Error(
+        `The index ${pos} for linkStyle is out of bounds. Valid indices for linkStyle are between 0 and ${
+          edges.length - 1
+        }. (Help: Ensure that the index is within the range of existing edges.)`
       );
-      throw error;
     }
     if (pos === 'default') {
       edges.defaultStyle = style;

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow-style.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow-style.spec.js
@@ -287,7 +287,23 @@ describe('[Style] when parsing', () => {
   });
 
   it('should handle style definitions within number of edges', function () {
-    const res = flow.parser.parse('graph TD\n' + 'A-->B\n' + 'linkStyle 0 stroke-width:1px;');
+    try {
+      flow.parser.parse(`graph TD
+      A-->B
+      linkStyle 1 stroke-width:1px;`);
+      // Fail test if above expression doesn't throw anything.
+      expect(true).toBe(false);
+    } catch (e) {
+      expect(e.message).toBe(
+        `The index for linkStyle is out of bounds. (Help: Ensure that the index is within the range of existing edges.)`
+      );
+    }
+  });
+
+  it('should handle style definitions within number of edges', function () {
+    const res = flow.parser.parse(`graph TD
+    A-->B
+    linkStyle 0 stroke-width:1px;`);
 
     const edges = flow.parser.yy.getEdges();
 

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow-style.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow-style.spec.js
@@ -287,17 +287,17 @@ describe('[Style] when parsing', () => {
   });
 
   it('should handle style definitions within number of edges', function () {
-    try {
-      flow.parser.parse(`graph TD
-      A-->B
-      linkStyle 1 stroke-width:1px;`);
-      // Fail test if above expression doesn't throw anything.
-      expect(true).toBe(false);
-    } catch (e) {
-      expect(e.message).toBe(
-        `The index for linkStyle is out of bounds. (Help: Ensure that the index is within the range of existing edges.)`
-      );
-    }
+    expect(() =>
+      flow.parser
+        .parse(
+          `graph TD
+    A-->B
+    linkStyle 1 stroke-width:1px;`
+        )
+        .toThrow(
+          'The index 1 for linkStyle is out of bounds. Valid indices for linkStyle are between 0 and 0. (Help: Ensure that the index is within the range of existing edges.)'
+        )
+    );
   });
 
   it('should handle style definitions within number of edges', function () {

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow-style.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow-style.spec.js
@@ -286,6 +286,14 @@ describe('[Style] when parsing', () => {
     expect(edges[0].type).toBe('arrow_point');
   });
 
+  it('should handle style definitions within number of edges', function () {
+    const res = flow.parser.parse('graph TD\n' + 'A-->B\n' + 'linkStyle 0 stroke-width:1px;');
+
+    const edges = flow.parser.yy.getEdges();
+
+    expect(edges[0].style[0]).toBe('stroke-width:1px');
+  });
+
   it('should handle multi-numbered style definitions with more then 1 digit in a row', function () {
     const res = flow.parser.parse(
       'graph TD\n' +


### PR DESCRIPTION
## :bookmark_tabs: Summary

In my fix, I've added a condition to handle the case where the index provided in linkStyle is greater than or equal to the length of the edges array. This provides a clear error message to the user and prevents a TypeError from occurring.

Resolves #3251

## :straight_ruler: Design Decisions

The implementation ensures that if the user attempts to apply a style to an index that exceeds the number of available edges, an error message will be displayed.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/docs/community/development.md#3-update-documentation) is used for all new features.
- [x] :bookmark: targeted `develop` branch
