### PR TITLE
Feature/support fa kit custom icons

### DIFF
--- a/docs/syntax/flowchart.md
+++ b/docs/syntax/flowchart.md
@@ -1178,6 +1178,16 @@ Adding this snippet in the `<head>` would add support for Font Awesome v6.5.1
 />
 ```
 
+It is possible to use custom icons served from Font Awesome as long as the website imports the corresponding kit. Note that this is currently a paid feature from Font Awesome.
+
+For custom icons, you need to use the `fak` prefix.
+
+```
+flowchart TD
+    B["fa:fa-twitter for peace"]
+    B-->E(fak:fa-custom-icon-name) %% this will try to find your kit's custom icon
+```
+
 ## Graph declarations with spaces between vertices and link and without semicolon
 
 - In graph declarations, the statements also can now end without a semicolon. After release 0.2.16, ending a graph statement with semicolon is just optional. So the below graph declaration is also valid along with the old declarations of the graph.

--- a/docs/syntax/flowchart.md
+++ b/docs/syntax/flowchart.md
@@ -1178,14 +1178,20 @@ Adding this snippet in the `<head>` would add support for Font Awesome v6.5.1
 />
 ```
 
-It is possible to use custom icons served from Font Awesome as long as the website imports the corresponding kit. Note that this is currently a paid feature from Font Awesome.
+### Custom icons
+
+It is possible to use custom icons served from Font Awesome as long as the website imports the corresponding kit.
+
+Note that this is currently a paid feature from Font Awesome.
 
 For custom icons, you need to use the `fak` prefix.
 
+**Example**
+
 ```
 flowchart TD
-    B["fa:fa-twitter for peace"]
-    B-->E(fak:fa-custom-icon-name) %% this will try to find your kit's custom icon
+    B[fa:fa-twitter] %% standard icon
+    B-->E(fak:fa-custom-icon-name) %% custom icon
 ```
 
 ## Graph declarations with spaces between vertices and link and without semicolon

--- a/packages/mermaid/src/dagre-wrapper/createLabel.js
+++ b/packages/mermaid/src/dagre-wrapper/createLabel.js
@@ -60,7 +60,7 @@ const createLabel = (_vertexText, style, isTitle, isNode) => {
     const node = {
       isNode,
       label: decodeEntities(vertexText).replace(
-        /fa[blrs]?:fa-[\w-]+/g, // cspell: disable-line
+        /fa[bklrs]?:fa-[\w-]+/g, // cspell: disable-line
         (s) => `<i class='${s.replace(':', ' ')}'></i>`
       ),
       labelStyle: style.replace('fill:', 'color:'),

--- a/packages/mermaid/src/diagrams/flowchart/flowRenderer.js
+++ b/packages/mermaid/src/diagrams/flowchart/flowRenderer.js
@@ -59,7 +59,7 @@ export const addVertices = async function (vert, g, svgId, root, _doc, diagObj) 
       const node = {
         label: await renderKatex(
           vertexText.replace(
-            /fa[blrs]?:fa-[\w-]+/g, // cspell:disable-line
+            /fa[bklrs]?:fa-[\w-]+/g, // cspell:disable-line
             (s) => `<i class='${s.replace(':', ' ')}'></i>`
           ),
           getConfig()
@@ -244,7 +244,7 @@ export const addEdges = async function (edges, g, diagObj) {
           edgeData.labelStyle
         }">${await renderKatex(
           edge.text.replace(
-            /fa[blrs]?:fa-[\w-]+/g, // cspell:disable-line
+            /fa[bklrs]?:fa-[\w-]+/g, // cspell:disable-line
             (s) => `<i class='${s.replace(':', ' ')}'></i>`
           ),
           getConfig()

--- a/packages/mermaid/src/docs/syntax/flowchart.md
+++ b/packages/mermaid/src/docs/syntax/flowchart.md
@@ -799,6 +799,16 @@ Adding this snippet in the `<head>` would add support for Font Awesome v6.5.1
 />
 ```
 
+It is possible to use custom icons served from Font Awesome as long as the website imports the corresponding kit. Note that this is currently a paid feature from Font Awesome.
+
+For custom icons, you need to use the `fak` prefix.
+
+```
+flowchart TD
+    B["fa:fa-twitter for peace"]
+    B-->E(fak:fa-custom-icon-name) %% this will try to find your kit's custom icon
+```
+
 ## Graph declarations with spaces between vertices and link and without semicolon
 
 - In graph declarations, the statements also can now end without a semicolon. After release 0.2.16, ending a graph statement with semicolon is just optional. So the below graph declaration is also valid along with the old declarations of the graph.

--- a/packages/mermaid/src/docs/syntax/flowchart.md
+++ b/packages/mermaid/src/docs/syntax/flowchart.md
@@ -799,14 +799,20 @@ Adding this snippet in the `<head>` would add support for Font Awesome v6.5.1
 />
 ```
 
-It is possible to use custom icons served from Font Awesome as long as the website imports the corresponding kit. Note that this is currently a paid feature from Font Awesome.
+### Custom icons
+
+It is possible to use custom icons served from Font Awesome as long as the website imports the corresponding kit.
+
+Note that this is currently a paid feature from Font Awesome.
 
 For custom icons, you need to use the `fak` prefix.
 
+**Example**
+
 ```
 flowchart TD
-    B["fa:fa-twitter for peace"]
-    B-->E(fak:fa-custom-icon-name) %% this will try to find your kit's custom icon
+    B[fa:fa-twitter] %% standard icon
+    B-->E(fak:fa-custom-icon-name) %% custom icon
 ```
 
 ## Graph declarations with spaces between vertices and link and without semicolon

--- a/packages/mermaid/src/rendering-util/createText.ts
+++ b/packages/mermaid/src/rendering-util/createText.ts
@@ -192,7 +192,7 @@ export const createText = (
     const node = {
       isNode,
       label: decodeEntities(htmlText).replace(
-        /fa[blrs]?:fa-[\w-]+/g, // cspell: disable-line
+        /fa[bklrs]?:fa-[\w-]+/g, // cspell: disable-line
         (s) => `<i class='${s.replace(':', ' ')}'></i>`
       ),
       labelStyle: style.replace('fill:', 'color:'),


### PR DESCRIPTION
## :bookmark_tabs: Summary

Extends the current fontawesome support to also handle the case of custom icons being served through the `fak` prefix. 

## :straight_ruler: Design Decisions

Logic already existed for the basic fontawesome prefixes so mainly extended that and added a section to the flowchart documentation about it.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :bookmark: targeted `develop` branch
