### PR TITLE
fix case that generate broken link on docs

### DIFF
--- a/packages/mermaid/src/docs/.vitepress/config.ts
+++ b/packages/mermaid/src/docs/.vitepress/config.ts
@@ -150,7 +150,7 @@ function sidebarSyntax() {
         { text: 'Timeline 🔥', link: '/syntax/timeline' },
         { text: 'Zenuml 🔥', link: '/syntax/zenuml' },
         { text: 'Sankey 🔥', link: '/syntax/sankey' },
-        { text: 'XYChart 🔥', link: '/syntax/xychart' },
+        { text: 'XYChart 🔥', link: '/syntax/xyChart' },
         { text: 'Other Examples', link: '/syntax/examples' },
       ],
     },


### PR DESCRIPTION
## :bookmark_tabs: Summary

Documentation url are case sensitive. This Typo generate broken link on all the documentation page when you want to go to XYchart.

## :clipboard: Tasks

Make sure you

- [X] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [X] :computer: have added necessary unit/e2e tests.
- [X] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/docs/community/development.md#3-update-documentation) is used for all new features.
- [X] :bookmark: targeted `develop` branch
