### PR TITLE
Add percentageDecimals options to pie chart, and use half even rounding

### DIFF
--- a/cypress/integration/rendering/pie.spec.ts
+++ b/cypress/integration/rendering/pie.spec.ts
@@ -74,11 +74,33 @@ describe('pie chart', () => {
     );
   });
 
+  it('should render a pie diagram when percentageDecimals is setted', () => {
+    imgSnapshotTest(
+      `pie
+        "Dogs" : 80
+        "Cats" : 86
+        "Rats" : 80
+      `,
+      { logLevel: 1, pie: { percentageDecimals: 2 } }
+    );
+  });
+
   it('should render a pie diagram with showData', () => {
     imgSnapshotTest(
       `pie showData
         "Dogs": 50
         "Cats": 25
+      `
+    );
+  });
+
+  it('should render a pie diagram and use half even rounding by default', () => {
+    // depending on the rounding method, the sum of the percentages can be 101 (default rounding), or 99 (half even)
+    imgSnapshotTest(
+      `pie
+        "Dogs" : 80
+        "Cats" : 86
+        "Rats" : 80
       `
     );
   });

--- a/docs/syntax/pie.md
+++ b/docs/syntax/pie.md
@@ -71,6 +71,7 @@ pie showData
 
 Possible pie diagram configuration parameters:
 
-| Parameter      | Description                                                                                                  | Default value |
-| -------------- | ------------------------------------------------------------------------------------------------------------ | ------------- |
-| `textPosition` | The axial position of the pie slice labels, from 0.0 at the center to 1.0 at the outside edge of the circle. | `0.75`        |
+| Parameter            | Description                                                                                                  | Default value |
+| -------------------- | ------------------------------------------------------------------------------------------------------------ | ------------- |
+| `textPosition`       | The axial position of the pie slice labels, from 0.0 at the center to 1.0 at the outside edge of the circle. | `0.75`        |
+| `percentageDecimals` | The number of decimal places to show in the percentage label, from 0 to 20. (v\<MERMAID_RELEASE_VERSION>+)   | `0`           |

--- a/packages/mermaid/src/config.type.ts
+++ b/packages/mermaid/src/config.type.ts
@@ -641,9 +641,9 @@ export interface PieDiagramConfig extends BaseDiagramConfig {
    *
    */
   textPosition?: number;
-
   /**
    * The number of decimal places to show in the percentage label.
+   *
    */
   percentageDecimals?: number;
 }

