### PR TITLE
Correct LaTeX Syntax for Inline Math in math.md Documentation

### DIFF
--- a/docs/config/math.md
+++ b/docs/config/math.md
@@ -20,16 +20,16 @@ Note that at the moment, the only supported diagrams are below:
  graph LR
       A["$$x^2$$"] -->|"$$\sqrt{x+3}$$"| B("$$\frac{1}{2}$$")
       A -->|"$$\overbrace{a+b+c}^{\text{note}}$$"| C("$$\pi r^2$$")
-      B --> D("$$x = \begin{cases} a &\text{if } b \\ c &\text{if } d \end{cases}$$")
-      C --> E("$$x(t)=c_1\begin{bmatrix}-\cos{t}+\sin{t}\\ 2\cos{t} \end{bmatrix}e^{2t}$$")
+      B --> D("$$x = \begin{cases} a &\text{if } b \\\ c &\text{if } d \end{cases}$$")
+      C --> E("$$x(t)=c_1\begin{bmatrix}-\cos{t}+\sin{t}\\\ 2\cos{t} \end{bmatrix}e^{2t}$$")
 ```
 
 ```mermaid
  graph LR
       A["$$x^2$$"] -->|"$$\sqrt{x+3}$$"| B("$$\frac{1}{2}$$")
       A -->|"$$\overbrace{a+b+c}^{\text{note}}$$"| C("$$\pi r^2$$")
-      B --> D("$$x = \begin{cases} a &\text{if } b \\ c &\text{if } d \end{cases}$$")
-      C --> E("$$x(t)=c_1\begin{bmatrix}-\cos{t}+\sin{t}\\ 2\cos{t} \end{bmatrix}e^{2t}$$")
+      B --> D("$$x = \begin{cases} a &\text{if } b \\\ c &\text{if } d \end{cases}$$")
+      C --> E("$$x(t)=c_1\begin{bmatrix}-\cos{t}+\sin{t}\\\ 2\cos{t} \end{bmatrix}e^{2t}$$")
 ```
 
 ### Sequence

--- a/packages/mermaid/src/docs/config/math.md
+++ b/packages/mermaid/src/docs/config/math.md
@@ -14,8 +14,8 @@ Note that at the moment, the only supported diagrams are below:
  graph LR
       A["$$x^2$$"] -->|"$$\sqrt{x+3}$$"| B("$$\frac{1}{2}$$")
       A -->|"$$\overbrace{a+b+c}^{\text{note}}$$"| C("$$\pi r^2$$")
-      B --> D("$$x = \begin{cases} a &\text{if } b \\ c &\text{if } d \end{cases}$$")
-      C --> E("$$x(t)=c_1\begin{bmatrix}-\cos{t}+\sin{t}\\ 2\cos{t} \end{bmatrix}e^{2t}$$")
+      B --> D("$$x = \begin{cases} a &\text{if } b \\\ c &\text{if } d \end{cases}$$")
+      C --> E("$$x(t)=c_1\begin{bmatrix}-\cos{t}+\sin{t}\\\ 2\cos{t} \end{bmatrix}e^{2t}$$")
 ```
 
 ### Sequence


### PR DESCRIPTION
## :bookmark_tabs: Summary

This PR fixes an issue with the LaTeX example in `math.md`. It ensures proper rendering and alignment of the example within the documentation.

## :straight_ruler: Design Decisions

- Fixed the LaTeX example to properly render inline math equations.

### :framed_picture: Screenshots

**Before:**

![image](https://github.com/user-attachments/assets/4d9b4d1d-0922-4959-9bc3-4d7c7ae5d13e)

**After:**

![image](https://github.com/user-attachments/assets/9effb435-b54d-45e1-a64d-086964affb8e)

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)