### PR TITLE
Allow architecture diagrams to support any character for titles

### DIFF
--- a/cypress/integration/rendering/architecture.spec.ts
+++ b/cypress/integration/rendering/architecture.spec.ts
@@ -1,6 +1,6 @@
 import { imgSnapshotTest, urlSnapshotTest } from '../../helpers/util.ts';
 
-describe.skip('architecture diagram', () => {
+describe('architecture diagram', () => {
   it('should render a simple architecture diagram with groups', () => {
     imgSnapshotTest(
       `architecture-beta
@@ -10,12 +10,12 @@ describe.skip('architecture diagram', () => {
                 service disk1(disk)[Storage] in api
                 service disk2(disk)[Storage] in api
                 service server(server)[Server] in api
-                service gateway(internet)[Gateway] 
+                service gateway(internet)[Gateway]
 
-                db L--R server
-                disk1 T--B server
-                disk2 T--B db
-                server T--B gateway
+                db:L -- R:server
+                disk1:T -- B:server
+                disk2:T -- B:db
+                server:T-- B:gateway
             `
     );
   });
@@ -25,17 +25,17 @@ describe.skip('architecture diagram', () => {
                 group api[API]
                 group public[Public API] in api
                 group private[Private API] in api
-        
+
                 service serv1(server)[Server] in public
-        
+
                 service serv2(server)[Server] in private
                 service db(database)[Database] in private
-        
+
                 service gateway(internet)[Gateway] in api
-        
-                serv1 B--T serv2
-                serv2 L--R db
-                serv1 L--R gateway
+
+                serv1:B -- T:serv2
+                serv2:L -- R:db
+                serv1:L -- R:gateway
             `
     );
   });
@@ -54,11 +54,11 @@ describe.skip('architecture diagram', () => {
                 service serv1(server)[Server 1]
                 service serv2(server)[Server 2]
                 service disk(disk)[Disk]
-        
-                db L--R s3
-                serv1 L--T s3
-                serv2 L--B s3
-                serv1 T--B disk
+
+                db:L--R:s3
+                serv1:L--T:s3
+                serv2:L--B:s3
+                serv1:T--B:disk
             `
     );
   });
@@ -70,16 +70,16 @@ describe.skip('architecture diagram', () => {
                 service servR(server)[Server 3]
                 service servT(server)[Server 4]
                 service servB(server)[Server 5]
-        
-                servC (L--R) servL
-                servC (R--L) servR
-                servC (T--B) servT
-                servC (B--T) servB
-        
-                servL (T--L) servT
-                servL (B--L) servB
-                servR (T--R) servT
-                servR (B--R) servB
+
+                servC:L<-->R:servL
+                servC:R<-->L:servR
+                servC:T<-->B:servT
+                servC:B<-->T:servB
+
+                servL:T<-->L:servT
+                servL:B<-->L:servB
+                servR:T<-->R:servT
+                servR:B<-->R:servB
             `
     );
   });
@@ -91,17 +91,17 @@ describe.skip('architecture diagram', () => {
                 group top_group(cloud)[Top]
                 group bottom_group(cloud)[Bottom]
                 group center_group(cloud)[Center]
-        
+
                 service left_disk(disk)[Disk] in left_group
                 service right_disk(disk)[Disk] in right_group
                 service top_disk(disk)[Disk] in top_group
                 service bottom_disk(disk)[Disk] in bottom_group
                 service center_disk(disk)[Disk] in center_group
-        
-                left_disk{group} (R--L) center_disk{group}
-                right_disk{group} (L--R) center_disk{group}
-                top_disk{group} (B--T) center_disk{group}
-                bottom_disk{group} (T--B) center_disk{group}
+
+                left_disk{group}:R <--> L:center_disk{group}
+                right_disk{group}:L <--> R:center_disk{group}
+                top_disk{group}:B <--> T:center_disk{group}
+                bottom_disk{group}:T <--> B:center_disk{group}
             `
     );
   });
@@ -113,16 +113,16 @@ describe.skip('architecture diagram', () => {
                 service servR(server)[Server 3]
                 service servT(server)[Server 4]
                 service servB(server)[Server 5]
-        
-                servC L-[Label]-R servL
-                servC R-[Label]-L servR
-                servC T-[Label]-B servT
-                servC B-[Label]-T servB
-        
-                servL T-[Label]-L servT
-                servL B-[Label]-L servB
-                servR T-[Label]-R servT
-                servR B-[Label]-R servB
+
+                servC:L-[Label]-R:servL
+                servC:R-[Label]-L:servR
+                servC:T-[Label]-B:servT
+                servC:B-[Label]-T:servB
+
+                servL:T-[Label]-L:servT
+                servL:B-[Label]-L:servB
+                servR:T-[Label]-R:servT
+                servR:B-[Label]-R:servB
             `
     );
   });
@@ -136,13 +136,13 @@ describe.skip('architecture diagram', () => {
                 service bottom_gateway(internet)[Gateway]
                 junction juncC
                 junction juncR
-        
-                left_disk R--L juncC
-                top_disk B--T juncC
-                bottom_disk T--B juncC
-                juncC R--L juncR
-                top_gateway B--T juncR
-                bottom_gateway T--B juncR
+
+                left_disk:R -- L:juncC
+                top_disk:B -- T:juncC
+                bottom_disk:T -- B:juncC
+                juncC:R -- L:juncR
+                top_gateway:B -- T:juncR
+                bottom_gateway:T -- B:juncR
             `
     );
   });
@@ -158,23 +158,46 @@ describe.skip('architecture diagram', () => {
                 service bottom_gateway(internet)[Gateway] in right
                 junction juncC in left
                 junction juncR in right
-        
-                left_disk R--L juncC
-                top_disk B--T juncC
-                bottom_disk T--B juncC
-        
-        
-                top_gateway (B--T juncR
-                bottom_gateway (T--B juncR
-        
-                juncC{group} R--L) juncR{group}
+
+                left_disk:R -- L:juncC
+                top_disk:B -- T:juncC
+                bottom_disk:T -- B:juncC
+
+
+                top_gateway:B <-- T:juncR
+                bottom_gateway:T <-- B:juncR
+
+                juncC{group}:R --> L:juncR{group}
+            `
+    );
+  });
+
+  it('should render unicode', () => {
+    imgSnapshotTest(
+      `architecture-beta
+                service left_disk(disk)[Disk]
+                service right_disk(disk)["❤ Disk"]
+
+                left_disk:R -- L:right_disk
+            `
+    );
+  });
+
+  it('should render markdown', () => {
+    imgSnapshotTest(
+      `architecture-beta
+                service left_disk(disk)["\`This **is** _Markdown_\`"]
+                service right_disk(disk)["\`Line1
+                  Line 2
+                  Line 3\`"]
+
+                left_disk:R -- L:right_disk
             `
     );
   });
 });
 
