### PR TITLE
fix: prevent escaping label styles

### DIFF
--- a/packages/mermaid/src/dagre-wrapper/createLabel.js
+++ b/packages/mermaid/src/dagre-wrapper/createLabel.js
@@ -25,15 +25,10 @@ function addHtmlLabel(node) {
 
   const label = node.label;
   const labelClass = node.isNode ? 'nodeLabel' : 'edgeLabel';
-  div.html(
-    '<span class="' +
-      labelClass +
-      '" ' +
-      (node.labelStyle ? 'style="' + node.labelStyle + '"' : '') +
-      '>' +
-      label +
-      '</span>'
-  );
+  const span = div.append('span');
+  span.html(label);
+  applyStyle(span, node.labelStyle);
+  span.attr('class', labelClass);
 
   applyStyle(div, node.labelStyle);
   div.style('display', 'inline-block');

--- a/packages/mermaid/src/rendering-util/createText.ts
+++ b/packages/mermaid/src/rendering-util/createText.ts
@@ -21,13 +21,10 @@ function addHtmlSpan(element, node, width, classes, addBackground = false) {
 
   const label = node.label;
   const labelClass = node.isNode ? 'nodeLabel' : 'edgeLabel';
-  div.html(
-    `<span class="${labelClass} ${classes}" ` +
-      (node.labelStyle ? 'style="' + node.labelStyle + '"' : '') +
-      '>' +
-      label +
-      '</span>'
-  );
+  const span = div.append('span');
+  span.html(label);
+  applyStyle(span, node.labelStyle);
+  span.attr('class', `${labelClass} ${classes}`);
 
   applyStyle(div, node.labelStyle);
   div.style('display', 'table-cell');


### PR DESCRIPTION
## :bookmark_tabs: Summary

Currently we use string concatenation to create the spans for labels inside diagrams, however this can be escaped in `securityLevel: loose` using a diagram syntax like the following:

```
flowchart
A --> B
style A color:red\"test \"
```

![Screenshot 2024-06-25 at 1 50 46 PM](https://github.com/mermaid-js/mermaid/assets/53054099/a5b1638a-cbd7-4c74-bec9-acc9cf40b35a)

This isn't a problem as of now because the equal sign (=) isn't allowed inside style statements on any of our diagram grammars, but it can cause problems further down the road.

## :straight_ruler: Design Decisions

Replaced string concatenation with instead using D3 syntax to insert a span and modify its attributes.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :bookmark: targeted `develop` branch
