### PR TITLE
Fix issue with wget not working during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM node:20.12.2-alpine3.19 AS base
 RUN apk --no-cache add openssl wget
-RUN wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.shrc" SHELL="$(which sh)" sh -
+RUN set -o pipefail && wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.shrc" SHELL="$(which sh)" sh -

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,3 @@
 FROM node:20.12.2-alpine3.19 AS base
+RUN apk --no-cache add openssl wget
 RUN wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.shrc" SHELL="$(which sh)" sh -


### PR DESCRIPTION
## :bookmark_tabs: Summary

`wget` was failed on Alpine as reported in https://github.com/Yelp/dumb-init/issues/73 during `docker build`.
This means that piped `pnpm` installs also fail.

Resolves #5754

## :straight_ruler: Design Decisions

- Add openssl and wget as reported in https://github.com/Yelp/dumb-init/issues/73. This switches wget from the BusyBox version to the GNU version.
- Enabling `pipefail` mode will make you aware of errors in the pipe.

### :clipboard: Tasks

_This is a development setup modification and appears to have no documentation or testing to begin with._

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
