### PR TITLE
fix(flow): fix invalid ellipseText regex

### DIFF
--- a/packages/mermaid/src/diagrams/flowchart/parser/flow-text.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow-text.spec.js
@@ -535,6 +535,10 @@ describe('[Text] when parsing', () => {
     expect(vert['A'].text).toBe('this is an ellipse');
   });
 
+  it('should not freeze when ellipse text has a `(`', function () {
+    expect(() => flow.parser.parse('graph\nX(- My Text (')).toThrowError();
+  });
+
   it('should handle text in diamond vertices with space', function () {
     const res = flow.parser.parse('graph TD;A(chimpansen hoppar)-->C;');
 

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
@@ -134,7 +134,7 @@ that id.
 <*>\s*\~\~[\~]+\s*              return 'LINK';
 
 <ellipseText>[-/\)][\)]         { this.popState(); return '-)'; }
-<ellipseText>[^\(\)\[\]\{\}]|-/!\)+       return "TEXT"
+<ellipseText>[^\(\)\[\]\{\}]|-\!\)+       return "TEXT"
 <*>"(-"                         { this.pushState("ellipseText"); return '(-'; }
 
 <text>"])"                { this.popState(); return 'STADIUMEND'; }


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fixes an invalid regex that was causing flowcharts to freeze if there was an ellipse node that had a `(` character in the text.

E.g.

````markdown

The following diagram freezes in Mermaid v10.6.0

```mermaid
flowchart
  X(- My Text (
```
````

Resolves https://github.com/mermaid-js/mermaid/issues/4964

## :straight_ruler: Design Decisions

I'm not 100% sure why this was causing a freeze (shouldn't JISON throw an error instead?), but this seems to fix the issue, so :shrug:.

As a side-note, if this test freezes, it completely locks up Vitest (setting a `timeout` parameter doesn't seem to help). We could instead run this test in a [`child_process`](https://nodejs.org/api/child_process.html), but since creating a child process is pretty slow normally, so it's probably not worth slowing down our unit tests for it.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/docs/community/development.md#3-update-documentation) is used for all new features.
- [x] :bookmark: targeted `develop` branch
