### PR TITLE
Update integrations-community.md

### DIFF
--- a/docs/ecosystem/integrations-community.md
+++ b/docs/ecosystem/integrations-community.md
@@ -99,8 +99,7 @@ Blogging frameworks and platforms
 - [Nextra](https://nextra.site/)
   - [Mermaid](https://nextra.site/docs/guide/mermaid)
 - [WordPress](https://wordpress.org)
-  - [WordPress Markdown Editor](https://wordpress.org/plugins/wp-githuber-md)
-  - [WP-ReliableMD](https://wordpress.org/plugins/wp-reliablemd/)
+  - [MerPRess](https://wordpress.org/plugins/merpress/)
 
 ### CMS/ECM
 

--- a/packages/mermaid/src/docs/ecosystem/integrations-community.md
+++ b/packages/mermaid/src/docs/ecosystem/integrations-community.md
@@ -94,8 +94,7 @@ Blogging frameworks and platforms
 - [Nextra](https://nextra.site/)
   - [Mermaid](https://nextra.site/docs/guide/mermaid)
 - [WordPress](https://wordpress.org)
-  - [WordPress Markdown Editor](https://wordpress.org/plugins/wp-githuber-md)
-  - [WP-ReliableMD](https://wordpress.org/plugins/wp-reliablemd/)
+  - [MerPRess](https://wordpress.org/plugins/merpress/)
 
 ### CMS/ECM
 


### PR DESCRIPTION
Replaced outdated and lo longer maintained WordPress plugins with actually maintained MerPress Plugin

## :bookmark_tabs: Summary

Both plugins in the actual Documentation are no longer maintainted. One is even no longer available due to security issues.  These are both removed. 

Luckily I found another plugin in the WP Plugin Repository that seems to be well maintained (as of Jan 2025)

## :straight_ruler: Design Decisions

n/a

### :clipboard: Tasks

n/a
