### PR TITLE
feat: Use marked instead of mdast-util-from-markdown

### DIFF
--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -81,7 +81,7 @@
     "katex": "^0.16.9",
     "khroma": "^2.1.0",
     "lodash-es": "^4.17.21",
-    "mdast-util-from-markdown": "^2.0.0",
+    "marked": "^13.0.2",
     "stylis": "^4.3.1",
     "ts-dedent": "^2.2.0",
     "uuid": "^9.0.1"

--- a/packages/mermaid/src/rendering-util/createText.ts
+++ b/packages/mermaid/src/rendering-util/createText.ts
@@ -153,7 +153,7 @@ function updateTextContentAndStyles(tspan: any, wrappedLine: MarkdownWord[]) {
   wrappedLine.forEach((word, index) => {
     const innerTspan = tspan
       .append('tspan')
-      .attr('font-style', word.type === 'emphasis' ? 'italic' : 'normal')
+      .attr('font-style', word.type === 'em' ? 'italic' : 'normal')
       .attr('class', 'text-inner-tspan')
       .attr('font-weight', word.type === 'strong' ? 'bold' : 'normal');
     if (index === 0) {

--- a/packages/mermaid/src/rendering-util/handle-markdown-text.spec.ts
+++ b/packages/mermaid/src/rendering-util/handle-markdown-text.spec.ts
@@ -295,7 +295,7 @@ test('markdownToHTML - no auto wrapping', () => {
   you do?`,
       { markdownAutoWrap: false }
     )
-  ).toMatchInlineSnapshot(`"<p>Hello,&nbsp;how&nbsp;do<br/>you&nbsp;do?</p>"`);
+  ).toMatchInlineSnapshot('"<p>Hello,&nbsp;how&nbsp;do<br/>you&nbsp;do?</p>"');
 });
 
 test('markdownToHTML - auto wrapping', () => {
@@ -305,5 +305,5 @@ test('markdownToHTML - auto wrapping', () => {
   you do?`,
       { markdownAutoWrap: true }
     )
-  ).toMatchInlineSnapshot(`"<p>Hello, how do<br/>you do?</p>"`);
+  ).toMatchInlineSnapshot('"<p>Hello, how do<br/>you do?</p>"');
 });

--- a/packages/mermaid/src/rendering-util/handle-markdown-text.spec.ts
+++ b/packages/mermaid/src/rendering-util/handle-markdown-text.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-irregular-whitespace */
 import { markdownToLines, markdownToHTML } from './handle-markdown-text.js';
 import { test, expect } from 'vitest';
 
@@ -215,13 +214,13 @@ test('markdownToLines - No auto wrapping', () => {
     [
       [
         {
-          "content": "Hello, how do",
+          "content": "Hello,&nbsp;how&nbsp;do",
           "type": "normal",
         },
       ],
       [
         {
-          "content": "you do?",
+          "content": "you&nbsp;do?",
           "type": "normal",
         },
       ],
@@ -296,5 +295,5 @@ test('markdownToHTML - no auto wrapping', () => {
   you do?`,
       { markdownAutoWrap: false }
     )
-  ).toMatchInlineSnapshot('"<p>Hello,&nbsp;how&nbsp;do<br/>you&nbsp;do?</p>"');
+  ).toMatchInlineSnapshot(`"<p>Hello,&nbsp;how&nbsp;do<br/>&nbsp;&nbsp;you&nbsp;do?</p>"`);
 });

--- a/packages/mermaid/src/rendering-util/handle-markdown-text.spec.ts
+++ b/packages/mermaid/src/rendering-util/handle-markdown-text.spec.ts
@@ -295,5 +295,15 @@ test('markdownToHTML - no auto wrapping', () => {
   you do?`,
       { markdownAutoWrap: false }
     )
-  ).toMatchInlineSnapshot(`"<p>Hello,&nbsp;how&nbsp;do<br/>&nbsp;&nbsp;you&nbsp;do?</p>"`);
+  ).toMatchInlineSnapshot(`"<p>Hello,&nbsp;how&nbsp;do<br/>you&nbsp;do?</p>"`);
+});
+
+test('markdownToHTML - auto wrapping', () => {
+  expect(
+    markdownToHTML(
+      `Hello, how do
+  you do?`,
+      { markdownAutoWrap: true }
+    )
+  ).toMatchInlineSnapshot(`"<p>Hello, how do<br/>you do?</p>"`);
 });

--- a/packages/mermaid/src/rendering-util/handle-markdown-text.spec.ts
+++ b/packages/mermaid/src/rendering-util/handle-markdown-text.spec.ts
@@ -36,9 +36,9 @@ Here is a line *with an italic* section`;
       { content: 'is', type: 'normal' },
       { content: 'a', type: 'normal' },
       { content: 'line', type: 'normal' },
-      { content: 'with', type: 'emphasis' },
-      { content: 'an', type: 'emphasis' },
-      { content: 'italic', type: 'emphasis' },
+      { content: 'with', type: 'em' },
+      { content: 'an', type: 'em' },
+      { content: 'italic', type: 'em' },
       { content: 'section', type: 'normal' },
     ],
   ];
@@ -142,7 +142,7 @@ test('markdownToLines - Only italic formatting', () => {
       { content: 'This', type: 'normal' },
       { content: 'is', type: 'normal' },
       { content: 'an', type: 'normal' },
-      { content: 'italic', type: 'emphasis' },
+      { content: 'italic', type: 'em' },
       { content: 'test', type: 'normal' },
     ],
   ];
@@ -155,7 +155,7 @@ it('markdownToLines - Mixed formatting', () => {
   let input = `*Italic* and **bold** formatting`;
   let expected = [
     [
-      { content: 'Italic', type: 'emphasis' },
+      { content: 'Italic', type: 'em' },
       { content: 'and', type: 'normal' },
       { content: 'bold', type: 'strong' },
       { content: 'formatting', type: 'normal' },
@@ -166,9 +166,9 @@ it('markdownToLines - Mixed formatting', () => {
   input = `*Italic with space* and **bold ws** formatting`;
   expected = [
     [
-      { content: 'Italic', type: 'emphasis' },
-      { content: 'with', type: 'emphasis' },
-      { content: 'space', type: 'emphasis' },
+      { content: 'Italic', type: 'em' },
+      { content: 'with', type: 'em' },
+      { content: 'space', type: 'em' },
       { content: 'and', type: 'normal' },
       { content: 'bold', type: 'strong' },
       { content: 'ws', type: 'strong' },
@@ -190,9 +190,9 @@ Word!`;
       { content: 'the', type: 'strong' },
       { content: 'hog...', type: 'normal' },
       { content: 'a', type: 'normal' },
-      { content: 'very', type: 'emphasis' },
-      { content: 'long', type: 'emphasis' },
-      { content: 'text', type: 'emphasis' },
+      { content: 'very', type: 'em' },
+      { content: 'long', type: 'em' },
+      { content: 'text', type: 'em' },
       { content: 'about', type: 'normal' },
       { content: 'it', type: 'normal' },
     ],

