### PR TITLE
feat: add name attribute to line

### DIFF
--- a/packages/mermaid/src/diagrams/sequence/svgDraw.js
+++ b/packages/mermaid/src/diagrams/sequence/svgDraw.js
@@ -343,10 +343,10 @@ const drawActorTypeParticipant = async function (elem, actor, conf, isFooter) {
       .attr('y1', centerY)
       .attr('x2', center)
       .attr('y2', 2000)
-      .attr('class', 'actor-line')
-      .attr('class', '200')
+      .attr('class', 'actor-line 200')
       .attr('stroke-width', '0.5px')
-      .attr('stroke', '#999');
+      .attr('stroke', '#999')
+      .attr('name', actor.name);
 
     g = boxplusLineGroup.append('g');
     actor.actorCnt = actorCnt;
@@ -425,10 +425,10 @@ const drawActorTypeActor = async function (elem, actor, conf, isFooter) {
       .attr('y1', centerY)
       .attr('x2', center)
       .attr('y2', 2000)
-      .attr('class', 'actor-line')
-      .attr('class', '200')
+      .attr('class', 'actor-line 200')
       .attr('stroke-width', '0.5px')
-      .attr('stroke', '#999');
+      .attr('stroke', '#999')
+      .attr('name', actor.name);
 
     actor.actorCnt = actorCnt;
   }


### PR DESCRIPTION
## :bookmark_tabs: Summary

- [ ] The actors have unique names so adding a name field to the line connecting the actors for easier identification in SVG nodes.
- [ ] Additionally fixes a bug - `actor-line` class was never added to the line as it was getting overridden so now that's fixed as well

```html
<line id="actor11" x1="714" y1="5" x2="714" y2="621" class="actor-line 200" stroke-width="0.5px" stroke="#999" name="4"></line>
```


## :straight_ruler: Design Decisions

similar to https://github.com/mermaid-js/mermaid/pull/5284, this is adding a unique identifier for line nodes connecting the actors

### :clipboard: Tasks

Make sure you

- [ ] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :bookmark: targeted `develop` branch
