### PR TITLE
docs/5199 Docs docker section run commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,8 +39,8 @@ That will be served at <http://localhost:9000/dev/your-file-name.html>.
 If you are using docker and docker-compose, you have self-documented `run` bash script, which is a convenient alias for docker-compose commands:
 
 ```bash
-./run install # npx pnpm install
-./run test # pnpm test
+./run pnpm install
+./run pnpm test
 ```
 
 ## Testing


### PR DESCRIPTION
The docker instructions for the runscript seem to not work:

```
./run install # npx pnpm install
./run test # pnpm test
```

This PR replaces them with the working ones:

```
./run pnpm install
./run pnpm test
```

## :bookmark_tabs: Summary

Brief description about the content of your PR.

Resolves [#<5199>](https://github.com/mermaid-js/mermaid/issues/5199)

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/docs/community/development.md#3-update-documentation) is used for all new features.
- [ ] :bookmark: targeted `develop` branch
