### PR TITLE
Show Full Title in Pie Chart SVG

### DIFF
--- a/packages/mermaid/src/diagrams/pie/pieRenderer.ts
+++ b/packages/mermaid/src/diagrams/pie/pieRenderer.ts
@@ -166,14 +166,28 @@ export const draw: DrawDefinition = (text, id, _version, diagObj) => {
       return label;
     });
 
-  const longestTextWidth = Math.max(
+  const titleTextElement = group.select('.pieTitleText');
+  const titleTextLeft = titleTextElement.node().getBoundingClientRect().left;
+  const titleTextWidth = titleTextElement.node().getBoundingClientRect().width;
+
+  // Adjust chart placement.
+  if (titleTextLeft < MARGIN && titleTextElement.text()) {
+    group.attr(
+      'transform',
+      'translate(' + (pieWidth / 2 - (titleTextLeft - MARGIN)) + ',' + height / 2 + ')'
+    );
+  }
+
+  const circleOffset = group.select('circle').node().getBoundingClientRect().left;
+
+  const furthestTextPos = Math.max(
     ...legend
       .selectAll('text')
       .nodes()
-      .map((node) => (node as Element)?.getBoundingClientRect().width ?? 0)
+      .map((node) => (node as Element)?.getBoundingClientRect().right ?? 0)
   );
 
-  const totalWidth = pieWidth + MARGIN + LEGEND_RECT_SIZE + LEGEND_SPACING + longestTextWidth;
+  const totalWidth = Math.max(circleOffset + furthestTextPos, MARGIN * 2 + titleTextWidth);
 
   // Set viewBox
   svg.attr('viewBox', `0 0 ${totalWidth} ${height}`);


### PR DESCRIPTION
## :bookmark_tabs: Summary

Aims to fix the title of a pie chart overflowing outside the bounds of the rendered SVG.

Resolves #5567

## :straight_ruler: Design Decisions

The goal was to keep the rendering the same but to account for the title length if it surpasses the length of the overall diagram. If so, it will update the total width of the diagram and offset the chart so it remains centered under the title text. It also maintains the margin on both sides.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :bookmark: targeted `develop` branch