### PR TITLE
Fix: flowchart-elk e2e test #6102

### DIFF
--- a/cypress/integration/rendering/flowchart-elk.spec.js
+++ b/cypress/integration/rendering/flowchart-elk.spec.js
@@ -109,7 +109,7 @@ describe('Flowchart ELK', () => {
       const style = svg.attr('style');
       expect(style).to.match(/^max-width: [\d.]+px;$/);
       const maxWidthValue = parseFloat(style.match(/[\d.]+/g).join(''));
-      expect(maxWidthValue).to.be.within(230 * 0.95, 230 * 1.05);
+      expect(maxWidthValue).to.be.within(390 * 0.95, 390 * 1.05);
     });
   });
   it('8-elk: should render a flowchart when useMaxWidth is false', () => {
@@ -128,7 +128,7 @@ describe('Flowchart ELK', () => {
       const width = parseFloat(svg.attr('width'));
       // use within because the absolute value can be slightly different depending on the environment ±5%
       // expect(height).to.be.within(446 * 0.95, 446 * 1.05);
-      expect(width).to.be.within(230 * 0.95, 230 * 1.05);
+      expect(width).to.be.within(390 * 0.95, 390 * 1.05);
       expect(svg).to.not.have.attr('style');
     });
   });
@@ -692,7 +692,7 @@ A --> B
       {}
     );
     cy.get('svg').should((svg) => {
-      const edges = svg.querySelectorAll('.edges > path');
+      const edges = svg[0].querySelectorAll('.edges > path');
       edges.forEach((edge) => {
         expect(edge).to.have.class('flowchart-link');
       });
@@ -743,10 +743,10 @@ NL\`") --"\`1o **bold**\`"--> c
         imgSnapshotTest(
           `%%{init: {"flowchart": {"htmlLabels": true}} }%%
 flowchart-elk LR
-b(\`The dog in **the** hog.(1).. a a a a *very long text* about it
+b("The dog in **the** hog.(1).. a a a a *very long text* about it
 Word!
 
-Another line with many, many words. Another line with many, many words. Another line with many, many words. Another line with many, many words. Another line with many, many words. Another line with many, many words. Another line with many, many words. Another line with many, many words. \`) --> c
+Another line with many, many words. Another line with many, many words. Another line with many, many words. Another line with many, many words. Another line with many, many words. Another line with many, many words. Another line with many, many words. Another line with many, many words. ") --> c
 
 `,
           { flowchart: { titleTopMargin: 0 } }
@@ -841,7 +841,7 @@ end
           { flowchart: { titleTopMargin: 0 } }
         );
       });
-      it('Sub graphs and markdown strings', () => {
+      it('Sub graphs and markdown strings2', () => {
         imgSnapshotTest(
           `---
 config:


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fix e2e test for flowchart-elk.

Resolves #6102

## :straight_ruler: Design Decisions

- change maxWidthValue range for "7-elk" and "8-elk".
- change `svg.querySelectorAll` to `svg[0].querySelectorAll` because of type errror.
- change  `` ` `` to ` " ` in mermaid text for "Wrapping long text with a new line", because back quote is invalid syntax.
- rename duplicate test name: "Sub graphs and markdown strings".

Changing the expectation instead of the implementation could break compatibility, but in this case, I believe it’s fine.

This is because the changed part was enabled when CI was stopped, so it hadn’t been tested before.

To explain further, `describe('Flowchart ELK')` was `describe.skip('Flowchart ELK')` until 0dff4ca. When this commit was merged, the e2e tests weren’t running due to API rate limits.


### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] ~~:notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.~~ unnecessary
- [x] ~~:butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.~~ unnecessary