-// Skipped as the layout is not deterministic, and causes issues in E2E tests.
-describe.skip('architecture - external', () => {
+describe('architecture - external', () => {
   it('should allow adding external icons', () => {
     urlSnapshotTest('http://localhost:9000/architecture-external.html');
   });

--- a/cypress/platform/architecture-external.html
+++ b/cypress/platform/architecture-external.html
@@ -21,6 +21,11 @@
       service ec2(logos:aws-ec2)[Server]
       service api(logos:aws-api-gateway)[Api Gateway]
       service fa(fa:image)[Font Awesome Icon]
+
+      api:L -- R:ec2
+      api:B -- T:s3
+      fa:L -- R:s3
+      fa:T -- B:ec2
     </pre>
 
     <script type="module">

--- a/demos/architecture.html
+++ b/demos/architecture.html
@@ -24,7 +24,7 @@
         service disk1(disk)[Storage] in api
         service disk2(disk)[Storage] in api
         service server(server)[Server] in api
-        service gateway(internet)[Gateway] 
+        service gateway(internet)[Gateway]
 
         db:L -- R:server
         disk1:T -- B:server
@@ -226,6 +226,40 @@
     </pre>
     <hr />
 
+    <h2>Unicode</h2>
+    <pre class="mermaid">
+      architecture-beta
+        service left_disk(disk)["someone@example.com"]
+        service right_disk(disk)["❤ Disk"]
+
+        left_disk:R -- L:right_disk
+    </pre>
+    <hr />
+
+    <h2>Markdown</h2>
+    <pre class="mermaid">
+      architecture-beta
+        service left_disk(disk)["`This **is** _Markdown_`"]
+        service right_disk(disk)["`Line1
+                Line 2
+                Line 3`"]
+
+        left_disk:R -- L:right_disk
+    </pre>
+    <hr />
+
+    <h2>Katex</h2>
+    <pre class="mermaid">
+      architecture-beta
+        service left_disk(disk)["`$$f(\relax{x}) = \int_{-\infty}^\infty \hat{f}(\xi)\,e^{2 \pi i \xi x}\,d\xi$$`"]
+        service center_disk(disk)["`$$\Bigg(\bigg(\Big(\big((\frac{-b\pm\sqrt{b^2-4ac}}{2a})\big)\Big)\bigg)\Bigg)$$`"]
+        service right_disk(disk)["`$$1+\frac{e^{-2\pi}} {1+\frac{e^{-4\pi}} {1+\frac{e^{-6\pi}} {1+\frac{e^{-8\pi}} {1+\cdots}}}}$$`"]
+
+        left_disk:R -- L:center_disk
+        center_disk:R -- L:right_disk
+    </pre>
+    <hr />
+
     <h2>External Icons Demo</h2>
     <pre class="mermaid">
     architecture-beta
@@ -233,6 +267,11 @@
       service ec2(logos:aws-ec2)[Server]
       service api(logos:aws-api-gateway)[Api Gateway]
       service fa(fa:image)[Font Awesome Icon]
+
+      api:L -- R:ec2
+      api:B -- T:s3
+      fa:L -- R:s3
+      fa:T -- B:ec2
     </pre>
 
     <script type="module">

--- a/packages/mermaid/src/rendering-util/handle-markdown-text.spec.ts
+++ b/packages/mermaid/src/rendering-util/handle-markdown-text.spec.ts
@@ -307,3 +307,7 @@ test('markdownToHTML - auto wrapping', () => {
     )
   ).toMatchInlineSnapshot('"<p>Hello, how do<br/>you do?</p>"');
 });
+
+test('markdownToHTML - email address', () => {
+  expect(markdownToHTML(`henri@test.fr`)).toMatchInlineSnapshot('"<p>henri@test.fr</p>"');
+});

--- a/packages/mermaid/src/rendering-util/handle-markdown-text.ts
+++ b/packages/mermaid/src/rendering-util/handle-markdown-text.ts
@@ -88,6 +88,8 @@ export function markdownToHTML(markdown: string, { markdownAutoWrap }: MermaidCo
       return `${node.text}`;
     } else if (node.type === 'escape') {
       return node.text;
+    } else if (node.type === 'link') {
+      return node.text;
     }
     return `Unsupported markdown: ${node.type}`;
   }

--- a/packages/parser/src/language/architecture/architecture.langium
+++ b/packages/parser/src/language/architecture/architecture.langium
@@ -3,12 +3,8 @@ import "../common/common";
 
 entry Architecture:
     NEWLINE*
-    "architecture-beta"
-    (
-    NEWLINE* TitleAndAccessibilities
-    | NEWLINE* Statement*
-    | NEWLINE*
-    )
+    "architecture-beta" EOL
+    TitleAndAccessibilities? Statement*
 ;
 
 fragment Statement:
@@ -50,6 +46,8 @@ terminal ARROW_DIRECTION: 'L' | 'R' | 'T' | 'B';
 terminal ARCH_ID: /[\w]+/;
 terminal ARCH_TEXT_ICON: /\("[^"]+"\)/;
 terminal ARCH_ICON: /\([\w-:]+\)/;
-terminal ARCH_TITLE: /\[[\w ]+\]/;
+terminal fragment ARCH_TITLE_MARKDOWN: '["`' -> '`"]';
+terminal fragment ARCH_TITLE_SIMPLE: /\[([\w ]+|"([^"]|\\")+")\]/;
+terminal ARCH_TITLE: ARCH_TITLE_MARKDOWN | ARCH_TITLE_SIMPLE;
 terminal ARROW_GROUP: /\{group\}/;
 terminal ARROW_INTO: /<|>/;

--- a/packages/parser/src/language/architecture/valueConverter.ts
+++ b/packages/parser/src/language/architecture/valueConverter.ts
@@ -13,7 +13,18 @@ export class ArchitectureValueConverter extends AbstractMermaidValueConverter {
     } else if (rule.name === 'ARCH_TEXT_ICON') {
       return input.replace(/["()]/g, '');
     } else if (rule.name === 'ARCH_TITLE') {
-      return input.replace(/[[\]]/g, '').trim();
+      if (input.startsWith('["`') && input.endsWith('`"]')) {
+        // markdown
+        return input.substring(3, input.length - 3).trim();
+      } else if (input.startsWith('["')) {
+        // unicode or markdown
+        return input
+          .substring(2, input.length - 2)
+          .replace(/\\"/g, '"')
+          .trim();
+      }
+      // simple
+      return input.substring(1, input.length - 1).trim();
     }
     return undefined;
   }

--- a/packages/parser/tests/architecture.test.ts
+++ b/packages/parser/tests/architecture.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import { Architecture } from '../src/index.js';
+import { expectNoErrorsOrAlternatives, architectureParse as parse } from './test-util.js';
+
+describe('architecture', () => {
+  it.each([
+    `architecture-beta`,
+    `  architecture-beta  `,
+    `\tarchitecture-beta\t`,
+    `
+    \tarchitecture-beta
+    `,
+  ])('should handle regular architecture-beta', (context: string) => {
+    const result = parse(context);
+    expectNoErrorsOrAlternatives(result);
+    expect(result.value.$type).toBe(Architecture);
+  });
+
+  it('should not allow architecture-beta & group in same line', () => {
+    const result = parse(`architecture-beta group api(cloud)[API]`);
+    expect(result.parserErrors).toHaveLength(1);
+    expect(result.parserErrors[0].message).toBe(
+      'Expecting: one of these possible Token sequences:\n' +
+        '  1. [NEWLINE]\n' +
+        '  2. [EOF]\n' +
+        "but found: 'group'"
+    );
+  });
+
+  it.each([
+    `architecture-beta
+    group api(cloud)[API]`,
+    `architecture-beta
+    group api(cloud)[API]
+    `,
+    `architecture-beta
+    group api(cloud)[API]`,
+    `architecture-beta
+    group api(cloud)[API]
+    `,
+  ])('should handle architecture-beta + group in different line', (context: string) => {
+    const result = parse(context);
+    expectNoErrorsOrAlternatives(result);
+    expect(result.value.$type).toBe(Architecture);
+
+    const { groups } = result.value;
+    expect(groups[0].title).toBe('API');
+  });
+
+  it.each([
+    `architecture-beta
+     group api(cloud)["a.b-t"]`,
+    `architecture-beta
+     group api(cloud)["user:password@some_domain.com"]
+    `,
+  ])('should handle special character in a title', (context: string) => {
+    const result = parse(context);
+    expectNoErrorsOrAlternatives(result);
+    expect(result.value.$type).toBe(Architecture);
+
+    const { groups } = result.value;
+    expect(groups[0]).toBeTruthy();
+  });
+
+  it.each([
+    `architecture-beta
+     group api(cloud)["\`The **cat** in the hat\`"]`,
+    `architecture-beta
+     group api(cloud)["\`The *bat*
+      in the chat\`"]
+    `,
+  ])('should handle markdown in a title', (context: string) => {
+    const result = parse(context);
+    expectNoErrorsOrAlternatives(result);
+    expect(result.value.$type).toBe(Architecture);
+
+    const { groups } = result.value;
+    expect(groups[0].title).toBeTruthy();
+  });
+
+  it('should handle unicode', () => {
+    const result = parse(`architecture-beta
+     group api(cloud)["Начало"]`);
+    expectNoErrorsOrAlternatives(result);
+    expect(result.value.$type).toBe(Architecture);
+
+    const { groups } = result.value;
+    expect(groups[0].title).toBe('Начало');
+  });
+
+  it('should handle escaping "', () => {
+    const result = parse('architecture-beta\ngroup api(cloud)["\\"Начало\\""]');
+    expectNoErrorsOrAlternatives(result);
+    expect(result.value.$type).toBe(Architecture);
+
+    const { groups } = result.value;
+    expect(groups[0].title).toBe('"Начало"');
+  });
+});

--- a/packages/parser/tests/test-util.ts
+++ b/packages/parser/tests/test-util.ts
@@ -7,11 +7,14 @@ import type {
   PieServices,
   GitGraph,
   GitGraphServices,
+  Architecture,
+  ArchitectureServices,
 } from '../src/language/index.js';
 import {
   createInfoServices,
   createPieServices,
   createGitGraphServices,
+  createArchitectureServices,
 } from '../src/language/index.js';
 
 const consoleMock = vi.spyOn(console, 'log').mockImplementation(() => undefined);
@@ -62,3 +65,14 @@ export function createGitGraphTestServices() {
   return { services: gitGraphServices, parse };
 }
 export const gitGraphParse = createGitGraphTestServices().parse;
+
+const architectureServices: ArchitectureServices = createArchitectureServices().Architecture;
+const architectureParser: LangiumParser = architectureServices.parser.LangiumParser;
+export function createArchitectureTestServices() {
+  const parse = (input: string) => {
+    return architectureParser.parse<Architecture>(input);
+  };
+
+  return { services: architectureServices, parse };
+}
+export const architectureParse = createArchitectureTestServices().parse;


### PR DESCRIPTION
## :bookmark_tabs: Summary

Allows any character between `[` and `]` for architecture diagram titles.

Resolves #5928 

## :straight_ruler: Design Decisions

Change of regex to allow any character. Also had to tweak the `entry Architecture` rule as tests were claiming ambiguity.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
