### PR TITLE
Enable CSS-like linear gradient fills for flowchart nodes

### DIFF
--- a/.changeset/small-kings-change.md
+++ b/.changeset/small-kings-change.md
@@ -1,0 +1,11 @@
+---
+'mermaid': minor
+---
+
+Flowchart changes:
+
+- Adds support for multi-layer `linear-gradient` fills in flowcharts, following CSS-like syntax.
+- Ensures dynamic adaptation of gradient lines to various node shapes.
+- Introduces a reusable gradient utility for broader diagram support in the future.
+
+pr: 5913

--- a/.changeset/small-kings-change.md
+++ b/.changeset/small-kings-change.md
@@ -2,9 +2,9 @@
 'mermaid': minor
 ---
 
-Flowchart changes:
+feat: Add support for multi-layer linear gradient fills in flowcharts
 
-- Adds support for multi-layer `linear-gradient` fills in flowcharts, following CSS-like syntax.
+- Implements CSS-like syntax for defining `linear-gradient()` fills in flowchart nodes.
 - Ensures dynamic adaptation of gradient lines to various node shapes.
 - Introduces a reusable gradient utility for broader diagram support in the future.
 

--- a/cypress/integration/rendering/flowchart-v2.spec.js
+++ b/cypress/integration/rendering/flowchart-v2.spec.js
@@ -475,7 +475,7 @@ flowchart TD
       `
 flowchart
   Node1:::class1 --> Node2:::class2
-  Node1:::class1 --> Node3:::class2
+  Node1 --> Node3:::class2
   Node3 --> Node4((I am a circle)):::larger
 
   classDef class1 fill:lightblue

--- a/docs/syntax/flowchart.md
+++ b/docs/syntax/flowchart.md
@@ -1789,6 +1789,415 @@ flowchart LR
     classDef foobar stroke:#00f
 ```
 
