### PR TITLE
bug(ClassDiagram): Fixed a combination abstract and static modifiers not working.

### DIFF
--- a/packages/mermaid/src/diagrams/class/classTypes.spec.ts
+++ b/packages/mermaid/src/diagrams/class/classTypes.spec.ts
@@ -4,6 +4,7 @@ const spyOn = vi.spyOn;
 
 const staticCssStyle = 'text-decoration:underline;';
 const abstractCssStyle = 'font-style:italic;';
+const staticAbstractCssStyle = 'text-decoration:underline;font-style:italic;';
 
 describe('given text representing a method, ', function () {
   describe('when method has no parameters', function () {
@@ -56,6 +57,22 @@ describe('given text representing a method, ', function () {
       const classMember = new ClassMember(str, 'method');
       expect(classMember.getDisplayDetails().displayText).toBe('getTime()');
       expect(classMember.getDisplayDetails().cssStyle).toBe(abstractCssStyle);
+    });
+
+    it('should return correct css for static and abstract classifier', function () {
+      const str = `getTime()$*`;
+
+      const classMember = new ClassMember(str, 'method');
+      expect(classMember.getDisplayDetails().displayText).toBe('getTime()');
+      expect(classMember.getDisplayDetails().cssStyle).toBe(staticAbstractCssStyle);
+    });
+
+    it('should return correct css for abstract and static classifier', function () {
+      const str = `getTime()*$`;
+
+      const classMember = new ClassMember(str, 'method');
+      expect(classMember.getDisplayDetails().displayText).toBe('getTime()');
+      expect(classMember.getDisplayDetails().cssStyle).toBe(staticAbstractCssStyle);
     });
   });
 
@@ -110,6 +127,21 @@ describe('given text representing a method, ', function () {
       expect(classMember.getDisplayDetails().displayText).toBe('getTime(int)');
       expect(classMember.getDisplayDetails().cssStyle).toBe(abstractCssStyle);
     });
+
+    it('should return correct css for static and abstract classifier', function () {
+      const str = `getTime(int)$*`;
+
+      const classMember = new ClassMember(str, 'method');
+      expect(classMember.getDisplayDetails().displayText).toBe('getTime(int)');
+      expect(classMember.getDisplayDetails().cssStyle).toBe(staticAbstractCssStyle);
+    });
+    it('should return correct css for abstract and static classifier', function () {
+      const str = `getTime(int)*$`;
+
+      const classMember = new ClassMember(str, 'method');
+      expect(classMember.getDisplayDetails().displayText).toBe('getTime(int)');
+      expect(classMember.getDisplayDetails().cssStyle).toBe(staticAbstractCssStyle);
+    });
   });
 
   describe('when method has single parameter type and name (type first)', function () {
@@ -162,6 +194,22 @@ describe('given text representing a method, ', function () {
       const classMember = new ClassMember(str, 'method');
       expect(classMember.getDisplayDetails().displayText).toBe('getTime(int count)');
       expect(classMember.getDisplayDetails().cssStyle).toBe(abstractCssStyle);
+    });
+
+    it('should return correct css for static and abstract classifier', function () {
+      const str = `getTime(int count)$*`;
+
+      const classMember = new ClassMember(str, 'method');
+      expect(classMember.getDisplayDetails().displayText).toBe('getTime(int count)');
+      expect(classMember.getDisplayDetails().cssStyle).toBe(staticAbstractCssStyle);
+    });
+
+    it('should return correct css for abstract classifier', function () {
+      const str = `getTime(int count)*$`;
+
+      const classMember = new ClassMember(str, 'method');
+      expect(classMember.getDisplayDetails().displayText).toBe('getTime(int count)');
+      expect(classMember.getDisplayDetails().cssStyle).toBe(staticAbstractCssStyle);
     });
   });
 
@@ -216,6 +264,22 @@ describe('given text representing a method, ', function () {
       expect(classMember.getDisplayDetails().displayText).toBe('getTime(count int)');
       expect(classMember.getDisplayDetails().cssStyle).toBe(abstractCssStyle);
     });
