### PR TITLE
Bug/#4497 Unable to Cherry Pick Merge Commit Solved

### DIFF
--- a/packages/mermaid/src/diagrams/git/gitGraphAst.js
+++ b/packages/mermaid/src/diagrams/git/gitGraphAst.js
@@ -256,7 +256,7 @@ export const merge = function (otherBranch, custom_id, override_type, custom_tag
   log.debug('in mergeBranch');
 };
 
-export const cherryPick = function (sourceId, targetId, tag) {
+export const cherryPick = function (sourceId, targetId, tag, parentCommit) {
   log.debug('Entering cherryPick:', sourceId, targetId, tag);
   sourceId = common.sanitizeText(sourceId, configApi.getConfig());
   targetId = common.sanitizeText(targetId, configApi.getConfig());
@@ -275,21 +275,35 @@ export const cherryPick = function (sourceId, targetId, tag) {
     };
     throw error;
   }
-
   let sourceCommit = commits[sourceId];
   let sourceCommitBranch = sourceCommit.branch;
   if (sourceCommit.type === commitType.MERGE) {
-    let error = new Error(
-      'Incorrect usage of "cherryPick". Source commit should not be a merge commit'
-    );
-    error.hash = {
-      text: 'cherryPick ' + sourceId + ' ' + targetId,
-      token: 'cherryPick ' + sourceId + ' ' + targetId,
-      line: '1',
-      loc: { first_line: 1, last_line: 1, first_column: 1, last_column: 1 },
-      expected: ['cherry-pick abc'],
-    };
-    throw error;
+    if (!parentCommit) {
+      let error = new Error(
+        'Incorrect usage of cherryPick: If the source commit is a merge commit, an immediate parent commit must be specified.'
+      );
+      error.hash = {
+        text: 'cherryPick ' + sourceId + ' ' + targetId,
+        token: 'cherryPick ' + sourceId + ' ' + targetId,
+        line: '1',
+        loc: { first_line: 1, last_line: 1, first_column: 1, last_column: 1 },
+        expected: ['cherry-pick abc'],
+      };
+      throw error;
+    }
+    if (!(Array.isArray(sourceCommit.parents) && sourceCommit.parents.includes(parentCommit))) {
+      let error = new Error(
+        'Invalid operation: The specified parent commit is not an immediate parent of the cherry-picked commit.'
+      );
+      error.hash = {
+        text: 'cherryPick ' + sourceId + ' ' + targetId,
+        token: 'cherryPick ' + sourceId + ' ' + targetId,
+        line: '1',
+        loc: { first_line: 1, last_line: 1, first_column: 1, last_column: 1 },
+        expected: ['cherry-pick abc'],
+      };
+      throw error;
+    }
   }
   if (!targetId || commits[targetId] === undefined) {
     // cherry-pick source commit to current branch
@@ -328,7 +342,11 @@ export const cherryPick = function (sourceId, targetId, tag) {
       parents: [head == null ? null : head.id, sourceCommit.id],
       branch: curBranch,
       type: commitType.CHERRY_PICK,
-      tag: tag ?? 'cherry-pick:' + sourceCommit.id,
+      tag: tag
+        ? `${tag}${sourceCommit.type === commitType.MERGE ? ` | parent: ${parentCommit}` : ''}`
+        : `cherry-pick: ${sourceCommit.id}${
+            sourceCommit.type === commitType.MERGE ? ` | parent: ${parentCommit}` : ''
+          }`,
     };
     head = commit;
     commits[commit.id] = commit;

--- a/packages/mermaid/src/diagrams/git/parser/gitGraph.jison
+++ b/packages/mermaid/src/diagrams/git/parser/gitGraph.jison
@@ -39,6 +39,7 @@ branch(?=\s|$)                          return 'BRANCH';
 "order:"                                return 'ORDER';
 merge(?=\s|$)                           return 'MERGE';
 cherry\-pick(?=\s|$)                    return 'CHERRY_PICK';
+"parent:"                               return 'PARENT_COMMIT'
 // "reset"                                 return 'RESET';
 checkout(?=\s|$)                        return 'CHECKOUT';
 "LR"                                    return 'DIR';
@@ -109,10 +110,15 @@ branchStatement
 
 cherryPickStatement
     : CHERRY_PICK COMMIT_ID STR {yy.cherryPick($3, '', undefined)}
+    | CHERRY_PICK COMMIT_ID STR PARENT_COMMIT STR {yy.cherryPick($3, '', undefined,$5)}
     | CHERRY_PICK COMMIT_ID STR COMMIT_TAG STR {yy.cherryPick($3, '', $5)}
+    | CHERRY_PICK COMMIT_ID STR PARENT_COMMIT STR COMMIT_TAG STR {yy.cherryPick($3, '', $7,$5)}
+    | CHERRY_PICK COMMIT_ID STR COMMIT_TAG STR PARENT_COMMIT STR {yy.cherryPick($3, '', $5,$7)}
     | CHERRY_PICK COMMIT_ID STR COMMIT_TAG EMPTYSTR {yy.cherryPick($3, '', '')}
-    | CHERRY_PICK COMMIT_TAG STR COMMIT_ID STR {yy.cherryPick($5, '', $3)}
-    | CHERRY_PICK COMMIT_TAG EMPTYSTR COMMIT_ID STR {yy.cherryPick($3, '', '')}
+    | CHERRY_PICK COMMIT_ID STR PARENT_COMMIT STR COMMIT_TAG EMPTYSTR {yy.cherryPick($3, '', '',$5)}
+    | CHERRY_PICK COMMIT_ID STR COMMIT_TAG EMPTYSTR PARENT_COMMIT STR {yy.cherryPick($3, '', '',$7)}
+    | CHERRY_PICK COMMIT_TAG STR COMMIT_ID STR PARENT_COMMIT STR {yy.cherryPick($5, '', $3,$7)}
+    | CHERRY_PICK COMMIT_TAG EMPTYSTR COMMIT_ID STR PARENT_COMMIT STR{yy.cherryPick($5, '', '',$7)}
     ;
 
 mergeStatement


### PR DESCRIPTION
## :bookmark_tabs: Summary

Cherry-pick a merge commit, requires a special flag because merge commits have more than one parent. When you cherry-pick a regular commit, Git knows to take the changes from the parent commit to the chosen commit. In the case of a merge commit, there are multiple parent commits, so you have to specify which parent's context you want to use for the cherry-pick.
If you try to cherry-pick a merge commit without specifying a parent, Git won't know what changes to apply and will prompt you to specify a mainline parent.


Resolves #4497 

## :straight_ruler: Design Decisions

The Pull Request addresses this issue by introducing additional syntax to the parser and modifying the cherryPick function to handle merge commit cherry-picking scenarios properly. Specifically:

A new identifier, PARENT_COMMIT, was introduced in the parser syntax to allow users to specify the parent commit when cherry-picking a merge commit.

The cherryPick function was enhanced to validate and handle the parentCommitId parameter when dealing with merge commits. It now checks if the specified parent commit is an immediate parent of the merge commit being cherry-picked and throws descriptive errors when incorrect usage is detected.
The function also handles tagging and branch checks to ensure the cherry-pick operation's correctness and to provide informative feedback to the user regarding any incorrect usage.

With these enhancements, users can now accurately represent cherry-picking merge commits within their Mermaid Git diagrams, improving the library's functionality and usability for illustrating complex Git workflows. The new syntax and function logic cover various cherry-picking scenarios, providing a robust solution to the initially reported problem.

### :clipboard: Tasks

Make sure you

- [ ] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/docs/community/development.md#3-update-documentation) is used for all new features.
- [ ] :bookmark: targeted `develop` branch
