### PR TITLE
feat(state): add from, to ids for edge

### DIFF
--- a/packages/mermaid/src/diagrams/state/dataFetcher.js
+++ b/packages/mermaid/src/diagrams/state/dataFetcher.js
@@ -1,4 +1,4 @@
-import { getEdgeId } from '$root/utils.js';
+import { getEdgeId } from '../../utils.js';
 import { getConfig } from '../../diagram-api/diagramAPI.js';
 import { log } from '../../logger.js';
 import common from '../common/common.js';

--- a/packages/mermaid/src/diagrams/state/dataFetcher.js
+++ b/packages/mermaid/src/diagrams/state/dataFetcher.js
@@ -1,3 +1,4 @@
+import { getEdgeId } from '$root/utils.js';
 import { getConfig } from '../../diagram-api/diagramAPI.js';
 import { log } from '../../logger.js';
 import common from '../common/common.js';
@@ -88,7 +89,10 @@ const setupDoc = (parentParsedItem, doc, diagramStates, nodes, edges, altFlag, l
             classes
           );
           const edgeData = {
-            id: 'edge' + graphItemCount,
+            id: getEdgeId(item.state1.id, item.state2.id, {
+              counter: graphItemCount,
+              prefix: 'edge',
+            }),
             start: item.state1.id,
             end: item.state2.id,
             arrowhead: 'normal',
@@ -349,7 +353,7 @@ export const dataFetcher = (
       }
 
       edges.push({
-        id: from + '-' + to,
+        id: getEdgeId(from, to, { prefix: 'edge' }),
         start: from,
         end: to,
         arrowhead: 'none',

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
@@ -26,7 +26,7 @@ import {
 import { log } from '../../../logger.js';
 import { getSubGraphTitleMargins } from '../../../utils/subGraphTitleMargins.js';
 import { getConfig } from '../../../diagram-api/diagramAPI.js';
-import { getEdgeId } from '$root/utils.js';
+import { getEdgeId } from '../../../utils.js';
 
 const recursiveRender = async (_elem, graph, diagramType, id, parentCluster, siteConfig) => {
   log.warn('Graph in recursive render:XAX', graphlibJson.write(graph), parentCluster);

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
@@ -26,6 +26,7 @@ import {
 import { log } from '../../../logger.js';
 import { getSubGraphTitleMargins } from '../../../utils/subGraphTitleMargins.js';
 import { getConfig } from '../../../diagram-api/diagramAPI.js';
+import { getEdgeId } from '$root/utils.js';
 
 const recursiveRender = async (_elem, graph, diagramType, id, parentCluster, siteConfig) => {
   log.warn('Graph in recursive render:XAX', graphlibJson.write(graph), parentCluster);
@@ -345,15 +346,21 @@ export const render = async (data4Layout, svg) => {
       const edge2 = structuredClone(edge);
       edge1.label = '';
       edge1.arrowTypeEnd = 'none';
-      edge1.id = nodeId + '-cyclic-special-1';
+      edge1.id = getEdgeId(nodeId, nodeId, {
+        counter: 'cyclic-special-1',
+      });
       edgeMid.arrowTypeEnd = 'none';
-      edgeMid.id = nodeId + '-cyclic-special-mid';
+      edgeMid.id = getEdgeId(nodeId, nodeId, {
+        counter: 'cyclic-special-mid',
+      });
       edge2.label = '';
       if (node.isGroup) {
         edge1.fromCluster = nodeId;
         edge2.toCluster = nodeId;
       }
-      edge2.id = nodeId + '-cyclic-special-2';
+      edge2.id = getEdgeId(nodeId, nodeId, {
+        counter: 'cyclic-special-2',
+      });
       graph.setEdge(nodeId, specialId1, edge1, nodeId + '-cyclic-special-0');
       graph.setEdge(specialId1, specialId2, edgeMid, nodeId + '-cyclic-special-1');
       graph.setEdge(specialId2, nodeId, edge2, nodeId + '-cyc<lic-special-2');

--- a/packages/mermaid/src/utils.ts
+++ b/packages/mermaid/src/utils.ts
@@ -939,7 +939,7 @@ export const getEdgeId = (
     suffix?: string;
   }
 ) => {
-  return `${prefix ? `${prefix}_` : ''}${from}_${to}_${counter}${suffix ? `_${suffix}` : ''}`;
+  return `${prefix ? `${prefix}__` : ''}${from}__${to}__${counter}${suffix ? `__${suffix}` : ''}`;
 };
 
 /**


### PR DESCRIPTION
## :bookmark_tabs: Summary

This PR reintroduces FROM-TO id in Edges.

https://github.com/mermaid-js/mermaid/pull/5503

<img width="917" alt="Captura de Tela 2024-11-08 às 11 15 48" src="https://github.com/user-attachments/assets/8d2bd4c0-c4b5-4a44-9cc1-6681cac85218">

## :straight_ruler: Design Decisions

I am currently working on converting state diagram to Excalidraw, and I felt the need to have an easier way to find the edges.

I tried some alternative paths but without success, for example:

1. Manually tracking each edge, and using it as an index to search in `.edgePaths`, however, the index does not always reflect how we iterate through the parser.doc.
2. Using the respective `graphCount` id to get the edge, but in cases where we have multiple relationships for the same state, it may not find the correct edge because we do not have access to the `graphCount` in the parser.doc, only to the node id.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :bookmark: targeted `develop` branch
