### PR TITLE
fix: long strings in markdown in flowcharts in firefox

### DIFF
--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mermaid",
-  "version": "11.0.0-alpha.7",
+  "version": "11.0.0-alpha.7+",
   "description": "Markdown-ish syntax for generating flowcharts, mindmaps, sequence diagrams, class diagrams, gantt charts, git graphs and more.",
   "type": "module",
   "module": "./dist/mermaid.core.mjs",

--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mermaid",
-  "version": "11.0.0-alpha.7+",
+  "version": "11.0.0-alpha.7",
   "description": "Markdown-ish syntax for generating flowcharts, mindmaps, sequence diagrams, class diagrams, gantt charts, git graphs and more.",
   "type": "module",
   "module": "./dist/mermaid.core.mjs",

--- a/packages/mermaid/src/dagre-wrapper/shapes/util.js
+++ b/packages/mermaid/src/dagre-wrapper/shapes/util.js
@@ -104,6 +104,7 @@ export const labelHelper = async (parent, node, _classes, isNode) => {
     bbox = div.getBoundingClientRect();
     dv.attr('width', bbox.width);
     dv.attr('height', bbox.height);
+    dv.style('height', bbox.height + 'px');
   }
 
   // Center the label

--- a/packages/mermaid/src/rendering-util/createText.ts
+++ b/packages/mermaid/src/rendering-util/createText.ts
@@ -40,11 +40,14 @@ function addHtmlSpan(element, node, width, classes, addBackground = false) {
     div.style('display', 'table');
     div.style('white-space', 'break-spaces');
     div.style('width', width + 'px');
-    bbox = div.node().getBoundingClientRect();
+    const newBbox = div.node().getBoundingClientRect();
+    if (newBbox.height > 0) {
+      bbox = newBbox;
+    }
   }
 
-  fo.style('width', bbox.width);
-  fo.style('height', bbox.height);
+  fo.style('width', bbox.width + 'px');
+  fo.style('height', bbox.height + 'px');
 
   return fo.node();
 }


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fixes an issue on firefox where long strings in markdown in flowchart diagrams would overflow and not render correctly.

Resolves #5646 

## :straight_ruler: Design Decisions

This problem resulted since the width and height inline styles were registering as `0` when the `px` units weren't specified in Firefox. The newly assigned bbox after switching the div to `display: table` didn't have a width or height either on Firefox only. This PR instead adds the height as a style upto where the `width` and `height` attributes are assigned on Firefox. I am not sure if the inline styles are needed because the attributes exist, but I kept them there for now.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :bookmark: targeted `develop` branch
