### PR TITLE
(Partial) Sequence Config - Message Margin 

### DIFF
--- a/packages/mermaid/src/diagrams/common/commonTypes.ts
+++ b/packages/mermaid/src/diagrams/common/commonTypes.ts
@@ -42,6 +42,7 @@ export interface TextObject {
   'text-anchor': string;
   style: string;
   textMargin: number;
+  wrapPadding: number;
   rx: number;
   ry: number;
   tspan: boolean;

--- a/packages/mermaid/src/diagrams/common/svgDrawCommon.ts
+++ b/packages/mermaid/src/diagrams/common/svgDrawCommon.ts
@@ -129,6 +129,7 @@ export const getTextObj = (): TextObject => {
     'text-anchor': 'start',
     style: '#666',
     textMargin: 0,
+    wrapPadding: 0,
     rx: 0,
     ry: 0,
     tspan: true,

--- a/packages/mermaid/src/diagrams/sequence/sequenceRenderer.ts
+++ b/packages/mermaid/src/diagrams/sequence/sequenceRenderer.ts
@@ -260,6 +260,7 @@ const drawNote = async function (elem: any, noteModel: NoteModel) {
   textObj.fontSize = conf.noteFontSize;
   textObj.fontWeight = conf.noteFontWeight;
   textObj.anchor = conf.noteAlign;
+  textObj.wrapPadding = conf.wrapPadding;
   textObj.textMargin = conf.noteMargin;
   textObj.valign = 'center';
 
@@ -380,7 +381,8 @@ const drawMessage = async function (diagram, msgModel, lineStartY: number, diagO
   textObj.fontWeight = conf.messageFontWeight;
   textObj.anchor = conf.messageAlign;
   textObj.valign = 'center';
-  textObj.textMargin = conf.wrapPadding;
+  textObj.wrapPadding = conf.wrapPadding;
+  textObj.textMargin = conf.textMargin;
   textObj.tspan = false;
 
   if (hasKatex(textObj.text)) {

--- a/packages/mermaid/src/diagrams/sequence/svgDraw.js
+++ b/packages/mermaid/src/diagrams/sequence/svgDraw.js
@@ -266,13 +266,13 @@ export const drawText = function (elem, textData) {
 //   let prevTextHeight = 0;
 //   let textHeight = 0;
 //   const lines = textData.text.split(common.lineBreakRegex);
- 
+
 //   const [_textFontSize, _textFontSizePx] = parseFontSize(textData.fontSize);
- 
+
 //   // Calculate the y position based on vertical alignment
 //   let yfunc = (lineIndex) => {
 //     let yOffset = 0;
- 
+
 //     switch (textData.valign) {
 //       case 'top':
 //       case 'start':
@@ -301,7 +301,7 @@ export const drawText = function (elem, textData) {
 //     }
 //     return Math.round(yOffset);
 //   };
- 
+
 //   // Adjust the x position and alignment based on the anchor
 //   if (
 //     textData.anchor !== undefined &&
@@ -334,7 +334,7 @@ export const drawText = function (elem, textData) {
 //         break;
 //     }
 //   }
- 
+
 //   // Draw each line of text
 //   lines.forEach((line, i) => {
 //     let dy = 0;
@@ -345,11 +345,11 @@ export const drawText = function (elem, textData) {
 //     ) {
 //       dy = i * _textFontSize;
 //     }
- 
+
 //     const textElem = elem.append('text');
 //     textElem.attr('x', textData.x);
 //     textElem.attr('y', yfunc(i));
- 
+
 //     // Set text attributes
 //     if (textData.anchor !== undefined) {
 //       textElem
@@ -377,7 +377,7 @@ export const drawText = function (elem, textData) {
 //     } else if (dy !== 0) {
 //       textElem.attr('dy', dy);
 //     }
- 
+
 //     const text = line || ZERO_WIDTH_SPACE;
 //     if (textData.tspan) {
 //       const span = textElem.append('tspan');
@@ -389,7 +389,7 @@ export const drawText = function (elem, textData) {
 //     } else {
 //       textElem.text(text);
 //     }
- 
+
 //     // Calculate the height after rendering
 //     if (
 //       textData.valign !== undefined &&
@@ -399,10 +399,10 @@ export const drawText = function (elem, textData) {
 //       textHeight += (textElem._groups || textElem)[0][0].getBBox().height;
 //       prevTextHeight = textHeight;
 //     }
- 
+
 //     textElems.push(textElem);
 //   });
- 
+
 //   return textElems;
 // };
 

--- a/packages/mermaid/src/diagrams/sequence/svgDraw.js
+++ b/packages/mermaid/src/diagrams/sequence/svgDraw.js
@@ -101,7 +101,7 @@ export const drawKatex = async function (elem, textData, msgModel = null) {
   if (textData.class === 'noteText') {
     const rectElem = elem.node().firstChild;
 
-    rectElem.setAttribute('height', dim.height + 2 * textData.textMargin);
+    rectElem.setAttribute('height', dim.height + 2 * textData.wrapPadding);
     const rectDim = rectElem.getBBox();
 
     textElem
@@ -139,26 +139,26 @@ export const drawText = function (elem, textData) {
   let yfunc = () => textData.y;
   if (
     textData.valign !== undefined &&
-    textData.textMargin !== undefined &&
-    textData.textMargin > 0
+    textData.wrapPadding !== undefined &&
+    textData.wrapPadding > 0
   ) {
     switch (textData.valign) {
       case 'top':
       case 'start':
-        yfunc = () => Math.round(textData.y + textData.textMargin);
+        yfunc = () => Math.round(textData.y + textData.wrapPadding);
         break;
       case 'middle':
       case 'center':
         yfunc = () =>
-          Math.round(textData.y + (prevTextHeight + textHeight + textData.textMargin) / 2);
+          Math.round(textData.y + (prevTextHeight + textHeight + textData.wrapPadding) / 2);
         break;
       case 'bottom':
       case 'end':
         yfunc = () =>
           Math.round(
             textData.y +
-              (prevTextHeight + textHeight + 2 * textData.textMargin) -
-              textData.textMargin
+              (prevTextHeight + textHeight + 2 * textData.wrapPadding) -
+              textData.wrapPadding
           );
         break;
     }
@@ -166,13 +166,13 @@ export const drawText = function (elem, textData) {
 
   if (
     textData.anchor !== undefined &&
-    textData.textMargin !== undefined &&
+    textData.wrapPadding !== undefined &&
     textData.width !== undefined
   ) {
     switch (textData.anchor) {
       case 'left':
       case 'start':
-        textData.x = Math.round(textData.x + textData.textMargin);
+        textData.x = Math.round(textData.x + textData.wrapPadding);
         textData.anchor = 'start';
         textData.dominantBaseline = 'middle';
         textData.alignmentBaseline = 'middle';
@@ -186,7 +186,7 @@ export const drawText = function (elem, textData) {
         break;
       case 'right':
       case 'end':
-        textData.x = Math.round(textData.x + textData.width - textData.textMargin);
+        textData.x = Math.round(textData.x + textData.width - textData.wrapPadding);
         textData.anchor = 'end';
         textData.dominantBaseline = 'middle';
         textData.alignmentBaseline = 'middle';
@@ -196,8 +196,8 @@ export const drawText = function (elem, textData) {
 
   for (let [i, line] of lines.entries()) {
     if (
-      textData.textMargin !== undefined &&
-      textData.textMargin === 0 &&
+      textData.wrapPadding !== undefined &&
+      textData.wrapPadding === 0 &&
       _textFontSize !== undefined
     ) {
       dy = i * _textFontSize;
@@ -246,8 +246,8 @@ export const drawText = function (elem, textData) {
     }
     if (
       textData.valign !== undefined &&
-      textData.textMargin !== undefined &&
-      textData.textMargin > 0
+      textData.wrapPadding !== undefined &&
+      textData.wrapPadding > 0
     ) {
       textHeight += (textElem._groups || textElem)[0][0].getBBox().height;
       prevTextHeight = textHeight;
@@ -258,6 +258,153 @@ export const drawText = function (elem, textData) {
 
   return textElems;
 };
+
+/* Function to draw text with margin - wrapping fails */
+
+// export const drawText = function (elem, textData) {
+//   let textElems = [];
+//   let prevTextHeight = 0;
+//   let textHeight = 0;
+//   const lines = textData.text.split(common.lineBreakRegex);
+ 
+//   const [_textFontSize, _textFontSizePx] = parseFontSize(textData.fontSize);
+ 
+//   // Calculate the y position based on vertical alignment
+//   let yfunc = (lineIndex) => {
+//     let yOffset = 0;
+ 
+//     switch (textData.valign) {
+//       case 'top':
+//       case 'start':
+//         yOffset = textData.y + textData.textMargin;
+//         break;
+//       case 'middle':
+//       case 'center':
+//         yOffset =
+//           textData.y +
+//           (lineIndex === 0
+//             ? (lines.length * _textFontSize) / 2
+//             : prevTextHeight + textData.textMargin / 2);
+//         break;
+//       case 'bottom':
+//       case 'end':
+//         yOffset =
+//           textData.y +
+//           textData.textMargin +
+//           (lineIndex === lines.length - 1
+//             ? (lines.length * _textFontSize)
+//             : prevTextHeight + textData.textMargin);
+//         break;
+//       default:
+//         yOffset = textData.y;
+//         break;
+//     }
+//     return Math.round(yOffset);
+//   };
+ 
+//   // Adjust the x position and alignment based on the anchor
+//   if (
+//     textData.anchor !== undefined &&
+//     textData.textMargin !== undefined &&
+//     textData.width !== undefined
+//   ) {
+//     switch (textData.anchor) {
+//       case 'left':
+//       case 'start':
+//         textData.x = Math.round(textData.x + textData.textMargin);
+//         textData.anchor = 'start';
+//         textData.dominantBaseline = 'middle';
+//         textData.alignmentBaseline = 'middle';
+//         break;
+//       case 'middle':
+//       case 'center':
+//         textData.x = Math.round(textData.x + textData.width / 2);
+//         textData.anchor = 'middle';
+//         textData.dominantBaseline = 'middle';
+//         textData.alignmentBaseline = 'middle';
+//         break;
+//       case 'right':
+//       case 'end':
+//         textData.x = Math.round(
+//           textData.x + textData.width - textData.textMargin
+//         );
+//         textData.anchor = 'end';
+//         textData.dominantBaseline = 'middle';
+//         textData.alignmentBaseline = 'middle';
+//         break;
+//     }
+//   }
+ 
+//   // Draw each line of text
+//   lines.forEach((line, i) => {
+//     let dy = 0;
+//     if (
+//       textData.textMargin !== undefined &&
+//       textData.textMargin === 0 &&
+//       _textFontSize !== undefined
+//     ) {
+//       dy = i * _textFontSize;
+//     }
+ 
+//     const textElem = elem.append('text');
+//     textElem.attr('x', textData.x);
+//     textElem.attr('y', yfunc(i));
+ 
+//     // Set text attributes
+//     if (textData.anchor !== undefined) {
+//       textElem
+//         .attr('text-anchor', textData.anchor)
+//         .attr('dominant-baseline', textData.dominantBaseline)
+//         .attr('alignment-baseline', textData.alignmentBaseline);
+//     }
+//     if (textData.fontFamily !== undefined) {
+//       textElem.style('font-family', textData.fontFamily);
+//     }
+//     if (_textFontSizePx !== undefined) {
+//       textElem.style('font-size', _textFontSizePx);
+//     }
+//     if (textData.fontWeight !== undefined) {
+//       textElem.style('font-weight', textData.fontWeight);
+//     }
+//     if (textData.fill !== undefined) {
+//       textElem.attr('fill', textData.fill);
+//     }
+//     if (textData.class !== undefined) {
+//       textElem.attr('class', textData.class);
+//     }
+//     if (textData.dy !== undefined) {
+//       textElem.attr('dy', textData.dy);
+//     } else if (dy !== 0) {
+//       textElem.attr('dy', dy);
+//     }
+ 
+//     const text = line || ZERO_WIDTH_SPACE;
+//     if (textData.tspan) {
+//       const span = textElem.append('tspan');
+//       span.attr('x', textData.x);
+//       if (textData.fill !== undefined) {
+//         span.attr('fill', textData.fill);
+//       }
+//       span.text(text);
+//     } else {
+//       textElem.text(text);
+//     }
+ 
+//     // Calculate the height after rendering
+//     if (
+//       textData.valign !== undefined &&
+//       textData.textMargin !== undefined &&
+//       textData.textMargin > 0
+//     ) {
+//       textHeight += (textElem._groups || textElem)[0][0].getBBox().height;
+//       prevTextHeight = textHeight;
+//     }
+ 
+//     textElems.push(textElem);
+//   });
+ 
+//   return textElems;
+// };
 
 export const drawLabel = function (elem, txtObject) {
   /**

--- a/packages/mermaid/src/schemas/config.schema.yaml
+++ b/packages/mermaid/src/schemas/config.schema.yaml
@@ -1842,7 +1842,7 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
         default: 10
       messageMargin:
         $ref: '#/$defs/JourneyDiagramConfig/properties/messageMargin'
-        default: 35
+        default: 10
       messageAlign:
         $ref: '#/$defs/JourneyDiagramConfig/properties/messageAlign'
         default: center


### PR DESCRIPTION
## :bookmark_tabs: Summary

This PR set _the baseline to solve_ the issue #5702. 
Here are my findings after the investigation: 

- The existing implementation of `drawMessage` function in` sequenceRender.ts` sets wrapPadding value to the textMargin and render the diagram. So the value passed for MessageMargin is not being used at all. 
- The existing implementation of `drawText` function in svgDraw.js uses the `textMargin` (which is the padding) to ensure proper wrapping. 



## :straight_ruler: Design Decisions

My changes includes: 
-  changing the variable names for `textMargin` to `wrapPadding` to fix the misleading naming convention.
-  introduced new version of the `drawText` function to handle `textMargin` properly, however, it somehow affects the wrapping functionality. Currently commented. **_So, some help is needed here to fix this_**. 

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
