### PR TITLE
docs/add bidirectional arrows to supported types in sequence diagram

### DIFF
--- a/docs/syntax/sequenceDiagram.md
+++ b/docs/syntax/sequenceDiagram.md
@@ -198,18 +198,20 @@ Messages can be of two displayed either solid or with a dotted line.
 
     [Actor][Arrow][Actor]:Message text
 
-There are six types of arrows currently supported:
+There are ten types of arrows currently supported:
 
-| Type   | Description                                      |
-| ------ | ------------------------------------------------ |
-| `->`   | Solid line without arrow                         |
-| `-->`  | Dotted line without arrow                        |
-| `->>`  | Solid line with arrowhead                        |
-| `-->>` | Dotted line with arrowhead                       |
-| `-x`   | Solid line with a cross at the end               |
-| `--x`  | Dotted line with a cross at the end.             |
-| `-)`   | Solid line with an open arrow at the end (async) |
-| `--)`  | Dotted line with a open arrow at the end (async) |
+| Type    | Description                                                              |
+| ------- | ------------------------------------------------------------------------ |
+| `->`    | Solid line without arrow                                                 |
+| `-->`   | Dotted line without arrow                                                |
+| `->>`   | Solid line with arrowhead                                                |
+| `-->>`  | Dotted line with arrowhead                                               |
+| `->*>`  | Solid line with bidirectional arrowheads (v\<MERMAID_RELEASE_VERSION>+)  |
+| `-->*>` | Dotted line with bidirectional arrowheads (v\<MERMAID_RELEASE_VERSION>+) |
+| `-x`    | Solid line with a cross at the end                                       |
+| `--x`   | Dotted line with a cross at the end.                                     |
+| `-)`    | Solid line with an open arrow at the end (async)                         |
+| `--)`   | Dotted line with a open arrow at the end (async)                         |
 
 ## Activations
 

--- a/packages/mermaid/src/docs/syntax/sequenceDiagram.md
+++ b/packages/mermaid/src/docs/syntax/sequenceDiagram.md
@@ -141,18 +141,20 @@ Messages can be of two displayed either solid or with a dotted line.
 [Actor][Arrow][Actor]:Message text
 ```
 
-There are six types of arrows currently supported:
+There are ten types of arrows currently supported:
 
-| Type   | Description                                      |
-| ------ | ------------------------------------------------ |
-| `->`   | Solid line without arrow                         |
-| `-->`  | Dotted line without arrow                        |
-| `->>`  | Solid line with arrowhead                        |
-| `-->>` | Dotted line with arrowhead                       |
-| `-x`   | Solid line with a cross at the end               |
-| `--x`  | Dotted line with a cross at the end.             |
-| `-)`   | Solid line with an open arrow at the end (async) |
-| `--)`  | Dotted line with a open arrow at the end (async) |
+| Type    | Description                                                             |
+| ------- | ----------------------------------------------------------------------- |
+| `->`    | Solid line without arrow                                                |
+| `-->`   | Dotted line without arrow                                               |
+| `->>`   | Solid line with arrowhead                                               |
+| `-->>`  | Dotted line with arrowhead                                              |
+| `->*>`  | Solid line with bidirectional arrowheads (v<MERMAID_RELEASE_VERSION>+)  |
+| `-->*>` | Dotted line with bidirectional arrowheads (v<MERMAID_RELEASE_VERSION>+) |
+| `-x`    | Solid line with a cross at the end                                      |
+| `--x`   | Dotted line with a cross at the end.                                    |
+| `-)`    | Solid line with an open arrow at the end (async)                        |
+| `--)`   | Dotted line with a open arrow at the end (async)                        |
 
 ## Activations
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

Update documentation to support bidirectional arrows in sequence diagram (PR #5209)

## :straight_ruler: Design Decisions

n/a
### :clipboard: Tasks

Make sure you

- [X] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added necessary unit/e2e tests.
- [X] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/docs/community/contributing.md#update-documentation) is used for all new features.
- [X] :bookmark: targeted `develop` branch
