### PR TITLE
Fix link to Contributors section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Try Live Editor previews of future releases: <a href="https://develop.git.mermai
 - [Examples](#examples)
 - [Release](#release)
 - [Related projects](#related-projects)
-- [Contributors](#contributors)
+- [Contributors](#contributors---)
 - [Security and safe diagrams](#security-and-safe-diagrams)
 - [Reporting vulnerabilities](#reporting-vulnerabilities)
 - [Appreciation](#appreciation)


### PR DESCRIPTION
The dashes are also part of the link to this section in the GitHub webview and without the link does not work on GitHub. Although, the additional dashes could not fix the link for other editors (e.g. VSCodium with "Markdwn All in One" or an JetBrains IDE).

## :bookmark_tabs: Summary

Fix one link in the Table of Content from Pull Request from https://github.com/mermaid-js/mermaid/pull/4961.
The badges in the section header are tricky to handle, while linking to the section. This change fix it atleast for the [webview here at GitHub](https://github.com/BaumiCoder/mermaid/tree/fixTableOfContent?tab=readme-ov-file#table-of-content).

## :straight_ruler: Design Decisions

Check the link which GitHub creates automatically for the section (click left from the header of the section) and change it to this version in the markdown file.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/docs/community/contributing.md#update-documentation) is used for all new features.
- [x] :bookmark: targeted `develop` branch
