### PR TITLE
feat: Make the examples interactive in the documentation site

### DIFF
--- a/packages/mermaid/scripts/docs.mts
+++ b/packages/mermaid/scripts/docs.mts
@@ -252,11 +252,12 @@ export function transformMarkdownAst({
         node.lang = MERMAID_KEYWORD;
         return [node];
       } else if (MERMAID_EXAMPLE_KEYWORDS.includes(node.lang)) {
-        // Return 2 nodes:
+        // If Vitepress, return only the original node with the language now set to 'mermaid-example' (will be rendered using custom renderer)
+        // Else Return 2 nodes:
         //   1. the original node with the language now set to 'mermaid-example' (will be rendered as code), and
         //   2. a copy of the original node with the language set to 'mermaid' (will be rendered as a diagram)
         node.lang = MERMAID_CODE_ONLY_KEYWORD;
-        return [node, Object.assign({}, node, { lang: MERMAID_KEYWORD })];
+        return vitepress ? [node] : [node, Object.assign({}, node, { lang: MERMAID_KEYWORD })];
       }
 
       // Transform these blocks into block quotes.

--- a/packages/mermaid/src/docs/.vitepress/mermaid-markdown-all.ts
+++ b/packages/mermaid/src/docs/.vitepress/mermaid-markdown-all.ts
@@ -18,20 +18,7 @@ const MermaidExample = async (md: MarkdownRenderer) => {
           'Missing MarkdownIt highlight function (should be automatically created by vitepress'
         );
       }
-
-      // doing ```mermaid-example {line-numbers=5 highlight=14-17} is not supported
-      const langAttrs = '';
-      return `
-      <h5>Code:</h5>
-      <div class="language-mermaid">
-        <button class="copy"></button>
-        <span class="lang">mermaid</span>
-        ${
-          // html is pre-escaped by the highlight function
-          // (it also adds `v-pre` to ignore Vue template syntax)
-          md.options.highlight(token.content, 'mermaid', langAttrs)
-        }
-      </div>`;
+      return '';
     } else if (token.info.trim() === 'mermaid') {
       const key = index;
       return `

--- a/packages/mermaid/src/docs/.vitepress/mermaid-markdown-all.ts
+++ b/packages/mermaid/src/docs/.vitepress/mermaid-markdown-all.ts
@@ -9,22 +9,15 @@ const MermaidExample = async (md: MarkdownRenderer) => {
 
   md.renderer.rules.fence = (tokens, index, options, env, slf) => {
     const token = tokens[index];
-
-    if (token.info.trim() === 'mermaid-example') {
-      if (!md.options.highlight) {
-        // this function is always created by vitepress, but we need to check it
-        // anyway to make TypeScript happy
-        throw new Error(
-          'Missing MarkdownIt highlight function (should be automatically created by vitepress'
-        );
-      }
-      return '';
-    } else if (token.info.trim() === 'mermaid') {
+    const language = token.info.trim();
+    if (language.startsWith('mermaid')) {
       const key = index;
       return `
       <Suspense> 
       <template #default>
-      <Mermaid id="mermaid-${key}"  graph="${encodeURIComponent(token.content)}"></Mermaid>
+      <Mermaid id="mermaid-${key}" :showCode="${
+        language === 'mermaid-example'
+      }" graph="${encodeURIComponent(token.content)}"></Mermaid>
       </template>
         <!-- loading state via #fallback slot -->
         <template #fallback>
@@ -32,25 +25,18 @@ const MermaidExample = async (md: MarkdownRenderer) => {
         </template>
       </Suspense>
 `;
-    }
-    if (token.info.trim() === 'warning') {
+    } else if (language === 'warning') {
       return `<div class="warning custom-block"><p class="custom-block-title">WARNING</p><p>${token.content}}</p></div>`;
-    }
-
-    if (token.info.trim() === 'note') {
+    } else if (language === 'note') {
       return `<div class="tip custom-block"><p class="custom-block-title">NOTE</p><p>${token.content}}</p></div>`;
-    }
-
-    if (token.info.trim() === 'regexp') {
+    } else if (language === 'regexp') {
       // shiki doesn't yet support regexp code blocks, but the javascript
       // one still makes RegExes look good
       token.info = 'javascript';
       // use trimEnd to move trailing `\n` outside if the JavaScript regex `/` block
       token.content = `/${token.content.trimEnd()}/\n`;
       return defaultRenderer(tokens, index, options, env, slf);
-    }
-
-    if (token.info.trim() === 'jison') {
+    } else if (language === 'jison') {
       return `<div class="language-">
       <button class="copy"></button>
       <span class="lang">jison</span>

--- a/packages/mermaid/src/docs/.vitepress/theme/Mermaid.vue
+++ b/packages/mermaid/src/docs/.vitepress/theme/Mermaid.vue
@@ -6,7 +6,7 @@
     <pre><code contenteditable="true" @input="updateCode"  @keydown.meta.enter="renderChart" ref="editableContent" class="editable-code"></code></pre>
     <div class="buttons-container">
       <span>{{ ctrlSymbol }} + Enter</span><span>|</span>
-      <button @click="renderChart">Run ►</button>
+      <button @click="renderChart">Run ▶</button>
     </div>
   </div>
   <div v-html="svg"></div>

--- a/packages/mermaid/src/docs/.vitepress/theme/Mermaid.vue
+++ b/packages/mermaid/src/docs/.vitepress/theme/Mermaid.vue
@@ -1,12 +1,14 @@
 <template>
