### PR TITLE
chore: bump testomatio/check-tests from stable to master

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -90,7 +90,7 @@ jobs:
         continue-on-error: "${{ github.event_name == 'push' }}"
         run: 'pnpm run docs:verify'
 
-      - uses: testomatio/check-tests@b969b09b9d7f400b12e7a3db02fe51a5ce27fb54
+      - uses: testomatio/check-tests@e772b3cde2f31f5609e89930043122c51dd0885a
         with:
           framework: cypress
           tests: ./cypress/e2e/**/**.spec.js


### PR DESCRIPTION
## :bookmark_tabs: Summary

Bump testomatio/check-tests from stable to 0.9.6

As stable branch is three years old, it’s better to stay aligned with latest version which is [0.9.6](https://github.com/testomatio/check-tests/releases/tag/0.9.6)

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