--- a/packages/mermaid/src/rendering-util/handle-markdown-text.ts
+++ b/packages/mermaid/src/rendering-util/handle-markdown-text.ts
@@ -44,7 +44,7 @@ export function markdownToLines(markdown: string, config: MermaidConfig = {}): M
       });
     } else if (node.type === 'strong' || node.type === 'em') {
       node.tokens.forEach((contentNode) => {
-        processNode(contentNode as MarkedToken, node.type === 'em' ? 'emphasis' : node.type);
+        processNode(contentNode as MarkedToken, node.type);
       });
     }
   }

--- a/packages/mermaid/src/rendering-util/handle-markdown-text.ts
+++ b/packages/mermaid/src/rendering-util/handle-markdown-text.ts
@@ -66,9 +66,9 @@ export function markdownToHTML(markdown: string, { markdownAutoWrap }: MermaidCo
   function output(node: Token): string {
     if (node.type === 'text') {
       if (markdownAutoWrap === false) {
-        return node.text.replace(/\n/g, '<br/>').replace(/ /g, '&nbsp;');
+        return node.text.replace(/\n */g, '<br/>').replace(/ /g, '&nbsp;');
       }
-      return node.text.replace(/\n/g, '<br/>');
+      return node.text.replace(/\n */g, '<br/>');
     } else if (node.type === 'strong') {
       return `<strong>${node.tokens?.map(output).join('')}</strong>`;
     } else if (node.type === 'em') {

--- a/packages/mermaid/src/rendering-util/types.d.ts
+++ b/packages/mermaid/src/rendering-util/types.d.ts
@@ -1,4 +1,4 @@
-export type MarkdownWordType = 'normal' | 'strong' | 'emphasis';
+export type MarkdownWordType = 'normal' | 'strong' | 'em';
 export interface MarkdownWord {
   content: string;
   type: MarkdownWordType;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,9 +239,9 @@ importers:
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
-      mdast-util-from-markdown:
-        specifier: ^2.0.0
-        version: 2.0.1
+      marked:
+        specifier: ^13.0.2
+        version: 13.0.2
       stylis:
         specifier: ^4.3.1
         version: 4.3.2
@@ -6783,6 +6783,11 @@ packages:
 
   markdown-table@3.0.3:
     resolution: {integrity: sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==}
+
+  marked@13.0.2:
+    resolution: {integrity: sha512-J6CPjP8pS5sgrRqxVRvkCIkZ6MFdRIjDkwUwgJ9nL2fbmM6qGQeB2C16hi8Cc9BOzj6xXzy0jyi0iPIfnMHYzA==}
+    engines: {node: '>= 18'}
+    hasBin: true
 
   marked@4.3.0:
     resolution: {integrity: sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==}
@@ -16892,6 +16897,8 @@ snapshots:
       uc.micro: 1.0.6
 
   markdown-table@3.0.3: {}
+
+  marked@13.0.2: {}
 
   marked@4.3.0: {}
 

--- a/scripts/size.ts
+++ b/scripts/size.ts
@@ -22,10 +22,10 @@ const readStats = async (path: string): Promise<Record<string, number>> => {
 };
 
 const formatBytes = (bytes: number): string => {
-  bytes = Math.abs(bytes);
   if (bytes == 0) {
     return '0 Bytes';
   }
+  bytes = Math.abs(bytes);
   const base = 1024;
   const decimals = 2;
   const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];

--- a/scripts/size.ts
+++ b/scripts/size.ts
@@ -22,6 +22,7 @@ const readStats = async (path: string): Promise<Record<string, number>> => {
 };
 
 const formatBytes = (bytes: number): string => {
+  bytes = Math.abs(bytes);
   if (bytes == 0) {
     return '0 Bytes';
   }


### PR DESCRIPTION
## :bookmark_tabs: Summary

This will remove 33 dependencies pulled down by mdast-util-from-markdown. marked has 0 dependencies.

|Before|After|
|--|--|
|<img width="350" alt="image" src="https://github.com/mermaid-js/mermaid/assets/10703445/eafdf10f-5873-46aa-8311-b9ae7cb704c3">|<img width="350" alt="image" src="https://github.com/user-attachments/assets/35341906-3d4e-4dc0-94d7-2395fe6ad884">|

mermaid's dependency count will go from 102 to 69

## Bundle size difference

| File           | Previous Size           | New Size                | Difference              | % Change |
| -------------- | ----------------------- | ----------------------- | ----------------------- | -------- |
| mermaid.min.js | 2.19 MB (2295094 Bytes) | 2.17 MB (2271841 Bytes) | 22.71 KB (-23253 Bytes) | -1.02%   |

## :straight_ruler: Design Decisions

Dependency Graphs

- [mermaid](https://npmgraph.js.org/?q=mermaid)
- [marked](https://npmgraph.js.org/?q=marked)
- [mdast-util-from-markdown](https://npmgraph.js.org/?q=mdast-util-from-markdown)

Removed 

<img width="814" alt="image" src="https://github.com/mermaid-js/mermaid/assets/10703445/d5953c48-a028-4753-8c3b-09f54b270423">

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :bookmark: targeted `develop` branch