### PR TITLE
fix: some demo ELK plugin imports and loads

### DIFF
--- a/demos/dev/example.html
+++ b/demos/dev/example.html
@@ -39,8 +39,8 @@ graph TB
 
     <script type="module">
       import mermaid from '/mermaid.esm.mjs';
-      import flowchartELK from '/mermaid-flowchart-elk.esm.mjs';
-      await mermaid.registerExternalDiagrams([flowchartELK]);
+      import layouts from '/mermaid-layout-elk.esm.mjs';
+      mermaid.registerLayoutLoaders(layouts);
       async function render(str) {
         const { svg } = await mermaid.render('dynamic', str);
         document.getElementById('dynamicDiagram').innerHTML = svg;

--- a/demos/flowchart-elk.html
+++ b/demos/flowchart-elk.html
@@ -25,8 +25,8 @@
 
     <script type="module">
       import mermaid from './mermaid.esm.mjs';
-      import flowchartELK from './mermaid-flowchart-elk.esm.mjs';
-      await mermaid.registerExternalDiagrams([flowchartELK]);
+      import layouts from './mermaid-layout-elk.esm.mjs';
+      mermaid.registerLayoutLoaders(layouts);
       mermaid.initialize({
         logLevel: 3,
       });

--- a/demos/index.html
+++ b/demos/index.html
@@ -41,6 +41,9 @@
         <h2><a href="./flowchart.html">Flow charts</a></h2>
       </li>
       <li>
+        <h2><a href="./flowchart-elk.html">Flow charts ELK</a></h2>
+      </li>
+      <li>
         <h2><a href="./gantt.html">Gantt</a></h2>
       </li>
       <li>

--- a/demos/index.html
+++ b/demos/index.html
@@ -41,6 +41,9 @@
         <h2><a href="./flowchart.html">Flow charts</a></h2>
       </li>
       <li>
+        <h2><a href="./flowchart-elk.html">Flow charts ELK</a></h2>
+      </li>
+      <li>
         <h2>
           <a href="./flowchart_expanded_node_shapes.html">Flowchart - expanded node shapes</a>
         </h2>


### PR DESCRIPTION
## :bookmark_tabs: Summary
Fix some demo ELK plugin imports and loads.
In particular, it fixes an issue where http://localhost:9000/dev/example.html would crash.

## :straight_ruler: Design Decisions

This method can be found in the repository by searching for the word: `mermaid-layout-elk.esm.mjs`.

```diff
-      import flowchartELK from './mermaid-flowchart-elk.esm.mjs';
-      await mermaid.registerExternalDiagrams([flowchartELK]);
+      import layouts from './mermaid-layout-elk.esm.mjs';
+      mermaid.registerLayoutLoaders(layouts);
```
### :clipboard: Tasks

This PR does not change any application code.

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)