+#### Linear gradient style
+
+Mermaid allows for linear gradient styling on nodes by leveraging the [<linearGradient>](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/linearGradient) element in SVG paired with CSS [linear-gradient()](https://www.w3.org/TR/css-images-4/#gradients) syntax, to design more visually distinct flowcharts. You can define gradients in much the same way as in CSS, specifying directions, multiple color stops, transition hints, and transparency to achieve unique effects. Color interpolation is done in `sRGB` space, as commonly supported by browsers. A linear gradient can be set as the fill property in a node’s `style` or `classDef` using the following syntax:
+
+```
+    style nodeId fill:linear-gradient(direction, colorStop1, colorStop2, ...);
+```
+
+or
+
+```
+    classDef classId fill:linear-gradient(direction, colorStop1, colorStop2, ...);
+    class nodeId classId
+```
+
+- _direction_ _(Optional)_: Defines the direction of the gradient line. It can be specified using directional keywords (e.g., `to right`, `to bottom`, `to top left`) or angles (e.g., `45deg`, `1.57rad`, `0.25turn`, `100grad`) measured clockwise from `to top` or `0deg`. If unspecified, it defaults to `to bottom` or `180deg`.
+- _colorStop1, colorStop2, ..._: A list of colors separated by commas where each color can have an optional position (e.g., `red 20%, blue 50px`). Positions can be given in percentage (`%`) or length units like `px`, `em`, `rem`, `ex`, `ch`, `vw`, `vh`, `vmin`, `vmax`, `cm`, `mm`, `in`, `pt`, and `pc`. Backward positions will be adjusted to the previous maximum. Missing positions are automatically set by assigning the first color stop to 0%, the last to 100%, and by evenly spacing any remaining unpositioned stops between the preceding and following color stops with positions. See [Color Stop Fixup](https://www.w3.org/TR/css-images-4/#color-stop-fixup).
+
+> **Note**
+> You may also add transition hints as position-only markers in between the color stops to control interpolation and adjust the flow of colors in the gradient. See an example of it in the non-linear interpolation section below.
+
+> **Note**
+> A comprehensive collection of side-by-side examples comparing Mermaid and CSS linear gradients is available on [this CodePen](https://codepen.io/enourbakhsh/full/jOgBNjN). This comparison shows that the two methods are practically indistinguishable across a wide range of use cases.
+
+##### Linear gradient examples
+
+**1. Basic gradient**
+
+Create a basic gradient from red to blue, flowing from top to bottom (default direction):
+
+```mermaid-example
+flowchart
+    A[Basic Gradient]
+    style A fill:linear-gradient(red, blue)
+```
+
+```mermaid
+flowchart
+    A[Basic Gradient]
+    style A fill:linear-gradient(red, blue)
+```
+
+or
+
+```mermaid-example
+flowchart
+    A[Basic Gradient]:::styleA
+    classDef styleA fill:linear-gradient(red, blue)
+```
+
+```mermaid
+flowchart
+    A[Basic Gradient]:::styleA
+    classDef styleA fill:linear-gradient(red, blue)
+```
+
+In this example, the gradient starts with red at the top and transitions to blue at the bottom.
+
+**2. Gradient with directional keywords**
+
+Use directional keywords to define the gradient's direction:
+
+```mermaid-example
+flowchart LR
+    A[Directional Gradient]
+    style A fill:linear-gradient(to bottom left, pink, cyan)
+```
+
+```mermaid
+flowchart LR
+    A[Directional Gradient]
+    style A fill:linear-gradient(to bottom left, pink, cyan)
+```
+
+This gradient moves from the top-right corner to the bottom-left corner, starting with pink and ending with cyan.
+
+**3. Gradient with angle**
+
+Specify the gradient angle to control the direction:
+
+```mermaid-example
+flowchart BT
+    A[Angle Gradient]
+    style A fill:linear-gradient(35deg, orange, purple);
+```
+
+```mermaid
+flowchart BT
+    A[Angle Gradient]
+    style A fill:linear-gradient(35deg, orange, purple);
+```
+
+The gradient line is tilted at a 35-degree angle, starting with orange and transitioning to purple.
+
+**4. Multiple color stops**
+
+Include multiple color stops at specific positions:
+
+```mermaid-example
+flowchart LR
+    A[Color Stops]
+    style A fill:linear-gradient(to bottom, red, yellow 30%, green 60%, brown 90%, #00BFFF);
+```
+
+```mermaid
+flowchart LR
+    A[Color Stops]
+    style A fill:linear-gradient(to bottom, red, yellow 30%, green 60%, brown 90%, #00BFFF);
+```
+
+Here, the gradient starts with red at the top, transitions to yellow at 30%, green at 60%, brown at 90%, and ends with Deep Sky Blue at the bottom.
+
+**5. Length Units for color stops**
+
+Use length units for color stop positions (physical units like `cm` are calculated assuming _96dpi_):
+
+```mermaid-example
+flowchart LR
+    A[Length Units]
+    style A fill:linear-gradient(to right, #FF5733 10px, #FFC300 20%, #DAF7A6 2cm, #900C3F);
+```
+
+```mermaid
+flowchart LR
+    A[Length Units]
+    style A fill:linear-gradient(to right, #FF5733 10px, #FFC300 20%, #DAF7A6 2cm, #900C3F);
+```
+
+This gradient moves from left to right, using specific lengths and percentages to control where colors change.
+
+**6. Gradients with opacity**
+
+Apply gradients using colors with opacity:
+
+```mermaid-example
+flowchart TD
+    A[Opacity Gradient]:::opacity
+    classDef opacity fill:linear-gradient(to bottom right, rgba(255,0,0,0.8), rgba(0,0,255,0.2));
+```
+
+```mermaid
+flowchart TD
+    A[Opacity Gradient]:::opacity
+    classDef opacity fill:linear-gradient(to bottom right, rgba(255,0,0,0.8), rgba(0,0,255,0.2));
+```
+
+The gradient transitions from semi-transparent red to semi-transparent blue diagonally.
+
+**7. Automatic positioning**
+
+If positions for color stops are not specified, they are distributed evenly:
+
+```mermaid-example
+flowchart LR
+    A[Automatic Positions]
+    style A fill:linear-gradient(to right, red 10%, green, orange, blue, cyan 90%);
+```
+
+```mermaid
+flowchart LR
+    A[Automatic Positions]
+    style A fill:linear-gradient(to right, red 10%, green, orange, blue, cyan 90%);
+```
+
+In this example, the gradient begins with red from 0% to 10% (specified), transitions smoothly to green at 30%, then to orange at 50%, blue at 70%, and finally reaches cyan at 90% (specified), remaining cyan until the end, distributing the colors with missing positions evenly throughout.
+
+**8. Overlapping positions**
+
+If color stops have overlapping positions, Mermaid adjusts them to maintain the correct order:
+
+```mermaid-example
+flowchart RL
+    A[Overlapping Positions]
+    style A fill:linear-gradient(to bottom, black 60%, white 40%);
+```
+
+```mermaid
+flowchart RL
+    A[Overlapping Positions]
+    style A fill:linear-gradient(to bottom, black 60%, white 40%);
+```
+
+Here, since 40% comes after 60%, the white color stop at 40% is adjusted to 60% to keep positions ascending.
+
+**9. Out-of-bounds positions**
+
+Color stops set outside the 0% to 100% range cause the gradient to stretch beyond the edges.
+
+```mermaid-example
+flowchart TD
+    A[Out-of-Bounds Positions]
+    style A fill:linear-gradient(to right, red -20%, yellow 50%, green 145%);
+```
+
+```mermaid
+flowchart TD
+    A[Out-of-Bounds Positions]
+    style A fill:linear-gradient(to right, red -20%, yellow 50%, green 145%);
+```
+
+In this gradient, red at -20% blends toward yellow and appears as a red-yellow mix at 0%. Likewise, green at 145% blends with yellow near 100%, creating a yellow-green mix rather than pure green at the end. Yellow is centered because the 50% stop is explicitly defined.
+
+**10. Sharp color transition**
+
+Specifying two identical positions for consecutive colors creates a sharp transition:
+
+```mermaid-example
+flowchart LR
+    A[Sharp Color Transition]
+    style A fill:linear-gradient(45deg, red 50%, blue 50%);
+```
+
+```mermaid
+flowchart LR
+    A[Sharp Color Transition]
+    style A fill:linear-gradient(45deg, red 50%, blue 50%);
+```
+
+This results in a sharp change from red to blue exactly at the 50% mark.
+
+**11. Double color stops**
+
+Using double positions for a color creates a solid zone with that colors:
+
+```mermaid-example
+flowchart LR
+    A[Double Color Stops]
+    style A fill:linear-gradient(45deg, yellow, red 30% 50%, blue);
+```
+
+```mermaid
+flowchart LR
+    A[Double Color Stops]
+    style A fill:linear-gradient(45deg, yellow, red 30% 50%, blue);
+```
+
+This is equivalent to:
+
+```mermaid-example
+flowchart TD
+    A[Double Color Stops]
+    style A fill:linear-gradient(45deg, yellow, red 30%, red 50%, blue);
+```
+
+```mermaid
+flowchart TD
+    A[Double Color Stops]
+    style A fill:linear-gradient(45deg, yellow, red 30%, red 50%, blue);
+```
+
+In this example, the gradient transitions from yellow to red between 0% and 30%, remains solid red between 30% and 50%, and then transitions from red to blue after 50%.
+
+**12. Color functions**
+
+Mermaid supports CSS color functions, provided they are supported by the browser:
+
+```mermaid-example
+flowchart LR
+    A[Color Functions]
+    style A fill:linear-gradient(to bottom, rgb(190, 0, 24), hwb(95 23% 50% / 0.4), hsla(30, 81%, 30%, 0.9));
+```
+
+```mermaid
+flowchart LR
+    A[Color Functions]
+    style A fill:linear-gradient(to bottom, rgb(190, 0, 24), hwb(95 23% 50% / 0.4), hsla(30, 81%, 30%, 0.9));
+```
+
+**13. Applying gradients to different shapes**
+
+Gradients adjust based on the node's shape and dimensions:
+
+```mermaid-example
+flowchart TD
+    A[A] --> B{Rhombus} --> C((Circle)) --> D[(Cylinder)]
+    B --> E[/Parallelogram/]
+    C --> F([Stadium])
+    E --> G[[Subroutine]]
+    classDef default fill:linear-gradient(135deg, #FF000080, #FFA50080, #FFFF0080, #00800080, #0000FF80, #4B008280, #EE82EE80);
+```
+
+```mermaid
+flowchart TD
+    A[A] --> B{Rhombus} --> C((Circle)) --> D[(Cylinder)]
+    B --> E[/Parallelogram/]
+    C --> F([Stadium])
+    E --> G[[Subroutine]]
+    classDef default fill:linear-gradient(135deg, #FF000080, #FFA50080, #FFFF0080, #00800080, #0000FF80, #4B008280, #EE82EE80);
+```
+
+> **Note**
+> The gradient line length is determined by projecting a shape's dimensions along the gradient's direction. For simple shapes, this uses trigonometric calculations, while for complex shapes, points are sampled along the shape’s outline. This approach ensures the gradient spans the entire shape by adapting to its unique geometry. You can explore an interactive demo showing this concept in action across various shapes on [this CodePen](https://codepen.io/enourbakhsh/full/WNVErLx).
+
+##### Non-Linear interpolation
+
+Non-linear color transitions occur when using transition hints or colors with varying opacity. See the two scenarios below.
+
+**Scenario I: interpolating between colors with color transition hint**
+
+Transition hints are positional markers that can be placed between color stops to guide the gradient's interpolation.
+
+```mermaid-example
+flowchart LR
+    A[Transition Hint]
+    style A fill:linear-gradient(to right, red, 20%, blue);
+```
+
+```mermaid
+flowchart LR
+    A[Transition Hint]
+    style A fill:linear-gradient(to right, red, 20%, blue);
+```
+
+In this gradient, the midpoint color occurs at 20% of the gradient's length, causing a faster transition from red to blue in the early part. Note that without a specified midpoint, it defaults to 50%, resulting in a linear interpolation.
+
+**Scenario II: transitioning between neighboring colors with different opacities**
+
+```mermaid-example
+flowchart LR
+    A[Opacity Transition]
+    style A fill:linear-gradient(to bottom right, rgba(255,0,0,0.9), rgba(0,0,255,0.2));
+```
+
+```mermaid
+flowchart LR
+    A[Opacity Transition]
+    style A fill:linear-gradient(to bottom right, rgba(255,0,0,0.9), rgba(0,0,255,0.2));
+```
+
+In this gradient, the transition is from a semi-transparent red (90% opacity) to a semi-transparent blue (20% opacity), moving diagonally from the top-left to the bottom-right. The gradient leans more heavily toward the side with higher opacity. This gives the more opaque red a stronger presence in the gradient’s interpolation, while the semi-transparent blue appears less dominant.
+
+> **Note**
+> You are allowed to have both transition hints and opacity variations in the same gradient.
+
+**Fine-tuning non-linear interpolation with custom transition stops**
+
+You can specify `num-transition-stops` directly in the `style` or `classDef` to customize the number of segments that make up the gradient transition. The default is `5`, which provides a decent transition, but adjusting this number allows for finer control. This value must be odd to align with the symmetry logic used for interpolation. Here is an example:
+
+```mermaid-example
+flowchart LR
+    A[Custom Number of Transition Stops]
+    style A fill:linear-gradient(to bottom left, navy, 35%, peachpuff, darkorchid), num-transition-stops: 13;
+```
+
+```mermaid
+flowchart LR
+    A[Custom Number of Transition Stops]
+    style A fill:linear-gradient(to bottom left, navy, 35%, peachpuff, darkorchid), num-transition-stops: 13;
+```
+
+In the gradient above, `num-transition-stops: 13` creates 13 stops, meaning 6 interpolation points on each side of the midpoint hint at 70% between `navy` and `peachpuff` for a higher-resolution interpolation than the default.
+
+##### Linear gradient overlay
+
+**Stacking multiple gradients**
+You can stack multiple `fill:linear-gradient`'s to achieve complex layered effects, with each gradient partially transparent to allow blending. For example, you can recreate the effect shown in [MDN’s CSS gradient demo](https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/linear-gradient#try_it) using the following Mermaid code:
+
+```mermaid-example
+flowchart TD
+    A[Gradient Overlay]:::gradientOverlay
+    classDef gradientOverlay fill:linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%), fill:linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%), fill:linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
+```
+
+```mermaid
+flowchart TD
+    A[Gradient Overlay]:::gradientOverlay
+    classDef gradientOverlay fill:linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%), fill:linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%), fill:linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
+```
+
+In this example, red, green, and blue gradients are angled differently and fade out around 70%, creating a layered, blended effect within the node.
+
+**Adding a solid background**
+To add single-color layers to the gradients, you can specify an explicit `fill` color, to establish a uniform background layer. Without this, no background fill will appear—even the theme’s default background color won’t apply—leaving only the gradient and any transparent areas visible. This allows the color or content of the underlying container element to show through, which can be useful for designs that embrace transparency. For example:
+
+```mermaid-example
+flowchart TD
+    E[No Background Fill] --> F[Solid Background Fill]
+    style E fill:linear-gradient(to left, rgba(255,0,0,0.4), rgba(0,0,255,0.4))
+    style F fill:linear-gradient(to left, rgba(255,0,0,0.4), rgba(0,0,255,0.4)), fill:yellow
+```
+
+```mermaid
+flowchart TD
+    E[No Background Fill] --> F[Solid Background Fill]
+    style E fill:linear-gradient(to left, rgba(255,0,0,0.4), rgba(0,0,255,0.4))
+    style F fill:linear-gradient(to left, rgba(255,0,0,0.4), rgba(0,0,255,0.4)), fill:yellow
+```
+
+In this example, node E has only a gradient fill, allowing the web page background to show through transparent areas, while node F includes a light gray (`#f2f2f2`) background beneath the gradient for a more opaque, cohesive look.
+
+**Combining gradients from class definition and style**
+You can also set a default gradient in `classDef`—which can apply to multiple nodes—and then layer additional gradients on specific nodes directly using `style`. This is especially useful when you have a default look for all nodes but want to add unique overlays on some for emphasis or distinction. Each gradient can be semi-transparent, allowing for blended visuals. For example:
+
+```mermaid-example
+flowchart TD
+    A[Layered Gradient from both classDef and style] --> B((Default)) & C[/Default\]
+    classDef default fill:linear-gradient(45deg, rgba(0,0,150,0.3), rgba(255,255,0,0.3))
+    style A fill:linear-gradient(to top, rgb(240,0,0,0.8), 5%, transparent 15% 85%, 95%, rgb(240,0,0,0.8))
+```
+
+```mermaid
+flowchart TD
+    A[Layered Gradient from both classDef and style] --> B((Default)) & C[/Default\]
+    classDef default fill:linear-gradient(45deg, rgba(0,0,150,0.3), rgba(255,255,0,0.3))
+    style A fill:linear-gradient(to top, rgb(240,0,0,0.8), 5%, transparent 15% 85%, 95%, rgb(240,0,0,0.8))
+```
+
+Here, a default pink-to-yellow gradient in `classDef` applies to all nodes, while an additional red-transparent-red gradient in `style` overlays only node A.
+
 ### CSS classes
 
 It is also possible to predefine classes in CSS styles that can be applied from the graph definition as in the example
@@ -1951,4 +2360,4 @@ mermaid.flowchartConfig = {
 }
 ```
 
-<!--- cspell:ignore lagom --->
+<!--- cspell:ignore lagom vmin vmax unpositioned --->

--- a/docs/syntax/flowchart.md
+++ b/docs/syntax/flowchart.md
@@ -1789,7 +1789,7 @@ flowchart LR
     classDef foobar stroke:#00f
 ```
 
-#### Linear gradient style
+#### Linear gradient style (v\<MERMAID_RELEASE_VERSION>+)
 
 Mermaid allows for linear gradient styling on nodes by leveraging the [linearGradient](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/linearGradient) element in SVG paired with CSS [linear-gradient()](https://www.w3.org/TR/css-images-4/#gradients) syntax, to design more visually distinct flowcharts. You can define gradients in much the same way as in CSS, specifying directions, multiple color stops, transition hints, and transparency to achieve unique effects. Color interpolation is done in `sRGB` space, as commonly supported by browsers. A linear gradient can be set as the fill property in a node’s `style` or `classDef` using the following syntax:
 
@@ -1807,8 +1807,8 @@ or
 - _direction_ _(Optional)_: Defines the direction of the gradient line. It can be specified using directional keywords (e.g., `to right`, `to bottom`, `to top left`) or angles (e.g., `45deg`, `1.57rad`, `0.25turn`, `100grad`) measured clockwise from `to top` or `0deg`. If unspecified, it defaults to `to bottom` or `180deg`.
 - _colorStop1, colorStop2, ..._: A list of colors separated by commas where each color can have an optional position (e.g., `red 20%, blue 50px`). Positions can be given in percentage (`%`) or length units like `px`, `em`, `rem`, `ex`, `ch`, `vw`, `vh`, `vmin`, `vmax`, `cm`, `mm`, `in`, `pt`, and `pc`. Backward positions will be adjusted to the previous maximum. Missing positions are automatically set by assigning the first color stop to 0%, the last to 100%, and by evenly spacing any remaining unpositioned stops between the preceding and following color stops with positions. See [Color Stop Fixup](https://www.w3.org/TR/css-images-4/#color-stop-fixup).
 
-> **Note**
-> You may also add transition hints as position-only markers in between the color stops to control interpolation and adjust the flow of colors in the gradient. See an example of it in the non-linear interpolation section below.
+> **💡 Tip**
+> You may also add the _transition hints_ as position-only markers between the color stops to control interpolation and adjust the flow of colors in the gradient. See an example in the non-linear interpolation section below.
 
 > **Note**
 > A comprehensive collection of side-by-side examples comparing Mermaid and CSS linear gradients is available on [this CodePen](https://codepen.io/enourbakhsh/full/jOgBNjN). This comparison shows that the two methods are practically indistinguishable across a wide range of use cases.
@@ -1850,13 +1850,13 @@ In this example, the gradient starts with red at the top and transitions to blue
 Use directional keywords to define the gradient's direction:
 
 ```mermaid-example
-flowchart LR
+flowchart
     A[Directional Gradient]
     style A fill:linear-gradient(to bottom left, pink, cyan)
 ```
 
 ```mermaid
-flowchart LR
+flowchart
     A[Directional Gradient]
     style A fill:linear-gradient(to bottom left, pink, cyan)
 ```
@@ -1867,13 +1867,13 @@ This gradient moves from the top-right corner to the bottom-left corner, startin
 Specify the gradient angle to control the direction:
 
 ```mermaid-example
-flowchart BT
+flowchart
     A[Angle Gradient]
     style A fill:linear-gradient(35deg, orange, purple);
 ```
 
 ```mermaid
-flowchart BT
+flowchart
     A[Angle Gradient]
     style A fill:linear-gradient(35deg, orange, purple);
 ```
@@ -1884,13 +1884,13 @@ The gradient line is tilted at a 35-degree angle, starting with orange and trans
 Include multiple color stops at specific positions:
 
 ```mermaid-example
-flowchart LR
+flowchart
     A[Color Stops]
     style A fill:linear-gradient(to bottom, red, yellow 30%, green 60%, brown 90%, #00BFFF);
 ```
 
 ```mermaid
-flowchart LR
+flowchart
     A[Color Stops]
     style A fill:linear-gradient(to bottom, red, yellow 30%, green 60%, brown 90%, #00BFFF);
 ```
@@ -1901,13 +1901,13 @@ Here, the gradient starts with red at the top, transitions to yellow at 30%, gre
 Use length units for color stop positions (physical units like `cm` are calculated assuming _96dpi_):
 
 ```mermaid-example
-flowchart LR
+flowchart
     A[Length Units]
     style A fill:linear-gradient(to right, #FF5733 10px, #FFC300 20%, #DAF7A6 2cm, #900C3F);
 ```
 
 ```mermaid
-flowchart LR
+flowchart
     A[Length Units]
     style A fill:linear-gradient(to right, #FF5733 10px, #FFC300 20%, #DAF7A6 2cm, #900C3F);
 ```
@@ -1918,13 +1918,13 @@ This gradient moves from left to right, using specific lengths and percentages t
 Apply gradients using colors with opacity:
 
 ```mermaid-example
-flowchart TD
+flowchart
     A[Opacity Gradient]:::opacity
     classDef opacity fill:linear-gradient(to bottom right, rgba(255,0,0,0.8), rgba(0,0,255,0.2));
 ```
 
 ```mermaid
-flowchart TD
+flowchart
     A[Opacity Gradient]:::opacity
     classDef opacity fill:linear-gradient(to bottom right, rgba(255,0,0,0.8), rgba(0,0,255,0.2));
 ```
@@ -1935,13 +1935,13 @@ The gradient transitions from semi-transparent red to semi-transparent blue diag
 If positions for color stops are not specified, they are distributed evenly:
 
 ```mermaid-example
-flowchart LR
+flowchart
     A[Automatic Positions]
     style A fill:linear-gradient(to right, red 10%, green, orange, blue, cyan 90%);
 ```
 
 ```mermaid
-flowchart LR
+flowchart
     A[Automatic Positions]
     style A fill:linear-gradient(to right, red 10%, green, orange, blue, cyan 90%);
 ```
@@ -1952,13 +1952,13 @@ In this example, the gradient begins with red from 0% to 10% (specified), transi
 If color stops have overlapping positions, Mermaid adjusts them to maintain the correct order:
 
 ```mermaid-example
-flowchart RL
+flowchart
     A[Overlapping Positions]
     style A fill:linear-gradient(to bottom, black 60%, white 40%);
 ```
 
 ```mermaid
-flowchart RL
+flowchart
     A[Overlapping Positions]
     style A fill:linear-gradient(to bottom, black 60%, white 40%);
 ```
@@ -1969,13 +1969,13 @@ Here, since 40% comes after 60%, the white color stop at 40% is adjusted to 60% 
 Color stops set outside the 0% to 100% range cause the gradient calculation to stretch beyond the node's shape while keeping all rendered content contained within.
 
 ```mermaid-example
-flowchart TD
+flowchart
     A[Out-of-Bounds Positions]
     style A fill:linear-gradient(to right, red -20%, yellow 50%, green 145%);
 ```
 
 ```mermaid
-flowchart TD
+flowchart
     A[Out-of-Bounds Positions]
     style A fill:linear-gradient(to right, red -20%, yellow 50%, green 145%);
 ```
@@ -1986,13 +1986,13 @@ In this gradient, red at -20% blends toward yellow and appears as a red-yellow m
 Specifying two identical positions for consecutive colors creates a sharp transition:
 
 ```mermaid-example
-flowchart LR
+flowchart
     A[Sharp Color Transition]
     style A fill:linear-gradient(45deg, red 50%, blue 50%);
 ```
 
 ```mermaid
-flowchart LR
+flowchart
     A[Sharp Color Transition]
     style A fill:linear-gradient(45deg, red 50%, blue 50%);
 ```
@@ -2003,13 +2003,13 @@ This results in a sharp change from red to blue exactly at the 50% mark.
 Using double positions for a color creates an unvarying zone with that color:
 
 ```mermaid-example
-flowchart LR
+flowchart
     A[Double Color Stops]
     style A fill:linear-gradient(45deg, yellow, red 30% 50%, blue);
 ```
 
 ```mermaid
-flowchart LR
+flowchart
     A[Double Color Stops]
     style A fill:linear-gradient(45deg, yellow, red 30% 50%, blue);
 ```
@@ -2017,13 +2017,13 @@ flowchart LR
 This is equivalent to:
 
 ```mermaid-example
-flowchart TD
+flowchart
     A[Double Color Stops]
     style A fill:linear-gradient(45deg, yellow, red 30%, red 50%, blue);
 ```
 
 ```mermaid
-flowchart TD
+flowchart
     A[Double Color Stops]
     style A fill:linear-gradient(45deg, yellow, red 30%, red 50%, blue);
 ```
@@ -2034,13 +2034,13 @@ In this example, the gradient transitions from yellow to red between 0% and 30%,
 Mermaid supports CSS color functions, provided they are supported by the browser:
 
 ```mermaid-example
-flowchart LR
+flowchart
     A[Color Functions]
     style A fill:linear-gradient(to bottom, rgb(190, 0, 24), hwb(95 23% 50% / 0.4), hsla(30, 81%, 30%, 0.9));
 ```
 
 ```mermaid
-flowchart LR
+flowchart
     A[Color Functions]
     style A fill:linear-gradient(to bottom, rgb(190, 0, 24), hwb(95 23% 50% / 0.4), hsla(30, 81%, 30%, 0.9));
 ```
@@ -2077,13 +2077,13 @@ Non-linear color transitions occur when using transition hints or colors with va
 Transition hints are positional markers that can be placed between color stops to guide the gradient's interpolation.
 
 ```mermaid-example
-flowchart LR
+flowchart
     A[Transition Hint]
     style A fill:linear-gradient(to right, red, 20%, blue);
 ```
 
 ```mermaid
-flowchart LR
+flowchart
     A[Transition Hint]
     style A fill:linear-gradient(to right, red, 20%, blue);
 ```
@@ -2093,33 +2093,33 @@ In this gradient, the midpoint color occurs at 20% of the gradient's length, cau
 **Scenario II: transitioning between neighboring colors with different opacities**
 
 ```mermaid-example
-flowchart LR
+flowchart
     A[Opacity Transition]
     style A fill:linear-gradient(to bottom right, rgba(255,0,0,0.9), rgba(0,0,255,0.2));
 ```
 
 ```mermaid
-flowchart LR
+flowchart
     A[Opacity Transition]
     style A fill:linear-gradient(to bottom right, rgba(255,0,0,0.9), rgba(0,0,255,0.2));
 ```
 
 In this gradient, the transition is from a semi-transparent red (90% opacity) to a semi-transparent blue (20% opacity), moving diagonally from the top-left to the bottom-right. The gradient leans more heavily toward the side with higher opacity. This gives the more opaque red a stronger presence in the gradient’s interpolation, while the semi-transparent blue appears less dominant.
 
-> **Note**
-> You are allowed to have both transition hints and opacity variations in the same gradient.
+> **💡 Tip**
+> You can use both transition hints and opacity variations in the same gradient.
 
 **Fine-tuning non-linear interpolation with custom transition stops**
 You can specify `num-transition-stops` directly in the `style` or `classDef` to customize the number of segments that make up the gradient transition. The default is `5`, which provides a decent transition, but adjusting this number allows for finer control. This value must be odd to align with the symmetry logic used for interpolation. Here is an example:
 
 ```mermaid-example
-flowchart LR
+flowchart
     A[Custom Number of Transition Stops]
     style A fill:linear-gradient(to bottom left, navy, 35%, peachpuff, darkorchid), num-transition-stops: 13;
 ```
 
 ```mermaid
-flowchart LR
+flowchart
     A[Custom Number of Transition Stops]
     style A fill:linear-gradient(to bottom left, navy, 35%, peachpuff, darkorchid), num-transition-stops: 13;
 ```

--- a/docs/syntax/flowchart.md
+++ b/docs/syntax/flowchart.md
@@ -1791,7 +1791,7 @@ flowchart LR
 
 #### Linear gradient style
 
-Mermaid allows for linear gradient styling on nodes by leveraging the [<linearGradient>](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/linearGradient) element in SVG paired with CSS [linear-gradient()](https://www.w3.org/TR/css-images-4/#gradients) syntax, to design more visually distinct flowcharts. You can define gradients in much the same way as in CSS, specifying directions, multiple color stops, transition hints, and transparency to achieve unique effects. Color interpolation is done in `sRGB` space, as commonly supported by browsers. A linear gradient can be set as the fill property in a node’s `style` or `classDef` using the following syntax:
+Mermaid allows for linear gradient styling on nodes by leveraging the [linearGradient](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/linearGradient) element in SVG paired with CSS [linear-gradient()](https://www.w3.org/TR/css-images-4/#gradients) syntax, to design more visually distinct flowcharts. You can define gradients in much the same way as in CSS, specifying directions, multiple color stops, transition hints, and transparency to achieve unique effects. Color interpolation is done in `sRGB` space, as commonly supported by browsers. A linear gradient can be set as the fill property in a node’s `style` or `classDef` using the following syntax:
 
 ```
     style nodeId fill:linear-gradient(direction, colorStop1, colorStop2, ...);
@@ -1816,7 +1816,6 @@ or
 ##### Linear gradient examples
 
 **1. Basic gradient**
-
 Create a basic gradient from red to blue, flowing from top to bottom (default direction):
 
 ```mermaid-example
@@ -1848,7 +1847,6 @@ flowchart
 In this example, the gradient starts with red at the top and transitions to blue at the bottom.
 
 **2. Gradient with directional keywords**
-
 Use directional keywords to define the gradient's direction:
 
 ```mermaid-example
@@ -1866,7 +1864,6 @@ flowchart LR
 This gradient moves from the top-right corner to the bottom-left corner, starting with pink and ending with cyan.
 
 **3. Gradient with angle**
-
 Specify the gradient angle to control the direction:
 
 ```mermaid-example
@@ -1884,7 +1881,6 @@ flowchart BT
 The gradient line is tilted at a 35-degree angle, starting with orange and transitioning to purple.
 
 **4. Multiple color stops**
-
 Include multiple color stops at specific positions:
 
 ```mermaid-example
@@ -1902,7 +1898,6 @@ flowchart LR
 Here, the gradient starts with red at the top, transitions to yellow at 30%, green at 60%, brown at 90%, and ends with Deep Sky Blue at the bottom.
 
 **5. Length Units for color stops**
-
 Use length units for color stop positions (physical units like `cm` are calculated assuming _96dpi_):
 
 ```mermaid-example
@@ -1920,7 +1915,6 @@ flowchart LR
 This gradient moves from left to right, using specific lengths and percentages to control where colors change.
 
 **6. Gradients with opacity**
-
 Apply gradients using colors with opacity:
 
 ```mermaid-example
@@ -1938,7 +1932,6 @@ flowchart TD
 The gradient transitions from semi-transparent red to semi-transparent blue diagonally.
 
 **7. Automatic positioning**
-
 If positions for color stops are not specified, they are distributed evenly:
 
 ```mermaid-example
@@ -1956,7 +1949,6 @@ flowchart LR
 In this example, the gradient begins with red from 0% to 10% (specified), transitions smoothly to green at 30%, then to orange at 50%, blue at 70%, and finally reaches cyan at 90% (specified), remaining cyan until the end, distributing the colors with missing positions evenly throughout.
 
 **8. Overlapping positions**
-
 If color stops have overlapping positions, Mermaid adjusts them to maintain the correct order:
 
 ```mermaid-example
@@ -1974,8 +1966,7 @@ flowchart RL
 Here, since 40% comes after 60%, the white color stop at 40% is adjusted to 60% to keep positions ascending.
 
 **9. Out-of-bounds positions**
-
-Color stops set outside the 0% to 100% range cause the gradient to stretch beyond the edges.
+Color stops set outside the 0% to 100% range cause the gradient calculation to stretch beyond the node's shape while keeping all rendered content contained within.
 
 ```mermaid-example
 flowchart TD
@@ -1992,7 +1983,6 @@ flowchart TD
 In this gradient, red at -20% blends toward yellow and appears as a red-yellow mix at 0%. Likewise, green at 145% blends with yellow near 100%, creating a yellow-green mix rather than pure green at the end. Yellow is centered because the 50% stop is explicitly defined.
 
 **10. Sharp color transition**
-
 Specifying two identical positions for consecutive colors creates a sharp transition:
 
 ```mermaid-example
@@ -2010,8 +2000,7 @@ flowchart LR
 This results in a sharp change from red to blue exactly at the 50% mark.
 
 **11. Double color stops**
-
-Using double positions for a color creates a solid zone with that colors:
+Using double positions for a color creates an unvarying zone with that color:
 
 ```mermaid-example
 flowchart LR
@@ -2039,10 +2028,9 @@ flowchart TD
     style A fill:linear-gradient(45deg, yellow, red 30%, red 50%, blue);
 ```
 
-In this example, the gradient transitions from yellow to red between 0% and 30%, remains solid red between 30% and 50%, and then transitions from red to blue after 50%.
+In this example, the gradient transitions from yellow to red between 0% and 30%, remains uniformly red between 30% and 50%, and then transitions from red to blue after 50%.
 
 **12. Color functions**
-
 Mermaid supports CSS color functions, provided they are supported by the browser:
 
 ```mermaid-example
@@ -2058,7 +2046,6 @@ flowchart LR
 ```
 
 **13. Applying gradients to different shapes**
-
 Gradients adjust based on the node's shape and dimensions:
 
 ```mermaid-example
@@ -2067,7 +2054,7 @@ flowchart TD
     B --> E[/Parallelogram/]
     C --> F([Stadium])
     E --> G[[Subroutine]]
-    classDef default fill:linear-gradient(135deg, #FF000080, #FFA50080, #FFFF0080, #00800080, #0000FF80, #4B008280, #EE82EE80);
+    classDef default fill:linear-gradient(135deg, #ff000080, #ffa50080, #ffff0080, #00800080, #0000ff80, #4b008280, #ee82ee80);
 ```
 
 ```mermaid
@@ -2076,7 +2063,7 @@ flowchart TD
     B --> E[/Parallelogram/]
     C --> F([Stadium])
     E --> G[[Subroutine]]
-    classDef default fill:linear-gradient(135deg, #FF000080, #FFA50080, #FFFF0080, #00800080, #0000FF80, #4B008280, #EE82EE80);
+    classDef default fill:linear-gradient(135deg, #ff000080, #ffa50080, #ffff0080, #00800080, #0000ff80, #4b008280, #ee82ee80);
 ```
 
 > **Note**
@@ -2087,7 +2074,6 @@ flowchart TD
 Non-linear color transitions occur when using transition hints or colors with varying opacity. See the two scenarios below.
 
 **Scenario I: interpolating between colors with color transition hint**
-
 Transition hints are positional markers that can be placed between color stops to guide the gradient's interpolation.
 
 ```mermaid-example
@@ -2124,7 +2110,6 @@ In this gradient, the transition is from a semi-transparent red (90% opacity) to
 > You are allowed to have both transition hints and opacity variations in the same gradient.
 
 **Fine-tuning non-linear interpolation with custom transition stops**
-
 You can specify `num-transition-stops` directly in the `style` or `classDef` to customize the number of segments that make up the gradient transition. The default is `5`, which provides a decent transition, but adjusting this number allows for finer control. This value must be odd to align with the symmetry logic used for interpolation. Here is an example:
 
 ```mermaid-example
@@ -2160,43 +2145,57 @@ flowchart TD
 
 In this example, red, green, and blue gradients are angled differently and fade out around 70%, creating a layered, blended effect within the node.
 
-**Adding a solid background**
-To add single-color layers to the gradients, you can specify an explicit `fill` color, to establish a uniform background layer. Without this, no background fill will appear—even the theme’s default background color won’t apply—leaving only the gradient and any transparent areas visible. This allows the color or content of the underlying container element to show through, which can be useful for designs that embrace transparency. For example:
+**Combining simple fills and linear gradients for layered node styling**
+When styling a node with a linear gradient, the theme’s default background color is ignored. This means that if you don’t specify a simple fill color, no background or foreground color will be applied to the gradient layers. This allows the color or content of the underlying container to show through (semi-)transparent areas of the gradient, if any, which can be useful for designs that embrace transparency.
+
+To include simple, single-colored layers alongside gradient layers, use the fill property to define a color. This fill doesn’t need to be fully opaque and creates a uniform, single-colored layer in the stack. The placement of this simple fill property in the style or class definition determines its influence on the final outcome when combined with other layers. Earlier fills take precedence and overlay subsequent layers.
 
 ```mermaid-example
-flowchart TD
-    E[No Background Fill] --> F[Solid Background Fill]
-    style E fill:linear-gradient(to left, rgba(255,0,0,0.4), rgba(0,0,255,0.4))
-    style F fill:linear-gradient(to left, rgba(255,0,0,0.4), rgba(0,0,255,0.4)), fill:yellow
+flowchart LR
+    A[No Yellow] --> B[Yellow First]
+    A --> C[Yellow Last]
+    B --> D[Transparent Yellow First]
+    C --> E[Transparent Yellow Last]
+    style A fill:linear-gradient(to left, rgba(255,0,0,0.8), rgba(0,0,255,0.3))
+    style B fill:yellow, fill:linear-gradient(to left, rgba(255,0,0,0.8), rgba(0,0,255,0.3))
+    style C fill:linear-gradient(to left, rgba(255,0,0,0.8), rgba(0,0,255,0.3)), fill:yellow
+    style D fill:rgba(255,255,0,0.6), fill:linear-gradient(to left, rgba(255,0,0,0.8), rgba(0,0,255,0.3))
+    style E fill:linear-gradient(to left, rgba(255,0,0,0.8), rgba(0,0,255,0.3)), fill:rgba(255,255,0,0.6)
 ```
 
 ```mermaid
-flowchart TD
-    E[No Background Fill] --> F[Solid Background Fill]
-    style E fill:linear-gradient(to left, rgba(255,0,0,0.4), rgba(0,0,255,0.4))
-    style F fill:linear-gradient(to left, rgba(255,0,0,0.4), rgba(0,0,255,0.4)), fill:yellow
+flowchart LR
+    A[No Yellow] --> B[Yellow First]
+    A --> C[Yellow Last]
+    B --> D[Transparent Yellow First]
+    C --> E[Transparent Yellow Last]
+    style A fill:linear-gradient(to left, rgba(255,0,0,0.8), rgba(0,0,255,0.3))
+    style B fill:yellow, fill:linear-gradient(to left, rgba(255,0,0,0.8), rgba(0,0,255,0.3))
+    style C fill:linear-gradient(to left, rgba(255,0,0,0.8), rgba(0,0,255,0.3)), fill:yellow
+    style D fill:rgba(255,255,0,0.6), fill:linear-gradient(to left, rgba(255,0,0,0.8), rgba(0,0,255,0.3))
+    style E fill:linear-gradient(to left, rgba(255,0,0,0.8), rgba(0,0,255,0.3)), fill:rgba(255,255,0,0.6)
 ```
 
-In this example, node E has only a gradient fill, allowing the web page background to show through transparent areas, while node F includes a light gray (`#f2f2f2`) background beneath the gradient for a more opaque, cohesive look.
+In the example above, node A uses only a gradient fill, allowing the page background to show through its transparent areas. The other nodes include a yellow layer—either opaque or transparent—in addition to the gradient. The order in which the fill properties are defined impacts how the layers blend visually.
 
 **Combining gradients from class definition and style**
-You can also set a default gradient in `classDef`—which can apply to multiple nodes—and then layer additional gradients on specific nodes directly using `style`. This is especially useful when you have a default look for all nodes but want to add unique overlays on some for emphasis or distinction. Each gradient can be semi-transparent, allowing for blended visuals. For example:
+You can also set a default gradient in `classDef`—which can apply to multiple nodes—and then layer additional gradients on top of specific nodes directly using `style`. This is especially useful when you have a default look for all nodes but want to add unique overlays on some for emphasis or distinction. Each gradient can be semi-transparent, allowing for blended visuals. For example:
 
 ```mermaid-example
-flowchart TD
-    A[Layered Gradient from both classDef and style] --> B((Default)) & C[/Default\]
-    classDef default fill:linear-gradient(45deg, rgba(0,0,150,0.3), rgba(255,255,0,0.3))
-    style A fill:linear-gradient(to top, rgb(240,0,0,0.8), 5%, transparent 15% 85%, 95%, rgb(240,0,0,0.8))
+ flowchart TD
+    A[Northern Lights] --> B((Default)) & C[/Default\]
+    classDef default fill:linear-gradient(to top, rgba(23, 10, 113, 0.9), 40%, transparent), fill:white
+    style A fill:linear-gradient(to right, rgba(0, 255, 127, 0.3) 10%, rgba(0, 191, 255, 0.3) 30%, transparent 50%, rgba(138, 43, 226, 0.2) 70%, rgba(19, 24, 98, 0.3) 90%)
 ```
 
 ```mermaid
-flowchart TD
-    A[Layered Gradient from both classDef and style] --> B((Default)) & C[/Default\]
-    classDef default fill:linear-gradient(45deg, rgba(0,0,150,0.3), rgba(255,255,0,0.3))
-    style A fill:linear-gradient(to top, rgb(240,0,0,0.8), 5%, transparent 15% 85%, 95%, rgb(240,0,0,0.8))
+ flowchart TD
+    A[Northern Lights] --> B((Default)) & C[/Default\]
+    classDef default fill:linear-gradient(to top, rgba(23, 10, 113, 0.9), 40%, transparent), fill:white
+    style A fill:linear-gradient(to right, rgba(0, 255, 127, 0.3) 10%, rgba(0, 191, 255, 0.3) 30%, transparent 50%, rgba(138, 43, 226, 0.2) 70%, rgba(19, 24, 98, 0.3) 90%)
 ```
 
-Here, a default pink-to-yellow gradient in `classDef` applies to all nodes, while an additional red-transparent-red gradient in `style` overlays only node A.
+Here, the default gradient in `classDef` features a twilight indigo base that transitions into white from a simple fill. On top of this, node A adds a vibrant northern-lights-inspired gradient, allowing traces of the default background to show through.
 
 ### CSS classes
 

--- a/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.ts
@@ -91,16 +91,21 @@ export const draw = async function (text: string, id: string, _version: string, 
       if (!shapeElement.empty() && shapeElement.node() !== null) {
         log.debug(`Working on node ${vertex.id}->${vertex.domId}`);
 
+        // Combine style arrays, defaulting to empty arrays if missing
+        // Note that `cssCompiledStyles` (from `classDef`) apply first, with `cssStyles` (from `style`)
+        // rendered on top, allowing layered effects like multiple semi-transparent backgrounds
+        const styles = [...(vertex.cssCompiledStyles || []), ...(vertex.cssStyles || [])];
+
         // Log all cssCompiledStyles for the node if available
-        if (vertex.cssCompiledStyles) {
-          log.debug(`Compiled styles for node ${vertex.id}:`, vertex.cssCompiledStyles);
+        if (styles) {
+          log.debug(`CSS styles for node ${vertex.id}:`, styles);
         } else {
-          log.debug(`No compiled styles found for node ${vertex.id}.`);
+          log.debug(`No CSS styles found for node ${vertex.id}.`);
         }
 
         // Look for all gradient styles, ensuring that nested parentheses due to color functions are handled properly
-        const linearGradientStyles = vertex.cssCompiledStyles
-          ?.join('')
+        const linearGradientStyles = styles
+          .join('')
           ?.match(/fill\s*:\s*linear-gradient\([^()]*?(?:\([^()]*?\)[^()]*)*\)/g);
 
         if (linearGradientStyles) {
@@ -151,12 +156,12 @@ export const draw = async function (text: string, id: string, _version: string, 
       continue; // Skip to the next iteration if no node was found
     }
 
-    // If the node selected by ID has a link, wrap it in an anchor SVG object.
+    // If the node selected by ID has a link, wrap it in an anchor SVG object
     log.debug(`Attempting to select node using ID with query: #${id} [id="${vertex.id}"]`);
     // We already selected nodeSvg based on domId; would it work if use it here instead of node?
     const node = select(`#${id} [id="${vertex.domId}"]`);
     if (!node || !vertex.link) {
-      continue; // Skip if the node does not exist or does not have a link property.
+      continue; // Skip if the node does not exist or does not have a link property
     }
     const link = doc.createElementNS('http://www.w3.org/2000/svg', 'a');
     link.setAttributeNS('http://www.w3.org/2000/svg', 'class', vertex.cssClasses);

--- a/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.ts
@@ -112,7 +112,7 @@ export const draw = async function (text: string, id: string, _version: string, 
         );
 
         // Filter out 'none' from fill styles
-        const effectiveFillStyles = allFillStyles.filter((style) => style !== 'none');
+        const effectiveFillStyles = allFillStyles.filter((style) => !/fill\s*:\s*none/.test(style));
 
         // Layer fill styles if there’s more than one given or if any are gradients
         if (
@@ -124,7 +124,7 @@ export const draw = async function (text: string, id: string, _version: string, 
           shapeElement.style('fill', 'none');
 
           // Iterate over fill styles in the order they were defined
-          allFillStyles.forEach((style, index) => {
+          effectiveFillStyles.forEach((style, index) => {
             // Clone the shape element to apply each fill as an overlay
             const shapeClone = shapeElement.clone(true);
 

--- a/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.ts
@@ -108,9 +108,21 @@ export const draw = async function (text: string, id: string, _version: string, 
           .join('')
           ?.match(/fill\s*:\s*linear-gradient\([^()]*?(?:\([^()]*?\)[^()]*)*\)/g);
 
+        // Look for all non-gradient "fill" styles (e.g., "fill: magenta", "fill: rgb(255,0,0,0.3)")
+        const solidFillStyles = styles.join('')?.match(/fill\s*:\s*(?!linear-gradient\()[^;]+/g);
+
         if (linearGradientStyles) {
-          // Clear any existing fill otherwise the theme's color bleeds through (semi-)transparent areas
-          shapeElement.style('fill', 'none');
+          if (solidFillStyles) {
+            solidFillStyles.forEach((s) => {
+              const color = s.replace(/fill\s*:\s*/, '');
+              shapeElement.style('fill', color);
+              log.debug(`Applied solid fill color "${color}" to node ${vertex.id}`);
+            });
+          } else {
+            // Remove any existing fill (e.g. from the theme) that might unexpectedly bleed through (semi-)transparent areas
+            shapeElement.style('fill', 'none');
+          }
+
           shapeElement.style('mix-blend-mode', 'normal');
 
           // Apply gradient style to the node's shape through a cloned element

--- a/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.ts
@@ -89,7 +89,7 @@ export const draw = async function (text: string, id: string, _version: string, 
       );
 
       if (!shapeElement.empty() && shapeElement.node() !== null) {
-        log.debug(`Working of node ${vertex.id}->${vertex.domId}`);
+        log.debug(`Working on node ${vertex.id}->${vertex.domId}`);
 
         // Log all cssCompiledStyles for the node if available
         if (vertex.cssCompiledStyles) {
@@ -104,11 +104,15 @@ export const draw = async function (text: string, id: string, _version: string, 
           ?.match(/fill\s*:\s*linear-gradient\([^()]*?(?:\([^()]*?\)[^()]*)*\)/g);
 
         if (linearGradientStyles) {
-          shapeElement.style('fill', null); // Clear any existing fill
+          // Clear any existing fill otherwise the theme's color bleeds through (semi-)transparent areas
+          shapeElement.style('fill', 'none');
+          shapeElement.style('mix-blend-mode', 'normal');
+
+          // Apply gradient style to the node's shape through a cloned element
           linearGradientStyles.forEach((style, index) => {
             log.debug(`Found gradient style ${index + 1} for node ${vertex.id}: "${style}"`);
 
-            // Remove the 'fill: linear-gradient()' wrapper to get the gradient definition
+            // Remove the 'fill: linear-gradient()' wrapper to get the gradient definition only
             const linearGradientStyle = style.replace(/fill\s*:\s*linear-gradient\((.+)\)/, '$1');
             const gradientId = `gradient-${vertex.id}-${index}`;
 

--- a/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.ts
@@ -1,4 +1,5 @@
 import { select } from 'd3';
+import type { Selection } from 'd3';
 import { getConfig } from '../../diagram-api/diagramAPI.js';
 import type { DiagramStyleClassDef } from '../../diagram-api/types.js';
 import { log } from '../../logger.js';
@@ -8,6 +9,7 @@ import { setupViewPortForSVG } from '../../rendering-util/setupViewPortForSVG.js
 import type { LayoutData } from '../../rendering-util/types.js';
 import utils from '../../utils.js';
 import { getDirection } from './flowDb.js';
+import { createLinearGradient } from '../../rendering-util/createGradient.js';
 
 export const getClasses = function (
   text: string,
@@ -54,6 +56,7 @@ export const draw = async function (text: string, id: string, _version: string, 
   data4Layout.diagramId = id;
   log.debug('REF1:', data4Layout);
   await render(data4Layout, svg);
+  log.debug('SVG structure:', svg.node().outerHTML);
   const padding = data4Layout.config.flowchart?.diagramPadding ?? 8;
   utils.insertTitle(
     svg,
@@ -62,12 +65,94 @@ export const draw = async function (text: string, id: string, _version: string, 
     diag.db.getDiagramTitle()
   );
   setupViewPortForSVG(svg, padding, 'flowchart', conf?.useMaxWidth || false);
+  log.debug(
+    'Rendering completed. Starting to process nodes for gradient application and link wrapping...'
+  );
 
-  // If node has a link, wrap it in an anchor SVG object.
+  // Loop through all nodes
   for (const vertex of data4Layout.nodes) {
-    const node = select(`#${id} [id="${vertex.id}"]`);
+    log.debug(
+      `Processing node - ID: "${vertex.id}", domID: "${vertex.domId}", Label: "${vertex.label}"`
+    );
+
+    // Apply gradients to the node's shape if specified in the node's CSS styles
+    // This has to be done before wrapping the node in an anchor element to avoid selection issues
+    log.debug(`Attempting to select node using domID with query: #${id} [id="${vertex.domId}"]`);
+    const nodeSvg = select(`#${id} [id="${vertex.domId}"]`); // selection of the node's SVG element using domId
+
+    if (!nodeSvg.empty()) {
+      log.debug(`Found SVG element for node: ${vertex.domId}`);
+      // Get the bounding box of the node's shape to extract dimensions
+      // Assuming shapeElement is a selection of various SVG elements
+      const shapeElement: Selection<SVGGraphicsElement, unknown, HTMLElement, any> = nodeSvg.select(
+        'rect, ellipse, circle, polygon, path'
+      );
+
+      if (!shapeElement.empty() && shapeElement.node() !== null) {
+        log.debug(`Working of node ${vertex.id}->${vertex.domId}`);
+
+        // Log all cssCompiledStyles for the node if available
+        if (vertex.cssCompiledStyles) {
+          log.debug(`Compiled styles for node ${vertex.id}:`, vertex.cssCompiledStyles);
+        } else {
+          log.debug(`No compiled styles found for node ${vertex.id}.`);
+        }
+
+        // Look for all gradient styles, ensuring that nested parentheses due to color functions are handled properly
+        const linearGradientStyles = vertex.cssCompiledStyles
+          ?.join('')
+          ?.match(/fill\s*:\s*linear-gradient\(([^()]*(\([^()]*\))*[^()]*)+\)/g);
+
+        if (linearGradientStyles) {
+          shapeElement.style('fill', null); // Clear any existing fill
+          linearGradientStyles.forEach((style, index) => {
+            log.debug(`Found gradient style ${index + 1} for node ${vertex.id}: "${style}"`);
+
+            // Remove the 'fill: linear-gradient()' wrapper to get the gradient definition
+            const linearGradientStyle = style.replace(/fill\s*:\s*linear-gradient\((.+)\)/, '$1');
+            const gradientId = `gradient-${vertex.id}-${index}`;
+
+            // Create the linear gradient for each occurrence
+            createLinearGradient(svg, shapeElement, linearGradientStyle, gradientId);
+
+            // Clone the shape element to apply each gradient as an overlay
+            const shapeClone = shapeElement.clone(true);
+            shapeClone.style('fill', `url(#${gradientId})`);
+
+            // Insert the cloned element before the original shape to keep the text/labels on top
+            const parentNode = shapeElement.node()?.parentNode;
+            const cloneNode = shapeClone.node();
+            if (parentNode && cloneNode) {
+              const nextSibling = shapeElement.node()?.nextSibling;
+              if (nextSibling) {
+                parentNode.insertBefore(cloneNode, nextSibling);
+              } else {
+                parentNode.appendChild(cloneNode);
+              }
+            } else {
+              log.error(`Parent or clone node not found for shape element: ${vertex.domId}`);
+            }
+            // Apply the gradient fill to the node
+            log.debug(
+              `Applying gradient ID "${gradientId}" to node: ${vertex.id} with URL: url(#${gradientId})`
+            );
+            log.debug(`Underlying SVG element: `, shapeElement.node());
+          });
+        } else {
+          log.debug(`No gradient style found for node ${vertex.id}->${vertex.domId}.`);
+        }
+      } else {
+        log.debug(`Could not find a shape element for node: ${vertex.id}->${vertex.domId}`);
+      }
+      continue; // Skip to the next iteration if no node was found
+    }
+
+    // If the node selected by ID has a link, wrap it in an anchor SVG object.
+    log.debug(`Attempting to select node using ID with query: #${id} [id="${vertex.id}"]`);
+    // We already selected nodeSvg based on domId; would it work if use it here instead of node?
+    const node = select(`#${id} [id="${vertex.domId}"]`);
     if (!node || !vertex.link) {
-      continue;
+      continue; // Skip if the node does not exist or does not have a link property.
     }
     const link = doc.createElementNS('http://www.w3.org/2000/svg', 'a');
     link.setAttributeNS('http://www.w3.org/2000/svg', 'class', vertex.cssClasses);

--- a/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.ts
@@ -104,7 +104,7 @@ export const draw = async function (text: string, id: string, _version: string, 
           log.debug(`No CSS styles found for node ${vertex.id}.`);
         }
 
-        // Separate out linear-gradient and solid fill styles in their original order
+        // Separate out linear-gradient and simple fill styles in their original order
         const allFillStyles = styles.flatMap(
           (style) =>
             style.match(/fill\s*:\s*(linear-gradient\([^()]*?(?:\([^()]*?\)[^()]*)*\)|[^;]+)/g) ||
@@ -150,12 +150,12 @@ export const draw = async function (text: string, id: string, _version: string, 
                 `Applied gradient ID "${gradientId}" to node ${vertex.id} with URL url(#${gradientId})`
               );
             } else {
-              // It's a solid fill style
+              // It's a simple fill style
               const color = style.replace(/fill\s*:\s*/, '');
 
-              // Apply the solid fill to the cloned shape
+              // Apply the simple fill to the cloned shape
               shapeClone.style('fill', color);
-              log.debug(`Applied solid fill color "${color}" to node ${vertex.id}`);
+              log.debug(`Applied simple fill color "${color}" to node ${vertex.id}`);
             }
 
             // Insert the cloned element before the original shape to keep the text/labels on top
@@ -174,7 +174,7 @@ export const draw = async function (text: string, id: string, _version: string, 
           });
         } else {
           log.debug(
-            `No gradient or solid fill style found for node ${vertex.id}->${vertex.domId}. Using the default fill color from the theme.`
+            `No gradient or simple fill style found for node ${vertex.id}->${vertex.domId}. Using the default fill color from the theme.`
           );
         }
 

--- a/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.ts
@@ -95,7 +95,7 @@ export const draw = async function (text: string, id: string, _version: string, 
         // Combine style arrays, defaulting to empty arrays if missing
         // Note that `cssCompiledStyles` (from `classDef`) applies first, with `cssStyles` (from `style`)
         // rendered on top, allowing layered effects like multiple semi-transparent backgrounds
-        const styles = [...(vertex.cssCompiledStyles || []), ...(vertex.cssStyles || [])];
+        const styles = [...(vertex.cssStyles || []), ...(vertex.cssCompiledStyles || [])];
 
         // Log all cssCompiledStyles for the node if available
         if (styles) {
@@ -119,9 +119,12 @@ export const draw = async function (text: string, id: string, _version: string, 
           effectiveFillStyles.length > 1 ||
           effectiveFillStyles.some((style) => style.includes('linear-gradient('))
         ) {
+          // Note: the `!important` flag is added directly to all the inline fill styles below to prevent overrides by
+          // cssImportantStyles in src/mermaidAPI.ts, ensuring classDef-based fill properties don’t block our fills
+
           // Remove any existing or default fill (e.g. from the theme) that might unexpectedly
           // bleed through (semi-)transparent areas of the fill layers
-          shapeElement.style('fill', 'none');
+          shapeElement.style('fill', 'none', 'important');
 
           // Iterate over fill styles in the order they were defined
           effectiveFillStyles.forEach((style, index) => {
@@ -152,7 +155,7 @@ export const draw = async function (text: string, id: string, _version: string, 
               );
 
               // Apply the gradient fill to the cloned shape
-              shapeClone.style('fill', `url(#${gradientId})`);
+              shapeClone.style('fill', `url(#${gradientId})`, 'important');
               log.debug(
                 `Applied gradient ID "${gradientId}" to node ${vertex.id} with URL url(#${gradientId})`
               );
@@ -161,7 +164,7 @@ export const draw = async function (text: string, id: string, _version: string, 
               const color = style.replace(/fill\s*:\s*/, '');
 
               // Apply the simple fill to the cloned shape
-              shapeClone.style('fill', color);
+              shapeClone.style('fill', color, 'important');
               log.debug(`Applied simple fill color "${color}" to node ${vertex.id}`);
             }
 

--- a/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.ts
@@ -101,7 +101,7 @@ export const draw = async function (text: string, id: string, _version: string, 
         // Look for all gradient styles, ensuring that nested parentheses due to color functions are handled properly
         const linearGradientStyles = vertex.cssCompiledStyles
           ?.join('')
-          ?.match(/fill\s*:\s*linear-gradient\(([^()]*(\([^()]*\))*[^()]*)+\)/g);
+          ?.match(/fill\s*:\s*linear-gradient\([^()]*?(?:\([^()]*?\)[^()]*)*\)/g);
 
         if (linearGradientStyles) {
           shapeElement.style('fill', null); // Clear any existing fill

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
@@ -7,6 +7,7 @@
 /* lexical grammar */
 %lex
 %x string
+%x linearGradientText
 %x md_string
 %x acc_title
 %x acc_descr
@@ -164,6 +165,16 @@ that id.
 
 
 <*>\s*\~\~[\~]+\s*              return 'LINK';
+
+
+/*
+Capture linear-gradient(...).
+This includes `linear-gradient(-...)` which otherwise conflicts with `(-` in ellipseText.
+*/
+<*>"linear-gradient"[\s]*\(\s*               { this.pushState("linearGradientText"); return 'LINEAR_GRADIENT_START'; }
+<linearGradientText>([^()]|(\([^()]*\)))+    { return 'LINEAR_GRADIENT_CONTENT'; }  // Handles text, commas, and nested parentheses
+<linearGradientText>\)                       { this.popState(); return 'LINEAR_GRADIENT_END'; }
+
 
 <ellipseText>[-/\)][\)]         { this.popState(); return '-)'; }
 <ellipseText>[^\(\)\[\]\{\}]|-\!\)+       return "TEXT"
@@ -582,7 +593,12 @@ style: styleComponent
     {$$ = $style + $styleComponent;}
     ;
 
-styleComponent: NUM | NODE_STRING| COLON | UNIT | SPACE | BRKT | STYLE | PCT ;
+styleComponent: NUM | NODE_STRING | COLON | UNIT | SPACE | BRKT | STYLE | PS | TEXT | PE | LINGRAD;
+
+LINGRAD
+    : LINEAR_GRADIENT_START LINEAR_GRADIENT_CONTENT LINEAR_GRADIENT_END
+        { $$ = 'linear-gradient(' + $2 + ')'; }
+    ;
 
 /* Token lists */
 idStringToken  :  NUM | NODE_STRING | DOWN | MINUS | DEFAULT | COMMA | COLON | AMP | BRKT | MULT | UNICODE_TEXT;

--- a/packages/mermaid/src/docs/syntax/flowchart.md
+++ b/packages/mermaid/src/docs/syntax/flowchart.md
@@ -1137,7 +1137,7 @@ flowchart LR
 
 #### Linear gradient style
 
-Mermaid allows for linear gradient styling on nodes by leveraging the [<linearGradient>](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/linearGradient) element in SVG paired with CSS [linear-gradient()](https://www.w3.org/TR/css-images-4/#gradients) syntax, to design more visually distinct flowcharts. You can define gradients in much the same way as in CSS, specifying directions, multiple color stops, transition hints, and transparency to achieve unique effects. Color interpolation is done in `sRGB` space, as commonly supported by browsers. A linear gradient can be set as the fill property in a node’s `style` or `classDef` using the following syntax:
+Mermaid allows for linear gradient styling on nodes by leveraging the [linearGradient](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/linearGradient) element in SVG paired with CSS [linear-gradient()](https://www.w3.org/TR/css-images-4/#gradients) syntax, to design more visually distinct flowcharts. You can define gradients in much the same way as in CSS, specifying directions, multiple color stops, transition hints, and transparency to achieve unique effects. Color interpolation is done in `sRGB` space, as commonly supported by browsers. A linear gradient can be set as the fill property in a node’s `style` or `classDef` using the following syntax:
 
 ```
     style nodeId fill:linear-gradient(direction, colorStop1, colorStop2, ...);
@@ -1164,7 +1164,6 @@ A comprehensive collection of side-by-side examples comparing Mermaid and CSS li
 ##### Linear gradient examples
 
 **1. Basic gradient**
-
 Create a basic gradient from red to blue, flowing from top to bottom (default direction):
 
 ```mermaid-example
@@ -1184,7 +1183,6 @@ flowchart
 In this example, the gradient starts with red at the top and transitions to blue at the bottom.
 
 **2. Gradient with directional keywords**
-
 Use directional keywords to define the gradient's direction:
 
 ```mermaid-example
@@ -1196,7 +1194,6 @@ flowchart LR
 This gradient moves from the top-right corner to the bottom-left corner, starting with pink and ending with cyan.
 
 **3. Gradient with angle**
-
 Specify the gradient angle to control the direction:
 
 ```mermaid-example
@@ -1208,7 +1205,6 @@ flowchart BT
 The gradient line is tilted at a 35-degree angle, starting with orange and transitioning to purple.
 
 **4. Multiple color stops**
-
 Include multiple color stops at specific positions:
 
 ```mermaid-example
@@ -1220,7 +1216,6 @@ flowchart LR
 Here, the gradient starts with red at the top, transitions to yellow at 30%, green at 60%, brown at 90%, and ends with Deep Sky Blue at the bottom.
 
 **5. Length Units for color stops**
-
 Use length units for color stop positions (physical units like `cm` are calculated assuming _96dpi_):
 
 ```mermaid-example
@@ -1232,7 +1227,6 @@ flowchart LR
 This gradient moves from left to right, using specific lengths and percentages to control where colors change.
 
 **6. Gradients with opacity**
-
 Apply gradients using colors with opacity:
 
 ```mermaid-example
@@ -1244,7 +1238,6 @@ flowchart TD
 The gradient transitions from semi-transparent red to semi-transparent blue diagonally.
 
 **7. Automatic positioning**
-
 If positions for color stops are not specified, they are distributed evenly:
 
 ```mermaid-example
@@ -1256,7 +1249,6 @@ flowchart LR
 In this example, the gradient begins with red from 0% to 10% (specified), transitions smoothly to green at 30%, then to orange at 50%, blue at 70%, and finally reaches cyan at 90% (specified), remaining cyan until the end, distributing the colors with missing positions evenly throughout.
 
 **8. Overlapping positions**
-
 If color stops have overlapping positions, Mermaid adjusts them to maintain the correct order:
 
 ```mermaid-example
@@ -1268,8 +1260,7 @@ flowchart RL
 Here, since 40% comes after 60%, the white color stop at 40% is adjusted to 60% to keep positions ascending.
 
 **9. Out-of-bounds positions**
-
-Color stops set outside the 0% to 100% range cause the gradient to stretch beyond the edges.
+Color stops set outside the 0% to 100% range cause the gradient calculation to stretch beyond the node's shape while keeping all rendered content contained within.
 
 ```mermaid-example
 flowchart TD
@@ -1280,7 +1271,6 @@ flowchart TD
 In this gradient, red at -20% blends toward yellow and appears as a red-yellow mix at 0%. Likewise, green at 145% blends with yellow near 100%, creating a yellow-green mix rather than pure green at the end. Yellow is centered because the 50% stop is explicitly defined.
 
 **10. Sharp color transition**
-
 Specifying two identical positions for consecutive colors creates a sharp transition:
 
 ```mermaid-example
@@ -1292,8 +1282,7 @@ flowchart LR
 This results in a sharp change from red to blue exactly at the 50% mark.
 
 **11. Double color stops**
-
-Using double positions for a color creates a solid zone with that colors:
+Using double positions for a color creates an unvarying zone with that color:
 
 ```mermaid-example
 flowchart LR
@@ -1309,10 +1298,9 @@ flowchart TD
     style A fill:linear-gradient(45deg, yellow, red 30%, red 50%, blue);
 ```
 
-In this example, the gradient transitions from yellow to red between 0% and 30%, remains solid red between 30% and 50%, and then transitions from red to blue after 50%.
+In this example, the gradient transitions from yellow to red between 0% and 30%, remains uniformly red between 30% and 50%, and then transitions from red to blue after 50%.
 
 **12. Color functions**
-
 Mermaid supports CSS color functions, provided they are supported by the browser:
 
 ```mermaid-example
@@ -1322,7 +1310,6 @@ flowchart LR
 ```
 
 **13. Applying gradients to different shapes**
-
 Gradients adjust based on the node's shape and dimensions:
 
 ```mermaid-example
@@ -1331,7 +1318,7 @@ flowchart TD
     B --> E[/Parallelogram/]
     C --> F([Stadium])
     E --> G[[Subroutine]]
-    classDef default fill:linear-gradient(135deg, #FF000080, #FFA50080, #FFFF0080, #00800080, #0000FF80, #4B008280, #EE82EE80);
+    classDef default fill:linear-gradient(135deg, #ff000080, #ffa50080, #ffff0080, #00800080, #0000ff80, #4b008280, #ee82ee80);
 ```
 
 ```note
@@ -1343,7 +1330,6 @@ The gradient line length is determined by projecting a shape's dimensions along 
 Non-linear color transitions occur when using transition hints or colors with varying opacity. See the two scenarios below.
 
 **Scenario I: interpolating between colors with color transition hint**
-
 Transition hints are positional markers that can be placed between color stops to guide the gradient's interpolation.
 
 ```mermaid-example
@@ -1369,7 +1355,6 @@ You are allowed to have both transition hints and opacity variations in the same
 ```
 
 **Fine-tuning non-linear interpolation with custom transition stops**
-
 You can specify `num-transition-stops` directly in the `style` or `classDef` to customize the number of segments that make up the gradient transition. The default is `5`, which provides a decent transition, but adjusting this number allows for finer control. This value must be odd to align with the symmetry logic used for interpolation. Here is an example:
 
 ```mermaid-example
@@ -1393,29 +1378,37 @@ flowchart TD
 
 In this example, red, green, and blue gradients are angled differently and fade out around 70%, creating a layered, blended effect within the node.
 
-**Adding a solid background**
-To add single-color layers to the gradients, you can specify an explicit `fill` color, to establish a uniform background layer. Without this, no background fill will appear—even the theme’s default background color won’t apply—leaving only the gradient and any transparent areas visible. This allows the color or content of the underlying container element to show through, which can be useful for designs that embrace transparency. For example:
+**Combining simple fills and linear gradients for layered node styling**
+When styling a node with a linear gradient, the theme’s default background color is ignored. This means that if you don’t specify a simple fill color, no background or foreground color will be applied to the gradient layers. This allows the color or content of the underlying container to show through (semi-)transparent areas of the gradient, if any, which can be useful for designs that embrace transparency.
+
+To include simple, single-colored layers alongside gradient layers, use the fill property to define a color. This fill doesn’t need to be fully opaque and creates a uniform, single-colored layer in the stack. The placement of this simple fill property in the style or class definition determines its influence on the final outcome when combined with other layers. Earlier fills take precedence and overlay subsequent layers.
 
 ```mermaid-example
-flowchart TD
-    E[No Background Fill] --> F[Solid Background Fill]
-    style E fill:linear-gradient(to left, rgba(255,0,0,0.4), rgba(0,0,255,0.4))
-    style F fill:linear-gradient(to left, rgba(255,0,0,0.4), rgba(0,0,255,0.4)), fill:yellow
+flowchart LR
+    A[No Yellow] --> B[Yellow First]
+    A --> C[Yellow Last]
+    B --> D[Transparent Yellow First]
+    C --> E[Transparent Yellow Last]
+    style A fill:linear-gradient(to left, rgba(255,0,0,0.8), rgba(0,0,255,0.3))
+    style B fill:yellow, fill:linear-gradient(to left, rgba(255,0,0,0.8), rgba(0,0,255,0.3))
+    style C fill:linear-gradient(to left, rgba(255,0,0,0.8), rgba(0,0,255,0.3)), fill:yellow
+    style D fill:rgba(255,255,0,0.6), fill:linear-gradient(to left, rgba(255,0,0,0.8), rgba(0,0,255,0.3))
+    style E fill:linear-gradient(to left, rgba(255,0,0,0.8), rgba(0,0,255,0.3)), fill:rgba(255,255,0,0.6)
 ```
 
-In this example, node E has only a gradient fill, allowing the web page background to show through transparent areas, while node F includes a light gray (`#f2f2f2`) background beneath the gradient for a more opaque, cohesive look.
+In the example above, node A uses only a gradient fill, allowing the page background to show through its transparent areas. The other nodes include a yellow layer—either opaque or transparent—in addition to the gradient. The order in which the fill properties are defined impacts how the layers blend visually.
 
 **Combining gradients from class definition and style**
-You can also set a default gradient in `classDef`—which can apply to multiple nodes—and then layer additional gradients on specific nodes directly using `style`. This is especially useful when you have a default look for all nodes but want to add unique overlays on some for emphasis or distinction. Each gradient can be semi-transparent, allowing for blended visuals. For example:
+You can also set a default gradient in `classDef`—which can apply to multiple nodes—and then layer additional gradients on top of specific nodes directly using `style`. This is especially useful when you have a default look for all nodes but want to add unique overlays on some for emphasis or distinction. Each gradient can be semi-transparent, allowing for blended visuals. For example:
 
 ```mermaid-example
-flowchart TD
-    A[Layered Gradient from both classDef and style] --> B((Default)) & C[/Default\]
-    classDef default fill:linear-gradient(45deg, rgba(0,0,150,0.3), rgba(255,255,0,0.3))
-    style A fill:linear-gradient(to top, rgb(240,0,0,0.8), 5%, transparent 15% 85%, 95%, rgb(240,0,0,0.8))
+ flowchart TD
+    A[Northern Lights] --> B((Default)) & C[/Default\]
+    classDef default fill:linear-gradient(to top, rgba(23, 10, 113, 0.9), 40%, transparent), fill:white
+    style A fill:linear-gradient(to right, rgba(0, 255, 127, 0.3) 10%, rgba(0, 191, 255, 0.3) 30%, transparent 50%, rgba(138, 43, 226, 0.2) 70%, rgba(19, 24, 98, 0.3) 90%)
 ```
 
-Here, a default pink-to-yellow gradient in `classDef` applies to all nodes, while an additional red-transparent-red gradient in `style` overlays only node A.
+Here, the default gradient in `classDef` features a twilight indigo base that transitions into white from a simple fill. On top of this, node A adds a vibrant northern-lights-inspired gradient, allowing traces of the default background to show through.
 
 ### CSS classes
 

--- a/packages/mermaid/src/docs/syntax/flowchart.md
+++ b/packages/mermaid/src/docs/syntax/flowchart.md
@@ -1135,7 +1135,7 @@ flowchart LR
     classDef foobar stroke:#00f
 ```
 
-#### Linear gradient style
+#### Linear gradient style (v<MERMAID_RELEASE_VERSION>+)
 
 Mermaid allows for linear gradient styling on nodes by leveraging the [linearGradient](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/linearGradient) element in SVG paired with CSS [linear-gradient()](https://www.w3.org/TR/css-images-4/#gradients) syntax, to design more visually distinct flowcharts. You can define gradients in much the same way as in CSS, specifying directions, multiple color stops, transition hints, and transparency to achieve unique effects. Color interpolation is done in `sRGB` space, as commonly supported by browsers. A linear gradient can be set as the fill property in a node’s `style` or `classDef` using the following syntax:
 
@@ -1153,8 +1153,8 @@ or
 - _direction_ _(Optional)_: Defines the direction of the gradient line. It can be specified using directional keywords (e.g., `to right`, `to bottom`, `to top left`) or angles (e.g., `45deg`, `1.57rad`, `0.25turn`, `100grad`) measured clockwise from `to top` or `0deg`. If unspecified, it defaults to `to bottom` or `180deg`.
 - _colorStop1, colorStop2, ..._: A list of colors separated by commas where each color can have an optional position (e.g., `red 20%, blue 50px`). Positions can be given in percentage (`%`) or length units like `px`, `em`, `rem`, `ex`, `ch`, `vw`, `vh`, `vmin`, `vmax`, `cm`, `mm`, `in`, `pt`, and `pc`. Backward positions will be adjusted to the previous maximum. Missing positions are automatically set by assigning the first color stop to 0%, the last to 100%, and by evenly spacing any remaining unpositioned stops between the preceding and following color stops with positions. See [Color Stop Fixup](https://www.w3.org/TR/css-images-4/#color-stop-fixup).
 
-```note
-You may also add transition hints as position-only markers in between the color stops to control interpolation and adjust the flow of colors in the gradient. See an example of it in the non-linear interpolation section below.
+```tip
+You may also add the _transition hints_ as position-only markers between the color stops to control interpolation and adjust the flow of colors in the gradient. See an example in the non-linear interpolation section below.
 ```
 
 ```note
@@ -1186,7 +1186,7 @@ In this example, the gradient starts with red at the top and transitions to blue
 Use directional keywords to define the gradient's direction:
 
 ```mermaid-example
-flowchart LR
+flowchart
     A[Directional Gradient]
     style A fill:linear-gradient(to bottom left, pink, cyan)
 ```
@@ -1197,7 +1197,7 @@ This gradient moves from the top-right corner to the bottom-left corner, startin
 Specify the gradient angle to control the direction:
 
 ```mermaid-example
-flowchart BT
+flowchart
     A[Angle Gradient]
     style A fill:linear-gradient(35deg, orange, purple);
 ```
@@ -1208,7 +1208,7 @@ The gradient line is tilted at a 35-degree angle, starting with orange and trans
 Include multiple color stops at specific positions:
 
 ```mermaid-example
-flowchart LR
+flowchart
     A[Color Stops]
     style A fill:linear-gradient(to bottom, red, yellow 30%, green 60%, brown 90%, #00BFFF);
 ```
@@ -1219,7 +1219,7 @@ Here, the gradient starts with red at the top, transitions to yellow at 30%, gre
 Use length units for color stop positions (physical units like `cm` are calculated assuming _96dpi_):
 
 ```mermaid-example
-flowchart LR
+flowchart
     A[Length Units]
     style A fill:linear-gradient(to right, #FF5733 10px, #FFC300 20%, #DAF7A6 2cm, #900C3F);
 ```
@@ -1230,7 +1230,7 @@ This gradient moves from left to right, using specific lengths and percentages t
 Apply gradients using colors with opacity:
 
 ```mermaid-example
-flowchart TD
+flowchart
     A[Opacity Gradient]:::opacity
     classDef opacity fill:linear-gradient(to bottom right, rgba(255,0,0,0.8), rgba(0,0,255,0.2));
 ```
@@ -1241,7 +1241,7 @@ The gradient transitions from semi-transparent red to semi-transparent blue diag
 If positions for color stops are not specified, they are distributed evenly:
 
 ```mermaid-example
-flowchart LR
+flowchart
     A[Automatic Positions]
     style A fill:linear-gradient(to right, red 10%, green, orange, blue, cyan 90%);
 ```
@@ -1252,7 +1252,7 @@ In this example, the gradient begins with red from 0% to 10% (specified), transi
 If color stops have overlapping positions, Mermaid adjusts them to maintain the correct order:
 
 ```mermaid-example
-flowchart RL
+flowchart
     A[Overlapping Positions]
     style A fill:linear-gradient(to bottom, black 60%, white 40%);
 ```
@@ -1263,7 +1263,7 @@ Here, since 40% comes after 60%, the white color stop at 40% is adjusted to 60% 
 Color stops set outside the 0% to 100% range cause the gradient calculation to stretch beyond the node's shape while keeping all rendered content contained within.
 
 ```mermaid-example
-flowchart TD
+flowchart
     A[Out-of-Bounds Positions]
     style A fill:linear-gradient(to right, red -20%, yellow 50%, green 145%);
 ```
@@ -1274,7 +1274,7 @@ In this gradient, red at -20% blends toward yellow and appears as a red-yellow m
 Specifying two identical positions for consecutive colors creates a sharp transition:
 
 ```mermaid-example
-flowchart LR
+flowchart
     A[Sharp Color Transition]
     style A fill:linear-gradient(45deg, red 50%, blue 50%);
 ```
@@ -1285,7 +1285,7 @@ This results in a sharp change from red to blue exactly at the 50% mark.
 Using double positions for a color creates an unvarying zone with that color:
 
 ```mermaid-example
-flowchart LR
+flowchart
     A[Double Color Stops]
     style A fill:linear-gradient(45deg, yellow, red 30% 50%, blue);
 ```
@@ -1293,7 +1293,7 @@ flowchart LR
 This is equivalent to:
 
 ```mermaid-example
-flowchart TD
+flowchart
     A[Double Color Stops]
     style A fill:linear-gradient(45deg, yellow, red 30%, red 50%, blue);
 ```
@@ -1304,7 +1304,7 @@ In this example, the gradient transitions from yellow to red between 0% and 30%,
 Mermaid supports CSS color functions, provided they are supported by the browser:
 
 ```mermaid-example
-flowchart LR
+flowchart
     A[Color Functions]
     style A fill:linear-gradient(to bottom, rgb(190, 0, 24), hwb(95 23% 50% / 0.4), hsla(30, 81%, 30%, 0.9));
 ```
@@ -1333,7 +1333,7 @@ Non-linear color transitions occur when using transition hints or colors with va
 Transition hints are positional markers that can be placed between color stops to guide the gradient's interpolation.
 
 ```mermaid-example
-flowchart LR
+flowchart
     A[Transition Hint]
     style A fill:linear-gradient(to right, red, 20%, blue);
 ```
@@ -1343,22 +1343,22 @@ In this gradient, the midpoint color occurs at 20% of the gradient's length, cau
 **Scenario II: transitioning between neighboring colors with different opacities**
 
 ```mermaid-example
-flowchart LR
+flowchart
     A[Opacity Transition]
     style A fill:linear-gradient(to bottom right, rgba(255,0,0,0.9), rgba(0,0,255,0.2));
 ```
 
 In this gradient, the transition is from a semi-transparent red (90% opacity) to a semi-transparent blue (20% opacity), moving diagonally from the top-left to the bottom-right. The gradient leans more heavily toward the side with higher opacity. This gives the more opaque red a stronger presence in the gradient’s interpolation, while the semi-transparent blue appears less dominant.
 
-```note
-You are allowed to have both transition hints and opacity variations in the same gradient.
+```tip
+You can use both transition hints and opacity variations in the same gradient.
 ```
 
 **Fine-tuning non-linear interpolation with custom transition stops**
 You can specify `num-transition-stops` directly in the `style` or `classDef` to customize the number of segments that make up the gradient transition. The default is `5`, which provides a decent transition, but adjusting this number allows for finer control. This value must be odd to align with the symmetry logic used for interpolation. Here is an example:
 
 ```mermaid-example
-flowchart LR
+flowchart
     A[Custom Number of Transition Stops]
     style A fill:linear-gradient(to bottom left, navy, 35%, peachpuff, darkorchid), num-transition-stops: 13;
 ```

--- a/packages/mermaid/src/docs/syntax/flowchart.md
+++ b/packages/mermaid/src/docs/syntax/flowchart.md
@@ -1135,6 +1135,288 @@ flowchart LR
     classDef foobar stroke:#00f
 ```
 
+#### Linear gradient style
+
+Mermaid allows for linear gradient styling on nodes by leveraging the [<linearGradient>](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/linearGradient) element in SVG paired with CSS [linear-gradient()](https://www.w3.org/TR/css-images-4/#gradients) syntax, to design more visually distinct flowcharts. You can define gradients in much the same way as in CSS, specifying directions, multiple color stops, transition hints, and transparency to achieve unique effects. Color interpolation is done in `sRGB` space, as commonly supported by browsers. A linear gradient can be set as the fill property in a node’s `style` or `classDef` using the following syntax:
+
+```
+    style nodeId fill:linear-gradient(direction, colorStop1, colorStop2, ...);
+```
+
+or
+
+```
+    classDef classId fill:linear-gradient(direction, colorStop1, colorStop2, ...);
+    class nodeId classId
+```
+
+- _direction_ _(Optional)_: Defines the direction of the gradient line. It can be specified using directional keywords (e.g., `to right`, `to bottom`, `to top left`) or angles (e.g., `45deg`, `1.57rad`, `0.25turn`, `100grad`) measured clockwise from `to top` or `0deg`. If unspecified, it defaults to `to bottom` or `180deg`.
+- _colorStop1, colorStop2, ..._: A list of colors separated by commas where each color can have an optional position (e.g., `red 20%, blue 50px`). Positions can be given in percentage (`%`) or length units like `px`, `em`, `rem`, `ex`, `ch`, `vw`, `vh`, `vmin`, `vmax`, `cm`, `mm`, `in`, `pt`, and `pc`. Backward positions will be adjusted to the previous maximum. Missing positions are automatically set by assigning the first color stop to 0%, the last to 100%, and by evenly spacing any remaining unpositioned stops between the preceding and following color stops with positions. See [Color Stop Fixup](https://www.w3.org/TR/css-images-4/#color-stop-fixup).
+
+```note
+You may also add transition hints as position-only markers in between the color stops to control interpolation and adjust the flow of colors in the gradient. See an example of it in the non-linear interpolation section below.
+```
+
+```note
+A comprehensive collection of side-by-side examples comparing Mermaid and CSS linear gradients is available on [this CodePen](https://codepen.io/enourbakhsh/full/jOgBNjN). This comparison shows that the two methods are practically indistinguishable across a wide range of use cases.
+```
+
+##### Linear gradient examples
+
+**1. Basic gradient**
+
+Create a basic gradient from red to blue, flowing from top to bottom (default direction):
+
+```mermaid-example
+flowchart
+    A[Basic Gradient]
+    style A fill:linear-gradient(red, blue)
+```
+
+or
+
+```mermaid-example
+flowchart
+    A[Basic Gradient]:::styleA
+    classDef styleA fill:linear-gradient(red, blue)
+```
+
+In this example, the gradient starts with red at the top and transitions to blue at the bottom.
+
+**2. Gradient with directional keywords**
+
+Use directional keywords to define the gradient's direction:
+
+```mermaid-example
+flowchart LR
+    A[Directional Gradient]
+    style A fill:linear-gradient(to bottom left, pink, cyan)
+```
+
+This gradient moves from the top-right corner to the bottom-left corner, starting with pink and ending with cyan.
+
+**3. Gradient with angle**
+
+Specify the gradient angle to control the direction:
+
+```mermaid-example
+flowchart BT
+    A[Angle Gradient]
+    style A fill:linear-gradient(35deg, orange, purple);
+```
+
+The gradient line is tilted at a 35-degree angle, starting with orange and transitioning to purple.
+
+**4. Multiple color stops**
+
+Include multiple color stops at specific positions:
+
+```mermaid-example
+flowchart LR
+    A[Color Stops]
+    style A fill:linear-gradient(to bottom, red, yellow 30%, green 60%, brown 90%, #00BFFF);
+```
+
+Here, the gradient starts with red at the top, transitions to yellow at 30%, green at 60%, brown at 90%, and ends with Deep Sky Blue at the bottom.
+
+**5. Length Units for color stops**
+
+Use length units for color stop positions (physical units like `cm` are calculated assuming _96dpi_):
+
+```mermaid-example
+flowchart LR
+    A[Length Units]
+    style A fill:linear-gradient(to right, #FF5733 10px, #FFC300 20%, #DAF7A6 2cm, #900C3F);
+```
+
+This gradient moves from left to right, using specific lengths and percentages to control where colors change.
+
+**6. Gradients with opacity**
+
+Apply gradients using colors with opacity:
+
+```mermaid-example
+flowchart TD
+    A[Opacity Gradient]:::opacity
+    classDef opacity fill:linear-gradient(to bottom right, rgba(255,0,0,0.8), rgba(0,0,255,0.2));
+```
+
+The gradient transitions from semi-transparent red to semi-transparent blue diagonally.
+
+**7. Automatic positioning**
+
+If positions for color stops are not specified, they are distributed evenly:
+
+```mermaid-example
+flowchart LR
+    A[Automatic Positions]
+    style A fill:linear-gradient(to right, red 10%, green, orange, blue, cyan 90%);
+```
+
+In this example, the gradient begins with red from 0% to 10% (specified), transitions smoothly to green at 30%, then to orange at 50%, blue at 70%, and finally reaches cyan at 90% (specified), remaining cyan until the end, distributing the colors with missing positions evenly throughout.
+
+**8. Overlapping positions**
+
+If color stops have overlapping positions, Mermaid adjusts them to maintain the correct order:
+
+```mermaid-example
+flowchart RL
+    A[Overlapping Positions]
+    style A fill:linear-gradient(to bottom, black 60%, white 40%);
+```
+
+Here, since 40% comes after 60%, the white color stop at 40% is adjusted to 60% to keep positions ascending.
+
+**9. Out-of-bounds positions**
+
+Color stops set outside the 0% to 100% range cause the gradient to stretch beyond the edges.
+
+```mermaid-example
+flowchart TD
+    A[Out-of-Bounds Positions]
+    style A fill:linear-gradient(to right, red -20%, yellow 50%, green 145%);
+```
+
+In this gradient, red at -20% blends toward yellow and appears as a red-yellow mix at 0%. Likewise, green at 145% blends with yellow near 100%, creating a yellow-green mix rather than pure green at the end. Yellow is centered because the 50% stop is explicitly defined.
+
+**10. Sharp color transition**
+
+Specifying two identical positions for consecutive colors creates a sharp transition:
+
+```mermaid-example
+flowchart LR
+    A[Sharp Color Transition]
+    style A fill:linear-gradient(45deg, red 50%, blue 50%);
+```
+
+This results in a sharp change from red to blue exactly at the 50% mark.
+
+**11. Double color stops**
+
+Using double positions for a color creates a solid zone with that colors:
+
+```mermaid-example
+flowchart LR
+    A[Double Color Stops]
+    style A fill:linear-gradient(45deg, yellow, red 30% 50%, blue);
+```
+
+This is equivalent to:
+
+```mermaid-example
+flowchart TD
+    A[Double Color Stops]
+    style A fill:linear-gradient(45deg, yellow, red 30%, red 50%, blue);
+```
+
+In this example, the gradient transitions from yellow to red between 0% and 30%, remains solid red between 30% and 50%, and then transitions from red to blue after 50%.
+
+**12. Color functions**
+
+Mermaid supports CSS color functions, provided they are supported by the browser:
+
+```mermaid-example
+flowchart LR
+    A[Color Functions]
+    style A fill:linear-gradient(to bottom, rgb(190, 0, 24), hwb(95 23% 50% / 0.4), hsla(30, 81%, 30%, 0.9));
+```
+
+**13. Applying gradients to different shapes**
+
+Gradients adjust based on the node's shape and dimensions:
+
+```mermaid-example
+flowchart TD
+    A[A] --> B{Rhombus} --> C((Circle)) --> D[(Cylinder)]
+    B --> E[/Parallelogram/]
+    C --> F([Stadium])
+    E --> G[[Subroutine]]
+    classDef default fill:linear-gradient(135deg, #FF000080, #FFA50080, #FFFF0080, #00800080, #0000FF80, #4B008280, #EE82EE80);
+```
+
+```note
+The gradient line length is determined by projecting a shape's dimensions along the gradient's direction. For simple shapes, this uses trigonometric calculations, while for complex shapes, points are sampled along the shape’s outline. This approach ensures the gradient spans the entire shape by adapting to its unique geometry. You can explore an interactive demo showing this concept in action across various shapes on [this CodePen](https://codepen.io/enourbakhsh/full/WNVErLx).
+```
+
+##### Non-Linear interpolation
+
+Non-linear color transitions occur when using transition hints or colors with varying opacity. See the two scenarios below.
+
+**Scenario I: interpolating between colors with color transition hint**
+
+Transition hints are positional markers that can be placed between color stops to guide the gradient's interpolation.
+
+```mermaid-example
+flowchart LR
+    A[Transition Hint]
+    style A fill:linear-gradient(to right, red, 20%, blue);
+```
+
+In this gradient, the midpoint color occurs at 20% of the gradient's length, causing a faster transition from red to blue in the early part. Note that without a specified midpoint, it defaults to 50%, resulting in a linear interpolation.
+
+**Scenario II: transitioning between neighboring colors with different opacities**
+
+```mermaid-example
+flowchart LR
+    A[Opacity Transition]
+    style A fill:linear-gradient(to bottom right, rgba(255,0,0,0.9), rgba(0,0,255,0.2));
+```
+
+In this gradient, the transition is from a semi-transparent red (90% opacity) to a semi-transparent blue (20% opacity), moving diagonally from the top-left to the bottom-right. The gradient leans more heavily toward the side with higher opacity. This gives the more opaque red a stronger presence in the gradient’s interpolation, while the semi-transparent blue appears less dominant.
+
+```note
+You are allowed to have both transition hints and opacity variations in the same gradient.
+```
+
+**Fine-tuning non-linear interpolation with custom transition stops**
+
+You can specify `num-transition-stops` directly in the `style` or `classDef` to customize the number of segments that make up the gradient transition. The default is `5`, which provides a decent transition, but adjusting this number allows for finer control. This value must be odd to align with the symmetry logic used for interpolation. Here is an example:
+
+```mermaid-example
+flowchart LR
+    A[Custom Number of Transition Stops]
+    style A fill:linear-gradient(to bottom left, navy, 35%, peachpuff, darkorchid), num-transition-stops: 13;
+```
+
+In the gradient above, `num-transition-stops: 13` creates 13 stops, meaning 6 interpolation points on each side of the midpoint hint at 70% between `navy` and `peachpuff` for a higher-resolution interpolation than the default.
+
+##### Linear gradient overlay
+
+**Stacking multiple gradients**
+You can stack multiple `fill:linear-gradient`'s to achieve complex layered effects, with each gradient partially transparent to allow blending. For example, you can recreate the effect shown in [MDN’s CSS gradient demo](https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/linear-gradient#try_it) using the following Mermaid code:
+
+```mermaid-example
+flowchart TD
+    A[Gradient Overlay]:::gradientOverlay
+    classDef gradientOverlay fill:linear-gradient(217deg, rgba(255,0,0,.8), rgba(255,0,0,0) 70.71%), fill:linear-gradient(127deg, rgba(0,255,0,.8), rgba(0,255,0,0) 70.71%), fill:linear-gradient(336deg, rgba(0,0,255,.8), rgba(0,0,255,0) 70.71%);
+```
+
+In this example, red, green, and blue gradients are angled differently and fade out around 70%, creating a layered, blended effect within the node.
+
+**Adding a solid background**
+To add single-color layers to the gradients, you can specify an explicit `fill` color, to establish a uniform background layer. Without this, no background fill will appear—even the theme’s default background color won’t apply—leaving only the gradient and any transparent areas visible. This allows the color or content of the underlying container element to show through, which can be useful for designs that embrace transparency. For example:
+
+```mermaid-example
+flowchart TD
+    E[No Background Fill] --> F[Solid Background Fill]
+    style E fill:linear-gradient(to left, rgba(255,0,0,0.4), rgba(0,0,255,0.4))
+    style F fill:linear-gradient(to left, rgba(255,0,0,0.4), rgba(0,0,255,0.4)), fill:yellow
+```
+
+In this example, node E has only a gradient fill, allowing the web page background to show through transparent areas, while node F includes a light gray (`#f2f2f2`) background beneath the gradient for a more opaque, cohesive look.
+
+**Combining gradients from class definition and style**
+You can also set a default gradient in `classDef`—which can apply to multiple nodes—and then layer additional gradients on specific nodes directly using `style`. This is especially useful when you have a default look for all nodes but want to add unique overlays on some for emphasis or distinction. Each gradient can be semi-transparent, allowing for blended visuals. For example:
+
+```mermaid-example
+flowchart TD
+    A[Layered Gradient from both classDef and style] --> B((Default)) & C[/Default\]
+    classDef default fill:linear-gradient(45deg, rgba(0,0,150,0.3), rgba(255,255,0,0.3))
+    style A fill:linear-gradient(to top, rgb(240,0,0,0.8), 5%, transparent 15% 85%, 95%, rgb(240,0,0,0.8))
+```
+
+Here, a default pink-to-yellow gradient in `classDef` applies to all nodes, while an additional red-transparent-red gradient in `style` overlays only node A.
+
 ### CSS classes
 
 It is also possible to predefine classes in CSS styles that can be applied from the graph definition as in the example
@@ -1269,4 +1551,4 @@ mermaid.flowchartConfig = {
 }
 ```
 
-<!--- cspell:ignore lagom --->
+<!--- cspell:ignore lagom vmin vmax unpositioned --->

--- a/packages/mermaid/src/rendering-util/createGradient.spec.ts
+++ b/packages/mermaid/src/rendering-util/createGradient.spec.ts
@@ -515,7 +515,7 @@ describe('Gradient application on different shapes', () => {
   });
 });
 
-describe('Basic gradient creation and attributes', () => {
+describe('Basic gradient creation and attributes with in-depth checks', () => {
   it('should create a linear gradient with two color stops', () => {
     // Call the function to test
     createLinearGradient(
@@ -559,21 +559,21 @@ describe('Basic gradient creation and attributes', () => {
     const gradientLineLength =
       Math.abs(nodeWidth * Math.sin(angleRad)) + Math.abs(nodeHeight * Math.cos(angleRad));
 
-    // Define the minimum and maximum stops for the gradient
+    // Define the minimum and maximum stops set for the gradient
     const minStop = 0;
     const maxStop = 100;
 
     // SVG linear gradient coordinates
     const xc = bbox.x + nodeWidth / 2;
     const yc = bbox.y + nodeHeight / 2;
-    const dmin = (gradientLineLength * Math.abs(minStop - 50)) / 100;
-    const dmax = (gradientLineLength * Math.abs(maxStop - 50)) / 100;
+    const d1 = (gradientLineLength * (50 - minStop)) / 100;
+    const d2 = (gradientLineLength * (50 - maxStop)) / 100;
 
-    // Verify gradient attributes
+    // Verify gradient coordinates and angle
     expect(+gradient.attr('x1')).toBeCloseTo(xc, 8);
-    expect(+gradient.attr('y1')).toBeCloseTo(yc + dmax, 8);
+    expect(+gradient.attr('y1')).toBeCloseTo(yc + d1, 8);
     expect(+gradient.attr('x2')).toBeCloseTo(xc, 8);
-    expect(+gradient.attr('y2')).toBeCloseTo(yc - dmin, 8);
+    expect(+gradient.attr('y2')).toBeCloseTo(yc + d2, 8);
     expect(parsedAngle).toBeCloseTo(expectedAngle, 8);
 
     // Check that there are two color stops
@@ -733,7 +733,7 @@ describe('Basic gradient creation and attributes', () => {
     });
   }
 
-  it('should handle gradient without direction and default to 180deg', () => {
+  it('should handle gradient without angle/direction and default to 180deg', () => {
     createLinearGradient(svg, shapeElement, 'red, blue', 'test-gradient-no-direction');
 
     const gradient = svg.select('defs').select('linearGradient');
@@ -744,13 +744,13 @@ describe('Basic gradient creation and attributes', () => {
     const h = bbox.height;
     const xc = bbox.x + w / 2;
     const yc = bbox.y + h / 2;
-    const dmax = h * 0.5;
-    const dmin = h * 0.5;
+    const d1 = h * 0.5;
+    const d2 = -h * 0.5;
 
     expect(+gradient.attr('x1')).toBeCloseTo(xc, 8);
-    expect(+gradient.attr('y1')).toBeCloseTo(yc + dmax, 8);
+    expect(+gradient.attr('y1')).toBeCloseTo(yc + d1, 8);
     expect(+gradient.attr('x2')).toBeCloseTo(xc, 8);
-    expect(+gradient.attr('y2')).toBeCloseTo(yc - dmin, 8);
+    expect(+gradient.attr('y2')).toBeCloseTo(yc + d2, 8);
     expect(parsedAngle).toBeCloseTo(180, 8);
   });
 
@@ -963,8 +963,36 @@ describe('Special cases for color stops and positions', () => {
       'test-gradient-out-of-bounds-renorm-interpolation'
     );
 
-    const stops = svg.select('defs').select('linearGradient').selectAll('stop') as any;
+    const gradient = svg.select('defs').select('linearGradient');
+    const stops = gradient.selectAll('stop') as any;
 
+    // Get the node's dimensions
+    const bbox = shapeElement.node()!.getBBox();
+    const nodeWidth = bbox.width;
+    const nodeHeight = bbox.height;
+
+    // Calculate the gradient line length applied to a rectangle
+    const angleRad = deg2rad(35);
+    const gradientLineLength =
+      Math.abs(nodeWidth * Math.sin(angleRad)) + Math.abs(nodeHeight * Math.cos(angleRad));
+
+    // Define the minimum and maximum stops set for the gradient
+    const minStop = -50;
+    const maxStop = 115;
+
+    // SVG linear gradient coordinates
+    const xc = bbox.x + nodeWidth / 2;
+    const yc = bbox.y + nodeHeight / 2;
+    const d1 = (gradientLineLength * (50 - minStop)) / 100;
+    const d2 = (gradientLineLength * (50 - maxStop)) / 100;
+
+    // Verify gradient coordinates
+    expect(+gradient.attr('x1')).toBeCloseTo(xc, 8);
+    expect(+gradient.attr('y1')).toBeCloseTo(yc + d1, 8);
+    expect(+gradient.attr('x2')).toBeCloseTo(xc, 8);
+    expect(+gradient.attr('y2')).toBeCloseTo(yc + d2, 8);
+
+    // Verify color stops positions
     expect(stops[0].attr('offset')).toBe('-50%');
     expect(parseFloat(stops[1].attr('offset'))).toBeCloseTo(27.27272727272727, 8);
     expect(parseFloat(stops[2].attr('offset'))).toBeCloseTo(54.54545454545454, 8);
@@ -1257,4 +1285,4 @@ describe('Error handling', () => {
   });
 });
 
-// cspell:ignore renorm vmin vmax oklab oklch dmin dmax
+// cspell:ignore renorm vmin vmax oklab oklch d2 d1

--- a/packages/mermaid/src/rendering-util/createGradient.spec.ts
+++ b/packages/mermaid/src/rendering-util/createGradient.spec.ts
@@ -1329,14 +1329,14 @@ describe('Error handling', () => {
       expect(stops[6].attr('stop-color')).toBe('#0df20d33');
     });
 
-    it('should respect the number of transition stops specified', () => {
+    it('should respect the number of transition stops specified, rounding up if needed', () => {
       createLinearGradient(
         svg,
         shapeElement,
         'to bottom, rgba(70, 20, 56, 0.4), 25%, rgba(110, 230, 8, 0.8)',
         'test-gradient-n-transition-stops',
         false,
-        11
+        10 // Will be rounded up to 11 for symmetry around the hint
       );
 
       const stops = svg.select('defs').select('linearGradient').selectAll('stop') as any;

--- a/packages/mermaid/src/rendering-util/createGradient.spec.ts
+++ b/packages/mermaid/src/rendering-util/createGradient.spec.ts
@@ -1,6 +1,7 @@
 import { createLinearGradient, directionMap, getGradientLineLength } from './createGradient.js';
 import { select, type Selection } from 'd3';
 import { JSDOM } from 'jsdom';
+import { expect } from 'vitest';
 
 /* Global declarations for all describe blocks */
 
@@ -235,7 +236,7 @@ const calculatePolygonBBox = (points: number[][]) => {
 const calculatePathBBox = (path: SVGPathElement, nsteps = 100) => {
   const length = path.getTotalLength();
   const step = length / nsteps;
-  const points = [];
+  const points: number[][] = [];
   for (let i = 0; i <= length; i += step) {
     const point = path.getPointAtLength(i);
     points.push([point.x, point.y]);
@@ -859,7 +860,7 @@ describe('Length units and conversions', () => {
 
     // Note: the positions are in increasing order, so no replacement will occur
     expect(stops[0].attr('offset')).toBe('0%');
-    expect(stops[1].attr('offset'), 4); // 12pt -> 4% of 400px
+    expect(stops[1].attr('offset')).toBe('4%'); // 12pt -> 4% of 400px
     expect(parseFloat(stops[2].attr('offset'))).toBeCloseTo(9.448818897637796, 8); // 10mm -> ~9.4% of 400px
     expect(stops[3].attr('offset')).toBe('12.5%'); // 50px -> 12.5% of 400px
     expect(stops[4].attr('offset')).toBe('16%'); // 4pc -> 16% of 400px

--- a/packages/mermaid/src/rendering-util/createGradient.spec.ts
+++ b/packages/mermaid/src/rendering-util/createGradient.spec.ts
@@ -1,0 +1,1260 @@
+import { createLinearGradient, directionMap, getGradientLineLength } from './createGradient.js';
+import { select, type Selection } from 'd3';
+import { JSDOM } from 'jsdom';
+
+/* Global declarations for all describe blocks */
+
+// D3 selection for the SVG and shape element
+let svg: Selection<SVGSVGElement, unknown, null, undefined>;
+let shapeElement: Selection<SVGGraphicsElement, unknown, HTMLElement, any>;
+
+// Create a mock DOM and assign the window and document objects to the global scope
+const dom = new JSDOM(`<!DOCTYPE html><html><body></body></html>`, { pretendToBeVisual: true });
+global.window = global.window || dom.window;
+global.document = window.document;
+
+// Define global classes for SVG shape elements
+const shapeTypes = ['rect', 'circle', 'ellipse', 'polygon', 'path'];
+shapeTypes.forEach((elementName) => {
+  const className = `SVG${elementName.charAt(0).toUpperCase() + elementName.slice(1)}Element`;
+  (globalThis as any)[className] =
+    (globalThis as any)[className] ||
+    class extends (globalThis.SVGGraphicsElement as any) {
+      static [Symbol.hasInstance](instance: any) {
+        return instance?.tagName?.toLowerCase() === elementName;
+      }
+    };
+});
+
+// Make sure the JSDOM window has a CSS object
+global.window.CSS = global.window.CSS || {};
+
+// Attach the mock function to window.CSS.supports
+global.window.CSS.supports = (property: string, value?: string): boolean => {
+  if (property === 'color' && value !== undefined) {
+    return isValidColor(value);
+  }
+  return false; // Default to unsupported for invalid colors and other properties
+};
+
+beforeEach(() => {
+  // Default to a rectangle shape unless overridden in tests
+  ({ svg, shapeElement } = createShape('rect'));
+});
+
+afterEach(() => {
+  // Clean up DOM after each test
+  document.body.innerHTML = '';
+  shapeElement = null as any;
+  svg = null as any;
+});
+
+// Functions for converting angles
+const deg2rad = (deg: number) => deg * (Math.PI / 180);
+const rad2deg = (rad: number) => rad * (180 / Math.PI);
+const turn2deg = (turn: number) => turn * 360;
+const grad2deg = (grad: number) => (grad * 180) / 200;
+
+// Function to parse the angle from a transform attribute
+const parseTransformAngle = (transform: string) =>
+  +transform.split('rotate(')[1].split(',')[0].trim();
+
+// Generate valid single and two-word directions for testing
+const horizontalDirs = ['left', 'right'];
+const verticalDirs = ['top', 'bottom'];
+const dirs = [...horizontalDirs, ...verticalDirs];
+const validDirections = new Set([
+  ...dirs.map((d) => `to ${d}`),
+  ...horizontalDirs.flatMap((h) => verticalDirs.map((v) => `to ${h} ${v}`)),
+  ...verticalDirs.flatMap((v) => horizontalDirs.map((h) => `to ${v} ${h}`)),
+]);
+
+/**
+ * Function to validate CSS color strings to be used in the CSS.supports() mock.
+ *
+ * This function validates named colors, hex codes, and advanced color functions.
+ * It's not the exact CSS behavior but close enough for testing outside browsers.
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_colors|CSS colors} for the formal syntax.
+ *
+ * @param color - The color string to validate.
+ * @returns - true if the color is valid, false otherwise.
+ */
+function isValidColor(color: string): boolean {
+  color = color.trim();
+
+  // Built-in validation for basic colors
+  const s = new Option().style;
+  s.color = color;
+  if (s.color !== '') {
+    return true;
+  }
+
+  // Regex validation for advanced color functions
+  const number = '[+-]?(?:\\d*\\.\\d+|\\d+)(?:[eE][+-]?\\d+)?';
+  const percentage = `${number}%`;
+  const angle = `${number}(?:deg|rad|grad|turn)`;
+  const hue = `(?:${angle}|${number})`;
+  const alphaValue = `(?:${number}|${percentage})`;
+  const none = 'none';
+  const lch =
+    `lch\\(\\s*` +
+    `(?:${percentage}|${number}|${none})\\s+` +
+    `(?:${percentage}|${number}|${none})\\s+` +
+    `(?:${hue}|${none})` +
+    `(?:\\s*/\\s*(?:${alphaValue}|${none}))?` +
+    `\\s*\\)`;
+  const oklch =
+    `oklch\\(\\s*` +
+    `(?:${percentage}|${number}|${none})\\s+` +
+    `(?:${percentage}|${number}|${none})\\s+` +
+    `(?:${hue}|${none})` +
+    `(?:\\s*/\\s*(?:${alphaValue}|${none}))?` +
+    `\\s*\\)`;
+  const oklab =
+    `oklab\\(\\s*` +
+    `(?:${percentage}|${number}|${none})\\s+` +
+    `(?:${percentage}|${number}|${none})\\s+` +
+    `(?:${percentage}|${number}|${none})` +
+    `(?:\\s*/\\s*(?:${alphaValue}|${none}))?` +
+    `\\s*\\)`;
+  const lab =
+    `lab\\(\\s*` +
+    `(?:${percentage}|${number}|${none})\\s+` +
+    `(?:${percentage}|${number}|${none})\\s+` +
+    `(?:${percentage}|${number}|${none})` +
+    `(?:\\s*/\\s*(?:${alphaValue}|${none}))?` +
+    `\\s*\\)`;
+  const hwb =
+    `hwb\\(\\s*` +
+    `(?:${hue}|${none})\\s+` +
+    `(?:${percentage}|${number}|${none})\\s+` +
+    `(?:${percentage}|${number}|${none})` +
+    `(?:\\s*/\\s*(?:${alphaValue}|${none}))?` +
+    `\\s*\\)`;
+  const rgbModern =
+    `rgba?\\(\\s*` +
+    `(?:${number}|${percentage}|${none})\\s+` +
+    `(?:${number}|${percentage}|${none})\\s+` +
+    `(?:${number}|${percentage}|${none})` +
+    `(?:\\s*/\\s*(?:${alphaValue}|${none}))?` +
+    `\\s*\\)`;
+  const rgbLegacy =
+    `rgba?\\(\\s*` +
+    `(?:${number}|${percentage})\\s*,\\s*` +
+    `(?:${number}|${percentage})\\s*,\\s*` +
+    `(?:${number}|${percentage})` +
+    `(?:\\s*,\\s*(?:${alphaValue}))?` +
+    `\\s*\\)`;
+  const hslModern =
+    `hsla?\\(\\s*` +
+    `(?:${hue}|${none})\\s+` +
+    `(?:${percentage}|${number}|${none})\\s+` +
+    `(?:${percentage}|${number}|${none})` +
+    `(?:\\s*/\\s*(?:${alphaValue}|${none}))?` +
+    `\\s*\\)`;
+  const hslLegacy =
+    `hsla?\\(\\s*` +
+    `(?:${hue})\\s*,\\s*` +
+    `(?:${percentage})\\s*,\\s*` +
+    `(?:${percentage})` +
+    `(?:\\s*,\\s*(?:${alphaValue}))?` +
+    `\\s*\\)`;
+  const patterns = [lch, oklch, oklab, lab, hwb, rgbModern, rgbLegacy, hslModern, hslLegacy];
+  const combinedPattern = `^(?:${patterns.join('|')})$`;
+  const colorFunctionRegex = new RegExp(combinedPattern, 'i'); // Case-insensitive
+
+  if (colorFunctionRegex.test(color)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Selects elements by 'type' in a mock SVG structure. Supports chaining for
+ * further selection and attribute retrieval.
+ *
+ * @param el - The mock SVG element to search.
+ * @param sel - The 'type' selector.
+ * @returns - The first matching element with chainable methods.
+ */
+function getElem(el: any, sel: string) {
+  const res: any[] = [];
+  (function f(el) {
+    if (el.attribs.get('type') === sel) {
+      res.push(el);
+    }
+    el._children?.forEach(f);
+  })(el);
+  const firstMatch = res[0];
+  return {
+    ...firstMatch,
+    nodes: () => res,
+    empty: () => !firstMatch,
+    select: (s: string) => getElem(firstMatch, s),
+    selectAll: (s: string) => getElem(firstMatch, s).nodes(),
+    attr: (attrName: string) => firstMatch?.attribs.get(attrName),
+  };
+}
+
+// Helper function to create a DOMRect-like object
+const createDOMRect = (x: number, y: number, width: number, height: number): DOMRect => {
+  const props = {
+    width,
+    height,
+    x,
+    y,
+    top: y,
+    left: x,
+    right: x + width,
+    bottom: y + height,
+  };
+  return { ...props, toJSON: () => props } as DOMRect;
+};
+
+// Utility to parse polygon points
+const parsePoints = (points: string) => {
+  return points
+    .trim()
+    .split(/\s+/)
+    .map((pair) => pair.split(',').map(parseFloat));
+};
+
+// Compute bounding box for a polygon by calculating min and max x/y coordinates
+const calculatePolygonBBox = (points: number[][]) => {
+  const xValues = points.map(([x]) => x);
+  const yValues = points.map(([, y]) => y);
+  const minX = Math.min(...xValues);
+  const minY = Math.min(...yValues);
+  const maxX = Math.max(...xValues);
+  const maxY = Math.max(...yValues);
+  return createDOMRect(minX, minY, maxX - minX, maxY - minY);
+};
+
+// Compute bounding box for paths by iterating over points along the path
+const calculatePathBBox = (path: SVGPathElement, nsteps = 100) => {
+  const length = path.getTotalLength();
+  const step = length / nsteps;
+  const points = [];
+  for (let i = 0; i <= length; i += step) {
+    const point = path.getPointAtLength(i);
+    points.push([point.x, point.y]);
+  }
+  return calculatePolygonBBox(points);
+};
+
+// Function to create and get bounding box for various SVG elements
+function getBBox(
+  shapeElement: Selection<SVGGraphicsElement, unknown, HTMLElement, any>,
+  shapeType: string
+): DOMRect {
+  if (shapeType === 'rect') {
+    const width = parseFloat(shapeElement.attr('width') || '200');
+    const height = parseFloat(shapeElement.attr('height') || '200');
+    const x = parseFloat(shapeElement.attr('x') || '0');
+    const y = parseFloat(shapeElement.attr('y') || '0');
+    return createDOMRect(x, y, width, height);
+  } else if (shapeType === 'circle') {
+    const r = parseFloat(shapeElement.attr('r') || '100');
+    const cx = parseFloat(shapeElement.attr('cx') || '0');
+    const cy = parseFloat(shapeElement.attr('cy') || '0');
+    return createDOMRect(cx - r, cy - r, 2 * r, 2 * r);
+  } else if (shapeType === 'ellipse') {
+    const rx = parseFloat(shapeElement.attr('rx') || '100');
+    const ry = parseFloat(shapeElement.attr('ry') || '50');
+    const cx = parseFloat(shapeElement.attr('cx') || '0');
+    const cy = parseFloat(shapeElement.attr('cy') || '0');
+    return createDOMRect(cx - rx, cy - ry, 2 * rx, 2 * ry);
+  } else if (shapeType === 'polygon') {
+    const points = parsePoints(shapeElement.attr('points') || '0,0');
+    return calculatePolygonBBox(points);
+  } else if (shapeType === 'path') {
+    const pathElement = shapeElement.node() as SVGPathElement;
+    return calculatePathBBox(pathElement);
+  }
+  // Default to 200x200 box for unknown shapes
+  return createDOMRect(0, 0, 200, 200);
+}
+
+// Function to create a shape element to test the gradient on
+function createShape(shapeType: string): {
+  svg: Selection<SVGSVGElement, unknown, null, undefined>;
+  shapeElement: Selection<SVGGraphicsElement, unknown, HTMLElement, any>;
+} {
+  // Create a mock parent element and append it to the document body
+  const parentElement = document.createElement('div');
+  document.body.appendChild(parentElement);
+
+  // Create an SVG element for each test and mock the select method
+  const svgElement = document.createElementNS(
+    'http://www.w3.org/2000/svg',
+    shapeType
+  ) as unknown as SVGSVGElement;
+  svg = select(svgElement);
+  svg.select = (sel) => getElem(svg, sel as string);
+
+  // Append the SVG inside the parent element
+  parentElement.appendChild(svgElement);
+
+  // Set the font size for the document root and parent element
+  document.documentElement.style.fontSize = '18px'; // Root font size for rem test
+  parentElement.style.fontSize = '30px'; // Parent font size for em/ex/ch tests
+
+  // Create a mock rectangle element
+  shapeElement = svg.append(shapeType) as unknown as Selection<
+    SVGGraphicsElement,
+    unknown,
+    HTMLElement,
+    any
+  >;
+
+  // Set default attributes based on shape type
+  if (shapeType === 'rect') {
+    shapeElement.attr('x', -54).attr('y', 13).attr('width', 400).attr('height', 300);
+  } else if (shapeType === 'circle') {
+    shapeElement.attr('r', 100).attr('cx', 100).attr('cy', 100);
+  } else if (shapeType === 'ellipse') {
+    shapeElement.attr('rx', 150).attr('ry', 100).attr('cx', 200).attr('cy', 150);
+  } else if (shapeType === 'polygon') {
+    shapeElement.attr('points', '50,15 90,85 10,85');
+  } else if (shapeType === 'path') {
+    shapeElement.attr('d', 'M10 80 C 40 10, 65 10, 95 80 S 150 150, 180 80');
+  }
+
+  // Override node() to return the SVG element containing the shape,
+  // allowing access to the parent node for font size testing
+  shapeElement.node = () => svgElement;
+
+  shapeElement.node()!.getAttribute = (attr: string) => {
+    return shapeElement.attr(attr);
+  };
+
+  // Mock getBBox() for the shape element
+  svgElement.getBBox = () => getBBox(shapeElement, shapeType);
+
+  return { svg, shapeElement };
+}
+
+/** Linear gradient tests start from here **/
+
+describe('Gradient application on different shapes', () => {
+  it('should apply linear gradient to a rectangle', () => {
+    expect(shapeElement.node()).toBeInstanceOf(SVGRectElement);
+    shapeElement.attr('x', 8).attr('y', -39).attr('width', 550).attr('height', 380);
+    const gradientStyle = 'to bottom right, red, blue';
+    createLinearGradient(svg, shapeElement, gradientStyle, 'test-gradient-rect');
+
+    const gradient = svg.select('defs').select('linearGradient');
+    const transform = gradient.attr('gradientTransform');
+    const parsedAngle = parseTransformAngle(transform);
+    const stops = gradient.selectAll('stop') as any;
+    const bbox = shapeElement.node()!.getBBox();
+
+    // Compute expected angle using helper function
+    const expectedAngle = directionMap('to bottom right', bbox.width, bbox.height);
+
+    // Compute gradient line length for rectangle manually
+    const angleDeg = expectedAngle;
+    const angleRad = deg2rad(angleDeg);
+    const expectedLineLength =
+      Math.abs(bbox.width * Math.sin(angleRad)) + Math.abs(bbox.height * Math.cos(angleRad));
+
+    // Compute gradient line length for rectangle using the code
+    const computedLineLength = getGradientLineLength(shapeElement, angleDeg);
+
+    // Check gradient transform angle
+    expect(parsedAngle).toBeCloseTo(expectedAngle, 8);
+
+    // Check gradient line length
+    expect(computedLineLength).toBeCloseTo(expectedLineLength, 8);
+
+    // Verify color stops
+    expect(stops[0].attr('stop-color')).toBe('red');
+    expect(stops[1].attr('stop-color')).toBe('blue');
+  });
+
+  it('should apply linear gradient to a circle', () => {
+    ({ svg, shapeElement } = createShape('circle'));
+    shapeElement.attr('r', 100).attr('cx', 100).attr('cy', 100);
+    expect(shapeElement.node()).toBeInstanceOf(SVGCircleElement);
+
+    const gradientStyle = '66deg, yellow, green';
+    createLinearGradient(svg, shapeElement, gradientStyle, 'test-gradient-circle');
+
+    const gradient = svg.select('defs').select('linearGradient');
+    const transform = gradient.attr('gradientTransform');
+    const parsedAngle = parseTransformAngle(transform);
+    const stops = gradient.selectAll('stop') as any;
+
+    // For a circle, the gradient line length is always 2 * radius
+    const expectedLineLength = 2 * +shapeElement.attr('r');
+
+    // Compute gradient line length for circle using the code
+    const expectedAngle = 66;
+    const computedLineLength = getGradientLineLength(shapeElement, expectedAngle);
+
+    // Check gradient transform angle
+    expect(parsedAngle).toBeCloseTo(expectedAngle, 8);
+
+    // Check gradient line length
+    expect(computedLineLength).toBeCloseTo(expectedLineLength, 8);
+
+    // Verify color stops
+    expect(stops[0].attr('stop-color')).toBe('yellow');
+    expect(stops[1].attr('stop-color')).toBe('green');
+  });
+
+  it('should apply linear gradient to an ellipse', () => {
+    ({ svg, shapeElement } = createShape('ellipse'));
+    expect(shapeElement.node()).toBeInstanceOf(SVGEllipseElement);
+
+    shapeElement.attr('rx', 150).attr('ry', 100).attr('cx', 200).attr('cy', 150);
+    const gradientStyle = '135deg, pink, purple';
+    createLinearGradient(svg, shapeElement, gradientStyle, 'test-gradient-ellipse');
+
+    const gradient = svg.select('defs').select('linearGradient');
+    const transform = gradient.attr('gradientTransform');
+    const parsedAngle = parseTransformAngle(transform);
+    const stops = gradient.selectAll('stop') as any;
+
+    const expectedAngle = 135;
+    const angleRad = deg2rad(expectedAngle);
+
+    // Compute gradient line length for ellipse manually
+    const a = +shapeElement.attr('rx');
+    const b = +shapeElement.attr('ry');
+    const expectedLineLength =
+      2 * Math.sqrt((a * Math.sin(angleRad)) ** 2 + (b * Math.cos(angleRad)) ** 2);
+
+    // Compute gradient line length for ellipse using the code
+    const computedLineLength = getGradientLineLength(shapeElement, expectedAngle);
+
+    // Check gradient transform angle
+    expect(parsedAngle).toBeCloseTo(expectedAngle, 8);
+
+    // Check gradient line length
+    expect(computedLineLength).toBeCloseTo(expectedLineLength, 8);
+
+    // Verify color stops
+    expect(stops[0].attr('stop-color')).toBe('pink');
+    expect(stops[1].attr('stop-color')).toBe('purple');
+  });
+
+  it('should apply linear gradient to a polygon', () => {
+    ({ svg, shapeElement } = createShape('polygon'));
+    expect(shapeElement.node()).toBeInstanceOf(SVGPolygonElement);
+
+    shapeElement.attr('points', '50,15 90,85 10,85'); // A simple triangle
+    const gradientStyle = 'to left bottom, red, blue';
+    createLinearGradient(svg, shapeElement, gradientStyle, 'test-gradient-polygon');
+
+    const gradient = svg.select('defs').select('linearGradient');
+    const transform = gradient.attr('gradientTransform');
+    const parsedAngle = parseTransformAngle(transform);
+    const stops = gradient.selectAll('stop') as any;
+    const bbox = shapeElement.node()!.getBBox();
+
+    // Compute gradient line length for polygon using the code
+    const expectedAngle = directionMap('to left bottom', bbox.width, bbox.height);
+    const computedLineLength = getGradientLineLength(shapeElement, expectedAngle);
+
+    // Check gradient transform angle
+    expect(parsedAngle).toBeCloseTo(expectedAngle, 8);
+
+    // Check gradient line length against a precomputed value
+    expect(computedLineLength).toBeCloseTo(79.02055294422217, 8);
+
+    // Verify color stops
+    expect(stops[0].attr('stop-color')).toBe('red');
+    expect(stops[1].attr('stop-color')).toBe('blue');
+  });
+
+  it('should apply gradient to a path', () => {
+    ({ svg, shapeElement } = createShape('path'));
+    expect(shapeElement.node()).toBeInstanceOf(SVGPathElement);
+
+    // Testing with a rectangular path from (0,0) to (85,100) for simplicity
+    shapeElement.attr('d', 'M0,0 H85 V100 H0 Z');
+
+    // Workaround for JSDOM not supporting getTotalLength() and getPointAtLength()
+    (shapeElement.node() as SVGPathElement).getTotalLength = () => 370; // 2 * (85 + 100) = 370
+    (shapeElement.node() as SVGPathElement).getPointAtLength = (length): DOMPoint => {
+      const totalLength = 370;
+      length %= totalLength; // Cycle length within the perimeter
+      if (length <= 85) {
+        return { x: length, y: 0 } as any;
+      } else if (length <= 185) {
+        return { x: 85, y: length - 85 } as any;
+      } else if (length <= 270) {
+        return { x: 85 - (length - 185), y: 100 } as any;
+      } else {
+        return { x: 0, y: 100 - (length - 270) } as any;
+      }
+    };
+
+    const gradientStyle = '0.47turn, darkorange, lightblue';
+    createLinearGradient(svg, shapeElement, gradientStyle, 'test-gradient-path');
+
+    const gradient = svg.select('defs').select('linearGradient');
+    const transform = gradient.attr('gradientTransform');
+    const parsedAngle = parseTransformAngle(transform);
+    const stops = gradient.selectAll('stop') as any;
+
+    // Compute gradient line length for path using the code
+    const expectedAngle = turn2deg(0.47);
+    const computedLineLength = getGradientLineLength(shapeElement, expectedAngle);
+
+    // Check gradient transform angle
+    expect(parsedAngle).toBeCloseTo(expectedAngle, 8);
+
+    // Check gradient line length against a precomputed value
+    expect(computedLineLength).toBeCloseTo(114.15613681265552, 8);
+
+    // Verify color stops
+    expect(stops[0].attr('stop-color')).toBe('darkorange');
+    expect(stops[1].attr('stop-color')).toBe('lightblue');
+  });
+});
+
+describe('Basic gradient creation and attributes', () => {
+  it('should create a linear gradient with two color stops', () => {
+    // Call the function to test
+    createLinearGradient(
+      svg,
+      shapeElement,
+      'to top right, red 0%, blue 100%',
+      'test-gradient',
+      true // Enforce linear interpolation for this test
+    );
+
+    // Find the `defs` element
+    const defs = svg.select('defs');
+
+    // Ensure `defs` is successfully created
+    expect(defs).toBeDefined();
+
+    // Ensure `defs` has children
+    expect(defs.empty()).toBe(false);
+
+    // Find the `linearGradient` inside `defs`
+    const gradient = defs.select('linearGradient');
+
+    // Check that `linearGradient` is defined
+    expect(gradient).toBeDefined();
+
+    // Verify the gradient ID
+    expect(gradient.attr('id')).toBe('test-gradient');
+
+    // Get the node's dimensions
+    const bbox = shapeElement.node()!.getBBox();
+    const nodeWidth = bbox.width;
+    const nodeHeight = bbox.height;
+
+    // Get the parsed and expected angle for the gradient
+    const transform = gradient.attr('gradientTransform');
+    const parsedAngle = parseTransformAngle(transform);
+    const expectedAngle = directionMap('to top right', nodeWidth, nodeHeight);
+
+    // Calculate the gradient line length applied to a rectangle (default shape)
+    const angleRad = deg2rad(expectedAngle);
+    const gradientLineLength =
+      Math.abs(nodeWidth * Math.sin(angleRad)) + Math.abs(nodeHeight * Math.cos(angleRad));
+
+    // Define the minimum and maximum stops for the gradient
+    const minStop = 0;
+    const maxStop = 100;
+
+    // SVG linear gradient coordinates
+    const xc = bbox.x + nodeWidth / 2;
+    const yc = bbox.y + nodeHeight / 2;
+    const dmin = (gradientLineLength * Math.abs(minStop - 50)) / 100;
+    const dmax = (gradientLineLength * Math.abs(maxStop - 50)) / 100;
+
+    // Verify gradient attributes
+    expect(+gradient.attr('x1')).toBeCloseTo(xc, 8);
+    expect(+gradient.attr('y1')).toBeCloseTo(yc + dmax, 8);
+    expect(+gradient.attr('x2')).toBeCloseTo(xc, 8);
+    expect(+gradient.attr('y2')).toBeCloseTo(yc - dmin, 8);
+    expect(parsedAngle).toBeCloseTo(expectedAngle, 8);
+
+    // Check that there are two color stops
+    const stops = gradient.selectAll('stop') as any;
+    expect(stops).toHaveLength(2);
+
+    // Verify the colors and positions of the stops
+    expect(stops[0].attr('stop-color')).toBe('red');
+    expect(stops[1].attr('stop-color')).toBe('blue');
+    expect(stops[0].attr('offset')).toBe('0%');
+    expect(stops[1].attr('offset')).toBe('100%');
+  });
+
+  it('should handle gradients with named colors', () => {
+    createLinearGradient(
+      svg,
+      shapeElement,
+      'to left bottom, red 0%, magenta, transparent 50%, PeachPuff, currentColor 85%, LavenderBlush 100%',
+      'test-gradient-named-colors',
+      true
+    );
+
+    const gradient = svg.select('defs').select('linearGradient');
+    const stops = gradient.selectAll('stop') as any;
+
+    expect(stops).toHaveLength(6);
+    expect(stops[0].attr('stop-color')).toBe('red');
+    expect(stops[1].attr('stop-color')).toBe('magenta');
+    expect(stops[2].attr('stop-color')).toBe('transparent');
+    expect(stops[3].attr('stop-color')).toBe('PeachPuff');
+    expect(stops[4].attr('stop-color')).toBe('currentColor');
+    expect(stops[5].attr('stop-color')).toBe('LavenderBlush');
+    expect(stops[0].attr('offset')).toBe('0%');
+    expect(stops[1].attr('offset')).toBe('25%');
+    expect(stops[2].attr('offset')).toBe('50%');
+    expect(stops[3].attr('offset')).toBe('67.5%');
+    expect(stops[4].attr('offset')).toBe('85%');
+    expect(stops[5].attr('offset')).toBe('100%');
+  });
+
+  it('should handle gradients with hex(a) color values', () => {
+    createLinearGradient(
+      svg,
+      shapeElement,
+      'to right, #ff0000 0%, #00ff0080 50%, #00f 70%, #F3A7 100%',
+      'test-gradient-hex-colors',
+      true // Turns off non-linear interpolation
+    );
+
+    const stops = svg.select('defs').select('linearGradient').selectAll('stop') as any;
+
+    expect(stops).toHaveLength(4);
+    expect(stops[0].attr('stop-color')).toBe('#ff0000');
+    expect(stops[1].attr('stop-color')).toBe('#00ff0080');
+    expect(stops[2].attr('stop-color')).toBe('#00f');
+    expect(stops[3].attr('stop-color')).toBe('#F3A7');
+    expect(stops[0].attr('offset')).toBe('0%');
+    expect(stops[1].attr('offset')).toBe('50%');
+    expect(stops[2].attr('offset')).toBe('70%');
+    expect(stops[3].attr('offset')).toBe('100%');
+  });
+
+  it('should handle gradients with color functions in flexible formats and spacing', () => {
+    createLinearGradient(
+      svg,
+      shapeElement,
+      ` rgb( 0%,100%, 50%),
+        rGB(none 81 none),
+        rgba(255,0 ,0,0.5),
+        hsl(180, 100%, 50%),
+        HSl(0.5turn, 76%, 50%),
+        hsla(140deg 100  24%),
+        hsla(3.14rad 80% 9% / 0.8 ),
+        #FF6347,
+        hwb(60 20%   40%),
+        hwb(96 none 11),
+        HWB( 0.25turn 30% 20%),
+        lab(70% 15    25),
+        lab(29.2345% -15.234% 32.345% / 0.16),
+        lch(33%  10 270),
+        LcH(50% 30 0.25turn),
+        lch(60% 77  100grad)`,
+      'test-gradient-color-functions',
+      true
+    );
+
+    const stops = svg.select('defs').select('linearGradient').selectAll('stop') as any;
+
+    expect(stops[0].attr('stop-color')).toBe('rgb( 0%,100%, 50%)');
+    expect(stops[1].attr('stop-color')).toBe('rGB(none 81 none)');
+    expect(stops[2].attr('stop-color')).toBe('rgba(255,0 ,0,0.5)');
+    expect(stops[3].attr('stop-color')).toBe('hsl(180, 100%, 50%)');
+    expect(stops[4].attr('stop-color')).toBe('HSl(0.5turn, 76%, 50%)');
+    expect(stops[5].attr('stop-color')).toBe('hsla(140deg 100  24%)');
+    expect(stops[6].attr('stop-color')).toBe('hsla(3.14rad 80% 9% / 0.8 )');
+    expect(stops[7].attr('stop-color')).toBe('#FF6347'); // A non-function in the mix to test
+    expect(stops[8].attr('stop-color')).toBe('hwb(60 20%   40%)');
+    expect(stops[9].attr('stop-color')).toBe('hwb(96 none 11)');
+    expect(stops[10].attr('stop-color')).toBe('HWB( 0.25turn 30% 20%)');
+    expect(stops[11].attr('stop-color')).toBe('lab(70% 15    25)');
+    expect(stops[12].attr('stop-color')).toBe('lab(29.2345% -15.234% 32.345% / 0.16)');
+    expect(stops[13].attr('stop-color')).toBe('lch(33%  10 270)');
+    expect(stops[14].attr('stop-color')).toBe('LcH(50% 30 0.25turn)');
+    expect(stops[15].attr('stop-color')).toBe('lch(60% 77  100grad)');
+  });
+
+  it('should handle gradients with degree angles', () => {
+    createLinearGradient(svg, shapeElement, '65deg, red, blue', 'test-gradient-degree');
+
+    const transform = svg.select('defs').select('linearGradient').attr('gradientTransform');
+    const parsedAngle = parseTransformAngle(transform);
+
+    expect(parsedAngle).toBeCloseTo(65, 8);
+  });
+
+  it('should handle gradients with radian angles', () => {
+    createLinearGradient(svg, shapeElement, '1.2rad, red, blue', 'test-gradient-radian');
+
+    const transform = svg.select('defs').select('linearGradient').attr('gradientTransform');
+    const parsedAngle = parseTransformAngle(transform);
+
+    expect(parsedAngle).toBeCloseTo(rad2deg(1.2), 8);
+  });
+
+  it('should handle gradients with turn angles', () => {
+    createLinearGradient(svg, shapeElement, '0.25turn, red, blue', 'test-gradient-turn');
+
+    const transform = svg.select('defs').select('linearGradient').attr('gradientTransform');
+    const parsedAngle = parseTransformAngle(transform);
+
+    expect(parsedAngle).toBeCloseTo(turn2deg(0.25), 8);
+  });
+
+  it('should handle gradients with gradian angles', () => {
+    createLinearGradient(svg, shapeElement, '30grad, red, blue', 'test-gradient-gradian');
+
+    const transform = svg.select('defs').select('linearGradient').attr('gradientTransform');
+    const parsedAngle = parseTransformAngle(transform);
+
+    expect(parsedAngle).toBeCloseTo(grad2deg(30), 8);
+  });
+
+  // Resetting is needed per direction for isolated tests, hence a new 'it' for each iteration below.
+  for (const direction of validDirections) {
+    const gradientId = `test-gradient-direction-keywords-${direction.replace(/\s+/g, '-')}`;
+    it(`should handle gradients with directional keyword: ${direction}`, () => {
+      createLinearGradient(svg, shapeElement, `${direction}, red, blue`, gradientId);
+
+      const gradient = svg.select('defs').select('linearGradient');
+      const parsedAngle = parseTransformAngle(gradient.attr('gradientTransform'));
+      const width = +shapeElement.attr('width');
+      const height = +shapeElement.attr('height');
+      const expectedAngle = directionMap(direction, width, height);
+
+      expect(gradient.attr('id')).toBe(gradientId); // As a precaution for looped tests
+      expect(parsedAngle).toBeCloseTo(expectedAngle, 8);
+    });
+  }
+
+  it('should handle gradient without direction and default to 180deg', () => {
+    createLinearGradient(svg, shapeElement, 'red, blue', 'test-gradient-no-direction');
+
+    const gradient = svg.select('defs').select('linearGradient');
+    const parsedAngle = parseTransformAngle(gradient.attr('gradientTransform'));
+
+    const bbox = shapeElement.node()!.getBBox();
+    const w = bbox.width;
+    const h = bbox.height;
+    const xc = bbox.x + w / 2;
+    const yc = bbox.y + h / 2;
+    const dmax = h * 0.5;
+    const dmin = h * 0.5;
+
+    expect(+gradient.attr('x1')).toBeCloseTo(xc, 8);
+    expect(+gradient.attr('y1')).toBeCloseTo(yc + dmax, 8);
+    expect(+gradient.attr('x2')).toBeCloseTo(xc, 8);
+    expect(+gradient.attr('y2')).toBeCloseTo(yc - dmin, 8);
+    expect(parsedAngle).toBeCloseTo(180, 8);
+  });
+
+  it('should treat the "to top right" direction like a 45-degree gradient on a square rectangle', () => {
+    shapeElement.attr('width', 400).attr('height', 400);
+    createLinearGradient(
+      svg,
+      shapeElement,
+      'to top right, #ff0000, #0000ff',
+      'test-gradient-45-square'
+    );
+
+    const gradient = svg.select('defs').select('linearGradient');
+    const parsedAngle = parseTransformAngle(gradient.attr('gradientTransform'));
+
+    expect(parsedAngle).toBeCloseTo(45, 8);
+  });
+
+  it('should not treat the "to top right" direction like a 45-degree gradient on a non-square rectangle', () => {
+    createLinearGradient(
+      svg,
+      shapeElement,
+      'to top right, #ff0000, #0000ff',
+      'test-gradient-45-non-square'
+    );
+
+    const gradient = svg.select('defs').select('linearGradient');
+    const parsedAngle = parseTransformAngle(gradient.attr('gradientTransform'));
+
+    expect(parsedAngle).not.toBeCloseTo(45, 8);
+  });
+
+  it('should handle percentage stops with extra spaces', () => {
+    createLinearGradient(
+      svg,
+      shapeElement,
+      ' to  right  , red  10% , blue   90% ',
+      'test-gradient-extra-spaces'
+    );
+
+    const stops = svg.select('defs').select('linearGradient').selectAll('stop') as any;
+
+    expect(stops[0].attr('stop-color')).toBe('red');
+    expect(stops[1].attr('stop-color')).toBe('red');
+    expect(stops[2].attr('stop-color')).toBe('blue');
+    expect(stops[3].attr('stop-color')).toBe('blue');
+    expect(stops[0].attr('offset')).toBe('0%'); // Added for coverage requirement
+    expect(stops[1].attr('offset')).toBe('10%');
+    expect(stops[2].attr('offset')).toBe('90%');
+    expect(stops[3].attr('offset')).toBe('100%'); // Added for coverage requirement
+  });
+});
+
+describe('Length units and conversions', () => {
+  it('should convert font-based units to percentages correctly', () => {
+    createLinearGradient(
+      svg,
+      shapeElement,
+      'to right, red 1rem, blue 1em, green 6ex, yellow 8ch',
+      'test-gradient-font-units',
+      true
+    );
+
+    const stops = svg.select('defs').select('linearGradient').selectAll('stop') as any;
+
+    // Note: positions are already in increasing order, so no replacement will occur
+    expect(stops[0].attr('offset')).toBe('0%');
+    expect(stops[1].attr('offset')).toBe('4.5%'); // 1rem (18px) -> 4.5% of 400px
+    expect(stops[2].attr('offset')).toBe('7.5%'); // 1em (30px) -> 7.5% of 400px
+    expect(stops[3].attr('offset')).toBe('22.5%'); // 6ex (90px) -> 22.5% of 400px
+    expect(stops[4].attr('offset')).toBe('30%'); // 8ch (120px) -> 30% of 400px
+    expect(stops[5].attr('offset')).toBe('100%');
+  });
+
+  it('should convert viewport-based units to percentages correctly', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1200, writable: true });
+    Object.defineProperty(window, 'innerHeight', { value: 900, writable: true });
+    createLinearGradient(
+      svg,
+      shapeElement,
+      'to right, blue 5vh, red 10vw, green 15vmin, yellow 20vmax',
+      'test-gradient-viewport-units'
+    );
+
+    const stops = svg.select('defs').select('linearGradient').selectAll('stop') as any;
+
+    // Note: positions are already in increasing order, so no replacement will occur
+    expect(stops[0].attr('offset')).toBe('0%');
+    expect(stops[1].attr('offset')).toBe('11.25%'); // 5vh (45px) -> 11.25% of 400px
+    expect(stops[2].attr('offset')).toBe('30%'); // 10vw (120px) -> 30% of 400px
+    expect(stops[3].attr('offset')).toBe('33.75%'); // 15vmin (135px) -> 33.75% of 400px
+    expect(stops[4].attr('offset')).toBe('60%'); // 20vmax (240px) -> 60% of 400px
+    expect(stops[5].attr('offset')).toBe('100%');
+  });
+
+  it('should convert pixel-based and physical units to percentages correctly assuming 96dpi', () => {
+    createLinearGradient(
+      svg,
+      shapeElement,
+      'to right, red 12pt, blue 10mm, green 50px, yellow 4pc, pink 2cm, orange 1in',
+      'test-gradient-physical-units'
+    );
+
+    const stops = svg.select('defs').select('linearGradient').selectAll('stop') as any;
+
+    // Note: the positions are in increasing order, so no replacement will occur
+    expect(stops[0].attr('offset')).toBe('0%');
+    expect(stops[1].attr('offset'), 4); // 12pt -> 4% of 400px
+    expect(parseFloat(stops[2].attr('offset'))).toBeCloseTo(9.448818897637796, 8); // 10mm -> ~9.4% of 400px
+    expect(stops[3].attr('offset')).toBe('12.5%'); // 50px -> 12.5% of 400px
+    expect(stops[4].attr('offset')).toBe('16%'); // 4pc -> 16% of 400px
+    expect(parseFloat(stops[5].attr('offset'))).toBeCloseTo(18.89763779527559, 8); // 2cm -> ~18.9% of 400px
+    expect(stops[6].attr('offset')).toBe('24%'); // 1in -> 24% of 400px
+    expect(stops[7].attr('offset')).toBe('100%');
+  });
+
+  it('should convert pixel-based and physical units to percentages for a slanted gradient', () => {
+    createLinearGradient(
+      svg,
+      shapeElement,
+      '37deg, red 12pt, blue 10mm, green 50px, yellow 4pc, pink 2cm, orange 1in',
+      'test-gradient-slanted-physical-units'
+    );
+
+    const stops = svg.select('defs').select('linearGradient').selectAll('stop') as any;
+
+    // Calculate the gradient line length for the slanted gradient
+    const bbox = shapeElement.node()!.getBBox();
+    const nodeWidth = bbox.width;
+    const nodeHeight = bbox.height;
+    const angleRad = deg2rad(37);
+    const gradientLineLength =
+      Math.abs(nodeWidth * Math.sin(angleRad)) + Math.abs(nodeHeight * Math.cos(angleRad));
+
+    // Note: the positions are in increasing order, so no replacement will occur
+    expect(stops[0].attr('offset')).toBe('0%');
+    expect(parseFloat(stops[1].attr('offset'))).toBeCloseTo(
+      (((12 / 72) * 96) / gradientLineLength) * 100,
+      8
+    );
+    expect(parseFloat(stops[2].attr('offset'))).toBeCloseTo(
+      (((10 / 25.4) * 96) / gradientLineLength) * 100,
+      8
+    );
+    expect(parseFloat(stops[3].attr('offset'))).toBeCloseTo((50 / gradientLineLength) * 100, 8);
+    expect(parseFloat(stops[4].attr('offset'))).toBeCloseTo(
+      ((((4 * 12) / 72) * 96) / gradientLineLength) * 100,
+      8
+    );
+    expect(parseFloat(stops[5].attr('offset'))).toBeCloseTo(
+      (((2 / 2.54) * 96) / gradientLineLength) * 100,
+      8
+    );
+    expect(parseFloat(stops[6].attr('offset'))).toBeCloseTo(
+      ((1 * 96) / gradientLineLength) * 100,
+      8
+    );
+    expect(stops[7].attr('offset')).toBe('100%');
+  });
+});
+
+describe('Special cases for color stops and positions', () => {
+  it('should correctly split double stops into two separate stops while adding 0% stop if not covered', () => {
+    createLinearGradient(
+      svg,
+      shapeElement,
+      'to left, green 10.45% 50.31%, yellow 80% 100%',
+      'test-gradient-double-stop'
+    );
+
+    const stops = svg.select('defs').select('linearGradient').selectAll('stop') as any;
+
+    expect(stops).toHaveLength(5);
+    expect(stops[0].attr('offset')).toBe('0%');
+    expect(stops[1].attr('offset')).toBe('10.45%');
+    expect(stops[2].attr('offset')).toBe('50.31%');
+    expect(stops[3].attr('offset')).toBe('80%');
+    expect(stops[4].attr('offset')).toBe('100%');
+  });
+
+  it('should correctly interpolate undefined color stop positions between specified ones', () => {
+    createLinearGradient(
+      svg,
+      shapeElement,
+      'red 6%, yellow, green, blue 50%, violet, indigo, orange, pink, black 98%',
+      'test-gradient-gap-interpolation'
+    );
+
+    const stops = svg.select('defs').select('linearGradient').selectAll('stop') as any;
+
+    expect(stops).toHaveLength(11);
+    expect(stops[0].attr('offset')).toBe('0%');
+    expect(stops[1].attr('offset')).toBe('6%');
+    expect(parseFloat(stops[2].attr('offset'))).toBeCloseTo(20.666666666666664, 8);
+    expect(parseFloat(stops[3].attr('offset'))).toBeCloseTo(35.33333333333333, 8);
+    expect(stops[4].attr('offset')).toBe('50%');
+    expect(stops[5].attr('offset')).toBe('59.6%');
+    expect(stops[6].attr('offset')).toBe('69.2%');
+    expect(stops[7].attr('offset')).toBe('78.8%');
+    expect(stops[8].attr('offset')).toBe('88.4%');
+    expect(stops[9].attr('offset')).toBe('98%');
+    expect(stops[10].attr('offset')).toBe('100%');
+  });
+
+  it('should interpolate and renorm correctly for out-of-bounds gradients', () => {
+    createLinearGradient(
+      svg,
+      shapeElement,
+      '35deg, red -50%, orange, green 40%, blue, yellow 115%',
+      'test-gradient-out-of-bounds-renorm-interpolation'
+    );
+
+    const stops = svg.select('defs').select('linearGradient').selectAll('stop') as any;
+
+    expect(stops[0].attr('offset')).toBe('-50%');
+    expect(parseFloat(stops[1].attr('offset'))).toBeCloseTo(27.27272727272727, 8);
+    expect(parseFloat(stops[2].attr('offset'))).toBeCloseTo(54.54545454545454, 8);
+    expect(parseFloat(stops[3].attr('offset'))).toBeCloseTo(77.27272727272727, 8);
+    expect(stops[4].attr('offset')).toBe('115%');
+  });
+
+  it('should adjust positions to maintain ascending order for overlapping stop positions', () => {
+    createLinearGradient(
+      svg,
+      shapeElement,
+      'to bottom, black 60%, white 40%',
+      'test-gradient-overlap-adjust'
+    );
+
+    const stops = svg.select('defs').select('linearGradient').selectAll('stop') as any;
+
+    expect(stops[1].attr('offset')).toBe('60%'); // Keep 60% as is
+    expect(stops[2].attr('offset')).toBe('60%'); // Replace 40% with 60% to maintain order
+  });
+
+  it('should handle gradients with all color stops beyond 100%', () => {
+    createLinearGradient(
+      svg,
+      shapeElement,
+      'to right, red 110%, blue 150%',
+      'test-gradient-beyond-100'
+    );
+
+    const stops = svg.select('defs').select('linearGradient').selectAll('stop') as any;
+
+    expect(stops).toHaveLength(3);
+    expect(stops[0].attr('offset')).toBe('0%');
+    expect(stops[1].attr('offset')).toBe('110%');
+    expect(stops[2].attr('offset')).toBe('150%');
+  });
+
+  it('should handle gradients with all color stops below 0%', () => {
+    createLinearGradient(svg, shapeElement, 'to top, red -50%, blue -10%', 'test-gradient-below-0');
+
+    const stops = svg.select('defs').select('linearGradient').selectAll('stop') as any;
+
+    expect(stops).toHaveLength(3);
+    expect(stops[0].attr('stop-color')).toBe('red');
+    expect(stops[1].attr('stop-color')).toBe('blue');
+    expect(stops[2].attr('stop-color')).toBe('blue');
+    expect(stops[0].attr('offset')).toBe('-50%');
+    expect(stops[1].attr('offset')).toBe('-10%');
+    expect(stops[2].attr('offset')).toBe('100%');
+  });
+
+  it('should handle mixed length units with out-of-bounds positions', () => {
+    createLinearGradient(
+      svg,
+      shapeElement,
+      'to right, red -50px, orange 1in, transparent 50%, black 20em',
+      'test-gradient-mixed-units-out-of-bounds',
+      true
+    );
+
+    const stops = svg.select('defs').select('linearGradient').selectAll('stop') as any;
+
+    // All stop positions, except first and last, are normalized as bounds exceed 0-100%
+    expect(stops[0].attr('offset')).toBe('-12.5%'); // -50px -> -12.5% of 400px
+    expect(parseFloat(stops[1].attr('offset'))).toBeCloseTo(22.46153846153846, 8); // 1in -> 24% of 400px, normalized to ~22.5%
+    expect(parseFloat(stops[2].attr('offset'))).toBeCloseTo(38.46153846153847, 8); // 50% is normalized to ~38.5%
+    expect(stops[3].attr('offset')).toBe('150%'); // 20em (600px) -> 150% of 400px
+  });
+});
+
+describe('Error handling', () => {
+  it('should handle gradients with consecutive commas', () => {
+    expect(() => {
+      createLinearGradient(
+        svg,
+        shapeElement,
+        'to right, red, , blue',
+        'test-gradient-consecutive-commas'
+      );
+    }).toThrow('Found consecutive commas (,,) in the gradient string.');
+  });
+
+  it('should throw an error for invalid unit types in gradient positions', () => {
+    const invalidUnits = ['pqr', 'mn', 'zz'];
+    invalidUnits.forEach((unit) => {
+      expect(() => {
+        createLinearGradient(
+          svg,
+          shapeElement,
+          `to top right, pink 3${unit}, red 10%, blue 100%`,
+          'test-gradient-invalid-unit'
+        );
+      }).toThrow(`Unsupported unit found in gradient position: ${unit}`);
+    });
+  });
+
+  it('should handle invalid color values in gradient', () => {
+    const invalidColors = [
+      'invalidColor', // Invalid named color
+      '#xyz123', // Invalid hex code
+      '#12345', // Invalid hex length
+      'rgc(0, 0, 0)', // Misspelled color function
+      'rgb(8, 17)', // Missing a color value in rgb()
+      'rgba(0, 0, 0, 0.5,)', // Extra comma in rgba()
+      'hsl(1.2turn, 63%, 3)', // Lightness should have '%' as well
+      'hsla(14%, 3%, 0.5%, 0.2)', // Hue should not have '%'
+      'hwb(240 20% 30%%)', // Double '%' in blackness
+      'hwb(240, 20%, 30%)', // Commas in hwb()
+      'hwb(240 20% a%)', // Non-numeric blackness in hwb()
+      'lab(7deg -10 20%)', // Luminance should not have 'deg'
+      'lch(50% 11 120%)', // Hue should not have '%' in lch()
+      'lch(40% 30 240 60)', // Too many parameters in lch()
+      'oklab(50% 0.5)', // Missing 'b' channel in oklab()
+      'oklab(50% 0.5 0.4turn)', // 'b' channel should be a number, not an angle
+      'oklch(80% 0.2 300%)', // Hue should not have '%' in oklch()
+      'oklch(80% 0.2)', // Missing hue value in oklch()
+      'oklch(80% 0.2 300 0.5 9)', // Extra parameter in oklch()
+    ];
+    invalidColors.forEach((color) => {
+      const gradientStyle = `0.43turn, pink 17%, ${color} 38%, brown`;
+      expect(() => {
+        createLinearGradient(svg, shapeElement, gradientStyle, 'test-gradient-invalid-color');
+      }).toThrow(`Invalid color value found in color stop: '${color} 38%'`);
+    });
+  });
+
+  it('should handle gradients with no color stops', () => {
+    expect(() => {
+      createLinearGradient(svg, shapeElement, '', 'test-gradient-no-stops');
+    }).toThrow('Linear gradient found with empty style.');
+  });
+
+  it('should handle gradients with only one color stop', () => {
+    expect(() => {
+      createLinearGradient(svg, shapeElement, 'red', 'test-gradient-one-stop');
+    }).toThrow('At least two stops are required to create a linear gradient. Found 1.');
+  });
+
+  it('should handle gradients with invalid direction keywords', () => {
+    expect(() => {
+      createLinearGradient(
+        svg,
+        shapeElement,
+        'to top right bottom, red, blue',
+        'test-gradient-invalid-direction'
+      );
+    }).toThrow("Invalid direction keyword found in gradient: 'to top right bottom'");
+  });
+
+  it('should handle gradients with invalid angle values', () => {
+    expect(() => {
+      createLinearGradient(svg, shapeElement, '4q5deg, green, cyan', 'test-gradient-invalid-angle');
+    }).toThrow("Invalid angle value found in gradient: '4q5deg'");
+  });
+
+  it('should throw an error if a color stop contains more than two positions', () => {
+    expect(() => {
+      createLinearGradient(
+        svg,
+        shapeElement,
+        '0.8rad, green 5% 10% 15%, purple',
+        'test-gradient-multiple-positions'
+      );
+    }).toThrow("Too many positions in color stop: 'green 5% 10% 15%'");
+  });
+
+  it('should throw an error if unsupported element is passed for gradient creation', () => {
+    ({ svg, shapeElement } = createShape('line'));
+    expect(() => {
+      createLinearGradient(svg, shapeElement, 'violet, gold', 'test-gradient-unsupported-element');
+    }).toThrow(
+      `Unsupported shape type for gradient line length calculation: ${shapeElement.node()?.tagName}`
+    );
+  });
+
+  it('should throw an error for a transition hint without surrounding color stops', () => {
+    expect(() => {
+      createLinearGradient(
+        svg,
+        shapeElement,
+        'to right, 20%, #013220',
+        'test-gradient-illegal-transition'
+      );
+    }).toThrow("The transition hint '20%' does not have surrounding color stops");
+  });
+
+  describe('Non-linear interpolation', () => {
+    it('should handle gradients requiring non-linear interpolation due to a transition hint', () => {
+      createLinearGradient(
+        svg,
+        shapeElement,
+        'to top left, red, 25%, blue',
+        'test-gradient-transition-hint-interpolation',
+        false // Allows for non-linear interpolation (default behavior)
+      );
+
+      const stops = svg.select('defs').select('linearGradient').selectAll('stop') as any;
+
+      // Should have 2 original + 5 transition stops
+      expect(stops).toHaveLength(7);
+      expect(stops[0].attr('offset')).toBe('0%');
+      expect(parseFloat(stops[1].attr('offset'))).toBeCloseTo(8.333333333333332, 8);
+      expect(parseFloat(stops[2].attr('offset'))).toBeCloseTo(16.666666666666664, 8);
+      expect(stops[3].attr('offset')).toBe('25%');
+      expect(stops[4].attr('offset')).toBe('50%');
+      expect(stops[5].attr('offset')).toBe('75%');
+      expect(stops[6].attr('offset')).toBe('100%');
+
+      // Colors should be interpolated rgba() values
+      expect(stops[0].attr('stop-color')).toBe('red');
+      expect(stops[1].attr('stop-color')).toBe('rgba(181, 0, 74, 1)');
+      expect(stops[2].attr('stop-color')).toBe('rgba(151, 0, 104, 1)');
+      expect(stops[3].attr('stop-color')).toBe('rgba(128, 0, 128, 1)');
+      expect(stops[4].attr('stop-color')).toBe('rgba(75, 0, 180, 1)');
+      expect(stops[5].attr('stop-color')).toBe('rgba(34, 0, 221, 1)');
+      expect(stops[6].attr('stop-color')).toBe('blue');
+    });
+
+    it('should handle gradients requiring non-linear interpolation due to opacity gradient', () => {
+      createLinearGradient(
+        svg,
+        shapeElement,
+        '88deg, pink, rgba(255, 0, 0, 0.27), hsla(240, 100%, 50%, 0.8)',
+        'test-gradient-opacity-gradient-interpolation'
+      );
+
+      const stops = svg.select('defs').select('linearGradient').selectAll('stop') as any;
+
+      // Should have 3 original + 10 transition stops
+      expect(stops).toHaveLength(13);
+      expect(stops[0].attr('offset')).toBe('0%');
+      expect(parseFloat(stops[1].attr('offset'))).toBeCloseTo(8.333333333333332, 8);
+      expect(parseFloat(stops[2].attr('offset'))).toBeCloseTo(16.666666666666664, 8);
+      expect(stops[3].attr('offset')).toBe('25%');
+      expect(parseFloat(stops[4].attr('offset'))).toBeCloseTo(33.333333333333336, 8);
+      expect(parseFloat(stops[5].attr('offset'))).toBeCloseTo(41.666666666666664, 8);
+      expect(stops[6].attr('offset')).toBe('50%');
+      expect(parseFloat(stops[7].attr('offset'))).toBeCloseTo(58.33333333333333, 8);
+      expect(parseFloat(stops[8].attr('offset'))).toBeCloseTo(66.66666666666666, 8);
+      expect(stops[9].attr('offset')).toBe('75%');
+      expect(parseFloat(stops[10].attr('offset'))).toBeCloseTo(83.33333333333334, 8);
+      expect(parseFloat(stops[11].attr('offset'))).toBeCloseTo(91.66666666666666, 8);
+      expect(stops[12].attr('offset')).toBe('100%');
+
+      // Should have interpolated colors in between the original ones
+      expect(stops[0].attr('stop-color')).toBe('pink');
+      expect(stops[1].attr('stop-color')).toBe('rgba(255, 182, 193, 0.8783333333333334)');
+      expect(stops[2].attr('stop-color')).toBe('rgba(255, 169, 179, 0.7566666666666667)');
+      expect(stops[3].attr('stop-color')).toBe('rgba(255, 151, 160, 0.635)');
+      expect(stops[4].attr('stop-color')).toBe('rgba(255, 125, 132, 0.5133333333333333)');
+      expect(stops[5].attr('stop-color')).toBe('rgba(255, 82, 86, 0.3916666666666667)');
+      expect(stops[6].attr('stop-color')).toBe('rgba(255, 0, 0, 0.27)');
+      expect(stops[7].attr('stop-color')).toBe('rgba(160, 0, 95, 0.3583333333333334)');
+      expect(stops[8].attr('stop-color')).toBe('rgba(103, 0, 152, 0.44666666666666666)');
+      expect(stops[9].attr('stop-color')).toBe('rgba(64, 0, 191, 0.535)');
+      expect(stops[10].attr('stop-color')).toBe('rgba(37, 0, 218, 0.6233333333333334)');
+      expect(stops[11].attr('stop-color')).toBe('rgba(16, 0, 239, 0.7116666666666667)');
+      expect(stops[12].attr('stop-color')).toBe('hsla(240, 100%, 50%, 0.8)');
+    });
+
+    it('should handle gradients requiring non-linear interpolation due to both transition hint and opacity gradient', () => {
+      createLinearGradient(
+        svg,
+        shapeElement,
+        'to bottom right, rgba(100, 240, 36, 0.9), 67%, #0df20d33', // #0df20d33 has a 0.2 opacity
+        'test-gradient-transition-hint-with-opacity-gradient-interpolation'
+      );
+
+      const stops = svg.select('defs').select('linearGradient').selectAll('stop') as any;
+
+      // Should have 2 original + 5 transition stops
+      expect(stops).toHaveLength(7);
+      expect(stops[0].attr('offset')).toBe('0%');
+      expect(parseFloat(stops[1].attr('offset'))).toBeCloseTo(22.333333333333332, 8);
+      expect(parseFloat(stops[2].attr('offset'))).toBeCloseTo(44.666666666666664, 8);
+      expect(stops[3].attr('offset')).toBe('67%');
+      expect(stops[4].attr('offset')).toBe('78%');
+      expect(stops[5].attr('offset')).toBe('89%');
+      expect(stops[6].attr('offset')).toBe('100%');
+
+      // Should have interpolated colors in between the original ones
+      expect(stops[0].attr('stop-color')).toBe('rgba(100, 240, 36, 0.9)');
+      expect(stops[1].attr('stop-color')).toBe('rgba(98, 240, 36, 0.8477283929954609)');
+      expect(stops[2].attr('stop-color')).toBe('rgba(94, 240, 34, 0.726504176075029)');
+      expect(stops[3].attr('stop-color')).toBe('rgba(84, 240, 32, 0.55)');
+      expect(stops[4].attr('stop-color')).toBe('rgba(75, 241, 29, 0.44466061728917605)');
+      expect(stops[5].attr('stop-color')).toBe('rgba(57, 241, 25, 0.32786016467038714)');
+      expect(stops[6].attr('stop-color')).toBe('#0df20d33');
+    });
+  });
+});
+
+// cspell:ignore renorm vmin vmax oklab oklch dmin dmax

--- a/packages/mermaid/src/rendering-util/createGradient.ts
+++ b/packages/mermaid/src/rendering-util/createGradient.ts
@@ -248,12 +248,8 @@ export function createLinearGradient(
     throw new Error('Found consecutive commas (,,) in the gradient string.');
   }
 
-  // Ensure that the total number of transition stops is positive and odd
-  if (numTransitionStops < 0 && numTransitionStops % 2 === 0) {
-    throw new Error(
-      'Total number of stops (excluding start and end) must be positive and odd for symmetry.'
-    );
-  }
+  // Round to the nearest odd integer, minimum 3, for symmetry around the hint
+  numTransitionStops = Math.max(Math.round(numTransitionStops) | 1, 3);
 
   if (!linearInterpOnly) {
     log.debug(

--- a/packages/mermaid/src/rendering-util/createGradient.ts
+++ b/packages/mermaid/src/rendering-util/createGradient.ts
@@ -349,11 +349,16 @@ export function createLinearGradient(
   // Parse color stops, convert units to %, and map to color and position
   const colorStops = linearGradientStyle
     .split(/,(?![^()]*\))/)
-    .map((stop): ColorStop | null => {
+    .map((stop, index, stopsArray): ColorStop | null => {
       stop = stop.trim();
-      if (/^[+-]?\d+(\.\d+)?[%A-Za-z]+$/.test(stop)) {
-        // Stops containing just a number with % or units (e.g., px, em) serve as transition hints
-        if (linearGradientStyle.startsWith(stop) || linearGradientStyle.endsWith(stop)) {
+
+      // Check if this is a standalone transition hint, i.e. a number (followed by % or a unit) without an associated color
+      const isTransitionHint = /^[+-]?\d+(\.\d+)?[%A-Za-z]+$/.test(stop);
+      const isFirstStop = index === 0;
+      const isLastStop = index === stopsArray.length - 1;
+
+      if (isTransitionHint) {
+        if (isFirstStop || isLastStop) {
           throw new Error(`The transition hint '${stop}' does not have surrounding color stops`);
         } else {
           log.debug(
@@ -366,6 +371,7 @@ export function createLinearGradient(
           }
         }
       }
+
       // Capture color (hex, named, or function) followed by optional position and units
       const regex = new RegExp(
         `(#[0-9a-fA-F]{3,8}|[a-zA-Z]+\\([^)]+\\)|[a-zA-Z]+)\\s*([-+]?\\d*\\.?\\d*)([a-zA-Z%]*)?$`

--- a/packages/mermaid/src/rendering-util/createGradient.ts
+++ b/packages/mermaid/src/rendering-util/createGradient.ts
@@ -63,7 +63,7 @@ export function getGradientLineLength(
     // Rectangle
     log.debug('Calculating gradient line length for a rectangle...');
     const bbox = node.getBBox();
-    const w = bbox.width; // node.getAttribute('width') does not reflect the width property set in classDefs
+    const w = bbox.width; // node.getAttribute('width') does not reflect the width property set in styles/classDefs
     const h = bbox.height; // Same as above for height
     return Math.abs(w * Math.sin(angleRad)) + Math.abs(h * Math.cos(angleRad));
   } else if (node instanceof SVGCircleElement) {
@@ -133,6 +133,7 @@ const getRGBA = (color: string) => {
   // Create a temporary <option> element to parse the color
   const option = new Option();
   option.style.color = color;
+  option.style.display = 'none';
   document.body.appendChild(option);
   const computedColor = getComputedStyle(option).color;
   document.body.removeChild(option);

--- a/packages/mermaid/src/rendering-util/createGradient.ts
+++ b/packages/mermaid/src/rendering-util/createGradient.ts
@@ -1,0 +1,336 @@
+import type { Selection } from 'd3';
+import { log } from '../logger.js';
+
+/**
+ * Creates an SVG linear gradient element given a CSS-like linear-gradient definition
+ * consisting of an angle/direction and color stops.
+ *
+ * @param svg - The SVG element to which the gradient is applied.
+ * @param shapeElement - The SVG shape element to which the gradient will be applied.
+ * @param linearGradientStyle - A CSS-like linear-gradient string specifying the gradient angle/direction (optional) and color stops.
+ * @param gradientId - The unique ID for the created linear gradient in the SVG's <defs> section.
+ * @returns void - The function does not return a value. In-place modifications are made to the SVG element.
+ */
+export function createLinearGradient(
+  svg: Selection<SVGSVGElement, unknown, null, undefined>,
+  shapeElement: Selection<SVGGraphicsElement, unknown, HTMLElement, any>,
+  linearGradientStyle: string,
+  gradientId: string
+): void {
+  log.debug(`Creating linear gradient for ${gradientId}: ${linearGradientStyle}`);
+
+  // Test if the double comma pattern exists in the input string to avoid user errors
+  if (/,\s*,/.test(linearGradientStyle)) {
+    log.error('Found consecutive commas (,,) in the gradient string.');
+  }
+
+  // Calculate the dimensions of the node's bounding box
+  const bbox = shapeElement.node()!.getBBox();
+  const nodeWidth = bbox.width;
+  const nodeHeight = bbox.height;
+  log.debug(`Dimensions of node bounding box: width = ${nodeWidth}px, height = ${nodeHeight}px`);
+
+  // Split the gradient details into a potential direction and color stops
+  const parts = /^([^,]+),\s*(.+)$/.exec(linearGradientStyle) || [];
+  log.debug('Parsed gradient parts:', parts);
+
+  let angleDeg = 180; // Default angle is 180deg (top to bottom) following CSS convention
+  let aspectRatio = nodeWidth / nodeHeight;
+  let hasAngleOrDirection = true;
+
+  // Handle numeric angles (e.g., -45deg, +12deg, 1rad, 0.25turn) or directional keywords (e.g., to right, to top left)
+  if (parts?.[1]) {
+    if (/deg|turn|grad|rad/.test(parts[1])) {
+      const match = /([+-]?\d+\.?\d*)(deg|turn|grad|rad)/.exec(parts[1]);
+      const [_, value, unit] = match ? match : [null, String(angleDeg), 'deg'];
+      angleDeg =
+        unit === 'turn'
+          ? parseFloat(value) * 360
+          : unit === 'grad'
+            ? parseFloat(value) * 0.9
+            : unit === 'rad'
+              ? parseFloat(value) * (180 / Math.PI)
+              : parseFloat(value);
+      log.debug(
+        `Angle ${value}${unit} ${unit === 'deg' ? 'is already in degrees, no conversion needed' : `is converted to ${angleDeg} degrees`}.`
+      );
+    } else if (parts[1].includes('to')) {
+      const direction = parts[1].replace(/\s{2,}/g, ' ').trim(); // Remove extra spaces and trim the direction
+      const directionMap: Record<string, number> = {
+        'to bottom': 180,
+        'to top': 0,
+        'to left': 270,
+        'to right': 90,
+        'to top left': 315,
+        'to left top': 315,
+        'to top right': 45,
+        'to right top': 45,
+        'to bottom left': 225,
+        'to left bottom': 225,
+        'to bottom right': 135,
+        'to right bottom': 135,
+      };
+      if (direction in directionMap) {
+        angleDeg = directionMap[direction];
+        log.debug(`Converted gradient direction ${direction} to angle: ${angleDeg} degrees.`);
+        // Set the aspect ratio to 1 for practical purposes to ensure accurate interpretation
+        // of the gradient direction relevant to the sides/corners
+        aspectRatio = 1;
+      } else {
+        log.error(`Invalid direction found in the gradient string.`);
+      }
+    } else {
+      hasAngleOrDirection = false;
+      log.debug(`No angle or direction specified in the gradient string.`);
+    }
+    // If an angle/direction is specified, remove it from the gradient style to leave only
+    // color stops going forward, otherwise, consider the whole string as color stops
+    linearGradientStyle = hasAngleOrDirection ? parts[2] : parts[0] || '';
+  }
+
+  log.debug(`Colors and positions for linear gradient: ${linearGradientStyle}`);
+
+  // Calculate the rotation angle for the gradient transformation using the original angle and
+  // the aspect ratio to ensure proper behavior (e.g., at 45 degrees) for non-square bounding boxes
+  const angleRad = angleDeg * (Math.PI / 180);
+  let transformAngleDeg = Math.atan(Math.tan(angleRad) * aspectRatio) * (180 / Math.PI);
+  transformAngleDeg += Math.cos(angleRad) > 0 ? 180 : 0; // Adjust kinks at 90 and 270 degrees
+  log.debug(`Calculated the angle for the rotational transform: ${transformAngleDeg} degrees`);
+
+  // Calculate the length of the gradient line based on the angle and the bounding box dimensions
+  // See https://patrickbrosset.medium.com/do-you-really-understand-css-linear-gradients-631d9a895caf
+  const gradientLineLength =
+    Math.abs(nodeWidth * Math.sin(angleRad)) + Math.abs(nodeHeight * Math.cos(angleRad));
+  log.debug(
+    `Calculated gradient line length: ${gradientLineLength} for angle = ${angleRad}rad, width = ${nodeWidth}px, height = ${nodeHeight}px`
+  );
+
+  // List of supported units for position values
+  const lengthUnits = '%|px|em|rem|vw|vh|vmin|vmax|ex|ch|cm|mm|in|pt|pc'; // cspell:ignore vmin vmax
+
+  // Create the dynamic regular expression for double stops (e.g., 'red -10% 35%')
+  const doubleStopRegex = new RegExp(
+    `(\\S+)\\s+([+-]?\\d*\\.?\\d+(?:${lengthUnits}))\\s+([+-]?\\d*\\.?\\d+(?:${lengthUnits}))`,
+    'g'
+  );
+
+  // Split double stops like 'red -10% 35%' into 'red -10%, red 35%' (same with other units)
+  linearGradientStyle = linearGradientStyle.replace(doubleStopRegex, (_, color, pos1, pos2) => {
+    log.debug(
+      `Split double stop: '${color} ${pos1} ${pos2}' into '${color} ${pos1}, ${color} ${pos2}'`
+    );
+    return `${color} ${pos1}, ${color} ${pos2}`;
+  });
+
+  // Parse color stops, convert units to %, and map to color and position
+  const colorStops = linearGradientStyle.split(/,(?![^()]*\))/).map((stop) => {
+    // Capture color (hex, named, or function) followed by optional position and units
+    // const [_, color, positionString, unit] = stop.trim().match(new RegExp(`(#[0-9a-fA-F]{3,6}|[a-zA-Z]+\\([^)]+\\)|[a-zA-Z]+)\\s*([-+]?\\d*\\.?\\d*)\\s*(${lengthUnits})?$`)) || [];
+    const regex = new RegExp(
+      `(#[0-9a-fA-F]{3,6}|[a-zA-Z]+\\([^)]+\\)|[a-zA-Z]+)\\s*([-+]?\\d*\\.?\\d*)\\s*(${lengthUnits})?$`
+    );
+    const [_, color, positionString, unit] = regex.exec(stop.trim()) || [];
+
+    if (!color) {
+      log.debug(`No valid color found for stop: '${stop}'`);
+      return { color: null, position: null };
+    }
+
+    // Define the root font size and parent font size for font-relative units (em, rem, ex, ch)
+    const rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize);
+    const parentNode = shapeElement.node()?.parentNode;
+    const parentFontSize = parentNode
+      ? parseFloat(getComputedStyle(parentNode as Element).fontSize)
+      : rootFontSize;
+
+    // CSS uses a standard DPI of 96 for physical unit conversions (in, cm, mm, etc.)
+    const dpi = 96;
+
+    // Conversion logic based on unit type, returning position as %
+    const position = positionString
+      ? (() => {
+          const value = parseFloat(positionString);
+          switch (unit) {
+            case '%':
+              // Already in the intended unit
+              return value;
+            case 'px':
+              // Pixels are converted to % based on the gradient line length
+              return (value / gradientLineLength) * 100;
+            case 'em':
+              // 'em' values are relative to the parent element's font size
+              return ((value * parentFontSize) / gradientLineLength) * 100;
+            case 'rem':
+              // 'rem' values are relative to the root element's font size
+              return ((value * rootFontSize) / gradientLineLength) * 100;
+            case 'vw':
+              // 'vw' represents viewport width, converted relative to window width
+              return (((value / 100) * window.innerWidth) / gradientLineLength) * 100;
+            case 'vh':
+              // 'vh' represents viewport height, converted relative to window height
+              return (((value / 100) * window.innerHeight) / gradientLineLength) * 100;
+            case 'vmin':
+              // 'vmin' is based on the smallest viewport dimension (width or height)
+              return (
+                (((value / 100) * Math.min(window.innerWidth, window.innerHeight)) /
+                  gradientLineLength) *
+                100
+              );
+            case 'vmax':
+              // 'vmax' is based on the largest viewport dimension (width or height)
+              return (
+                (((value / 100) * Math.max(window.innerWidth, window.innerHeight)) /
+                  gradientLineLength) *
+                100
+              );
+            case 'ex':
+              // 'ex' is the height of the lowercase letter x, assumed to be 0.5em for simplicity
+              return ((value * parentFontSize * 0.5) / gradientLineLength) * 100;
+            case 'ch':
+              // 'ch' is the width of the '0' character, often estimated as 0.5em
+              return ((value * parentFontSize * 0.5) / gradientLineLength) * 100;
+            case 'cm':
+              // Centimeters converted to pixels using the standard DPI, then to %
+              return ((value * dpi) / 2.54 / gradientLineLength) * 100;
+            case 'mm':
+              // Millimeters converted to pixels using DPI, then to %
+              return ((value * dpi) / 25.4 / gradientLineLength) * 100;
+            case 'in':
+              // Inches converted to pixels using DPI, then to %
+              return ((value * dpi) / gradientLineLength) * 100;
+            case 'pt':
+              // Points (1pt = 1/72 inch) converted to pixels, then to %
+              return ((value * dpi) / 72 / gradientLineLength) * 100;
+            case 'pc':
+              // Picas (1pc = 12pt = 1/6 inch) converted to pixels, then to %
+              return ((value * dpi) / 6 / gradientLineLength) * 100;
+            default:
+              // For any unsupported units, return null
+              return null;
+          }
+        })()
+      : null;
+
+    if (positionString) {
+      log.debug(
+        `Position ${positionString}${unit} ${unit === '%' ? 'is already in percentage, no conversion needed' : `is converted to ${position}% of the gradient line length`}.`
+      );
+    }
+    log.debug(`Parsed color stop: color = '${color}', position = '${position}%'`);
+
+    return { color, position };
+  });
+
+  // Ensure the first stop is set to 0% if it's not defined
+  if (colorStops[0].position === null) {
+    colorStops[0].position = 0;
+    log.debug(`No position defined for the first stop '${colorStops[0].color}'. Setting to 0%.`);
+  }
+
+  // Ensure the last stop is set to 100% if it's not defined
+  if (colorStops[colorStops.length - 1].position === null) {
+    colorStops[colorStops.length - 1].position = 100;
+    log.debug(
+      `No position defined for the last stop '${colorStops[colorStops.length - 1].color}'. Setting to 100%.`
+    );
+  }
+
+  // Get the maximum and minimum stop positions
+  const minStop = colorStops[0].position;
+  const maxStop = colorStops[colorStops.length - 1].position || 100;
+
+  // Normalize all explicit stop positions when gradient bounds exceed 0-100%, except for the first and last stops
+  if (minStop < 0 || maxStop > 100) {
+    colorStops.forEach((stop, index) => {
+      if (stop.position !== null) {
+        const { position: original, color } = stop;
+        if (!(index === 0 || index === colorStops.length - 1)) {
+          stop.position = ((stop.position - minStop) / (maxStop - minStop)) * 100;
+          log.debug(
+            `Normalized position for stop #${index + 1}: color = '${color}', position = '${original}%' -> '${stop.position}%'`
+          );
+        }
+      }
+    });
+  }
+
+  // Enforce ascending order and interpolate missing positions between stops
+  for (let i = 1; i < colorStops.length - 1; i++) {
+    let prevPos = colorStops[i - 1].position!;
+    prevPos = Math.max(0, Math.min(100, prevPos)); // Cap for CSS-like interpolation
+
+    // Interpolate missing positions
+    if (colorStops[i].position === null) {
+      let j = i;
+      while (j < colorStops.length && colorStops[j].position === null) {
+        j++;
+      }
+      let nextPos = colorStops[j].position!;
+      nextPos = Math.max(0, Math.min(100, nextPos)); // Cap for CSS-like interpolation
+
+      const step = (nextPos - prevPos) / (j - i + 1);
+      log.debug(
+        `Interpolating missing positions for colors #${i + 1} ['${colorStops[i].color}'] to #${j} ['${colorStops[j - 1].color}'] with step ${step}.`
+      );
+
+      for (let k = i; k < j; k++) {
+        colorStops[k].position = prevPos + step * (k - i + 1);
+        log.debug(
+          `Interpolated position for stop #${k + 1} ['${colorStops[k].color}'] to ${colorStops[k].position}%`
+        );
+      }
+      i = j - 1; // Skip to the next defined position
+    } else if (Number(colorStops[i].position) < prevPos) {
+      // This ensures monotonically increasing positions
+      log.debug(
+        `Adjusted position of stop #${i + 1} ['${colorStops[i].color}'] from ${colorStops[i].position}% to ${prevPos}% to maintain ascending order.`
+      );
+      colorStops[i].position = prevPos;
+    }
+  }
+
+  // Select or create <defs> element in the SVG
+  let defs = svg.select<SVGDefsElement>('defs');
+  if (defs.empty()) {
+    defs = svg.append('defs');
+  }
+
+  // Create the linear gradient element
+  const linearGradient = defs
+    .append('linearGradient')
+    .attr('id', gradientId)
+    .attr('spreadMethod', 'pad');
+  log.debug(`Created <linearGradient> element with ID: ${gradientId}`);
+
+  // Initialize SVG coordinates
+  const { x1, y1, x2, y2 } = { x1: 0, y1: minStop, x2: 0, y2: maxStop };
+
+  // Apply SVG coordinates to the linear gradient element
+  linearGradient
+    .attr('x1', `${x1}%`)
+    .attr('y1', `${y1}%`)
+    .attr('x2', `${x2}%`)
+    .attr('y2', `${y2}%`);
+  log.debug(`Coordinates for linear gradient: x1=${x1}%, y1=${y1}%, x2=${x2}%, y2=${y2}%`);
+
+  // Calculate the scale factor to ensure the rendered gradient line length matches that of css
+  const blendFactor = Math.abs(Math.sin(angleRad));
+  const scale = gradientLineLength / (blendFactor * nodeWidth + (1 - blendFactor) * nodeHeight);
+
+  // Apply the gradient rotation with appropriate scaling and translation to get the desired result similar to CSS
+  const gradientTransform = `rotate(${transformAngleDeg}, 0.5, 0.5) translate(0.5, 0.5) scale(${scale}) translate(-0.5, -0.5)`;
+  linearGradient.attr('gradientTransform', gradientTransform);
+  log.debug(`Applied gradient transform: ${gradientTransform}`);
+
+  // Apply the color stops to the linear gradient element
+  colorStops.forEach((stop, index) => {
+    linearGradient
+      .append('stop')
+      .attr('offset', `${stop.position}%`)
+      .attr('stop-color', stop.color);
+    log.debug(
+      `Added stop ${index + 1} to <linearGradient>: color = '${stop.color}', position = '${stop.position}%'`
+    );
+  });
+  log.debug(`Gradient creation process completed for '${gradientId}'.`);
+}

--- a/packages/mermaid/src/rendering-util/createGradient.ts
+++ b/packages/mermaid/src/rendering-util/createGradient.ts
@@ -40,14 +40,14 @@ function isValidColor(color: string): boolean {
 }
 
 /**
- * Calculates the distance L between two parallel tangent lines at a given angle for a specified SVG shape.
+ * Calculates the distance L between two encasing parallel lines at a given angle for a specified SVG shape.
  * Replicates the behavior of CSS linear gradients based on https://www.w3.org/TR/css-images-4/#linear-gradients
  * @see {@link https://www.w3.org/TR/css-images-4/#linear-gradients|CSS linear-gradient() notation} for the formal syntax.
  *
  * @param shapeElement - The D3 selection of the SVG shape.
  * @param angleDeg - The clockwise angle in degrees between the upward vertical axis and the gradient line.
  * @param numSamplePoints - The number of points to sample along the shape's path for path elements (default: 150).
- * @returns - The distance between the two parallel tangent lines to the shape at the given angle.
+ * @returns - The distance between the two encasing parallel lines to the shape at the given angle.
  */
 export function getGradientLineLength(
   shapeElement: Selection<SVGGraphicsElement, unknown, HTMLElement, any>,

--- a/packages/mermaid/src/rendering-util/createGradient.ts
+++ b/packages/mermaid/src/rendering-util/createGradient.ts
@@ -713,9 +713,9 @@ export function createLinearGradient(
   // Setup SVG coordinates
   const xc = bbox.x + nodeWidth / 2;
   const yc = bbox.y + nodeHeight / 2;
-  const dmin = (gradientLineLength * Math.abs(minStop - 50)) / 100; // cspell:ignore dmin
-  const dmax = (gradientLineLength * Math.abs(maxStop - 50)) / 100; // cspell:ignore dmax
-  const { x1, y1, x2, y2 } = { x1: xc, y1: yc + dmax, x2: xc, y2: yc - dmin }; // Vertical gradient @ 0deg (bottom to top)
+  const d1 = (gradientLineLength * (50 - minStop)) / 100;
+  const d2 = (gradientLineLength * (50 - maxStop)) / 100;
+  const { x1, y1, x2, y2 } = { x1: xc, y1: yc + d1, x2: xc, y2: yc + d2 }; // Vertical gradient @ 0deg (bottom to top)
 
   // Apply SVG coordinates to the linear gradient element
   linearGradient.attr('x1', `${x1}`).attr('y1', `${y1}`).attr('x2', `${x2}`).attr('y2', `${y2}`);

--- a/packages/mermaid/src/rendering-util/createGradient.ts
+++ b/packages/mermaid/src/rendering-util/createGradient.ts
@@ -1,27 +1,253 @@
 import type { Selection } from 'd3';
 import { log } from '../logger.js';
 
+// Map of direction keywords to angles in degrees
+export const directionMap = (direction: string, width: number, height: number): number => {
+  const error = () => {
+    throw new Error(`Invalid direction keyword found in gradient: '${direction}'`);
+  };
+  const base = { bottom: 180, top: 0, left: 270, right: 90 };
+  const diagonal = Math.atan2(height, width) * (180 / Math.PI);
+  const normalized = direction
+    .split(' ')
+    .filter((dir) => dir in base)
+    .sort()
+    .join(' ');
+  if (!normalized) {
+    error();
+  }
+  return (
+    base[normalized as keyof typeof base] ??
+    {
+      'left top': 360 - diagonal,
+      'right top': diagonal,
+      'bottom left': 180 + diagonal,
+      'bottom right': 180 - diagonal,
+    }[normalized] ??
+    error()
+  );
+};
+
+// Validate a color string according to CSS color syntax
+function isValidColor(color: string): boolean {
+  if (window?.CSS) {
+    return window.CSS.supports('color', color);
+  }
+  // Fallback to the built-in validation
+  const s = new Option().style;
+  s.color = color;
+  return s.color !== '';
+}
+
+/**
+ * Calculates the distance L between two parallel tangent lines at a given angle for a specified SVG shape.
+ * Replicates the behavior of CSS linear gradients based on https://www.w3.org/TR/css-images-4/#linear-gradients
+ * @see {@link https://www.w3.org/TR/css-images-4/#linear-gradients|CSS linear-gradient() notation} for the formal syntax.
+ *
+ * @param shapeElement - The D3 selection of the SVG shape.
+ * @param angleDeg - The clockwise angle in degrees between the upward vertical axis and the gradient line.
+ * @param numSamplePoints - The number of points to sample along the shape's path for path elements (default: 150).
+ * @returns - The distance between the two parallel tangent lines to the shape at the given angle.
+ */
+export function getGradientLineLength(
+  shapeElement: Selection<SVGGraphicsElement, unknown, HTMLElement, any>,
+  angleDeg: number,
+  numSamplePoints = 150
+) {
+  const angleRad = angleDeg * (Math.PI / 180);
+  const perpendicularAngle = angleRad + Math.PI / 2;
+  const node = shapeElement.node();
+
+  // See https://patrickbrosset.medium.com/do-you-really-understand-css-linear-gradients-631d9a895caf
+  if (node instanceof SVGRectElement) {
+    // Rectangle
+    log.debug('Calculating gradient line length for a rectangle...');
+    const bbox = node.getBBox();
+    const w = bbox.width; // node.getAttribute('width') does not reflect the width property set in classDefs
+    const h = bbox.height; // Same as above for height
+    return Math.abs(w * Math.sin(angleRad)) + Math.abs(h * Math.cos(angleRad));
+  } else if (node instanceof SVGCircleElement) {
+    // Circle
+    log.debug('Calculating gradient line length for a circle...');
+    const r = parseFloat(node.getAttribute('r') || '0');
+    return 2 * r;
+  } else if (node instanceof SVGEllipseElement) {
+    // Ellipse
+    log.debug('Calculating gradient line length for an ellipse...');
+    const a = parseFloat(node.getAttribute('rx') || '0');
+    const b = parseFloat(node.getAttribute('ry') || '0');
+    return 2 * Math.sqrt((a * Math.sin(angleRad)) ** 2 + (b * Math.cos(angleRad)) ** 2);
+  } else if (node instanceof SVGPolygonElement) {
+    // Polygon
+    log.debug('Calculating gradient line length for a polygon...');
+    const pointsAttr = node.getAttribute('points')!;
+
+    // Extract the vertices of the polygon
+    const points = pointsAttr
+      .trim()
+      .split(/\s+/)
+      .map((pt) => {
+        const [x, y] = pt.split(',').map(Number);
+        return { x, y };
+      });
+
+    // Project each vertex onto the perpendicular direction
+    const projections = points.map(
+      (pt) => pt.x * Math.cos(perpendicularAngle) + pt.y * Math.sin(perpendicularAngle)
+    );
+
+    // Calculate the length of the gradient line based on the min/max projections
+    return Math.max(...projections) - Math.min(...projections);
+  } else if (node instanceof SVGPathElement) {
+    // For more arbitrary shapes, sample many points along the path
+    log.debug('Calculating gradient line length for a path...');
+    const totalLength = node.getTotalLength();
+
+    const points = [];
+    for (let i = 0; i <= numSamplePoints; i++) {
+      const t = (i / numSamplePoints) * totalLength;
+      const pt = node.getPointAtLength(t);
+      points.push({ x: pt.x, y: pt.y });
+    }
+
+    // Project points onto the perpendicular direction
+    const projections = points.map(
+      (pt) => pt.x * Math.cos(perpendicularAngle) + pt.y * Math.sin(perpendicularAngle)
+    );
+
+    // Calculate the length of the gradient line based on the min/max projections
+    return Math.max(...projections) - Math.min(...projections);
+  } else {
+    throw Error(`Unsupported shape type for gradient line length calculation: ${node?.tagName}`);
+  }
+}
+
+// Value mixing function for color/position interpolation
+const mix = (a: number, b: number, t: number) => a * (1 - t) + b * t;
+
+// Extract RGBA values from any valid CSS color
+const getRGBA = (color: string) => {
+  if (color === 'HINT') {
+    return { r: 0, g: 0, b: 0, a: 0 }; // A placeholder that will be replaced with interpolated values
+  }
+  // Create a temporary <option> element to parse the color
+  const option = new Option();
+  option.style.color = color;
+  document.body.appendChild(option);
+  const computedColor = getComputedStyle(option).color;
+  document.body.removeChild(option);
+  const matches = /rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\)/.exec(computedColor);
+
+  // Destructure the matched values into r, g, b, and a components
+  if (matches) {
+    const [, r = 0, g = 0, b = 0, a = 1] = matches;
+    return {
+      r: parseFloat(String(r)),
+      g: parseFloat(String(g)),
+      b: parseFloat(String(b)),
+      a: parseFloat(String(a)),
+    };
+  } else {
+    throw new Error(
+      `Cannot parse RGBA values from color '${color}'. Got computed color '${computedColor}'.`
+    );
+  }
+};
+
+/**
+ * Non-linear color interpolation between start and end colors based on a transition hint
+ * Positions must be relative to the total interval and fractional in the range [0, 1], e.g. 0.23 instead of 23/
+ * @see {@link https://www.w3.org/TR/css-color-4/#interpolation|CSS color interpolation} for more details.
+ *
+ * @param start - The RGBA values for the start color.
+ * @param end - The RGBA values for the end color.
+ * @param pos - The relative position of the point we want to interpolate the color for.
+ * @param hint - The relative position of the transition hint between the start and end colors (default: 0.5, i.e., linear interpolation).
+ * @returns - The interpolated color as an RGBA string
+ */
+const interpolateColor = (
+  start: { r: number; g: number; b: number; a: number },
+  end: { r: number; g: number; b: number; a: number },
+  pos: number,
+  hint = 0.5
+): string => {
+  // Color weighting factor based on the transition hint
+  let C = hint > 0 ? Math.pow(pos, Math.log(0.5) / Math.log(hint)) : 1;
+  C = Math.min(Math.max(C, 0), 1); // Clamp between 0 and 1 just in case
+
+  // Interpolate RGBA channels premultiplied by alpha
+  let r = mix(start.r * start.a, end.r * end.a, C);
+  let g = mix(start.g * start.a, end.g * end.a, C);
+  let b = mix(start.b * start.a, end.b * end.a, C);
+  const a = mix(start.a, end.a, C);
+
+  // Un-premultiply RGB channels by alpha only if alpha is not zero
+  if (a !== 0) {
+    r = Math.round(r / a);
+    g = Math.round(g / a);
+    b = Math.round(b / a);
+  }
+
+  return `rgba(${r}, ${g}, ${b}, ${a})`;
+};
+
+// Generate interpolated positions around the transition hint
+const generateStops = (
+  start: number,
+  hint: number,
+  end: number,
+  n: number,
+  includeStart = false,
+  includeEnd = false
+): number[] => {
+  if (n < 0 && n % 2 === 0) {
+    throw new Error(
+      'Total number of stops (excluding start and end) must be positive and odd for symmetry.'
+    );
+  }
+  const half = (n - 1) / 2; // Number of stops between start->hint and hint->end
+  return [
+    // Conditionally include start
+    ...(includeStart ? [start] : []),
+    // Intermediate stops between start and hint (excluding start)
+    ...Array.from({ length: half }, (_, i) => mix(start, hint, (i + 1) / (half + 1))),
+    // Include the hint position
+    hint,
+    // Intermediate stops between hint and end (excluding end)
+    ...Array.from({ length: half }, (_, i) => mix(hint, end, (i + 1) / (half + 1))),
+    // Conditionally include end
+    ...(includeEnd ? [end] : []),
+  ];
+};
+
 /**
  * Creates an SVG linear gradient element given a CSS-like linear-gradient definition
  * consisting of an angle/direction and color stops.
  *
- * @param svg - The SVG element to which the gradient is applied.
+ * @param svgSelection - The SVG selection to which the linear gradient will be appended.
  * @param shapeElement - The SVG shape element to which the gradient will be applied.
- * @param linearGradientStyle - A CSS-like linear-gradient string specifying the gradient angle/direction (optional) and color stops.
+ * @param linearGradientStyle - A CSS-like linear-gradient string specifying the gradient angle/direction (optional) and color stops (color and position).
  * @param gradientId - The unique ID for the created linear gradient in the SVG's <defs> section.
+ * @param linearInterpOnly - Restricts to linear interpolation, skipping transition hints and opacity gradients between stops (default: false).
  * @returns void - The function does not return a value. In-place modifications are made to the SVG element.
  */
 export function createLinearGradient(
-  svg: Selection<SVGSVGElement, unknown, null, undefined>,
+  svgSelection: Selection<SVGSVGElement, unknown, null, undefined>,
   shapeElement: Selection<SVGGraphicsElement, unknown, HTMLElement, any>,
   linearGradientStyle: string,
-  gradientId: string
+  gradientId: string,
+  linearInterpOnly = false
 ): void {
   log.debug(`Creating linear gradient for ${gradientId}: ${linearGradientStyle}`);
 
+  // Throw an error if the gradient style is empty
+  if (linearGradientStyle.trim() === '') {
+    throw new Error('Linear gradient found with empty style.');
+  }
+
   // Test if the double comma pattern exists in the input string to avoid user errors
   if (/,\s*,/.test(linearGradientStyle)) {
-    log.error('Found consecutive commas (,,) in the gradient string.');
+    throw new Error('Found consecutive commas (,,) in the gradient string.');
   }
 
   // Calculate the dimensions of the node's bounding box
@@ -35,14 +261,17 @@ export function createLinearGradient(
   log.debug('Parsed gradient parts:', parts);
 
   let angleDeg = 180; // Default angle is 180deg (top to bottom) following CSS convention
-  let aspectRatio = nodeWidth / nodeHeight;
-  let hasAngleOrDirection = true;
+  let hasAngleOrDirectionKwd = true;
 
   // Handle numeric angles (e.g., -45deg, +12deg, 1rad, 0.25turn) or directional keywords (e.g., to right, to top left)
   if (parts?.[1]) {
     if (/deg|turn|grad|rad/.test(parts[1])) {
-      const match = /([+-]?\d+\.?\d*)(deg|turn|grad|rad)/.exec(parts[1]);
+      const match = /^(.+?)(deg|turn|grad|rad)$/.exec(parts[1]);
       const [_, value, unit] = match ? match : [null, String(angleDeg), 'deg'];
+      if (/^[+-]?(\d+\.?\d*|\.\d+)$/.test(value) === false) {
+        // Allow positive/negative numbers with optional decimal points
+        throw new Error(`Invalid angle value found in gradient: '${parts[1]}'`);
+      }
       angleDeg =
         unit === 'turn'
           ? parseFloat(value) * 360
@@ -56,170 +285,194 @@ export function createLinearGradient(
       );
     } else if (parts[1].includes('to')) {
       const direction = parts[1].replace(/\s{2,}/g, ' ').trim(); // Remove extra spaces and trim the direction
-      const directionMap: Record<string, number> = {
-        'to bottom': 180,
-        'to top': 0,
-        'to left': 270,
-        'to right': 90,
-        'to top left': 315,
-        'to left top': 315,
-        'to top right': 45,
-        'to right top': 45,
-        'to bottom left': 225,
-        'to left bottom': 225,
-        'to bottom right': 135,
-        'to right bottom': 135,
-      };
-      if (direction in directionMap) {
-        angleDeg = directionMap[direction];
-        log.debug(`Converted gradient direction ${direction} to angle: ${angleDeg} degrees.`);
-        // Set the aspect ratio to 1 for practical purposes to ensure accurate interpretation
-        // of the gradient direction relevant to the sides/corners
-        aspectRatio = 1;
-      } else {
-        log.error(`Invalid direction found in the gradient string.`);
-      }
+      angleDeg = directionMap(direction, nodeWidth, nodeHeight);
+      log.debug(`Converted gradient direction ${direction} to angle: ${angleDeg} degrees.`);
     } else {
-      hasAngleOrDirection = false;
+      hasAngleOrDirectionKwd = false;
       log.debug(`No angle or direction specified in the gradient string.`);
     }
     // If an angle/direction is specified, remove it from the gradient style to leave only
     // color stops going forward, otherwise, consider the whole string as color stops
-    linearGradientStyle = hasAngleOrDirection ? parts[2] : parts[0] || '';
+    linearGradientStyle = hasAngleOrDirectionKwd ? parts[2] : parts[0] || '';
   }
 
+  linearGradientStyle = linearGradientStyle.trim();
   log.debug(`Colors and positions for linear gradient: ${linearGradientStyle}`);
 
-  // Calculate the rotation angle for the gradient transformation using the original angle and
-  // the aspect ratio to ensure proper behavior (e.g., at 45 degrees) for non-square bounding boxes
-  const angleRad = angleDeg * (Math.PI / 180);
-  let transformAngleDeg = Math.atan(Math.tan(angleRad) * aspectRatio) * (180 / Math.PI);
-  transformAngleDeg += Math.cos(angleRad) > 0 ? 180 : 0; // Adjust kinks at 90 and 270 degrees
-  log.debug(`Calculated the angle for the rotational transform: ${transformAngleDeg} degrees`);
-
-  // Calculate the length of the gradient line based on the angle and the bounding box dimensions
-  // See https://patrickbrosset.medium.com/do-you-really-understand-css-linear-gradients-631d9a895caf
-  const gradientLineLength =
-    Math.abs(nodeWidth * Math.sin(angleRad)) + Math.abs(nodeHeight * Math.cos(angleRad));
+  // Calculate the length of the gradient line based on the angle and the SVG shape element
+  const gradientLineLength = getGradientLineLength(shapeElement, angleDeg);
   log.debug(
-    `Calculated gradient line length: ${gradientLineLength} for angle = ${angleRad}rad, width = ${nodeWidth}px, height = ${nodeHeight}px`
+    `Calculated gradient line length: ${gradientLineLength} for angle = ${angleDeg}deg, width = ${nodeWidth}px, height = ${nodeHeight}px`
   );
 
-  // List of supported units for position values
-  const lengthUnits = '%|px|em|rem|vw|vh|vmin|vmax|ex|ch|cm|mm|in|pt|pc'; // cspell:ignore vmin vmax
+  // Regular expression for capturing color stops with multiple positions (invalid cases will be handled further down)
+  const multiStopRegex =
+    /([A-Za-z]+\([^)]+\)|#[\dA-Fa-f]{3,8}|[A-Za-z]+)\s+([+-]?\d*\.?\d+[%A-Za-z]*)\s*([+-]?\d*\.?\d+[%A-Za-z]*)?\s*([+-]?\d*\.?\d+[%A-Za-z]*)?/g;
 
-  // Create the dynamic regular expression for double stops (e.g., 'red -10% 35%')
-  const doubleStopRegex = new RegExp(
-    `(\\S+)\\s+([+-]?\\d*\\.?\\d+(?:${lengthUnits}))\\s+([+-]?\\d*\\.?\\d+(?:${lengthUnits}))`,
-    'g'
+  linearGradientStyle = linearGradientStyle.replace(
+    multiStopRegex,
+    (match, color, pos1, pos2, pos3) => {
+      if (!isValidColor(color)) {
+        return match; // Ignore the match if it doesn't start with a valid color
+      }
+      const positionArray = [pos1, pos2, pos3].filter(Boolean); // Filter out undefined/null values
+      if (positionArray.length > 2) {
+        throw new Error(`Too many positions in color stop: '${match}'`);
+      } else if (positionArray.length === 2) {
+        // Split double stops like 'red -10% 35%' into 'red -10%, red 35%' (same with other units)
+        log.debug(
+          `Split double stop: '${color} ${pos1} ${pos2}' into '${color} ${pos1}, ${color} ${pos2}'`
+        );
+        return `${color} ${pos1}, ${color} ${pos2}`;
+      }
+      return match; // No split for 1 or 0 positions
+    }
   );
 
-  // Split double stops like 'red -10% 35%' into 'red -10%, red 35%' (same with other units)
-  linearGradientStyle = linearGradientStyle.replace(doubleStopRegex, (_, color, pos1, pos2) => {
-    log.debug(
-      `Split double stop: '${color} ${pos1} ${pos2}' into '${color} ${pos1}, ${color} ${pos2}'`
-    );
-    return `${color} ${pos1}, ${color} ${pos2}`;
-  });
+  // Interface for color stops with optional positions to guide TypeScript in handling nullable stops safely
+  interface ColorStop {
+    color: string;
+    position: number | null;
+  }
 
   // Parse color stops, convert units to %, and map to color and position
-  const colorStops = linearGradientStyle.split(/,(?![^()]*\))/).map((stop) => {
-    // Capture color (hex, named, or function) followed by optional position and units
-    // const [_, color, positionString, unit] = stop.trim().match(new RegExp(`(#[0-9a-fA-F]{3,6}|[a-zA-Z]+\\([^)]+\\)|[a-zA-Z]+)\\s*([-+]?\\d*\\.?\\d*)\\s*(${lengthUnits})?$`)) || [];
-    const regex = new RegExp(
-      `(#[0-9a-fA-F]{3,6}|[a-zA-Z]+\\([^)]+\\)|[a-zA-Z]+)\\s*([-+]?\\d*\\.?\\d*)\\s*(${lengthUnits})?$`
-    );
-    const [_, color, positionString, unit] = regex.exec(stop.trim()) || [];
-
-    if (!color) {
-      log.debug(`No valid color found for stop: '${stop}'`);
-      return { color: null, position: null };
-    }
-
-    // Define the root font size and parent font size for font-relative units (em, rem, ex, ch)
-    const rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize);
-    const parentNode = shapeElement.node()?.parentNode;
-    const parentFontSize = parentNode
-      ? parseFloat(getComputedStyle(parentNode as Element).fontSize)
-      : rootFontSize;
-
-    // CSS uses a standard DPI of 96 for physical unit conversions (in, cm, mm, etc.)
-    const dpi = 96;
-
-    // Conversion logic based on unit type, returning position as %
-    const position = positionString
-      ? (() => {
-          const value = parseFloat(positionString);
-          switch (unit) {
-            case '%':
-              // Already in the intended unit
-              return value;
-            case 'px':
-              // Pixels are converted to % based on the gradient line length
-              return (value / gradientLineLength) * 100;
-            case 'em':
-              // 'em' values are relative to the parent element's font size
-              return ((value * parentFontSize) / gradientLineLength) * 100;
-            case 'rem':
-              // 'rem' values are relative to the root element's font size
-              return ((value * rootFontSize) / gradientLineLength) * 100;
-            case 'vw':
-              // 'vw' represents viewport width, converted relative to window width
-              return (((value / 100) * window.innerWidth) / gradientLineLength) * 100;
-            case 'vh':
-              // 'vh' represents viewport height, converted relative to window height
-              return (((value / 100) * window.innerHeight) / gradientLineLength) * 100;
-            case 'vmin':
-              // 'vmin' is based on the smallest viewport dimension (width or height)
-              return (
-                (((value / 100) * Math.min(window.innerWidth, window.innerHeight)) /
-                  gradientLineLength) *
-                100
-              );
-            case 'vmax':
-              // 'vmax' is based on the largest viewport dimension (width or height)
-              return (
-                (((value / 100) * Math.max(window.innerWidth, window.innerHeight)) /
-                  gradientLineLength) *
-                100
-              );
-            case 'ex':
-              // 'ex' is the height of the lowercase letter x, assumed to be 0.5em for simplicity
-              return ((value * parentFontSize * 0.5) / gradientLineLength) * 100;
-            case 'ch':
-              // 'ch' is the width of the '0' character, often estimated as 0.5em
-              return ((value * parentFontSize * 0.5) / gradientLineLength) * 100;
-            case 'cm':
-              // Centimeters converted to pixels using the standard DPI, then to %
-              return ((value * dpi) / 2.54 / gradientLineLength) * 100;
-            case 'mm':
-              // Millimeters converted to pixels using DPI, then to %
-              return ((value * dpi) / 25.4 / gradientLineLength) * 100;
-            case 'in':
-              // Inches converted to pixels using DPI, then to %
-              return ((value * dpi) / gradientLineLength) * 100;
-            case 'pt':
-              // Points (1pt = 1/72 inch) converted to pixels, then to %
-              return ((value * dpi) / 72 / gradientLineLength) * 100;
-            case 'pc':
-              // Picas (1pc = 12pt = 1/6 inch) converted to pixels, then to %
-              return ((value * dpi) / 6 / gradientLineLength) * 100;
-            default:
-              // For any unsupported units, return null
-              return null;
+  const colorStops = linearGradientStyle
+    .split(/,(?![^()]*\))/)
+    .map((stop): ColorStop | null => {
+      stop = stop.trim();
+      if (/^[+-]?\d+(\.\d+)?[%A-Za-z]+$/.test(stop)) {
+        // Stops containing just a number with % or units (e.g., px, em) serve as transition hints
+        if (linearGradientStyle.startsWith(stop) || linearGradientStyle.endsWith(stop)) {
+          throw new Error(`The transition hint '${stop}' does not have surrounding color stops`);
+        } else {
+          log.debug(
+            `Found a transition hint at '${stop}'. Will interpolate colors around it if needed.`
+          );
+          if (linearInterpOnly) {
+            return null; // Ignore the hint if linear interpolation is enforced
+          } else {
+            stop = `HINT ${stop}`; // Placeholder for future handling
           }
-        })()
-      : null;
-
-    if (positionString) {
-      log.debug(
-        `Position ${positionString}${unit} ${unit === '%' ? 'is already in percentage, no conversion needed' : `is converted to ${position}% of the gradient line length`}.`
+        }
+      }
+      // Capture color (hex, named, or function) followed by optional position and units
+      const regex = new RegExp(
+        `(#[0-9a-fA-F]{3,8}|[a-zA-Z]+\\([^)]+\\)|[a-zA-Z]+)\\s*([-+]?\\d*\\.?\\d*)([a-zA-Z%]*)?$`
       );
-    }
-    log.debug(`Parsed color stop: color = '${color}', position = '${position}%'`);
+      const [_, color, positionString, unit] = regex.exec(stop.trim()) || [];
+      log.debug(
+        `Parsed color stop (pre conversion): '${stop.trim()}' -> color = '${color}', position = '${positionString}', position unit = '${unit}'`
+      );
 
-    return { color, position };
-  });
+      // Throw an error if the color is invalid
+      if (color !== 'HINT' && !isValidColor(color)) {
+        throw new Error(`Invalid color value found in color stop: '${stop.trim()}'`);
+      }
+
+      // Define the root font size and parent font size for font-based units (em, rem, ex, ch)
+      const rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize);
+      const parentNode = shapeElement.node()?.parentNode;
+      const parentFontSize = parentNode
+        ? parseFloat(getComputedStyle(parentNode as Element).fontSize)
+        : rootFontSize;
+
+      // Some log messages to help with debugging for font-based units
+      if (unit === 'em' || unit === 'ex' || unit === 'ch') {
+        if (parentNode) {
+          log.debug(`Parent detected for node: font-size = ${parentFontSize}px`);
+        } else {
+          log.debug(`No parent detected for node: using root font-size = ${rootFontSize}px`);
+        }
+      } else if (unit === 'rem') {
+        log.debug(`Root font-size: ${rootFontSize}px`);
+      }
+
+      // CSS uses a standard DPI of 96 for physical unit conversions (in, cm, mm, etc.)
+      const dpi = 96;
+
+      // Conversion logic based on unit type, returning position as %
+      const position = positionString
+        ? (() => {
+            const value = parseFloat(positionString); // cspell:ignore vmin vmax
+            switch (unit) {
+              case '%':
+                // Already in the intended unit
+                return value;
+              case 'px':
+                // Pixels are converted to % based on the gradient line length
+                return (value / gradientLineLength) * 100;
+              case 'em':
+                // 'em' values are relative to the parent element's font size
+                return ((value * parentFontSize) / gradientLineLength) * 100;
+              case 'rem':
+                // 'rem' values are relative to the root element's font size
+                return ((value * rootFontSize) / gradientLineLength) * 100;
+              case 'vw':
+                // 'vw' represents viewport width, converted relative to window width
+                return (((value / 100) * window.innerWidth) / gradientLineLength) * 100;
+              case 'vh':
+                // 'vh' represents viewport height, converted relative to window height
+                return (((value / 100) * window.innerHeight) / gradientLineLength) * 100;
+              case 'vmin':
+                // 'vmin' is based on the smallest viewport dimension (width or height)
+                return (
+                  (((value / 100) * Math.min(window.innerWidth, window.innerHeight)) /
+                    gradientLineLength) *
+                  100
+                );
+              case 'vmax':
+                // 'vmax' is based on the largest viewport dimension (width or height)
+                return (
+                  (((value / 100) * Math.max(window.innerWidth, window.innerHeight)) /
+                    gradientLineLength) *
+                  100
+                );
+              case 'ex':
+                // 'ex' is the height of the lowercase letter x, often estimated as 0.5em
+                return ((value * parentFontSize * 0.5) / gradientLineLength) * 100;
+              case 'ch':
+                // 'ch' is the width of the '0' character, often estimated as 0.5em
+                return ((value * parentFontSize * 0.5) / gradientLineLength) * 100;
+              case 'cm':
+                // Centimeters converted to pixels using the standard DPI, then to %
+                return ((value * dpi) / 2.54 / gradientLineLength) * 100;
+              case 'mm':
+                // Millimeters converted to pixels using DPI, then to %
+                return ((value * dpi) / 25.4 / gradientLineLength) * 100;
+              case 'in':
+                // Inches converted to pixels using DPI, then to %
+                return ((value * dpi) / gradientLineLength) * 100;
+              case 'pt':
+                // Points (1pt = 1/72 inch) converted to pixels, then to %
+                return ((value * dpi) / 72 / gradientLineLength) * 100;
+              case 'pc':
+                // Picas (1pc = 12pt = 1/6 inch) converted to pixels, then to %
+                return ((value * dpi) / 6 / gradientLineLength) * 100;
+              default:
+                throw new Error(`Unsupported unit found in gradient position: ${unit}`);
+            }
+          })()
+        : null;
+
+      if (positionString) {
+        log.debug(
+          `Position ${positionString}${unit} ${unit === '%' ? 'is already in percentage, no conversion needed' : `is converted to ${position}% of the gradient line length`}.`
+        );
+      }
+      log.debug(
+        `Parsed color stop (post conversion): color = '${color}', position = '${position}%'`
+      );
+
+      return { color, position };
+    })
+    .filter((stop): stop is ColorStop => stop !== null); // Remove null stops (i.e. ignored transition hints)
+
+  // As in CSS, you can't have a gradient with less than two stops
+  if (colorStops.length < 2) {
+    throw new Error(
+      `At least two stops are required to create a linear gradient. Found ${colorStops.length}.`
+    );
+  }
 
   // Ensure the first stop is set to 0% if it's not defined
   if (colorStops[0].position === null) {
@@ -235,9 +488,9 @@ export function createLinearGradient(
     );
   }
 
-  // Get the maximum and minimum stop positions
-  const minStop = colorStops[0].position;
-  const maxStop = colorStops[colorStops.length - 1].position || 100;
+  // Get the minimum and maximum stop positions
+  const minStop = Math.min(colorStops[0].position ?? 0, 0);
+  const maxStop = Math.max(colorStops[colorStops.length - 1].position ?? 100, 100);
 
   // Normalize all explicit stop positions when gradient bounds exceed 0-100%, except for the first and last stops
   if (minStop < 0 || maxStop > 100) {
@@ -255,12 +508,12 @@ export function createLinearGradient(
   }
 
   // Enforce ascending order and interpolate missing positions between stops
-  for (let i = 1; i < colorStops.length - 1; i++) {
-    let prevPos = colorStops[i - 1].position!;
-    prevPos = Math.max(0, Math.min(100, prevPos)); // Cap for CSS-like interpolation
+  for (let i = 1; i < colorStops.length; i++) {
+    const prevPos = colorStops[i - 1].position!;
+    const prevPosCapped = Math.max(0, Math.min(100, prevPos)); // Cap for CSS-like interpolation
 
     // Interpolate missing positions
-    if (colorStops[i].position === null) {
+    if (colorStops[i].position === null && i < colorStops.length - 1) {
       let j = i;
       while (j < colorStops.length && colorStops[j].position === null) {
         j++;
@@ -268,13 +521,13 @@ export function createLinearGradient(
       let nextPos = colorStops[j].position!;
       nextPos = Math.max(0, Math.min(100, nextPos)); // Cap for CSS-like interpolation
 
-      const step = (nextPos - prevPos) / (j - i + 1);
+      const step = (nextPos - prevPosCapped) / (j - i + 1);
       log.debug(
-        `Interpolating missing positions for colors #${i + 1} ['${colorStops[i].color}'] to #${j} ['${colorStops[j - 1].color}'] with step ${step}.`
+        `Interpolating missing positions for colors #${i + 1} '${colorStops[i].color}' to #${j} '${colorStops[j - 1].color}' with step ${step}.`
       );
 
       for (let k = i; k < j; k++) {
-        colorStops[k].position = prevPos + step * (k - i + 1);
+        colorStops[k].position = prevPosCapped + step * (k - i + 1);
         log.debug(
           `Interpolated position for stop #${k + 1} ['${colorStops[k].color}'] to ${colorStops[k].position}%`
         );
@@ -289,48 +542,188 @@ export function createLinearGradient(
     }
   }
 
+  // If the first color stop has a position greater than 0, add a new stop at position 0
+  // This check is essential for aligning with CSS behavior in cases where the last stop is beyond 100% for edge cases like 'red 30%, yellow, blue 140%'
+  if (colorStops[0].position > 0) {
+    colorStops.unshift({ color: colorStops[0].color || '', position: 0 });
+    log.debug(
+      `Added a new start position for color '${colorStops[0].color}' at 0% to ensure at least 0-100% coverage.`
+    );
+  }
+
+  // If the last color stop is not maxed out at least at 100%, add a new stop at position 100
+  // Suspected this may not be required, but including it just to be safe
+  if ((colorStops[colorStops.length - 1].position || 100) < 100) {
+    colorStops.push({ color: colorStops[colorStops.length - 1].color || '', position: 100 });
+    log.debug(
+      `Added a new end position for color '${colorStops[colorStops.length - 1].color}' at 100% to ensure at least 0-100% coverage.`
+    );
+  }
+
   // Select or create <defs> element in the SVG
-  let defs = svg.select<SVGDefsElement>('defs');
+  let defs = svgSelection.select<SVGDefsElement>('defs');
   if (defs.empty()) {
-    defs = svg.append('defs');
+    log.debug('No <defs> element found in the SVG. Creating a new one.');
+    defs = svgSelection.append('defs');
   }
 
   // Create the linear gradient element
   const linearGradient = defs
     .append('linearGradient')
     .attr('id', gradientId)
-    .attr('spreadMethod', 'pad');
+    .attr('spreadMethod', 'pad')
+    .attr('gradientUnits', 'userSpaceOnUse');
   log.debug(`Created <linearGradient> element with ID: ${gradientId}`);
 
-  // Initialize SVG coordinates
-  const { x1, y1, x2, y2 } = { x1: 0, y1: minStop, x2: 0, y2: maxStop };
+  // Apply color stops to the linear gradient element
+  colorStops.forEach((currentStop, index) => {
+    // Get RGBA values for potential color interpolation
+    let startColor = linearInterpOnly ? { r: 0, g: 0, b: 0, a: 0 } : getRGBA(currentStop.color);
+    const nextStop = colorStops[index + 1];
+    const endColor = linearInterpOnly ? startColor : nextStop ? getRGBA(nextStop.color) : undefined;
+
+    // Check if the stop is a transition hint or in need of interpolation due to opacity gradient between stops
+    if (
+      !linearInterpOnly &&
+      endColor &&
+      nextStop.color !== 'HINT' &&
+      (startColor.a !== endColor.a || currentStop.color === 'HINT')
+    ) {
+      const prevStop = colorStops[index - 1];
+
+      // Number of interpolated stops around the transition hint including the hint itself
+      const nTransitionStops = 5; // 5 is tested to be optimal
+
+      // Defaults for opacity-gradient-based interpolation
+      let relativeHint = 0.5;
+      let totalInterval = nextStop.position! - currentStop.position!;
+      let absoluteStartPos = currentStop.position;
+
+      // No need to interpolate if this stop is a transition hint with the same position as an adjacent stop
+      if (currentStop.color === 'HINT') {
+        if (currentStop.position == prevStop.position) {
+          linearGradient
+            .append('stop')
+            .attr('offset', `${currentStop.position}%`)
+            .attr('stop-color', nextStop.color);
+          log.debug(
+            `Added stop #${index + 1} to <linearGradient> using the next color since the transition hint's position is not more than the position of the previous stop: color = '${nextStop.color}', position = '${currentStop.position}%'`
+          );
+          // Skip to the next iteration after adding a regular stop
+          return;
+        }
+        if (currentStop.position == nextStop.position) {
+          linearGradient
+            .append('stop')
+            .attr('offset', `${currentStop.position}%`)
+            .attr('stop-color', prevStop.color);
+          log.debug(
+            `Added stop #${index + 1} to <linearGradient> using the previous color since the transition hint's position is not less than the position of the next stop: color = '${prevStop.color}', position = '${currentStop.position}%'`
+          );
+          // Skip to the next iteration after adding a regular stop
+          return;
+        }
+
+        // Start interpolating from the previous stop's color if this is a transition hint
+        startColor = getRGBA(prevStop.color);
+
+        // Relative value of the hint within the total interval
+        totalInterval = nextStop.position! - prevStop.position!;
+        relativeHint = (currentStop.position! - prevStop.position!) / totalInterval;
+        absoluteStartPos = prevStop.position;
+      }
+
+      if (currentStop.position == nextStop.position) {
+        // No interpolation needed if the positions are the same even though the colors have different opacities
+        [currentStop, nextStop].forEach((stop) => {
+          linearGradient
+            .append('stop')
+            .attr('offset', `${stop.position}%`)
+            .attr('stop-color', stop.color);
+          log.debug(
+            `Added stop #${index + 1} to <linearGradient> (no opacity-gradient-based interpolation needed because the positions are the same): color = '${stop.color}', position = '${stop.position}%'`
+          );
+        });
+        // Skip to the next iteration now that both stops are added
+        return;
+      }
+
+      /**
+       * Interpolate colors between stops based on the transition hint or opacity differences
+       */
+
+      // For opacity-gradient-based interpolation, keep the start color in the list so that it can be
+      // treated as a regular stop later since this is our only chance to do so
+      const includeStart = currentStop.color !== 'HINT';
+
+      // Generate interpolated relative positions within the interval
+      const interpolatedRelativePositions = generateStops(
+        0,
+        relativeHint,
+        1,
+        nTransitionStops,
+        includeStart,
+        false
+      );
+      log.debug(
+        `Generated ${nTransitionStops + (includeStart ? 1 : 0)} interpolated relative positions around the relative transition hint at ${relativeHint} between colors ${currentStop.color === 'HINT' ? prevStop.color : currentStop.color} and ${nextStop.color}: ${interpolatedRelativePositions.join(', ')}`
+      );
+
+      // Append interpolated stops to the gradient
+      interpolatedRelativePositions.forEach((relativePos, hintIndex) => {
+        const absolutePos = absoluteStartPos! + relativePos * totalInterval;
+        const interpolatedColor =
+          hintIndex === 0 && includeStart
+            ? currentStop.color
+            : interpolateColor(startColor, endColor, relativePos, relativeHint);
+        linearGradient
+          .append('stop')
+          .attr('offset', `${absolutePos}%`)
+          .attr('stop-color', interpolatedColor);
+        if (currentStop.color === 'HINT') {
+          log.debug(
+            `Added interpolated transition stop ${hintIndex + 1}/${nTransitionStops} for transition hint between colors ${prevStop.color} and ${nextStop.color} to <linearGradient>: color (interpolated) = '${interpolatedColor}', position = '${absolutePos}%'`
+          );
+        } else {
+          if (hintIndex === 0) {
+            // Treated like a regular stop as this is the starting point of an opacity-gradient-based interpolation
+            log.debug(
+              `Added stop ${index + 1} to <linearGradient>: color = '${interpolatedColor}', position = '${absolutePos}%'`
+            );
+          } else {
+            log.debug(
+              `Added interpolated transition stop ${hintIndex}/${nTransitionStops} for opacity gradient between colors ${currentStop.color} and ${nextStop.color} to <linearGradient>: color (interpolated) = '${interpolatedColor}', position = '${absolutePos}%'`
+            );
+          }
+        }
+      });
+    } else {
+      // Append the standard stop to the gradient with no transition hint or opacity gradient involved in the interpolation
+      linearGradient
+        .append('stop')
+        .attr('offset', `${currentStop.position}%`)
+        .attr('stop-color', currentStop.color);
+      log.debug(
+        `Added stop ${index + 1} to <linearGradient>: color = '${currentStop.color}', position = '${currentStop.position}%'`
+      );
+    }
+  });
+
+  // Setup SVG coordinates
+  const xc = bbox.x + nodeWidth / 2;
+  const yc = bbox.y + nodeHeight / 2;
+  const dmin = (gradientLineLength * Math.abs(minStop - 50)) / 100; // cspell:ignore dmin
+  const dmax = (gradientLineLength * Math.abs(maxStop - 50)) / 100; // cspell:ignore dmax
+  const { x1, y1, x2, y2 } = { x1: xc, y1: yc + dmax, x2: xc, y2: yc - dmin }; // Vertical gradient @ 0deg (bottom to top)
 
   // Apply SVG coordinates to the linear gradient element
-  linearGradient
-    .attr('x1', `${x1}%`)
-    .attr('y1', `${y1}%`)
-    .attr('x2', `${x2}%`)
-    .attr('y2', `${y2}%`);
-  log.debug(`Coordinates for linear gradient: x1=${x1}%, y1=${y1}%, x2=${x2}%, y2=${y2}%`);
+  linearGradient.attr('x1', `${x1}`).attr('y1', `${y1}`).attr('x2', `${x2}`).attr('y2', `${y2}`);
+  log.debug(`Coordinates for linear gradient: x1=${x1}, y1=${y1}, x2=${x2}, y2=${y2}`);
 
-  // Calculate the scale factor to ensure the rendered gradient line length matches that of css
-  const blendFactor = Math.abs(Math.sin(angleRad));
-  const scale = gradientLineLength / (blendFactor * nodeWidth + (1 - blendFactor) * nodeHeight);
-
-  // Apply the gradient rotation with appropriate scaling and translation to get the desired result similar to CSS
-  const gradientTransform = `rotate(${transformAngleDeg}, 0.5, 0.5) translate(0.5, 0.5) scale(${scale}) translate(-0.5, -0.5)`;
+  // Rotate the gradient using the gradient transform attribute
+  const gradientTransform = `rotate(${angleDeg}, ${xc}, ${yc})`;
   linearGradient.attr('gradientTransform', gradientTransform);
   log.debug(`Applied gradient transform: ${gradientTransform}`);
 
-  // Apply the color stops to the linear gradient element
-  colorStops.forEach((stop, index) => {
-    linearGradient
-      .append('stop')
-      .attr('offset', `${stop.position}%`)
-      .attr('stop-color', stop.color);
-    log.debug(
-      `Added stop ${index + 1} to <linearGradient>: color = '${stop.color}', position = '${stop.position}%'`
-    );
-  });
   log.debug(`Gradient creation process completed for '${gradientId}'.`);
 }


### PR DESCRIPTION
## :bookmark_tabs: Summary

This PR adds support for CSS-like linear-gradient fills to Mermaid, following the [CSS linear-gradient syntax](https://www.w3schools.com/cssref/func_linear-gradient.php). It introduces a reusable gradient utility that can be applied to other diagrams in the future, though this PR focuses on flowcharts as an example of how the feature can be used. A wide-ranging, editable collection of side-by-side examples comparing Mermaid and CSS linear gradients is available on [this CodePen](https://codepen.io/enourbakhsh/full/jOgBNjN).
<p align="center">
<img width="80%" alt="mermaid-css" src="https://github.com/user-attachments/assets/352c102c-e4cc-4e7a-8b68-1adcefc7c9fb">
</p>

Resolves #2907 and #4476

## :straight_ruler: Design Decisions

The implementation involves updating the lexer to recognize the linear-gradient syntax and modifying the renderer to correctly apply the gradient fills to flowchart nodes. The design follows a CSS-like approach to maintain familiarity for users. See how gradient lines adapt dynamically to various shapes in [this CodePen demo](https://codepen.io/enourbakhsh/full/WNVErLx), which reflects the design principles behind the added feature.
<p align="center">
<img width="70%" alt="gradient-line-length" src="https://github.com/user-attachments/assets/57a181fd-e0d0-4d14-a079-baeddde422dc">
</p>

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
