### PR TITLE
Add support for markdown-style links

### DIFF
--- a/.changeset/witty-beds-turn.md
+++ b/.changeset/witty-beds-turn.md
@@ -2,4 +2,4 @@
 'mermaid': minor
 ---
 
-Added support for markdown-style links in line messages and notes
+feat:Added support for markdown-style links in line messages and notes

--- a/.changeset/witty-beds-turn.md
+++ b/.changeset/witty-beds-turn.md
@@ -1,0 +1,5 @@
+---
+'mermaid': minor
+---
+
+Added support for markdown-style links in line messages and notes

--- a/cypress/integration/rendering/sequencediagram.spec.js
+++ b/cypress/integration/rendering/sequencediagram.spec.js
@@ -79,6 +79,15 @@ describe('Sequence diagram', () => {
       `
     );
   });
+  it('should render links', () => {
+    imgSnapshotTest(
+      `
+      sequenceDiagram
+      Alice->John: Look at [MermaidJS](https://mermaid.js.org/)
+      John->>Alice: Thanks for the link
+      `
+    );
+  });
   it('should handle different line breaks', () => {
     imgSnapshotTest(
       `

--- a/docs/syntax/sequenceDiagram.md
+++ b/docs/syntax/sequenceDiagram.md
@@ -209,6 +209,8 @@ Messages can be of two displayed either solid or with a dotted line.
 [Actor][Arrow][Actor]:Message text
 ```
 
+### Arrow Types
+
 There are ten types of arrows currently supported:
 
 | Type     | Description                                          |
@@ -223,6 +225,26 @@ There are ten types of arrows currently supported:
 | `--x`    | Dotted line with a cross at the end                  |
 | `-)`     | Solid line with an open arrow at the end (async)     |
 | `--)`    | Dotted line with a open arrow at the end (async)     |
+
+### Links in Messages (v\<MERMAID_RELEASE_VERSION>+)
+
+You can add one or more markdown-style links to messages.
+
+```
+[Actor][Arrow][Actor]:[Label](URL)
+```
+
+Example:
+
+```mermaid-example
+sequenceDiagram
+    Alice->>John: Alice shared [MermaidJS](https://mermaid.js.org/) and [the Getting Started guide](https://mermaid.js.org/intro/getting-started.html) with John
+```
+
+```mermaid
+sequenceDiagram
+    Alice->>John: Alice shared [MermaidJS](https://mermaid.js.org/) and [the Getting Started guide](https://mermaid.js.org/intro/getting-started.html) with John
+```
 
 ## Activations
 

--- a/packages/mermaid/src/diagrams/common/common.ts
+++ b/packages/mermaid/src/diagrams/common/common.ts
@@ -313,6 +313,10 @@ export const markdownLinkRegex = /\[([^\]]+)]\(([^)]+)\)/;
  */
 export const hasMarkdownLink = (text: string): boolean => markdownLinkRegex.test(text);
 
+export const removeUrlsFromLinks = (text: string): string => {
+  return text.replace(markdownLinkRegex, '$1');
+};
+
 /**
  * Computes the minimum dimensions needed to display a div containing MathML
  *

--- a/packages/mermaid/src/diagrams/common/common.ts
+++ b/packages/mermaid/src/diagrams/common/common.ts
@@ -303,6 +303,16 @@ export const katexRegex = /\$\$(.*)\$\$/g;
  */
 export const hasKatex = (text: string): boolean => (text.match(katexRegex)?.length ?? 0) > 0;
 
+export const markdownLinkRegex = /\[([^\]]+)]\(([^)]+)\)/;
+
+/**
+ * Detect markdown links
+ *
+ * @param text - The text to test
+ * @returns Whether or not the text has markdown links
+ */
+export const hasMarkdownLink = (text: string): boolean => markdownLinkRegex.test(text);
+
 /**
  * Computes the minimum dimensions needed to display a div containing MathML
  *

--- a/packages/mermaid/src/diagrams/sequence/parser/sequenceDiagram.jison
+++ b/packages/mermaid/src/diagrams/sequence/parser/sequenceDiagram.jison
@@ -84,7 +84,7 @@ accDescr\s*"{"\s*                                { this.begin("acc_descr_multili
 \-\-[x]                                                         return 'DOTTED_CROSS';
 \-[\)]                                                          return 'SOLID_POINT';
 \-\-[\)]                                                        return 'DOTTED_POINT';
-":"(?:(?:no)?wrap:)?[^#\n;]+                                    return 'TXT';
+":"(?:(?:no)?wrap:)?[^\n;]+                                     return 'TXT';
 "+"                                                             return '+';
 "-"                                                             return '-';
 <<EOF>>                                                         return 'NEWLINE';

--- a/packages/mermaid/src/diagrams/sequence/styles.js
+++ b/packages/mermaid/src/diagrams/sequence/styles.js
@@ -48,6 +48,10 @@ const getStyles = (options) =>
     stroke: none;
   }
 
+  .link {
+    fill: #0000EE;
+  }
+
   .labelBox {
     stroke: ${options.labelBoxBorderColor};
     fill: ${options.labelBoxBkgColor};

--- a/packages/mermaid/src/diagrams/sequence/svgDraw.js
+++ b/packages/mermaid/src/diagrams/sequence/svgDraw.js
@@ -1,4 +1,10 @@
-import common, { calculateMathMLDimensions, hasKatex, renderKatex } from '../common/common.js';
+import common, {
+  calculateMathMLDimensions,
+  hasKatex,
+  renderKatex,
+  hasMarkdownLink,
+  markdownLinkRegex,
+} from '../common/common.js';
 import * as svgDrawCommon from '../common/svgDrawCommon.js';
 import { ZERO_WIDTH_SPACE, parseFontSize } from '../../utils.js';
 import { sanitizeUrl } from '@braintree/sanitize-url';
@@ -127,6 +133,65 @@ export const drawKatex = async function (elem, textData, msgModel = null) {
   return [textElem];
 };
 
+export const drawLink = function (elem, label, url) {
+  elem
+    .append('a')
+    .attr('xlink:href', sanitizeUrl(url))
+    .attr('xlink:show', 'new')
+    .attr('target', '_blank')
+    .attr('rel', 'noopener noreferrer')
+    .append('tspan')
+    .attr('class', 'link')
+    .text(label);
+};
+
+export const drawMarkdownLinkText = function (elem, text) {
+  // Split text into segments - links and text between links
+  const segments = [];
+  let remainingText = text;
+  let match;
+
+  // Markdown link regex: [text](url)
+  const linkRegex = markdownLinkRegex;
+
+  while ((match = remainingText.match(linkRegex))) {
+    // Push text before link if exists
+    if (match.index > 0) {
+      segments.push({
+        type: 'text',
+        content: remainingText.substring(0, match.index),
+      });
+    }
+
+    // Push link
+    segments.push({
+      type: 'link',
+      text: match[1],
+      url: match[2],
+    });
+
+    // Update remaining text
+    remainingText = remainingText.substring(match.index + match[0].length);
+  }
+
+  // Push remaining text if any
+  if (remainingText) {
+    segments.push({
+      type: 'text',
+      content: remainingText,
+    });
+  }
+
+  // Append all segments
+  segments.forEach((segment) => {
+    if (segment.type === 'link') {
+      drawLink(elem, segment.text, segment.url);
+    } else {
+      elem.append('tspan').text(segment.content);
+    }
+  });
+};
+
 export const drawText = function (elem, textData) {
   let prevTextHeight = 0;
   let textHeight = 0;
@@ -234,13 +299,19 @@ export const drawText = function (elem, textData) {
     }
 
     const text = line || ZERO_WIDTH_SPACE;
+    let textSpan;
     if (textData.tspan) {
-      const span = textElem.append('tspan');
-      span.attr('x', textData.x);
+      textSpan = textElem.append('tspan');
+      textSpan.attr('x', textData.x);
       if (textData.fill !== undefined) {
-        span.attr('fill', textData.fill);
+        textSpan.attr('fill', textData.fill);
       }
-      span.text(text);
+    } else {
+      textSpan = textElem;
+    }
+
+    if (hasMarkdownLink(text)) {
+      drawMarkdownLinkText(textSpan, text);
     } else {
       textElem.text(text);
     }

--- a/packages/mermaid/src/diagrams/sequence/svgDraw.js
+++ b/packages/mermaid/src/diagrams/sequence/svgDraw.js
@@ -134,11 +134,13 @@ export const drawKatex = async function (elem, textData, msgModel = null) {
 };
 
 export const drawLink = function (elem, label, url) {
+  const sanitizedUrl = sanitizeUrl(url);
   elem
     .append('a')
-    .attr('xlink:href', sanitizeUrl(url))
-    .attr('xlink:show', 'new')
+    .attr('href', sanitizedUrl)
+    .attr('xlink:href', sanitizedUrl)
     .attr('target', '_blank')
+    .attr('xlink:show', 'new')
     .attr('rel', 'noopener noreferrer')
     .append('tspan')
     .attr('class', 'link')

--- a/packages/mermaid/src/docs/syntax/sequenceDiagram.md
+++ b/packages/mermaid/src/docs/syntax/sequenceDiagram.md
@@ -144,6 +144,8 @@ Messages can be of two displayed either solid or with a dotted line.
 [Actor][Arrow][Actor]:Message text
 ```
 
+### Arrow Types
+
 There are ten types of arrows currently supported:
 
 | Type     | Description                                          |
@@ -158,6 +160,21 @@ There are ten types of arrows currently supported:
 | `--x`    | Dotted line with a cross at the end                  |
 | `-)`     | Solid line with an open arrow at the end (async)     |
 | `--)`    | Dotted line with a open arrow at the end (async)     |
+
+### Links in Messages (v<MERMAID_RELEASE_VERSION>+)
+
+You can add one or more markdown-style links to messages.
+
+```
+[Actor][Arrow][Actor]:[Label](URL)
+```
+
+Example:
+
+```mermaid-example
+sequenceDiagram
+    Alice->>John: Alice shared [MermaidJS](https://mermaid.js.org/) and [the Getting Started guide](https://mermaid.js.org/intro/getting-started.html) with John
+```
 
 ## Activations
 

--- a/packages/mermaid/src/utils.ts
+++ b/packages/mermaid/src/utils.ts
@@ -23,7 +23,7 @@ import {
   curveStepBefore,
   select,
 } from 'd3';
-import common from './diagrams/common/common.js';
+import common, { removeUrlsFromLinks } from './diagrams/common/common.js';
 import { sanitizeDirective } from './utils/sanitizeDirective.js';
 import { log } from './logger.js';
 import { detectType } from './diagram-api/detectType.js';
@@ -713,7 +713,7 @@ export const calculateTextDimensions: (
       const dim = { width: 0, height: 0, lineHeight: 0 };
       for (const line of lines) {
         const textObj = getTextObj();
-        textObj.text = line || ZERO_WIDTH_SPACE;
+        textObj.text = removeUrlsFromLinks(line) || ZERO_WIDTH_SPACE;
         // @ts-ignore TODO: Fix D3 types
         const textElem = drawSimpleText(g, textObj)
           // @ts-ignore TODO: Fix D3 types


### PR DESCRIPTION
## :bookmark_tabs: Summary

Add support for markdown-style links on line messages and notes

Resolves #1279 

## :straight_ruler: Design Decisions

This currently only affects line messages and notes on sequence diagrams

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