--- a/packages/mermaid/src/config.type.ts
+++ b/packages/mermaid/src/config.type.ts
@@ -641,6 +641,11 @@ export interface PieDiagramConfig extends BaseDiagramConfig {
    *
    */
   textPosition?: number;
+
+  /**
+   * The number of decimal places to show in the percentage label.
+   */
+  percentageDecimals?: number;
 }
 /**
  * This interface was referenced by `MermaidConfig`'s JSON-Schema

--- a/packages/mermaid/src/diagrams/pie/pie.spec.ts
+++ b/packages/mermaid/src/diagrams/pie/pie.spec.ts
@@ -164,6 +164,9 @@ describe('pie', () => {
       // db.setConfig({ textPosition: 0 });
       // db.resetConfig();
       expect(db.getConfig().textPosition).toStrictEqual(DEFAULT_PIE_DB.config.textPosition);
+      expect(db.getConfig().percentageDecimals).toStrictEqual(
+        DEFAULT_PIE_DB.config.percentageDecimals
+      );
     });
   });
 });

--- a/packages/mermaid/src/docs/syntax/pie.md
+++ b/packages/mermaid/src/docs/syntax/pie.md
@@ -51,4 +51,4 @@ Possible pie diagram configuration parameters:
 | Parameter            | Description                                                                                                  | Default value |
 | -------------------- | ------------------------------------------------------------------------------------------------------------ | ------------- |
 | `textPosition`       | The axial position of the pie slice labels, from 0.0 at the center to 1.0 at the outside edge of the circle. | `0.75`        |
-| `percentageDecimals` | The number of decimal places to show in the percentage label, from 0 to 100.                                 | `0`           |
+| `percentageDecimals` | The number of decimal places to show in the percentage label, from 0 to 100. (v<MERMAID_RELEASE_VERSION>+)   | `0`           |

--- a/packages/mermaid/src/docs/syntax/pie.md
+++ b/packages/mermaid/src/docs/syntax/pie.md
@@ -51,4 +51,4 @@ Possible pie diagram configuration parameters:
 | Parameter            | Description                                                                                                  | Default value |
 | -------------------- | ------------------------------------------------------------------------------------------------------------ | ------------- |
 | `textPosition`       | The axial position of the pie slice labels, from 0.0 at the center to 1.0 at the outside edge of the circle. | `0.75`        |
-| `percentageDecimals` | The number of decimal places to show in the percentage label, from 0 to 100. (v<MERMAID_RELEASE_VERSION>+)   | `0`           |
+| `percentageDecimals` | The number of decimal places to show in the percentage label, from 0 to 20. (v<MERMAID_RELEASE_VERSION>+)    | `0`           |

--- a/packages/mermaid/src/docs/syntax/pie.md
+++ b/packages/mermaid/src/docs/syntax/pie.md
@@ -48,6 +48,7 @@ pie showData
 
 Possible pie diagram configuration parameters:
 
-| Parameter      | Description                                                                                                  | Default value |
-| -------------- | ------------------------------------------------------------------------------------------------------------ | ------------- |
-| `textPosition` | The axial position of the pie slice labels, from 0.0 at the center to 1.0 at the outside edge of the circle. | `0.75`        |
+| Parameter            | Description                                                                                                  | Default value |
+| -------------------- | ------------------------------------------------------------------------------------------------------------ | ------------- |
+| `textPosition`       | The axial position of the pie slice labels, from 0.0 at the center to 1.0 at the outside edge of the circle. | `0.75`        |
+| `percentageDecimals` | The number of decimal places to show in the percentage label, from 0 to 100.                                 | `0`           |

--- a/packages/mermaid/src/schemas/config.schema.yaml
+++ b/packages/mermaid/src/schemas/config.schema.yaml
@@ -877,7 +877,7 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
           Axial position of slice's label from zero at the center to 1 at the outside edges.
         default: 0.75
       percentageDecimals:
-        type: number
+        type: integer
         minimum: 0
         maximum: 20
         description: |

--- a/packages/mermaid/src/schemas/config.schema.yaml
+++ b/packages/mermaid/src/schemas/config.schema.yaml
@@ -876,6 +876,13 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
         description: |
           Axial position of slice's label from zero at the center to 1 at the outside edges.
         default: 0.75
+      percentageDecimals:
+        type: number
+        minimum: 0
+        maximum: 100
+        description: |
+          The number of decimal places to show in the percentage label.
+        default: 0
 
   QuadrantChartConfig:
     title: Quadrant Chart Config

--- a/packages/mermaid/src/schemas/config.schema.yaml
+++ b/packages/mermaid/src/schemas/config.schema.yaml
@@ -879,7 +879,7 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
       percentageDecimals:
         type: number
         minimum: 0
-        maximum: 100
+        maximum: 20
         description: |
           The number of decimal places to show in the percentage label.
         default: 0


### PR DESCRIPTION
## :bookmark_tabs: Summary

Rounding percentages is hard, as rounded percentages like to not sum up to 100% anymore.

This PR introduced two smaller changes, the use of the half even rounding mode, and a pie chart option to specify the number of digits to show in the chart. Both can be used to reduce or even fix greater or smaller than 100% issues.

Resolves #3987

## :straight_ruler: Design Decisions

### Rounding Mode

There are different ways of rounding a number, the default way in JavaScript is the [rounding half up](https://en.wikipedia.org/wiki/Rounding#Rounding_half_up) mode ([see mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round#description)), which has a rounding bias and leads for percentages to sums over 100%. By using the [rounding half even](https://en.wikipedia.org/wiki/Rounding#Rounding_half_to_even) mode (also called "bankers' rounding", or "statistician's rounding"), we instead round .5 numbers to the nearest, even number. This rounding mode is to prefer, as it minimizes the overall error, and reduces rounding bias compared to other rounding modes like half up.

As you can see, this still does not make perfect 100%, but will lead to less than 100% instead of greater than 100%. I think this is to prefer, as a sum of greater than 100% always looks more suspicious than the other way around. Also, the question is if we should make this configurable too.

<details><summary>Different behaviour of rounding modes</summary>
<p>

![bug-3987-old-behaviour](https://github.com/mermaid-js/mermaid/assets/1100180/8c87b58d-a3a3-428f-a35c-5ffcd3bd19b9)

![bug-3987-new-behaviour](https://github.com/mermaid-js/mermaid/assets/1100180/f4f116dc-dbfa-414b-8ee8-66473775d25a)

</p>
</details> 

### `percentageDecimals` option

Another way of decreasing percentage sum errors is to less round the numbers, by using/showing more decimal places. At the moment the pie chart does not show decimals at all. I introduced an option `percentageDecimals` to allow setting the number of decimal places showed in the chart.

As the Intl.NumberFormat component already knows how to use different rounding modes, how to select the number of decimal places, and how to format percentages, I decided to use it here.

The allowed values are taken from the [Intl.NumberFormat minimumFractionDigits options](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#minimumfractiondigits).

<details><summary>Pie Chart with decimal places</summary>
<p>

![bug-3987-decimals-1 html](https://github.com/mermaid-js/mermaid/assets/1100180/4a1898d9-59af-4d59-b2bb-88f8f85f301c)
![bug-3987-decimals-2](https://github.com/mermaid-js/mermaid/assets/1100180/314ed3e5-17e6-441f-be99-a3670a85e25f)

</p>
</details> 

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/docs/community/contributing.md#update-documentation) is used for all new features.
- [x] :bookmark: targeted `develop` branch
