### PR TITLE
Fix code block typo in syntax-reference.md

### DIFF
--- a/packages/mermaid/src/docs/intro/syntax-reference.md
+++ b/packages/mermaid/src/docs/intro/syntax-reference.md
@@ -149,8 +149,9 @@ flowchart LR
   B -->|Option 1| C[Path 1]
   B -->|Option 2| D[Path 2]
 
-#### Using Dagre Layout with Classic Look:
 ```
+
+#### Using Dagre Layout with Classic Look:
 
 Another example:
 


### PR DESCRIPTION

## :bookmark_tabs: Summary

The subheading "Using Dagre Layout with Classic Look:" is inside the Example configuration code block. I moved the line to below the closing backticks of the previous code block so that it can render as a h4.


### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