-  <h5>Code:</h5>
-  <div class="language-mermaid">
-    <button class="copy"></button>
-    <span class="lang">mermaid</span>
-    <pre><code contenteditable="true" @input="updateCode"  @keydown.meta.enter="renderChart" ref="editableContent" class="editable-code"></code></pre>
-    <div class="buttons-container">
-      <span>{{ ctrlSymbol }} + Enter</span><span>|</span>
-      <button @click="renderChart">Run ▶</button>
+  <div v-if="props.showCode">
+    <h5>Code:</h5>
+    <div class="language-mermaid">
+      <button class="copy"></button>
+      <span class="lang">mermaid</span>
+      <pre><code contenteditable="plaintext-only" @input="updateCode"  @keydown.meta.enter="renderChart" @keydown.ctrl.enter="renderChart" ref="editableContent" class="editable-code"></code></pre>
+      <div class="buttons-container">
+        <span>{{ ctrlSymbol }} + Enter</span><span>|</span>
+        <button @click="renderChart">Run ▶</button>
+      </div>
     </div>
   </div>
   <div v-html="svg"></div>
@@ -25,6 +27,10 @@ const props = defineProps({
     type: String,
     required: true,
   },
+  showCode: {
+    type: Boolean,
+    default: true,
+  },
 });
 
 const svg = ref('');
@@ -42,10 +48,12 @@ onMounted(async () => {
   mut = new MutationObserver(() => renderChart());
   mut.observe(document.documentElement, { attributes: true });
 
-  // Set the initial value of the contenteditable element
-  // We cannot bind using `{{ code }}` because it will rerender the whole component
-  // when the value changes, shifting the cursor when enter is used
-  editableContent.value.textContent = code.value;
+  if (editableContent.value) {
+    // Set the initial value of the contenteditable element
+    // We cannot bind using `{{ code }}` because it will rerender the whole component
+    // when the value changes, shifting the cursor when enter is used
+    editableContent.value.textContent = code.value;
+  }
 
   await renderChart();
 

--- a/packages/mermaid/src/docs/.vitepress/theme/Mermaid.vue
+++ b/packages/mermaid/src/docs/.vitepress/theme/Mermaid.vue
@@ -1,4 +1,14 @@
 <template>
+  <h5>Code:</h5>
+  <div class="language-mermaid">
+    <button class="copy"></button>
+    <span class="lang">mermaid</span>
+    <pre><code contenteditable="true" @input="updateCode"  @keydown.meta.enter="renderChart" ref="editableContent" class="editable-code"></code></pre>
+    <div class="buttons-container">
+      <span>{{ ctrlSymbol }} + Enter</span><span>|</span>
+      <button @click="renderChart">Run ►</button>
+    </div>
+  </div>
   <div v-html="svg"></div>
 </template>
 
@@ -18,15 +28,29 @@ const props = defineProps({
 });
 
 const svg = ref('');
+const code = ref(decodeURIComponent(props.graph));
+const ctrlSymbol = ref(navigator.platform.includes('Mac') ? '⌘' : 'Ctrl');
+const editableContent = ref(null);
+
 let mut = null;
+
+const updateCode = (event) => {
+  code.value = event.target.innerText;
+};
 
 onMounted(async () => {
   mut = new MutationObserver(() => renderChart());
   mut.observe(document.documentElement, { attributes: true });
+
+  // Set the initial value of the contenteditable element
+  // We cannot bind using `{{ code }}` because it will rerender the whole component
+  // when the value changes, shifting the cursor when enter is used
+  editableContent.value.textContent = code.value;
+
   await renderChart();
 
   //refresh images on first render
-  const hasImages = /<img([\w\W]+?)>/.exec(decodeURIComponent(props.graph))?.length > 0;
+  const hasImages = /<img([\w\W]+?)>/.exec(code.value)?.length > 0;
   if (hasImages)
     setTimeout(() => {
       let imgElements = document.getElementsByTagName('img');
@@ -51,16 +75,14 @@ onMounted(async () => {
 onUnmounted(() => mut.disconnect());
 
 const renderChart = async () => {
-  console.log('rendering chart' + props.id + props.graph);
+  console.log('rendering chart' + props.id + code.value);
   const hasDarkClass = document.documentElement.classList.contains('dark');
   const mermaidConfig = {
     securityLevel: 'loose',
     startOnLoad: false,
     theme: hasDarkClass ? 'dark' : 'default',
   };
-
-  console.log({ mermaidConfig });
-  let svgCode = await render(props.id, decodeURIComponent(props.graph), mermaidConfig);
+  let svgCode = await render(props.id, code.value, mermaidConfig);
   // This is a hack to force v-html to re-render, otherwise the diagram disappears
   // when **switching themes** or **reloading the page**.
   // The cause is that the diagram is deleted during rendering (out of Vue's knowledge).
@@ -70,3 +92,35 @@ const renderChart = async () => {
   svg.value = `${svgCode} <span style="display: none">${salt}</span>`;
 };
 </script>
+
+<style>
+.editable-code:focus {
+  outline: none; /* Removes the default focus indicator */
+}
+
+.buttons-container {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  z-index: 1;
+  padding: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.buttons-container > span {
+  cursor: default;
+  opacity: 0.5;
+  font-size: 0.8rem;
+}
+
+.buttons-container > button {
+  color: #007bffbf;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.buttons-container > button:hover {
+  color: #007bff;
+}
+</style>


### PR DESCRIPTION
## :bookmark_tabs: Summary

Ctrl/Cmd + Enter and a run button is added.

## :straight_ruler: Design Decisions

The feature was first implemented in https://github.com/mermaid-js/mermaid/pull/5330 by @nalgeon.

This is a simplified version without introducing additional dependencies.

<img width="834" alt="image" src="https://github.com/mermaid-js/mermaid/assets/10703445/17f4a8c8-49a5-4566-8c96-37de7a39dd5f">


### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :bookmark: targeted `master` branch
