### PR TITLE
chore(mermaid): marked package as free of side-effects for improved tree shaking

### DIFF
--- a/.changeset/khaki-needles-hope.md
+++ b/.changeset/khaki-needles-hope.md
@@ -1,0 +1,5 @@
+---
+"mermaid": patch
+---
+
+Marked `mermaid` as free of side-effects for improved tree shaking

--- a/.changeset/khaki-needles-hope.md
+++ b/.changeset/khaki-needles-hope.md
@@ -1,5 +1,5 @@
 ---
-"mermaid": patch
+'mermaid': patch
 ---
 
 Marked `mermaid` as free of side-effects for improved tree shaking

--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "module": "./dist/mermaid.core.mjs",
   "types": "./dist/mermaid.d.ts",
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./dist/mermaid.d.ts",


### PR DESCRIPTION
## :bookmark_tabs: Summary

Hey!

I'm using mermaid on a svelte-kit website and the server bundle does include a bare `import "mermaid";` because esbuild is not able to determine if this import can be entirely tree-shaken. This package.json directive is common among bundlers ([webpack](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free)) and will ensure that bare mermaid imports are removed.

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [ ] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
