### PR TITLE
fix: double space in wrapped sequence diagram messages

### DIFF
--- a/packages/mermaid/src/utils.ts
+++ b/packages/mermaid/src/utils.ts
@@ -567,7 +567,7 @@ export const wrapLabel: (label: string, maxWidth: number, config: WrapLabelConfi
       if (common.lineBreakRegex.test(label)) {
         return label;
       }
-      const words = label.split(' ');
+      const words = label.split(' ').filter(Boolean);
       const completedLines: string[] = [];
       let nextLine = '';
       words.forEach((word, index) => {


### PR DESCRIPTION
## :bookmark_tabs: Summary

Some sequence diagrams that had multiple spaces in them and were wrapped, explicitly set wrapping in the config or message and/or a message inside a break statement, resulted in rendering errors since the words weren't split correctly resulting in mermaid trying to calculate the text dimensions of an empty string.

Resolves #4298

Repro:
```text
        sequenceDiagram
break Get the Salesforce  Account
AWS->>LamdaGetAccount : GetAccount
LamdaGetAccount->>Salesforce: sd
Salesforce->>LamdaGetAccount: ds
end
```

Resolves #5617

Repro:
```text

sequenceDiagram

actor User as User/Browser
participant API1 as api.example.com
participant API2 as contacts.example.com

User ->> API1 :wrap: Send Access Token As Cookies  With Different Request
 
```

## :straight_ruler: Design Decisions

Simple one-liner fix to filter out empty strings in word split in `wrapLabel`.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :bookmark: targeted `develop` branch
