### PR TITLE
Fix tutorials.md with url safe encoding

### DIFF
--- a/.cspell/code-terms.txt
+++ b/.cspell/code-terms.txt
@@ -138,6 +138,7 @@ tsdoc
 typeof
 typestr
 unshift
+urlsafe
 verifymethod
 VERIFYMTHD
 WARN_DOCSDIR_DOESNT_MATCH

--- a/docs/ecosystem/tutorials.md
+++ b/docs/ecosystem/tutorials.md
@@ -63,7 +63,7 @@ import matplotlib.pyplot as plt
 
 def mm(graph):
     graphbytes = graph.encode("utf8")
-    base64_bytes = base64.b64encode(graphbytes)
+    base64_bytes = base64.urlsafe_b64encode(graphbytes)
     base64_string = base64_bytes.decode("ascii")
     display(Image(url="https://mermaid.ink/img/" + base64_string))
 

--- a/packages/mermaid/src/docs/ecosystem/tutorials.md
+++ b/packages/mermaid/src/docs/ecosystem/tutorials.md
@@ -57,7 +57,7 @@ import matplotlib.pyplot as plt
 
 def mm(graph):
     graphbytes = graph.encode("utf8")
-    base64_bytes = base64.b64encode(graphbytes)
+    base64_bytes = base64.urlsafe_b64encode(graphbytes)
     base64_string = base64_bytes.decode("ascii")
     display(Image(url="https://mermaid.ink/img/" + base64_string))
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

Resolves https://github.com/jihchi/mermaid.ink/issues/396.

As is, `base64_bytes` can include a `/` which then breaks the routing system of mermaid ink. Using `base64.urlsafe_b64encode` solves this edge case.
