### PR TITLE
Replace version number placeholder

### DIFF
--- a/packages/mermaid/src/docs/syntax/gantt.md
+++ b/packages/mermaid/src/docs/syntax/gantt.md
@@ -221,7 +221,7 @@ gantt
 ```
 
 ```warning
-`millisecond` and `second` support was added in vMERMAID_RELEASE_VERSION
+`millisecond` and `second` support was added in v10.3.0
 ```
 
 ## Output in compact mode


### PR DESCRIPTION
The header of the section contains the version number for the feature, so the warning box should contain the same version

## :bookmark_tabs: Summary

In own section of the documentation the `MERMAID_RELEASE_VERSION` was used literally at one place. May it was an misunderstand or a slip in 4efac67.

## :straight_ruler: Design Decisions

The `MERMAID_RELEASE_VERSION` is not suitable here. If I understand correctly a `<MERMAID_RELEASE_VERSION>` in the markdown would be replaced with the current version of mermaid (e.g., in the [Contributing page](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/docs/community/contributing.md#update-documentation)), but a specific feature is introduced in a specific version. So a dynamic version number is not suitable here.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://github.com/mermaid-js/mermaid/blob/develop/CONTRIBUTING.md)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/docs/community/contributing.md#update-documentation) is used for all new features.
- [x] :bookmark: targeted `develop` branch
