### PR TITLE
ci(e2e): avoid commenting on PRs in CI, fixing PRs from forks

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 env:
   # For PRs and MergeQueues, the target commit is used, and for push events, github.event.previous is used.
@@ -56,8 +55,8 @@ jobs:
           # just perform install
           runTests: false
 
-      - name: Build
-        if: ${{ steps.cache-snapshot.outputs.cache-hit != 'true' && github.event_name == 'pull_request' }}
+      - name: Calculate bundle size
+        if: ${{ steps.cache-snapshot.outputs.cache-hit != 'true'}}
         run: |
           pnpm run build:viz
           mkdir -p cypress/snapshots/stats/base
@@ -107,26 +106,14 @@ jobs:
         with:
           runTests: false
 
-      - name: Build
-        id: size
-        if: ${{ github.event_name == 'pull_request' && matrix.containers == 1 }}
+      - name: Output size diff
+        if: ${{ matrix.containers == 1 }}
         run: |
           pnpm run build:viz
           mv stats cypress/snapshots/stats/head
-          {
-            echo 'size_diff<<EOF'
-            npx tsx scripts/size.ts
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
-
-      # Size diff only needs to be posted from one job, on PRs.
-      - name: Comment PR size difference
-        if: ${{ github.event_name == 'pull_request' && matrix.containers == 1 }}
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: |
-            ${{ steps.size.outputs.size_diff }}
-          comment_tag: size-diff
+          echo '## Bundle size difference' >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          npx tsx scripts/size.ts >> "$GITHUB_STEP_SUMMARY"
 
       # Install NPM dependencies, cache them correctly
       # and run all Cypress tests


### PR DESCRIPTION
## :bookmark_tabs: Summary

GitHub Actions can't comment on PRs, if the PR is made from a forked repo, as [the github token won't have write permissions][1]. This causes the E2E CI to fail in most PRs, e.g. see https://github.com/mermaid-js/mermaid/pull/5338#issuecomment-1980930325

However, we can instead use GitHub Actions' [Adding a Job Summary][2] feature, which prints some custom output for each job. This also means that we can calculate the bundle size for push events, not just PRs. For example, see https://github.com/aloisklink/mermaid/actions/runs/8177226929:

![image](https://github.com/mermaid-js/mermaid/assets/19716675/fea5b2cd-0678-40ee-b712-d8e03fc52972)

The only issue is that 


[1]: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#changing-the-permissions-in-a-forked-repository
[2]: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary

Fix: e0448a7b7be4fcad775f9dd0292f49845c84836c

## :straight_ruler: Design Decisions

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :bookmark: targeted `develop` branch
