### PR TITLE
Sequence Diagram: Start participant timeline from the bottom of the participant

### DIFF
--- a/packages/mermaid/src/diagrams/sequence/svgDraw.js
+++ b/packages/mermaid/src/diagrams/sequence/svgDraw.js
@@ -329,7 +329,7 @@ export const fixLifeLineHeights = (diagram, actors, actorKeys, conf) => {
 const drawActorTypeParticipant = function (elem, actor, conf, isFooter) {
   const actorY = isFooter ? actor.stopy : actor.starty;
   const center = actor.x + actor.width / 2;
-  const centerY = actorY + 5;
+  const centerY = actorY + actor.height;
 
   const boxplusLineGroup = elem.append('g').lower();
   var g = boxplusLineGroup;


### PR DESCRIPTION

## :bookmark_tabs: Summary

On the sequence diagram, the participant timeline should start from the bottom of the participant instead of the top. In normal cases it doesn't look bad because the line color is the same as the background color of the participant, but when using rough mode, the this portion of the line shows up.

This PR fixes that. 

Resolves #5716

## :straight_ruler: Design Decisions

In the old code, the y1 position was set the `actorY + 5` instead, this changes to `actorY + actor.height`.
This ensures, y1 position of the line starts at the bottom of the actor.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
