### PR TITLE
fix: render the participants in same order as they are created

### DIFF
--- a/demos/sequence.html
+++ b/demos/sequence.html
@@ -164,6 +164,13 @@
       end
     </pre>
 
+    <pre class="mermaid">
+    sequenceDiagram
+      actor Alice
+      actor John
+      Alice-xJohn: Hello John, how are you?
+      John--xAlice: Great!
+    </pre>
     <script type="module">
       import mermaid from './mermaid.esm.mjs';
       mermaid.initialize({
@@ -174,7 +181,7 @@
         flowchart: { curve: 'basis' },
         gantt: { axisFormat: '%m/%d/%Y' },
         sequence: { actorMargin: 50 },
-        // sequenceDiagram: { actorMargin: 300 } // deprecated
+        sequenceDiagram: { actorMargin: 300 }, // deprecated
       });
     </script>
   </body>

--- a/demos/sequence.html
+++ b/demos/sequence.html
@@ -181,7 +181,7 @@
         flowchart: { curve: 'basis' },
         gantt: { axisFormat: '%m/%d/%Y' },
         sequence: { actorMargin: 50 },
-        // sequenceDiagram: { actorMargin: 300 }, // deprecated
+        // sequenceDiagram: { actorMargin: 300 } // deprecated
       });
     </script>
   </body>

--- a/demos/sequence.html
+++ b/demos/sequence.html
@@ -181,7 +181,7 @@
         flowchart: { curve: 'basis' },
         gantt: { axisFormat: '%m/%d/%Y' },
         sequence: { actorMargin: 50 },
-        sequenceDiagram: { actorMargin: 300 }, // deprecated
+        // sequenceDiagram: { actorMargin: 300 }, // deprecated
       });
     </script>
   </body>

--- a/packages/mermaid/src/diagrams/sequence/sequenceRenderer.ts
+++ b/packages/mermaid/src/diagrams/sequence/sequenceRenderer.ts
@@ -829,6 +829,11 @@ export const draw = function (_text: string, id: string, _version: string, diagO
     bounds.insert(activationData.startx, verticalPos - 10, activationData.stopx, verticalPos);
   }
 
+  log.debug('createdActors', createdActors);
+  log.debug('destroyedActors', destroyedActors);
+
+  drawActors(diagram, actors, actorKeys, false);
+
   // Draw the messages/signals
   let sequenceIndex = 1;
   let sequenceIndexStep = 1;
@@ -1028,14 +1033,12 @@ export const draw = function (_text: string, id: string, _version: string, diagO
     }
   });
 
-  log.debug('createdActors', createdActors);
-  log.debug('destroyedActors', destroyedActors);
-
-  drawActors(diagram, actors, actorKeys, false);
   messagesToDraw.forEach((e) => drawMessage(diagram, e.messageModel, e.lineStartY, diagObj));
+
   if (conf.mirrorActors) {
     drawActors(diagram, actors, actorKeys, true);
   }
+
   backgrounds.forEach((e) => svgDraw.drawBackgroundRect(diagram, e));
   fixLifeLineHeights(diagram, actors, actorKeys, conf);
 

--- a/packages/mermaid/src/diagrams/sequence/svgDraw.js
+++ b/packages/mermaid/src/diagrams/sequence/svgDraw.js
@@ -324,7 +324,7 @@ const drawActorTypeParticipant = function (elem, actor, conf, isFooter) {
   const center = actor.x + actor.width / 2;
   const centerY = actorY + 5;
 
-  const boxpluslineGroup = elem.append('g').raise();
+  const boxpluslineGroup = elem.append('g');
   var g = boxpluslineGroup;
 
   if (!isFooter) {

--- a/packages/mermaid/src/diagrams/sequence/svgDraw.js
+++ b/packages/mermaid/src/diagrams/sequence/svgDraw.js
@@ -1038,7 +1038,6 @@ export default {
   drawText,
   drawLabel,
   drawActor,
-  drawActorTypeParticipant,
   drawBox,
   drawPopup,
   anchorElement,

--- a/packages/mermaid/src/diagrams/sequence/svgDraw.js
+++ b/packages/mermaid/src/diagrams/sequence/svgDraw.js
@@ -324,7 +324,7 @@ const drawActorTypeParticipant = function (elem, actor, conf, isFooter) {
   const center = actor.x + actor.width / 2;
   const centerY = actorY + 5;
 
-  const boxpluslineGroup = elem.append('g').lower();
+  const boxpluslineGroup = elem.append('g').raise();
   var g = boxpluslineGroup;
 
   if (!isFooter) {
@@ -1038,6 +1038,7 @@ export default {
   drawText,
   drawLabel,
   drawActor,
+  drawActorTypeParticipant,
   drawBox,
   drawPopup,
   anchorElement,


### PR DESCRIPTION
## :bookmark_tabs: Summary
Until v10.2.4, the order of DOM nodes was fine - which means that participant actors were rendered in same order as creation. However in https://github.com/mermaid-js/mermaid/commit/d06bb05c5fe7544ec2b34cfa71c788e15f27499d the order was reversed using `.lower()` which is confusing, hence I am reverting to the previous behaviour.

I am not sure if the change was intentional but I hope this won't break any behaviour and tests are passing

Additionally I have added one more example in docs with actor symbols for sequence diagram as there were none with actor symbols.

Resolves #4946

## :straight_ruler: Design Decisions

Keeping the order same as creation simplifies and makes it more intutive

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/docs/community/development.md#3-update-documentation) is used for all new features.
- [x] :bookmark: targeted `develop` branch


I tried to add a unit test but unfortunately this is dependent on `D3.js` hence its not working out, I will need to mock the implementation of `lower`correctly  to make it work.