+
+    it('should return correct css for static and abstract classifier', function () {
+      const str = `getTime(count int)$*`;
+
+      const classMember = new ClassMember(str, 'method');
+      expect(classMember.getDisplayDetails().displayText).toBe('getTime(count int)');
+      expect(classMember.getDisplayDetails().cssStyle).toBe(staticAbstractCssStyle);
+    });
+
+    it('should return correct css for abstract and static classifier', function () {
+      const str = `getTime(count int)*$`;
+
+      const classMember = new ClassMember(str, 'method');
+      expect(classMember.getDisplayDetails().displayText).toBe('getTime(count int)');
+      expect(classMember.getDisplayDetails().cssStyle).toBe(staticAbstractCssStyle);
+    });
   });
 
   describe('when method has multiple parameters', function () {
@@ -268,6 +332,22 @@ describe('given text representing a method, ', function () {
       const classMember = new ClassMember(str, 'method');
       expect(classMember.getDisplayDetails().displayText).toBe('getTime(string text, int count)');
       expect(classMember.getDisplayDetails().cssStyle).toBe(abstractCssStyle);
+    });
+
+    it('should return correct css for static and abstract classifier', function () {
+      const str = `getTime(string text, int count)$*`;
+
+      const classMember = new ClassMember(str, 'method');
+      expect(classMember.getDisplayDetails().displayText).toBe('getTime(string text, int count)');
+      expect(classMember.getDisplayDetails().cssStyle).toBe(staticAbstractCssStyle);
+    });
+
+    it('should return correct css for abstract and static classifier', function () {
+      const str = `getTime(string text, int count)*$`;
+
+      const classMember = new ClassMember(str, 'method');
+      expect(classMember.getDisplayDetails().displayText).toBe('getTime(string text, int count)');
+      expect(classMember.getDisplayDetails().cssStyle).toBe(staticAbstractCssStyle);
     });
   });
 
@@ -322,6 +402,22 @@ describe('given text representing a method, ', function () {
       expect(classMember.getDisplayDetails().displayText).toBe('getTime() : DateTime');
       expect(classMember.getDisplayDetails().cssStyle).toBe(abstractCssStyle);
     });
+
+    it('should return correct css for static and abstract classifier', function () {
+      const str = `getTime()  DateTime$*`;
+
+      const classMember = new ClassMember(str, 'method');
+      expect(classMember.getDisplayDetails().displayText).toBe('getTime() : DateTime');
+      expect(classMember.getDisplayDetails().cssStyle).toBe(staticAbstractCssStyle);
+    });
+
+    it('should return correct css for abstract and static classifier', function () {
+      const str = `getTime()  DateTime*$`;
+
+      const classMember = new ClassMember(str, 'method');
+      expect(classMember.getDisplayDetails().displayText).toBe('getTime() : DateTime');
+      expect(classMember.getDisplayDetails().cssStyle).toBe(staticAbstractCssStyle);
+    });
   });
 
   describe('when method parameter is generic', function () {
@@ -374,6 +470,22 @@ describe('given text representing a method, ', function () {
       const classMember = new ClassMember(str, 'method');
       expect(classMember.getDisplayDetails().displayText).toBe('getTimes(List<T>)');
       expect(classMember.getDisplayDetails().cssStyle).toBe(abstractCssStyle);
+    });
+
+    it('should return correct css for static and abstract classifier', function () {
+      const str = `getTimes(List~T~)$*`;
+
+      const classMember = new ClassMember(str, 'method');
+      expect(classMember.getDisplayDetails().displayText).toBe('getTimes(List<T>)');
+      expect(classMember.getDisplayDetails().cssStyle).toBe(staticAbstractCssStyle);
+    });
+
+    it('should return correct css for abstract and static classifier', function () {
+      const str = `getTimes(List~T~)*$`;
+
+      const classMember = new ClassMember(str, 'method');
+      expect(classMember.getDisplayDetails().displayText).toBe('getTimes(List<T>)');
+      expect(classMember.getDisplayDetails().cssStyle).toBe(staticAbstractCssStyle);
     });
   });
 
@@ -428,6 +540,22 @@ describe('given text representing a method, ', function () {
       expect(classMember.getDisplayDetails().displayText).toBe('getTimes(List<T>, List<OT>)');
       expect(classMember.getDisplayDetails().cssStyle).toBe(abstractCssStyle);
     });
