### PR TITLE
build(types): disable `preserveSymlinks` in tsconfig

### DIFF
--- a/docs/config/setup/classes/mermaid.UnknownDiagramError.md
+++ b/docs/config/setup/classes/mermaid.UnknownDiagramError.md
@@ -127,7 +127,7 @@ Error.prepareStackTrace
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:28
+node_modules/.pnpm/@types+node\@20.16.2/node_modules/@types/node/globals.d.ts:28
 
 ---
 
@@ -141,7 +141,7 @@ Error.stackTraceLimit
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:30
+node_modules/.pnpm/@types+node\@20.16.2/node_modules/@types/node/globals.d.ts:30
 
 ## Methods
 
@@ -168,4 +168,4 @@ Error.captureStackTrace
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:21
+node_modules/.pnpm/@types+node\@20.16.2/node_modules/@types/node/globals.d.ts:21

--- a/packages/mermaid/src/diagrams/class/classDb.ts
+++ b/packages/mermaid/src/diagrams/class/classDb.ts
@@ -389,7 +389,6 @@ const setupToolTips = function (element: Element) {
       // @ts-ignore - getBoundingClientRect is not part of the d3 type definition
       const rect = this.getBoundingClientRect();
 
-      // @ts-expect-error - Incorrect types
       tooltipElem.transition().duration(200).style('opacity', '.9');
       tooltipElem
         .text(el.attr('title'))
@@ -399,7 +398,6 @@ const setupToolTips = function (element: Element) {
       el.classed('hover', true);
     })
     .on('mouseout', function () {
-      // @ts-expect-error - Incorrect types
       tooltipElem.transition().duration(500).style('opacity', 0);
       const el = select(this);
       el.classed('hover', false);

--- a/packages/mermaid/src/diagrams/flowchart/flowDb.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.ts
@@ -425,7 +425,6 @@ const setupToolTips = function (element: Element) {
       }
       const rect = (this as Element)?.getBoundingClientRect();
 
-      // @ts-ignore TODO: fix this
       tooltipElem.transition().duration(200).style('opacity', '.9');
       tooltipElem
         .text(el.attr('title'))
@@ -435,7 +434,6 @@ const setupToolTips = function (element: Element) {
       el.classed('hover', true);
     })
     .on('mouseout', function () {
-      // @ts-ignore TODO: fix this
       tooltipElem.transition().duration(500).style('opacity', 0);
       const el = select(this);
       el.classed('hover', false);

--- a/packages/mermaid/src/diagrams/gantt/parser/gantt.spec.js
+++ b/packages/mermaid/src/diagrams/gantt/parser/gantt.spec.js
@@ -1,7 +1,6 @@
 import { parser } from './gantt.jison';
 import ganttDb from '../ganttDb.js';
-import { convert } from '../../../tests/util.js';
-import { vi } from 'vitest';
+import { vi, it } from 'vitest';
 const spyOn = vi.spyOn;
 const parserFnConstructor = (str) => {
   return () => {
@@ -150,14 +149,14 @@ describe('when parsing a gantt diagram it', function () {
     expect(tasks[3].id).toEqual('d');
     expect(tasks[3].task).toEqual('task D');
   });
-  it.each(convert`
+  it.each`
     tags                     | milestone | done     | crit     | active
     ${'milestone'}           | ${true}   | ${false} | ${false} | ${false}
     ${'done'}                | ${false}  | ${true}  | ${false} | ${false}
     ${'crit'}                | ${false}  | ${false} | ${true}  | ${false}
     ${'active'}              | ${false}  | ${false} | ${false} | ${true}
     ${'crit,milestone,done'} | ${true}   | ${true}  | ${true}  | ${false}
-  `)('should handle a task with tags $tags', ({ tags, milestone, done, crit, active }) => {
+  `('should handle a task with tags $tags', ({ tags, milestone, done, crit, active }) => {
     const str =
       'gantt\n' +
       'dateFormat YYYY-MM-DD\n' +

--- a/packages/mermaid/src/diagrams/pie/pie.spec.ts
+++ b/packages/mermaid/src/diagrams/pie/pie.spec.ts
@@ -130,8 +130,8 @@ describe('pie', () => {
       expect(sections.get('bat')).toBe(40);
     });
 
-    it('should handle simple pie with negative decimal', () => {
-      expect(async () => {
+    it('should handle simple pie with negative decimal', async () => {
+      await expect(async () => {
         await parser.parse(`pie
         "ash" : -60.67
         "bat" : 40.12

--- a/packages/mermaid/src/diagrams/sequence/sequenceDiagram.spec.js
+++ b/packages/mermaid/src/diagrams/sequence/sequenceDiagram.spec.js
@@ -2063,8 +2063,8 @@ participant Alice`;
     });
   });
 
-  it.each(['__proto__', 'constructor'])('should allow %s as an actor name', function (prop) {
-    expect(
+  it.each(['__proto__', 'constructor'])('should allow %s as an actor name', async function (prop) {
+    await expect(
       mermaidAPI.parse(`
 sequenceDiagram
 ${prop}-->>A: Hello, how are you?`)

--- a/packages/parser/tsconfig.json
+++ b/packages/parser/tsconfig.json
@@ -4,7 +4,6 @@
     "rootDir": ".",
     "outDir": "./dist",
     "allowJs": false,
-    "preserveSymlinks": false,
     "strictPropertyInitialization": false
   },
   "include": ["./src/**/*.ts", "./tests/**/*.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -75,7 +75,7 @@
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
     "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */,
-    "preserveSymlinks": true /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */,
+    // "preserveSymlinks": true /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */,
     "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
 
     /* Type Checking */


### PR DESCRIPTION
## :bookmark_tabs: Summary

PNPM uses symlinks by default for `node_modules` (see the [`node-linker`][1] options), which doesn't work with [TypeScript's `preserveSymlinks: true`][2] setting.

This meant that the `d3-transition` types were not applying properly in our code.

[1]: https://pnpm.io/npmrc#node-linker
[2]: https://www.typescriptlang.org/tsconfig/#preserveSymlinks

As this is an internal/refactoring change only, there are no user-facing changes and there's no need for a changeset file.

## :straight_ruler: Design Decisions

N/A

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
  - N/A
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
  - As this is an internal/refactoring change only, there are no user-facing changes and there's no need for a changeset file.
