### PR TITLE
feature/5950_architecture_icon_loading_in_config

### DIFF
--- a/docs/config/setup/modules/defaultConfig.md
+++ b/docs/config/setup/modules/defaultConfig.md
@@ -14,7 +14,7 @@
 
 #### Defined in
 
-[packages/mermaid/src/defaultConfig.ts:270](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/defaultConfig.ts#L270)
+[packages/mermaid/src/defaultConfig.ts:273](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/defaultConfig.ts#L273)
 
 ---
 

--- a/docs/syntax/architecture.md
+++ b/docs/syntax/architecture.md
@@ -225,3 +225,45 @@ architecture-beta
     disk1:T -- B:server
     disk2:T -- B:db
 ```
+
+### Config Loading
+
+It is also possible to load icons hosted at a URL by declaring them in the config:
+
+```mermaid-example
+---
+icons:
+    - name: logos
+      url: https://unpkg.com/@iconify-json/logos@1/icons.json
+---
+architecture-beta
+    group api(logos:aws-lambda)[API]
+
+    service db(logos:aws-aurora)[Database] in api
+    service disk1(logos:aws-glacier)[Storage] in api
+    service disk2(logos:aws-s3)[Storage] in api
+    service server(logos:aws-ec2)[Server] in api
+
+    db:L -- R:server
+    disk1:T -- B:server
+    disk2:T -- B:db
+```
+
+```mermaid
+---
+icons:
+    - name: logos
+      url: https://unpkg.com/@iconify-json/logos@1/icons.json
+---
+architecture-beta
+    group api(logos:aws-lambda)[API]
+
+    service db(logos:aws-aurora)[Database] in api
+    service disk1(logos:aws-glacier)[Storage] in api
+    service disk2(logos:aws-s3)[Storage] in api
+    service server(logos:aws-ec2)[Server] in api
+
+    db:L -- R:server
+    disk1:T -- B:server
+    disk2:T -- B:db
+```

--- a/packages/mermaid/src/config.type.ts
+++ b/packages/mermaid/src/config.type.ts
@@ -1012,6 +1012,7 @@ export interface RequirementDiagramConfig extends BaseDiagramConfig {
  */
 export interface ArchitectureDiagramConfig extends BaseDiagramConfig {
   padding?: number;
+  icons?: unknown[];
   iconSize?: number;
   fontSize?: number;
 }

--- a/packages/mermaid/src/defaultConfig.ts
+++ b/packages/mermaid/src/defaultConfig.ts
@@ -255,6 +255,9 @@ const config: RequiredDeep<MermaidConfig> = {
   packet: {
     ...defaultConfigJson.packet,
   },
+  architecture: {
+    ...defaultConfigJson.architecture,
+  },
 };
 
 const keyify = (obj: any, prefix = ''): string[] =>

--- a/packages/mermaid/src/diagrams/architecture/architectureRenderer.ts
+++ b/packages/mermaid/src/diagrams/architecture/architectureRenderer.ts
@@ -44,6 +44,8 @@ registerIconPacks([
 ]);
 cytoscape.use(fcose);
 
+getConfigField('icons').forEach((iconLoader) => iconLoader);
+
 function addServices(services: ArchitectureService[], cy: cytoscape.Core) {
   services.forEach((service) => {
     cy.add({

--- a/packages/mermaid/src/docs/syntax/architecture.md
+++ b/packages/mermaid/src/docs/syntax/architecture.md
@@ -173,3 +173,26 @@ architecture-beta
     disk1:T -- B:server
     disk2:T -- B:db
 ```
+
+### Config Loading
+
+It is also possible to load icons hosted at a URL by declaring them in the config:
+
+```mermaid-example
+---
+icons:
+    - name: logos
+      url: https://unpkg.com/@iconify-json/logos@1/icons.json
+---
+architecture-beta
+    group api(logos:aws-lambda)[API]
+
+    service db(logos:aws-aurora)[Database] in api
+    service disk1(logos:aws-glacier)[Storage] in api
+    service disk2(logos:aws-s3)[Storage] in api
+    service server(logos:aws-ec2)[Server] in api
+
+    db:L -- R:server
+    disk1:T -- B:server
+    disk2:T -- B:db
+```

--- a/packages/mermaid/src/rendering-util/icons.ts
+++ b/packages/mermaid/src/rendering-util/icons.ts
@@ -1,7 +1,7 @@
-import { log } from '../logger.js';
 import type { ExtendedIconifyIcon, IconifyIcon, IconifyJSON } from '@iconify/types';
 import type { IconifyIconCustomisations } from '@iconify/utils';
 import { getIconData, iconToHTML, iconToSVG, replaceIDs, stringToIcon } from '@iconify/utils';
+import { log } from '../logger.js';
 
 interface AsyncIconLoader {
   name: string;
@@ -13,7 +13,12 @@ interface SyncIconLoader {
   icons: IconifyJSON;
 }
 
-export type IconLoader = AsyncIconLoader | SyncIconLoader;
+interface UrlIconLoader {
+  name: string;
+  url: string;
+}
+
+export type IconLoader = AsyncIconLoader | SyncIconLoader | UrlIconLoader;
 
 export const unknownIcon: IconifyIcon = {
   body: '<g><rect width="80" height="80" style="fill: #087ebf; stroke-width: 0px;"/><text transform="translate(21.16 64.67)" style="fill: #fff; font-family: ArialMT, Arial; font-size: 67.75px;"><tspan x="0" y="0">?</tspan></text></g>',
@@ -36,6 +41,9 @@ export const registerIconPacks = (iconLoaders: IconLoader[]) => {
       loaderStore.set(iconLoader.name, iconLoader.loader);
     } else if ('icons' in iconLoader) {
       iconsStore.set(iconLoader.name, iconLoader.icons);
+    } else if ('url' in iconLoader) {
+      loaderStore.set(iconLoader.name, () =>
+        fetch(iconLoader.url).then((res) => res.json()))
     } else {
       log.error('Invalid icon loader:', iconLoader);
       throw new Error('Invalid icon loader. Must have either "icons" or "loader" property.');

--- a/packages/mermaid/src/rendering-util/icons.ts
+++ b/packages/mermaid/src/rendering-util/icons.ts
@@ -13,7 +13,7 @@ interface SyncIconLoader {
   icons: IconifyJSON;
 }
 
-interface UrlIconLoader {
+export interface UrlIconLoader {
   name: string;
   url: string;
 }
@@ -42,8 +42,7 @@ export const registerIconPacks = (iconLoaders: IconLoader[]) => {
     } else if ('icons' in iconLoader) {
       iconsStore.set(iconLoader.name, iconLoader.icons);
     } else if ('url' in iconLoader) {
-      loaderStore.set(iconLoader.name, () =>
-        fetch(iconLoader.url).then((res) => res.json()))
+      loaderStore.set(iconLoader.name, () => fetch(iconLoader.url).then((res) => res.json()));
     } else {
       log.error('Invalid icon loader:', iconLoader);
       throw new Error('Invalid icon loader. Must have either "icons" or "loader" property.');

--- a/packages/mermaid/src/schemas/config.schema.yaml
+++ b/packages/mermaid/src/schemas/config.schema.yaml
@@ -942,6 +942,9 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
       padding:
         type: number
         default: 40
+      icons:
+        type: array
+        default: []
       iconSize:
         type: number
         default: 80


### PR DESCRIPTION
## :bookmark_tabs: Summary

Adding option to load architecture diagram icons via the config using URLs. This enables icon loading when not using the full renderer (e.g. when using the Live Editor or CLI).

Resolves #5950 

## :straight_ruler: Design Decisions

- Adding option to register icons by providing only a URL (using inline async loader)
- Adding a new option in the architecture diagram config that takes array of `UrlIconLoader` parameters (defaults to empty array), loads all icons as defined
- This allows loading of icons in config without the need to write code in yaml (following the same paradigm as outlined already in the docs)

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
