### PR TITLE
Fixed wrong ELK detector

### DIFF
--- a/packages/mermaid-flowchart-elk/src/detector.spec.ts
+++ b/packages/mermaid-flowchart-elk/src/detector.spec.ts
@@ -48,7 +48,7 @@ describe('flowchart-elk detector', () => {
           defaultRenderer: 'elk',
         },
       })
-    ).toBe(false)
+    ).toBe(false);
 
     expect(
       detector('mindmap ["Descendant node in graph"]', {
@@ -56,7 +56,7 @@ describe('flowchart-elk detector', () => {
           defaultRenderer: 'elk',
         },
       })
-    ).toBe(false)
+    ).toBe(false);
   });
 
   it('should detect flowchart-elk', () => {

--- a/packages/mermaid-flowchart-elk/src/detector.spec.ts
+++ b/packages/mermaid-flowchart-elk/src/detector.spec.ts
@@ -39,6 +39,26 @@ describe('flowchart-elk detector', () => {
     ).toBe(true);
   });
 
+  // The error from the issue was reproduced with mindmap, so this is just an example
+  // what matters is the keyword somewhere inside graph definition
+  it('should check only the beginning of the line in search of keywords', () => {
+    expect(
+      detector('mindmap ["Descendant node in flowchart"]', {
+        flowchart: {
+          defaultRenderer: 'elk',
+        },
+      })
+    ).toBe(false)
+
+    expect(
+      detector('mindmap ["Descendant node in graph"]', {
+        flowchart: {
+          defaultRenderer: 'elk',
+        },
+      })
+    ).toBe(false)
+  });
+
   it('should detect flowchart-elk', () => {
     expect(detector('flowchart-elk')).toBe(true);
   });

--- a/packages/mermaid-flowchart-elk/src/detector.ts
+++ b/packages/mermaid-flowchart-elk/src/detector.ts
@@ -11,7 +11,7 @@ const detector: DiagramDetector = (txt, config): boolean => {
     // If diagram explicitly states flowchart-elk
     /^\s*flowchart-elk/.test(txt) ||
     // If a flowchart/graph diagram has their default renderer set to elk
-    (/^\s*flowchart|graph/.test(txt) && config?.flowchart?.defaultRenderer === 'elk')
+    (/^\s*(flowchart|graph)/.test(txt) && config?.flowchart?.defaultRenderer === 'elk')
   ) {
     return true;
   }


### PR DESCRIPTION
## :bookmark_tabs: Summary

Brief description about the content of your PR.

Resolves #5507

## :straight_ruler: Design Decisions

We have to check only the beginning of the line so we need grouping.
This
```
/^\s*flowchar|graph/.test("some graph")
```
was returning `true`, but it should not.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] ~~:notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.~~
- [x] :bookmark: targeted `develop` branch
