### PR TITLE
#5858 - fix: Timeline node width made dynamic

### DIFF
--- a/cypress/integration/rendering/timeline.spec.ts
+++ b/cypress/integration/rendering/timeline.spec.ts
@@ -161,4 +161,42 @@ describe('Timeline diagram', () => {
       {}
     );
   });
+
+  it('11: should render a simple timeline with a custom width of 300', () => {
+    imgSnapshotTest(
+      `%%{init: { 'logLevel': 'debug', 'timeline': { 'width': 300 } } }%%
+    timeline
+        title History of Social Media Platform
+          2002 : LinkedIn
+          2004 : Facebook : Google
+          2005 : Youtube
+          2006 : Twitter
+          2007 : Tumblr
+          2008 : Instagram
+          2010 : Pinterest
+      `,
+      {
+        timeline: {
+          width: 300,
+        },
+      }
+    );
+  });
+
+  it('12: should render a simple timeline with default width of 150', () => {
+    imgSnapshotTest(
+      `%%{init: { 'logLevel': 'debug', 'timeline': { 'width': 150 } } }%%
+    timeline
+        title History of Social Media Platform
+          2002 : LinkedIn
+          2004 : Facebook : Google
+          2005 : Youtube
+          2006 : Twitter
+          2007 : Tumblr
+          2008 : Instagram
+          2010 : Pinterest
+      `,
+      {}
+    );
+  });
 });

--- a/packages/mermaid/src/diagrams/timeline/timelineRenderer.ts
+++ b/packages/mermaid/src/diagrams/timeline/timelineRenderer.ts
@@ -322,6 +322,11 @@ export const drawEvents = function (
   let maxEventHeight = 0;
   const eventBeginY = masterY;
   masterY = masterY + 100;
+
+  const DEFAULT_NODE_WIDTH = 150;
+
+  const nodeWidth = conf?.timeline?.width ?? DEFAULT_NODE_WIDTH;
+
   // Draw the events
   for (const event of events) {
     // create node from event
@@ -329,7 +334,7 @@ export const drawEvents = function (
       descr: event,
       section: sectionColor,
       number: sectionColor,
-      width: 150,
+      width: nodeWidth,
       padding: 20,
       maxHeight: 50,
     };


### PR DESCRIPTION

## :bookmark_tabs: Summary

In [timelineRenderer](https://github.com/afmireski/mermaid/blob/146b86ccea1b1ddc61240cbce3e3aedb1507fe1d/packages/mermaid/src/diagrams/timeline/timelineRenderer.ts), the width of the timeline diagram nodes is hardcoded, making width configuration changes ineffective.

Resolves #5858 

## :straight_ruler: Design Decisions

Extract the hardcoded value, defined [here](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/diagrams/timeline/timelineRenderer.ts?rgh-link-date=2024-09-13T04%3A46%3A14Z#L332), into a constant and use it as the default if the node width is not specified in the timeline configuration.
I've added tests to verify the application of both the default and custom widths.


### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
