### PR TITLE
[PR#5468] refactor: remove TypeScript non null assertions

### DIFF
--- a/docs/config/setup/modules/mermaidAPI.md
+++ b/docs/config/setup/modules/mermaidAPI.md
@@ -98,7 +98,7 @@ mermaid.initialize(config);
 
 #### Defined in
 
-[mermaidAPI.ts:635](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/mermaidAPI.ts#L635)
+[mermaidAPI.ts:634](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/mermaidAPI.ts#L634)
 
 ## Functions
 
@@ -129,7 +129,7 @@ Return the last node appended
 
 #### Defined in
 
-[mermaidAPI.ts:277](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/mermaidAPI.ts#L277)
+[mermaidAPI.ts:276](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/mermaidAPI.ts#L276)
 
 ---
 
@@ -155,7 +155,7 @@ the cleaned up svgCode
 
 #### Defined in
 
-[mermaidAPI.ts:223](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/mermaidAPI.ts#L223)
+[mermaidAPI.ts:222](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/mermaidAPI.ts#L222)
 
 ---
 
@@ -203,7 +203,7 @@ the string with all the user styles
 
 #### Defined in
 
-[mermaidAPI.ts:200](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/mermaidAPI.ts#L200)
+[mermaidAPI.ts:199](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/mermaidAPI.ts#L199)
 
 ---
 
@@ -256,7 +256,7 @@ Put the svgCode into an iFrame. Return the iFrame code
 
 #### Defined in
 
-[mermaidAPI.ts:254](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/mermaidAPI.ts#L254)
+[mermaidAPI.ts:253](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/mermaidAPI.ts#L253)
 
 ---
 
@@ -281,4 +281,4 @@ Remove any existing elements from the given document
 
 #### Defined in
 
-[mermaidAPI.ts:327](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/mermaidAPI.ts#L327)
+[mermaidAPI.ts:326](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/mermaidAPI.ts#L326)

--- a/packages/mermaid/src/diagrams/class/classDb.ts
+++ b/packages/mermaid/src/diagrams/class/classDb.ts
@@ -226,8 +226,9 @@ export const setCssClass = function (ids: string, className: string) {
     if (_id[0].match(/\d/)) {
       id = MERMAID_DOM_ID_PREFIX + id;
     }
-    if (classes.has(id)) {
-      classes.get(id)!.cssClasses.push(className);
+    const classNode = classes.get(id);
+    if (classNode) {
+      classNode.cssClasses.push(className);
     }
   });
 };
@@ -268,8 +269,8 @@ export const setLink = function (ids: string, linkStr: string, target: string) {
     if (_id[0].match(/\d/)) {
       id = MERMAID_DOM_ID_PREFIX + id;
     }
-    if (classes.has(id)) {
-      const theClass = classes.get(id)!;
+    const theClass = classes.get(id);
+    if (theClass) {
       theClass.link = utils.formatUrl(linkStr, config);
       if (config.securityLevel === 'sandbox') {
         theClass.linkTarget = '_top';

--- a/packages/mermaid/src/diagrams/class/classRenderer-v2.ts
+++ b/packages/mermaid/src/diagrams/class/classRenderer-v2.ts
@@ -44,14 +44,11 @@ export const addNamespaces = function (
   _id: string,
   diagObj: any
 ) {
-  const keys = [...namespaces.keys()];
-  log.info('keys:', keys);
+  log.info('keys:', [...namespaces.keys()]);
   log.info(namespaces);
 
   // Iterate through each item in the vertex object (containing all the vertices found) in the graph definition
-  keys.forEach(function (id) {
-    const vertex = namespaces.get(id)!;
-
+  namespaces.forEach(function (vertex) {
     // parent node must be one of [rect, roundedWithTitle, noteGroup, divider]
     const shape = 'rect';
 
@@ -89,16 +86,13 @@ export const addClasses = function (
   diagObj: any,
   parent?: string
 ) {
-  const keys = [...classes.keys()];
-  log.info('keys:', keys);
+  log.info('keys:', [...classes.keys()]);
   log.info(classes);
 
   // Iterate through each item in the vertex object (containing all the vertices found) in the graph definition
-  keys
-    .filter((id) => classes.get(id)!.parent == parent)
-    .forEach(function (id) {
-      const vertex = classes.get(id)!;
-
+  [...classes.values()]
+    .filter((vertex) => vertex.parent === parent)
+    .forEach(function (vertex) {
       /**
        * Variable for storing the classes for the vertex
        */

--- a/packages/mermaid/src/diagrams/git/gitGraphAst.js
+++ b/packages/mermaid/src/diagrams/git/gitGraphAst.js
@@ -479,9 +479,7 @@ export const getCommits = function () {
   return commits;
 };
 export const getCommitsArray = function () {
-  const commitArr = [...commits.keys()].map(function (key) {
-    return commits.get(key);
-  });
+  const commitArr = [...commits.values()];
   commitArr.forEach(function (o) {
     log.debug(o.id);
   });

--- a/packages/mermaid/src/diagrams/git/gitGraphParserV2.spec.js
+++ b/packages/mermaid/src/diagrams/git/gitGraphParserV2.spec.js
@@ -339,9 +339,7 @@ describe('when parsing a gitGraph', function () {
     expect(parser.yy.getCurrentBranch()).toBe('main');
     expect(parser.yy.getDirection()).toBe('LR');
     expect(parser.yy.getBranches().size).toBe(2);
-    const commit1 = commits.keys().next().value;
-    const commit2 = [...commits.keys()][1];
-    const commit3 = [...commits.keys()][2];
+    const [commit1, commit2, commit3] = commits.keys();
     expect(commits.get(commit1).branch).toBe('main');
     expect(commits.get(commit2).branch).toBe('branch');
     expect(commits.get(commit3).branch).toBe('main');
@@ -477,8 +475,7 @@ describe('when parsing a gitGraph', function () {
     expect(parser.yy.getCurrentBranch()).toBe('testBranch');
     expect(parser.yy.getDirection()).toBe('LR');
     expect(parser.yy.getBranches().size).toBe(2);
-    const commit1 = commits.keys().next().value;
-    const commit2 = [...commits.keys()][1];
+    const [commit1, commit2] = commits.keys();
     expect(commits.get(commit1).branch).toBe('main');
     expect(commits.get(commit1).parents).toStrictEqual([]);
     expect(commits.get(commit2).branch).toBe('testBranch');
@@ -502,10 +499,7 @@ describe('when parsing a gitGraph', function () {
     expect(parser.yy.getCurrentBranch()).toBe('main');
     expect(parser.yy.getDirection()).toBe('LR');
     expect(parser.yy.getBranches().size).toBe(2);
-    const commit1 = commits.keys().next().value;
-    const commit2 = [...commits.keys()][1];
-    const commit3 = [...commits.keys()][2];
-    const commit4 = [...commits.keys()][3];
+    const [commit1, commit2, commit3, commit4] = commits.keys();
     expect(commits.get(commit1).branch).toBe('main');
     expect(commits.get(commit1).parents).toStrictEqual([]);
     expect(commits.get(commit2).branch).toBe('testBranch');
@@ -552,8 +546,7 @@ describe('when parsing a gitGraph', function () {
     expect(parser.yy.getCurrentBranch()).toBe('testBranch');
     expect(parser.yy.getDirection()).toBe('LR');
     expect(parser.yy.getBranches().size).toBe(2);
-    const commit1 = commits.keys().next().value;
-    const commit2 = [...commits.keys()][1];
+    const [commit1, commit2] = commits.keys();
     expect(commits.get(commit1).branch).toBe('main');
     expect(commits.get(commit1).parents).toStrictEqual([]);
     expect(commits.get(commit2).branch).toBe('testBranch');
@@ -577,10 +570,7 @@ describe('when parsing a gitGraph', function () {
     expect(parser.yy.getCurrentBranch()).toBe('main');
     expect(parser.yy.getDirection()).toBe('LR');
     expect(parser.yy.getBranches().size).toBe(2);
-    const commit1 = commits.keys().next().value;
-    const commit2 = [...commits.keys()][1];
-    const commit3 = [...commits.keys()][2];
-    const commit4 = [...commits.keys()][3];
+    const [commit1, commit2, commit3, commit4] = commits.keys();
     expect(commits.get(commit1).branch).toBe('main');
     expect(commits.get(commit1).parents).toStrictEqual([]);
     expect(commits.get(commit2).branch).toBe('testBranch');
@@ -614,10 +604,7 @@ describe('when parsing a gitGraph', function () {
     expect(parser.yy.getCurrentBranch()).toBe('main');
     expect(parser.yy.getDirection()).toBe('LR');
     expect(parser.yy.getBranches().size).toBe(2);
-    const commit1 = commits.keys().next().value;
-    const commit2 = [...commits.keys()][1];
-    const commit3 = [...commits.keys()][2];
-
+    const [commit1, commit2, commit3] = commits.keys();
     expect(commits.get(commit1).branch).toBe('main');
     expect(commits.get(commit1).parents).toStrictEqual([]);
 

--- a/packages/mermaid/src/diagrams/pie/pieRenderer.ts
+++ b/packages/mermaid/src/diagrams/pie/pieRenderer.ts
@@ -105,8 +105,8 @@ export const draw: DrawDefinition = (text, id, _version, diagObj) => {
     .attr('class', 'pieCircle');
 
   let sum = 0;
-  [...sections.keys()].forEach((key: string): void => {
-    sum += sections.get(key)!;
+  sections.forEach((section) => {
+    sum += section;
   });
   // Now add the percentage.
   // Use the centroid method to get the best coordinates.

--- a/packages/mermaid/src/diagrams/requirement/requirementRenderer.js
+++ b/packages/mermaid/src/diagrams/requirement/requirementRenderer.js
@@ -191,9 +191,13 @@ const drawRelationshipFromLayout = function (svg, rel, g, insert, diagObj) {
   return;
 };
 
+/**
+ * @param {Map<string, any>} reqs
+ * @param graph
+ * @param svgNode
+ */
 export const drawReqs = (reqs, graph, svgNode) => {
-  [...reqs.keys()].forEach((reqName) => {
-    let req = reqs.get(reqName);
+  reqs.forEach((req, reqName) => {
     reqName = elementString(reqName);
     log.info('Added new requirement: ', reqName);
 
@@ -236,9 +240,13 @@ export const drawReqs = (reqs, graph, svgNode) => {
   });
 };
 
+/**
+ * @param {Map<string, any>} els
+ * @param graph
+ * @param svgNode
+ */
 export const drawElements = (els, graph, svgNode) => {
-  [...els.keys()].forEach((elName) => {
-    let el = els.get(elName);
+  els.forEach((el, elName) => {
     const id = elementString(elName);
 
     const groupNode = svgNode.append('g').attr('id', id);

--- a/packages/mermaid/src/diagrams/sankey/sankeyDB.ts
+++ b/packages/mermaid/src/diagrams/sankey/sankeyDB.ts
@@ -48,11 +48,13 @@ class SankeyNode {
 const findOrCreateNode = (ID: string): SankeyNode => {
   ID = common.sanitizeText(ID, getConfig());
 
-  if (!nodesMap.has(ID)) {
-    nodesMap.set(ID, new SankeyNode(ID));
-    nodes.push(nodesMap.get(ID)!);
+  let node = nodesMap.get(ID);
+  if (node === undefined) {
+    node = new SankeyNode(ID);
+    nodesMap.set(ID, node);
+    nodes.push(node);
   }
-  return nodesMap.get(ID)!;
+  return node;
 };
 
 const getNodes = () => nodes;

--- a/packages/mermaid/src/diagrams/sequence/sequenceDb.ts
+++ b/packages/mermaid/src/diagrams/sequence/sequenceDb.ts
@@ -99,8 +99,11 @@ export const addActor = function (
     rectData: null,
     type: type ?? 'participant',
   });
-  if (state.records.prevActor && state.records.actors.has(state.records.prevActor)) {
-    state.records.actors.get(state.records.prevActor)!.nextActor = id;
+  if (state.records.prevActor) {
+    const prevActorInRecords = state.records.actors.get(state.records.prevActor);
+    if (prevActorInRecords) {
+      prevActorInRecords.nextActor = id;
+    }
   }
 
   if (state.records.currentBox) {
@@ -207,6 +210,7 @@ export const getDestroyedActors = function () {
   return state.records.destroyedActors;
 };
 export const getActor = function (id: string) {
+  // TODO: do we ever use this function in a way that it might return undefined?
   return state.records.actors.get(id)!;
 };
 export const getActorKeys = function () {

--- a/packages/mermaid/src/diagrams/state/stateDb.js
+++ b/packages/mermaid/src/diagrams/state/stateDb.js
@@ -239,8 +239,6 @@ export const addState = function (
     }
   }
 
-  const doc2 = currentDocument.states.get(trimmedId);
-
   if (descr) {
     log.info('Setting state description', trimmedId, descr);
     if (typeof descr === 'string') {
@@ -253,6 +251,7 @@ export const addState = function (
   }
 
   if (note) {
+    const doc2 = currentDocument.states.get(trimmedId);
     doc2.note = note;
     doc2.note.text = common.sanitizeText(doc2.note.text, getConfig());
   }

--- a/packages/mermaid/src/mermaidAPI.ts
+++ b/packages/mermaid/src/mermaidAPI.ts
@@ -171,7 +171,7 @@ export const createCssStyles = (
   }
 
   // classDefs defined in the diagram text
-  if (!isEmpty(classDefs) && classDefs instanceof Map) {
+  if (classDefs instanceof Map) {
     const htmlLabels = config.htmlLabels || config.flowchart?.htmlLabels; // TODO why specifically check the Flowchart diagram config?
 
     const cssHtmlElements = ['> *', 'span']; // TODO make a constant
@@ -180,8 +180,7 @@ export const createCssStyles = (
     const cssElements = htmlLabels ? cssHtmlElements : cssShapeElements;
 
     // create the CSS styles needed for each styleClass definition and css element
-    for (const classId of classDefs!.keys()) {
-      const styleClassDef = classDefs.get(classId)!;
+    classDefs.forEach((styleClassDef) => {
       // create the css styles for each cssElement and the styles (only if there are styles)
       if (!isEmpty(styleClassDef.styles)) {
         cssElements.forEach((cssElement) => {
@@ -192,7 +191,7 @@ export const createCssStyles = (
       if (!isEmpty(styleClassDef.textStyles)) {
         cssStyles += cssImportantStyles(styleClassDef.id, 'tspan', styleClassDef.textStyles);
       }
-    }
+    });
   }
   return cssStyles;
 };


### PR DESCRIPTION
## :bookmark_tabs: Summary

> [!Note]
>
> This PR does not target the `develop` branch. Instead it targets:
>
> - #5468

I'm not a big fan of using TypeScript's non-null assertion operator (e.g. `map.get(val)!`).

Instead, I've tried to rewrite the code when possible, so it's not needed. E.g., instead of doing:

```ts
if (map.has(x)) {
  return map.get(x);
}
```

I've tried to do things that TypeScript can understand, e.g.

```ts
const val = map.get(x);
if (val !== undefined) {
  return val;
}
```

There's also some other misc improvements I found when reviewing #5468.

There should be no functional changes to the code, this is a refactoring only change.

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :bookmark: targeted `develop` branch
  - **NOPE**, targets #5468
