### PR TITLE
An example of how to add UML-style triggers, guards, actions to state diagrams

### DIFF
--- a/docs/syntax/stateDiagram.md
+++ b/docs/syntax/stateDiagram.md
@@ -669,4 +669,36 @@ stateDiagram
     YetAnotherState --> [*]
 ```
 
+## Adding Triggers, Guards, and Actions
+
+You can add UML-style triggers, guards, and actions to your diagrams.
+
+```mermaid-example
+stateDiagram
+    state "Still State" as Still
+    Still: enter [hasGps] / recordLocation()
+
+    [*] --> Still
+    Still --> [*]
+
+    Still --> Moving
+    Moving --> Still
+    Moving --> Crash
+    Crash --> [*]
+```
+
+```mermaid
+stateDiagram
+    state "Still State" as Still
+    Still: enter [hasGps] / recordLocation()
+
+    [*] --> Still
+    Still --> [*]
+
+    Still --> Moving
+    Moving --> Still
+    Moving --> Crash
+    Crash --> [*]
+```
+
 <!--- cspell:ignore yswsii --->

--- a/packages/mermaid/src/docs/syntax/stateDiagram.md
+++ b/packages/mermaid/src/docs/syntax/stateDiagram.md
@@ -419,4 +419,22 @@ stateDiagram
     YetAnotherState --> [*]
 ```
 
+## Adding Triggers, Guards, and Actions
+
+You can add UML-style triggers, guards, and actions to your diagrams.
+
+```mermaid-example
+stateDiagram
+    state "Still State" as Still
+    Still: enter [hasGps] / recordLocation()
+
+    [*] --> Still
+    Still --> [*]
+
+    Still --> Moving
+    Moving --> Still
+    Moving --> Crash
+    Crash --> [*]
+```
+
 <!--- cspell:ignore yswsii --->


### PR DESCRIPTION
## :bookmark_tabs: Summary

Adds an example showing how to add text to a node below the title, specifically so that it can be used for UML-style triggers/guards/actions.

It would be nice to be able to say something like "You may use the XXX feature to add additional text to the state, for example for adding triggers, actions, and guards." But I wasn't sure what the XXX feature is called. What do you call it when you add additional lines to a mermaid box diagram using the colon? Subtitle? Label? Multiple lines?

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :bookmark: targeted `develop` branch