+
+    it('should return correct css for static and abstract classifier', function () {
+      const str = `getTimes(List~T~, List~OT~)$*`;
+
+      const classMember = new ClassMember(str, 'method');
+      expect(classMember.getDisplayDetails().displayText).toBe('getTimes(List<T>, List<OT>)');
+      expect(classMember.getDisplayDetails().cssStyle).toBe(staticAbstractCssStyle);
+    });
+
+    it('should return correct css for abstract and static classifier', function () {
+      const str = `getTimes(List~T~, List~OT~)*$`;
+
+      const classMember = new ClassMember(str, 'method');
+      expect(classMember.getDisplayDetails().displayText).toBe('getTimes(List<T>, List<OT>)');
+      expect(classMember.getDisplayDetails().cssStyle).toBe(staticAbstractCssStyle);
+    });
   });
 
   describe('when method parameter is a nested generic', function () {
@@ -480,6 +608,22 @@ describe('given text representing a method, ', function () {
       const classMember = new ClassMember(str, 'method');
       expect(classMember.getDisplayDetails().displayText).toBe('getTimetableList(List<List<T>>)');
       expect(classMember.getDisplayDetails().cssStyle).toBe(abstractCssStyle);
+    });
+
+    it('should return correct css for static and abstract classifier', function () {
+      const str = `getTimetableList(List~List~T~~)$*`;
+
+      const classMember = new ClassMember(str, 'method');
+      expect(classMember.getDisplayDetails().displayText).toBe('getTimetableList(List<List<T>>)');
+      expect(classMember.getDisplayDetails().cssStyle).toBe(staticAbstractCssStyle);
+    });
+
+    it('should return correct css for abstract and static classifier', function () {
+      const str = `getTimetableList(List~List~T~~)*$`;
+
+      const classMember = new ClassMember(str, 'method');
+      expect(classMember.getDisplayDetails().displayText).toBe('getTimetableList(List<List<T>>)');
+      expect(classMember.getDisplayDetails().cssStyle).toBe(staticAbstractCssStyle);
     });
   });
 
@@ -540,6 +684,20 @@ describe('given text representing a method, ', function () {
       expect(classMember.getDisplayDetails().displayText).toBe(expectedMethodNameAndParameters);
       expect(classMember.getDisplayDetails().cssStyle).toBe(abstractCssStyle);
     });
+
+    it('should return correct css for static and abstract classifier', function () {
+      const str = methodNameAndParameters + '$*';
+      const classMember = new ClassMember(str, 'method');
+      expect(classMember.getDisplayDetails().displayText).toBe(expectedMethodNameAndParameters);
+      expect(classMember.getDisplayDetails().cssStyle).toBe(staticAbstractCssStyle);
+    });
+
+    it('should return correct css for abstract and static classifier', function () {
+      const str = methodNameAndParameters + '*$';
+      const classMember = new ClassMember(str, 'method');
+      expect(classMember.getDisplayDetails().displayText).toBe(expectedMethodNameAndParameters);
+      expect(classMember.getDisplayDetails().cssStyle).toBe(staticAbstractCssStyle);
+    });
   });
 
   describe('when method return type is generic', function () {
@@ -592,6 +750,22 @@ describe('given text representing a method, ', function () {
       const classMember = new ClassMember(str, 'method');
       expect(classMember.getDisplayDetails().displayText).toBe('getTimes() : List<T>');
       expect(classMember.getDisplayDetails().cssStyle).toBe(abstractCssStyle);
+    });
+
+    it('should return correct css for static and abstract classifier', function () {
+      const str = `getTimes() List~T~$*`;
+
+      const classMember = new ClassMember(str, 'method');
+      expect(classMember.getDisplayDetails().displayText).toBe('getTimes() : List<T>');
+      expect(classMember.getDisplayDetails().cssStyle).toBe(staticAbstractCssStyle);
+    });
+
+    it('should return correct css for abstract and static classifier', function () {
+      const str = `getTimes() List~T~*$`;
+
+      const classMember = new ClassMember(str, 'method');
+      expect(classMember.getDisplayDetails().displayText).toBe('getTimes() : List<T>');
+      expect(classMember.getDisplayDetails().cssStyle).toBe(staticAbstractCssStyle);
     });
   });
 
@@ -659,6 +833,26 @@ describe('given text representing a method, ', function () {
         'getTimetableList() : List<List<T>>'
       );
       expect(classMember.getDisplayDetails().cssStyle).toBe(abstractCssStyle);
+    });
+
+    it('should return correct css for static and abstract classifier', function () {
+      const str = `getTimetableList() List~List~T~~$*`;
+
+      const classMember = new ClassMember(str, 'method');
+      expect(classMember.getDisplayDetails().displayText).toBe(
+        'getTimetableList() : List<List<T>>'
+      );
+      expect(classMember.getDisplayDetails().cssStyle).toBe(staticAbstractCssStyle);
+    });
+
+    it('should return correct css for abstract and static classifier', function () {
+      const str = `getTimetableList() List~List~T~~*$`;
+
+      const classMember = new ClassMember(str, 'method');
+      expect(classMember.getDisplayDetails().displayText).toBe(
+        'getTimetableList() : List<List<T>>'
+      );
+      expect(classMember.getDisplayDetails().cssStyle).toBe(staticAbstractCssStyle);
     });
   });
 
