### PR TITLE
Add gitgraph parallel commits to docs

### DIFF
--- a/docs/syntax/gitgraph.md
+++ b/docs/syntax/gitgraph.md
@@ -419,6 +419,7 @@ In Mermaid, you have the option to configure the gitgraph diagram. You can confi
 - `showCommitLabel` : Boolean, default is `true`. If set to `false`, the commit labels are not shown in the diagram.
 - `mainBranchName` : String, default is `main`. The name of the default/root branch.
 - `mainBranchOrder` : Position of the main branch in the list of branches. default is `0`, meaning, by default `main` branch is the first in the order.
+- `parallelCommits`: Boolean, default is `false`. If set to `true`, commits x distance away from the parent are shown at the same level in the diagram.
 
 Let's look at them one by one.
 
@@ -911,6 +912,62 @@ Usage example:
        commit
        commit
        merge develop
+       commit
+       commit
+```
+
+## Parallel commits (v10.8.0+)
+
+Commits in Mermaid display temporal information in gitgraph by default. For example if two commits are one commit away from its parent, the commit that was made earlier is rendered closer to its parent. You can turn this off by enabling the `parallelCommits` flag.
+
+### Temporal Commits (default, `parallelCommits: false`)
+
+```mermaid-example
+    %%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'parallelCommits': false}} }%%
+    gitGraph:
+       commit
+       branch develop
+       commit
+       commit
+       checkout main
+       commit
+       commit
+```
+
+```mermaid
+    %%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'parallelCommits': false}} }%%
+    gitGraph:
+       commit
+       branch develop
+       commit
+       commit
+       checkout main
+       commit
+       commit
+```
+
+### Parallel commits (`parallelCommits: true`)
+
+```mermaid-example
+    %%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'parallelCommits': true}} }%%
+    gitGraph:
+       commit
+       branch develop
+       commit
+       commit
+       checkout main
+       commit
+       commit
+```
+
+```mermaid
+    %%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'parallelCommits': true}} }%%
+    gitGraph:
+       commit
+       branch develop
+       commit
+       commit
+       checkout main
        commit
        commit
 ```

--- a/docs/syntax/gitgraph.md
+++ b/docs/syntax/gitgraph.md
@@ -923,53 +923,69 @@ Commits in Mermaid display temporal information in gitgraph by default. For exam
 ### Temporal Commits (default, `parallelCommits: false`)
 
 ```mermaid-example
-    %%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'parallelCommits': false}} }%%
-    gitGraph:
-       commit
-       branch develop
-       commit
-       commit
-       checkout main
-       commit
-       commit
+---
+config:
+  gitGraph:
+    parallelCommits: false
+---
+gitGraph:
+  commit
+  branch develop
+  commit
+  commit
+  checkout main
+  commit
+  commit
 ```
 
 ```mermaid
-    %%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'parallelCommits': false}} }%%
-    gitGraph:
-       commit
-       branch develop
-       commit
-       commit
-       checkout main
-       commit
-       commit
+---
+config:
+  gitGraph:
+    parallelCommits: false
+---
+gitGraph:
+  commit
+  branch develop
+  commit
+  commit
+  checkout main
+  commit
+  commit
 ```
 
 ### Parallel commits (`parallelCommits: true`)
 
 ```mermaid-example
-    %%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'parallelCommits': true}} }%%
-    gitGraph:
-       commit
-       branch develop
-       commit
-       commit
-       checkout main
-       commit
-       commit
+---
+config:
+  gitGraph:
+    parallelCommits: true
+---
+gitGraph:
+  commit
+  branch develop
+  commit
+  commit
+  checkout main
+  commit
+  commit
 ```
 
 ```mermaid
-    %%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'parallelCommits': true}} }%%
-    gitGraph:
-       commit
-       branch develop
-       commit
-       commit
-       checkout main
-       commit
-       commit
+---
+config:
+  gitGraph:
+    parallelCommits: true
+---
+gitGraph:
+  commit
+  branch develop
+  commit
+  commit
+  checkout main
+  commit
+  commit
 ```
 
 ## Themes

--- a/packages/mermaid/src/docs/syntax/gitgraph.md
+++ b/packages/mermaid/src/docs/syntax/gitgraph.md
@@ -277,6 +277,7 @@ In Mermaid, you have the option to configure the gitgraph diagram. You can confi
 - `showCommitLabel` : Boolean, default is `true`. If set to `false`, the commit labels are not shown in the diagram.
 - `mainBranchName` : String, default is `main`. The name of the default/root branch.
 - `mainBranchOrder` : Position of the main branch in the list of branches. default is `0`, meaning, by default `main` branch is the first in the order.
+- `parallelCommits`: Boolean, default is `false`. If set to `true`, commits x distance away from the parent are shown at the same level in the diagram.
 
 Let's look at them one by one.
 
@@ -564,6 +565,38 @@ Usage example:
        commit
        commit
        merge develop
+       commit
+       commit
+```
+
+## Parallel commits (v10.8.0+)
+
+Commits in Mermaid display temporal information in gitgraph by default. For example if two commits are one commit away from its parent, the commit that was made earlier is rendered closer to its parent. You can turn this off by enabling the `parallelCommits` flag.
+
+### Temporal Commits (default, `parallelCommits: false`)
+
+```mermaid-example
+    %%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'parallelCommits': false}} }%%
+    gitGraph:
+       commit
+       branch develop
+       commit
+       commit
+       checkout main
+       commit
+       commit
+```
+
+### Parallel commits (`parallelCommits: true`)
+
+```mermaid-example
+    %%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'parallelCommits': true}} }%%
+    gitGraph:
+       commit
+       branch develop
+       commit
+       commit
+       checkout main
        commit
        commit
 ```

--- a/packages/mermaid/src/docs/syntax/gitgraph.md
+++ b/packages/mermaid/src/docs/syntax/gitgraph.md
@@ -576,29 +576,37 @@ Commits in Mermaid display temporal information in gitgraph by default. For exam
 ### Temporal Commits (default, `parallelCommits: false`)
 
 ```mermaid-example
-    %%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'parallelCommits': false}} }%%
-    gitGraph:
-       commit
-       branch develop
-       commit
-       commit
-       checkout main
-       commit
-       commit
+---
+config:
+  gitGraph:
+    parallelCommits: false
+---
+gitGraph:
+  commit
+  branch develop
+  commit
+  commit
+  checkout main
+  commit
+  commit
 ```
 
 ### Parallel commits (`parallelCommits: true`)
 
 ```mermaid-example
-    %%{init: { 'logLevel': 'debug', 'theme': 'base', 'gitGraph': {'parallelCommits': true}} }%%
-    gitGraph:
-       commit
-       branch develop
-       commit
-       commit
-       checkout main
-       commit
-       commit
+---
+config:
+  gitGraph:
+    parallelCommits: true
+---
+gitGraph:
+  commit
+  branch develop
+  commit
+  commit
+  checkout main
+  commit
+  commit
 ```
 
 ## Themes


### PR DESCRIPTION
## :bookmark_tabs: Summary

Add gitgraph parallel commits to docs 

Resolves #5324 

## :straight_ruler: Design Decisions
- Released in [v10.8.0](https://github.com/mermaid-js/mermaid/releases/tag/v10.8.0) in #5161 

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :bookmark: targeted `develop` branch
