### PR TITLE
chore: Fix peer dependencies

### DIFF
--- a/packages/mermaid-layout-elk/package.json
+++ b/packages/mermaid-layout-elk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mermaid-js/layout-elk",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "ELK layout engine for mermaid",
   "module": "dist/mermaid-layout-elk.core.mjs",
   "types": "dist/packages/mermaid-layout-elk/src/index.d.ts",
@@ -34,13 +34,14 @@
     "d3": "^7.9.0",
     "elkjs": "^0.9.3"
   },
-  "peerDependencies": {
+  "devDependencies": {
+    "@types/d3": "^7.4.3",
     "mermaid": "workspace:^"
+  },
+  "peerDependencies": {
+    "mermaid": "^11.0.0"
   },
   "files": [
     "dist"
-  ],
-  "devDependencies": {
-    "@types/d3": "^7.4.3"
-  }
+  ]
 }

--- a/packages/mermaid-zenuml/package.json
+++ b/packages/mermaid-zenuml/package.json
@@ -40,7 +40,7 @@
     "mermaid": "workspace:^"
   },
   "peerDependencies": {
-    "mermaid": "workspace:>=10.0.0"
+    "mermaid": "^10 || ^11"
   },
   "files": [
     "dist"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,13 +409,13 @@ importers:
       elkjs:
         specifier: ^0.9.3
         version: 0.9.3
-      mermaid:
-        specifier: workspace:^
-        version: link:../mermaid
     devDependencies:
       '@types/d3':
         specifier: ^7.4.3
         version: 7.4.3
+      mermaid:
+        specifier: workspace:^
+        version: link:../mermaid
 
   packages/mermaid-zenuml:
     dependencies:


### PR DESCRIPTION
Fixes the peer dependency versions of mermaid for layout-elk and zenuml. 