@@ -757,6 +951,28 @@ describe('given text representing an attribute', () => {
 
       expect(displayDetails.displayText).toBe('name String');
       expect(displayDetails.cssStyle).toBe(abstractCssStyle);
+    });
+  });
+
+  describe('when the attribute has static and abstract "$*" modifier', () => {
+    it('should parse the display text correctly and apply abstract css style', () => {
+      const str = 'name String$*';
+
+      const displayDetails = new ClassMember(str, 'attribute').getDisplayDetails();
+
+      expect(displayDetails.displayText).toBe('name String');
+      expect(displayDetails.cssStyle).toBe(staticAbstractCssStyle);
+    });
+  });
+
+  describe('when the attribute has abstract and static "*$" modifier', () => {
+    it('should parse the display text correctly and apply abstract css style', () => {
+      const str = 'name String*$';
+
+      const displayDetails = new ClassMember(str, 'attribute').getDisplayDetails();
+
+      expect(displayDetails.displayText).toBe('name String');
+      expect(displayDetails.cssStyle).toBe(staticAbstractCssStyle);
     });
   });
 });

--- a/packages/mermaid/src/diagrams/class/classTypes.ts
+++ b/packages/mermaid/src/diagrams/class/classTypes.ts
@@ -76,45 +76,28 @@ export class ClassMember {
     let potentialClassifier = '';
 
     if (this.memberType === 'method') {
-      const methodRegEx = /([#+~-])?(.+)\((.*)\)([\s$*])?(.*)([$*])?/;
+      const methodRegEx = /([#+~-])?(.+)\((.*)\)([$*]{0,2})(.*?)([$*]{0,2})$/;
       const match = input.match(methodRegEx);
       if (match) {
-        const detectedVisibility = match[1] ? match[1].trim() : '';
-
-        if (visibilityValues.includes(detectedVisibility)) {
-          this.visibility = detectedVisibility as Visibility;
-        }
-
+        this.visibility = (match[1] ? match[1].trim() : '') as Visibility;
         this.id = match[2].trim();
         this.parameters = match[3] ? match[3].trim() : '';
         potentialClassifier = match[4] ? match[4].trim() : '';
         this.returnType = match[5] ? match[5].trim() : '';
 
         if (potentialClassifier === '') {
-          const lastChar = this.returnType.substring(this.returnType.length - 1);
-          if (lastChar.match(/[$*]/)) {
-            potentialClassifier = lastChar;
-            this.returnType = this.returnType.substring(0, this.returnType.length - 1);
-          }
+          potentialClassifier = match[6] ? match[6].trim() : '';
         }
       }
     } else {
-      const length = input.length;
-      const firstChar = input.substring(0, 1);
-      const lastChar = input.substring(length - 1);
+      const fieldRegEx = /([#+~-])?(.*?)([$*]{0,2})$/;
+      const match = input.match(fieldRegEx);
 
-      if (visibilityValues.includes(firstChar)) {
-        this.visibility = firstChar as Visibility;
+      if (match) {
+        this.visibility = (match[1] ? match[1].trim() : '') as Visibility;
+        this.id = match[2] ? match[2].trim() : '';
+        potentialClassifier = match[3] ? match[3].trim() : '';
       }
-
-      if (lastChar.match(/[$*]/)) {
-        potentialClassifier = lastChar;
-      }
-
-      this.id = input.substring(
-        this.visibility === '' ? 0 : 1,
-        potentialClassifier === '' ? length : length - 1
-      );
     }
 
     this.classifier = potentialClassifier;
@@ -122,10 +105,13 @@ export class ClassMember {
 
   parseClassifier() {
     switch (this.classifier) {
-      case '*':
-        return 'font-style:italic;';
       case '$':
         return 'text-decoration:underline;';
+      case '*':
+        return 'font-style:italic;';
+      case '$*':
+      case '*$':
+        return 'text-decoration:underline;font-style:italic;';
       default:
         return '';
     }


### PR DESCRIPTION
## :bookmark_tabs: Summary

This pull requests fixes a combination of abstract and static modifiers not working.

Resolves #5459

## :straight_ruler: Design Decisions

I updated the RegEx for detecting methods to take into account a possible combination of $* instead of just * or $. In that process I also found out that the last capture group didn't do anything because a "hack" was used where it checked if the last character was $ or *. This was removed.

For the fields, a similar tactic of checking for the first and last characters was replaced with a RegEx similar to the first one.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features. --> Will add an issue later for documentation.
- [x] :bookmark: targeted `develop` branch
