### PR TITLE
Adds parser support for commas in ER diagram attribute types

### DIFF
--- a/cypress/integration/rendering/er/erDiagram.spec.js
+++ b/cypress/integration/rendering/er/erDiagram.spec.js
@@ -239,6 +239,25 @@ describe('Entity Relationship Diagram', () => {
     );
   });
 
+  it('should render entities with unescaped attribute names or types containing commas or periods', () => {
+    imgSnapshotTest(
+      `
+    erDiagram
+        HOTEL {
+          string               address
+          GEOMETRY(point,4326) location
+          DECIMAL(10,2)        price_per_night
+        }
+        HOTEL ||--o{ ROOM : has
+        ROOM {
+          int room.number
+          string bed.type
+        }
+        `,
+      { loglevel: 1 }
+    );
+  });
+
   it('should render entities with keys', () => {
     renderGraph(
       `

--- a/packages/mermaid/src/diagrams/er/parser/erDiagram.jison
+++ b/packages/mermaid/src/diagrams/er/parser/erDiagram.jison
@@ -25,7 +25,7 @@ accDescr\s*"{"\s*                                { this.begin("acc_descr_multili
 <block>\s+                      /* skip whitespace in block */
 <block>\b((?:PK)|(?:FK)|(?:UK))\b      return 'ATTRIBUTE_KEY'
 <block>(.*?)[~](.*?)*[~]        return 'ATTRIBUTE_WORD';
-<block>[\*A-Za-z_][A-Za-z0-9\-_\[\]\(\)]*  return 'ATTRIBUTE_WORD'
+<block>[\*A-Za-z_][A-Za-z0-9\-_\[\]\(\),]*  return 'ATTRIBUTE_WORD'
 <block>\"[^"]*\"                return 'COMMENT';
 <block>[\n]+                    /* nothing */
 <block>"}"                      { this.popState(); return 'BLOCK_STOP'; }

--- a/packages/mermaid/src/diagrams/er/parser/erDiagram.jison
+++ b/packages/mermaid/src/diagrams/er/parser/erDiagram.jison
@@ -35,7 +35,7 @@ accDescr\s*"{"\s*                                { this.begin("acc_descr_multili
 <block>\s+                      /* skip whitespace in block */
 <block>\b((?:PK)|(?:FK)|(?:UK))\b      return 'ATTRIBUTE_KEY'
 <block>([^\s]*)[~].*[~]([^\s]*)        return 'ATTRIBUTE_WORD';
-<block>([\*A-Za-z_\u00C0-\uFFFF][A-Za-z0-9\-\_\[\]\(\)\u00C0-\uFFFF\*]*)  return 'ATTRIBUTE_WORD';
+<block>([\*A-Za-z_\u00C0-\uFFFF][A-Za-z0-9\-\_\[\]\(\)\.,\u00C0-\uFFFF\*]*)  return 'ATTRIBUTE_WORD';
 <block>[`]                      { this.begin("block_bq"); }
 <block_bq>[^`]+                 return 'ATTRIBUTE_WORD';
 <block_bq>[`]                   { this.popState(); }

--- a/packages/mermaid/src/diagrams/er/parser/erDiagram.spec.js
+++ b/packages/mermaid/src/diagrams/er/parser/erDiagram.spec.js
@@ -218,6 +218,16 @@ describe('when parsing ER diagram it...', function () {
       expect(entities[entity].attributes.length).toBe(1);
     });
 
+    it('should allow commas within an attribute type', () => {
+      const entity = 'BUILDING';
+      const attribute = 'location geometry(point,4326)';
+
+      erDiagram.parser.parse(`erDiagram\n${entity} {\n${attribute}}`);
+      const entities = erDb.getEntities();
+      expect(Object.keys(entities).length).toBe(1);
+      expect(entities[entity].attributes.length).toBe(1);
+    });
+
     it('should not allow leading numbers, dashes or brackets', function () {
       const entity = 'BOOK';
       const nonLeadingChars = '0-[]()';

--- a/packages/mermaid/src/diagrams/er/parser/erDiagram.spec.js
+++ b/packages/mermaid/src/diagrams/er/parser/erDiagram.spec.js
@@ -219,6 +219,20 @@ describe('when parsing ER diagram it...', function () {
       expect(entities.get(entity).attributes.length).toBe(1);
     });
 
+    it('should allow commas within an attribute type', () => {
+      const entity = 'BUILDING';
+      const type = 'public.geometry(point,4326)';
+      const name = 'location';
+      const attribute = `${type} ${name}`;
+
+      erDiagram.parser.parse(`erDiagram\n${entity} {\n${attribute}}`);
+      const entities = erDb.getEntities();
+      expect(entities.size).toBe(1);
+      expect(entities.get(entity).attributes.length).toBe(1);
+      expect(entities.get(entity).attributes[0].type).toBe(type);
+      expect(entities.get(entity).attributes[0].name).toBe(name);
+    });
+
     it('should not allow leading numbers, dashes or brackets', function () {
       const entity = 'BOOK';
       const nonLeadingChars = '0-[]()';


### PR DESCRIPTION
## :bookmark_tabs: Summary

This short patch adds support for commas in the attribute types of ER diagrams. This helps to support commonly used SQL types such as `NUMERIC(precision,scale)` (or `DECIMAL`) or `GEOMETRY(geometry_type,SRID)`. While ER diagrams are not exclusive to SQL, this kind of additional support may help others to leverage Mermaid's ER diagrams for the use case of describing SQL databases, without impacting functionality for those who aren't using ER diagrams for SQL.

AFAIK, this has not yet been reported as an issue.

## :straight_ruler: Design Decisions

The implementation is pretty straightforward:

- Added a `,` to the set of accepted characters in the ER diagram grammar (maybe this needs to be even more sophisticated by looking specifically for a comma-delimited list of tokens only within parentheses? let me know what you think!)
- Added a unit test to the ER diagram parser spec to ensure that it works

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added necessary unit/e2e tests.
- [x] ~:notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/docs/community/development.md#3-update-documentation) is used for all new features.~ I did not add any new documentation, as this might be considered a bug vs. a new feature. Let me know if you think this is relevant for this patch!
- [x] :bookmark: targeted `develop` branch
