### PR TITLE
Fix #6056 allows all characters except [ and ]

### DIFF
--- a/.changeset/weak-carpets-cross.md
+++ b/.changeset/weak-carpets-cross.md
@@ -1,0 +1,5 @@
+---
+'@mermaid-js/parser': patch
+---
+
+fix: Allow most characters in architecture node titles

--- a/demos/architecture.html
+++ b/demos/architecture.html
@@ -64,6 +64,14 @@
     </pre>
     <hr />
 
+    <h2>Non-Alphanumeric Title</h2>
+    <pre class="mermaid">
+      architecture-beta
+        service noalpha(server)[Non-Alpha]
+        service noalpha2(disk)[A/B/C]
+    </pre>
+    <hr />
+
     <h2>Split Direction</h2>
     <pre class="mermaid">
       architecture-beta

--- a/packages/parser/src/language/architecture/architecture.langium
+++ b/packages/parser/src/language/architecture/architecture.langium
@@ -4,10 +4,10 @@ import "../common/common";
 entry Architecture:
     NEWLINE*
     "architecture-beta"
+    NEWLINE*
     (
-    NEWLINE* TitleAndAccessibilities
-    | NEWLINE* Statement*
-    | NEWLINE*
+    TitleAndAccessibilities
+    | Statement*
     )
 ;
 
@@ -50,6 +50,6 @@ terminal ARROW_DIRECTION: 'L' | 'R' | 'T' | 'B';
 terminal ARCH_ID: /[\w]+/;
 terminal ARCH_TEXT_ICON: /\("[^"]+"\)/;
 terminal ARCH_ICON: /\([\w-:]+\)/;
-terminal ARCH_TITLE: /\[[\w ]+\]/;
+terminal ARCH_TITLE: /\[[^[\]]+\]/;
 terminal ARROW_GROUP: /\{group\}/;
 terminal ARROW_INTO: /<|>/;

--- a/packages/parser/tests/architecture.test.ts
+++ b/packages/parser/tests/architecture.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { Architecture } from '../src/language/index.js';
+import { expectNoErrorsOrAlternatives, architectureParse as parse } from './test-util.js';
+
+describe('architecture', () => {
+  it.each([
+    `architecture-beta`,
+    `  architecture-beta  `,
+    `\tarchitecture-beta\t`,
+    `
+    \tarchitecture-beta
+    `,
+    `
+
+
+    \tarchitecture-beta
+
+
+
+    `,
+  ])('should handle regular architecture', (context: string) => {
+    const result = parse(context);
+    expectNoErrorsOrAlternatives(result);
+    expect(result.value.$type).toBe(Architecture);
+  });
+
+  it.each([
+    `architecture-beta
+
+      group foo(cloud)`,
+    `architecture-beta
+
+      service foo(server)
+
+      `,
+  ])('should handle group and service', (context: string) => {
+    const result = parse(context);
+    expectNoErrorsOrAlternatives(result);
+    expect(result.value.$type).toBe(Architecture);
+  });
+
+  it.each([
+    `architecture-beta
+      service foo(cloud)[Foo]
+      service bar(cloud)[Foo-Bar]
+      service bar2(cloud)[Foo/Bar]
+      service bar3(cloud)[Foo:Bar]
+      service bar4(cloud)["Foo:Bar"]
+      `,
+  ])('should handle labels with non-alpha characters', (context: string) => {
+    const result = parse(context);
+    expectNoErrorsOrAlternatives(result);
+    expect(result.value.$type).toBe(Architecture);
+  });
+});

--- a/packages/parser/tests/test-util.ts
+++ b/packages/parser/tests/test-util.ts
@@ -7,11 +7,14 @@ import type {
   PieServices,
   GitGraph,
   GitGraphServices,
+  Architecture,
+  ArchitectureServices,
 } from '../src/language/index.js';
 import {
   createInfoServices,
   createPieServices,
   createGitGraphServices,
+  createArchitectureServices,
 } from '../src/language/index.js';
 
 const consoleMock = vi.spyOn(console, 'log').mockImplementation(() => undefined);
@@ -51,6 +54,17 @@ export function createPieTestServices() {
   return { services: pieServices, parse };
 }
 export const pieParse = createPieTestServices().parse;
+
+const architectureServices: ArchitectureServices = createArchitectureServices().Architecture;
+const architectureParser: LangiumParser = architectureServices.parser.LangiumParser;
+export function createArchitectureTestServices() {
+  const parse = (input: string) => {
+    return architectureParser.parse<Architecture>(input);
+  };
+
+  return { services: architectureServices, parse };
+}
+export const architectureParse = createArchitectureTestServices().parse;
 
 const gitGraphServices: GitGraphServices = createGitGraphServices().GitGraph;
 const gitGraphParser: LangiumParser = gitGraphServices.parser.LangiumParser;


### PR DESCRIPTION
## :bookmark_tabs: Summary

This PR expands the allowed characters for node titles to include any characters except the square brackets (i.e., `[ ]`)

Add example in demos/architecture.html
Adds some rudimentary unit tests for architecture parser

Resolves #6056

## :straight_ruler: Design Decisions

This was a straight forward change to the langium grammar file to change the regex for the ARCH_TITLE definition.

### :clipboard: Tasks

Make sure you

- [X] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [X] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [X] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
