### PR TITLE
refactor!(git): default to `useMaxWidth` true

### DIFF
--- a/docs/config/setup/modules/defaultConfig.md
+++ b/docs/config/setup/modules/defaultConfig.md
@@ -14,7 +14,7 @@
 
 #### Defined in
 
-[packages/mermaid/src/defaultConfig.ts:279](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/defaultConfig.ts#L279)
+[packages/mermaid/src/defaultConfig.ts:272](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/defaultConfig.ts#L272)
 
 ---
 

--- a/packages/mermaid/src/defaultConfig.ts
+++ b/packages/mermaid/src/defaultConfig.ts
@@ -248,13 +248,6 @@ const config: RequiredDeep<MermaidConfig> = {
     ...defaultConfigJson.requirement,
     useWidth: undefined,
   },
-  gitGraph: {
-    ...defaultConfigJson.gitGraph,
-    // TODO: This is a temporary override for `gitGraph`, since every other
-    //       diagram does have `useMaxWidth`, but instead sets it to `true`.
-    //       Should we set this to `true` instead?
-    useMaxWidth: false,
-  },
   sankey: {
     ...defaultConfigJson.sankey,
     // this is false, unlike every other diagram (other than gitGraph)


### PR DESCRIPTION
## :bookmark_tabs: Summary

Change the default value for `gitGraphs.useMaxWidth` to `true`, as all mermaid diagrams default to `useMaxWidth` as `true`, with the exception of Sankey diagrams and git graphs.

The documentation currently says it defaults to `true`, so changing this matches the documentation. See:

https://github.com/mermaid-js/mermaid/blob/d4d7ca7d658256aa46a99f48e017ac0f7f328ebc/packages/mermaid/src/schemas/config.schema.yaml#L306-L312

**BREAKING CHANGE**: Changes the default value of `useMaxWidth` for gitgraphs to `true`. This is technically a breaking change, but considering that most of the other diagrams default to `true`, I think this is unlikely to impact anybody.

However, if anybody does want the old behavior, they can always explicitly set `{ gitGraph: { useMaxWidth: false } }`.

## :straight_ruler: Design Decisions

N/A

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
  - Aligns the code with the existing documentation at https://mermaid.js.org/config/schema-docs/config-defs-base-diagram-config.html#usemaxwidth
- [x] :bookmark: targeted `develop` branch
