### PR TITLE
fix: Display no arrows for open links

### DIFF
--- a/.changeset/six-tigers-clap.md
+++ b/.changeset/six-tigers-clap.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+Display no arrows for open links

--- a/packages/mermaid/src/diagrams/flowchart/flowDb.spec.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.spec.ts
@@ -65,3 +65,36 @@ describe('flow db addClass', () => {
     expect(classes.get('a')?.styles).toEqual(['stroke-width: 8px']);
   });
 });
+
+describe('flow db getData', () => {
+  beforeEach(() => {
+    flowDb.clear();
+  });
+  it('should end in point for for single directional arrows', () => {
+    flowDb.addLink(['A'], ['B'], { type: 'arrow_point' });
+
+    const { edges } = flowDb.getData();
+
+    expect(edges.length).toBe(1);
+    expect(edges[0].arrowTypeStart).toBe('none');
+    expect(edges[0].arrowTypeEnd).toBe('arrow_point');
+  });
+  it('should start and end in points for multi directional arrows', () => {
+    flowDb.addLink(['A'], ['B'], { type: 'double_arrow_point' });
+
+    const { edges } = flowDb.getData();
+
+    expect(edges.length).toBe(1);
+    expect(edges[0].arrowTypeStart).toBe('arrow_point');
+    expect(edges[0].arrowTypeEnd).toBe('arrow_point');
+  });
+  it('should have no points for open arrows', () => {
+    flowDb.addLink(['A'], ['B'], { type: 'arrow_open' });
+
+    const { edges } = flowDb.getData();
+
+    expect(edges.length).toBe(1);
+    expect(edges[0].arrowTypeStart).toBe('none');
+    expect(edges[0].arrowTypeEnd).toBe('none');
+  });
+});

--- a/packages/mermaid/src/diagrams/flowchart/flowDb.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.ts
@@ -872,6 +872,9 @@ const destructEdgeType = (type: string | undefined) => {
       arrowTypeStart = type.replace('double_', '');
       arrowTypeEnd = arrowTypeStart;
       break;
+    case 'arrow_open':
+      arrowTypeEnd = 'none';
+      break;
   }
   return { arrowTypeStart, arrowTypeEnd };
 };


### PR DESCRIPTION
## :bookmark_tabs: Summary

In Flowcharts "Open links" (Links with no direction) are currently being displayed with single-directional arrows.

I believe this started occurring sometime in v11.

This change makes it so open links display with no arrow on their start or end.

Resolves https://github.com/mermaid-js/mermaid/issues/6020

## :straight_ruler: Design Decisions

Edges of type `arrow_open` should be treated as a special case, they are neither a single or `double_` directional arrow.

I've added tests for single and double directional arrows to make the difference in use-case easier to see.

**Example Before Change**

![mermaid-local-docs-before-change](https://github.com/user-attachments/assets/4fc61d42-f4cd-491d-be31-1ac0920c8189)

**Example After Change**

![mermaid-local-docs-after-change](https://github.com/user-attachments/assets/afd93a39-4296-4664-80c9-591c3e64ba23)


### :clipboard: Tasks

I have:

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
