### PR TITLE
#5782 fix: adding backwards compatability for defaultRenderer directive

### DIFF
--- a/packages/mermaid/src/diagrams/flowchart/flowDetector-v2.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDetector-v2.ts
@@ -7,11 +7,12 @@ import type {
 const id = 'flowchart-v2';
 
 const detector: DiagramDetector = (txt, config) => {
-  if (
-    config?.flowchart?.defaultRenderer === 'dagre-d3' ||
-    config?.flowchart?.defaultRenderer === 'elk'
-  ) {
+  if (config?.flowchart?.defaultRenderer === 'dagre-d3') {
     return false;
+  }
+
+  if (config?.flowchart?.defaultRenderer === 'elk') {
+    config.layout = 'elk';
   }
 
   // If we have configured to use dagre-wrapper then we should return true in this function for graph code thus making it use the new flowchart diagram

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
@@ -111,7 +111,7 @@ const recursiveRender = async (_elem, graph, diagramType, id, parentCluster, sit
         if (graph.children(v).length > 0) {
           // This is a cluster but not to be rendered recursively
           // Render as before
-          log.info(
+          log.trace(
             'Cluster - the non recursive path XBX',
             v,
             node.id,
@@ -120,11 +120,11 @@ const recursiveRender = async (_elem, graph, diagramType, id, parentCluster, sit
             'Graph:',
             graph
           );
-          log.info(findNonClusterChild(node.id, graph));
+          log.trace(findNonClusterChild(node.id, graph));
           clusterDb.set(node.id, { id: findNonClusterChild(node.id, graph), node });
           // insertCluster(clusters, graph.node(v));
         } else {
-          log.warn('Node - the non recursive path XAX', v, nodes, graph.node(v), dir);
+          log.trace('Node - the non recursive path XAX', v, nodes, graph.node(v), dir);
           await insertNode(nodes, graph.node(v), dir);
         }
       }


### PR DESCRIPTION
## :bookmark_tabs: Summary

Brief description about the content of your PR.

Resolves #5782
## :straight_ruler: Design Decisions

Apply defaultRenderer configuration to layout for backwards compatability.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
