### PR TITLE
Update Requirement diagram to unified renderer

### DIFF
--- a/cypress/integration/rendering/requirementDiagram-unified.spec.js
+++ b/cypress/integration/rendering/requirementDiagram-unified.spec.js
@@ -1,0 +1,703 @@
+import { imgSnapshotTest, renderGraph } from '../../helpers/util.ts';
+
+const testOptions = [
+  { description: '', options: { logLevel: 1 } },
+  { description: 'ELK: ', options: { logLevel: 1, layout: 'elk' } },
+  { description: 'HD: ', options: { logLevel: 1, look: 'handDrawn' } },
+];
+
+describe('Requirement Diagram Unified', () => {
+  testOptions.forEach(({ description, options }) => {
+    it(`${description}should render a simple Requirement diagram`, () => {
+      imgSnapshotTest(
+        `
+    requirementDiagram
+        requirement test_req {
+        id: 1
+        text: the test text.
+        risk: high
+        verifymethod: test
+        }
+
+        element test_entity {
+        type: simulation
+        }
+
+        test_entity - satisfies -> test_req
+        `,
+        options
+      );
+    });
+
+    it(`${description}should render a simple Requirement diagram without htmlLabels`, () => {
+      imgSnapshotTest(
+        `
+    requirementDiagram
+        requirement test_req {
+        id: 1
+        text: the test text.
+        risk: high
+        verifymethod: test
+        }
+
+        element test_entity {
+        type: simulation
+        }
+
+        test_entity - satisfies -> test_req
+        `,
+        { ...options, htmlLabels: false }
+      );
+    });
+
+    it(`${description}should render a not-so-simple Requirement diagram`, () => {
+      imgSnapshotTest(
+        `
+    requirementDiagram
+
+        requirement test_req {
+        id: 1
+        text: the test text.
+        risk: high
+        verifymethod: test
+        }
+
+        functionalRequirement test_req2 {
+        id: 1.1
+        text: the second test text.
+        risk: low
+        verifymethod: inspection
+        }
+
+        performanceRequirement test_req3 {
+        id: 1.2
+        text: the third test text.
+        risk: medium
+        verifymethod: demonstration
+        }
+
+        interfaceRequirement test_req4 {
+        id: 1.2.1
+        text: the fourth test text.
+        risk: medium
+        verifymethod: analysis
+        }
+
+        physicalRequirement test_req5 {
+        id: 1.2.2
+        text: the fifth test text.
+        risk: medium
+        verifymethod: analysis
+        }
+
+        designConstraint test_req6 {
+        id: 1.2.3
+        text: the sixth test text.
+        risk: medium
+        verifymethod: analysis
+        }
+
+        element test_entity {
+        type: simulation
+        }
+
+        element test_entity2 {
+        type: word doc
+        docRef: reqs/test_entity
+        }
+
+        element test_entity3 {
+        type: "test suite"
+        docRef: github.com/all_the_tests
+        }
+
+
+        test_entity - satisfies -> test_req2
+        test_req - traces -> test_req2
+        test_req - contains -> test_req3
+        test_req3 - contains -> test_req4
+        test_req4 - derives -> test_req5
+        test_req5 - refines -> test_req6
+        test_entity3 - verifies -> test_req5
+        test_req <- copies - test_entity2
+        `,
+        options
+      );
+    });
+
+    it(`${description}should render a not-so-simple Requirement diagram without htmlLabels`, () => {
+      imgSnapshotTest(
+        `
+    requirementDiagram
+
+        requirement test_req {
+        id: 1
+        text: the test text.
+        risk: high
+        verifymethod: test
+        }
+
+        functionalRequirement test_req2 {
+        id: 1.1
+        text: the second test text.
+        risk: low
+        verifymethod: inspection
+        }
+
+        performanceRequirement test_req3 {
+        id: 1.2
+        text: the third test text.
+        risk: medium
+        verifymethod: demonstration
+        }
+
+        interfaceRequirement test_req4 {
+        id: 1.2.1
+        text: the fourth test text.
+        risk: medium
+        verifymethod: analysis
+        }
+
+        physicalRequirement test_req5 {
+        id: 1.2.2
+        text: the fifth test text.
+        risk: medium
+        verifymethod: analysis
+        }
+
+        designConstraint test_req6 {
+        id: 1.2.3
+        text: the sixth test text.
+        risk: medium
+        verifymethod: analysis
+        }
+
+        element test_entity {
+        type: simulation
+        }
+
+        element test_entity2 {
+        type: word doc
+        docRef: reqs/test_entity
+        }
+
+        element test_entity3 {
+        type: "test suite"
+        docRef: github.com/all_the_tests
+        }
+
+
+        test_entity - satisfies -> test_req2
+        test_req - traces -> test_req2
+        test_req - contains -> test_req3
+        test_req3 - contains -> test_req4
+        test_req4 - derives -> test_req5
+        test_req5 - refines -> test_req6
+        test_entity3 - verifies -> test_req5
+        test_req <- copies - test_entity2
+        `,
+        { ...options, htmlLabels: false }
+      );
+    });
+
+    it(`${description}should render multiple Requirement diagrams`, () => {
+      imgSnapshotTest(
+        [
+          `
+    requirementDiagram
+
+    requirement test_req {
+    id: 1
+    text: the test text.
+    risk: high
+    verifymethod: test
+    }
+
+    element test_entity {
+    type: simulation
+    }
+
+    test_entity - satisfies -> test_req
+    `,
+          `
+    requirementDiagram
+
+    requirement test_req {
+    id: 1
+    text: the test text.
+    risk: high
+    verifymethod: test
+    }
+
+    element test_entity {
+    type: simulation
+    }
+
+    test_entity - satisfies -> test_req
+    `,
+        ],
+        options
+      );
+    });
+
+    it(`${description}should render a Requirement diagram with empty information`, () => {
+      imgSnapshotTest(
+        `
+    requirementDiagram
+        requirement test_req {
+        }
+        element test_entity {
+        }
+        `,
+        options
+      );
+    });
+
+    it(`${description}should render requirements and elements with and without information`, () => {
+      renderGraph(
+        `
+    requirementDiagram
+        requirement test_req {
+            id: 1
+            text: the test text.
+            risk: high
+            verifymethod: test
+        }
+        element test_entity {
+        }
+        `,
+        options
+      );
+    });
+
+    it(`${description}should render requirements and elements with long and short text`, () => {
+      renderGraph(
+        `
+    requirementDiagram
+        requirement test_req {
+            id: 1
+            text: the test text that is long and takes up a lot of space.
+            risk: high
+            verifymethod: test
+        }
+        element test_entity_name_that_is_extra_long {
+        }
+        `,
+        options
+      );
+    });
+
+    it(`${description}should render requirements and elements with long and short text without htmlLabels`, () => {
+      renderGraph(
+        `
+      requirementDiagram
+          requirement test_req {
+              id: 1
+              text: the test text that is long and takes up a lot of space.
+              risk: high
+              verifymethod: test
+          }
+          element test_entity_name_that_is_extra_long {
+          }
+          `,
+        { ...options, htmlLabels: false }
+      );
+    });
+
+    it(`${description}should render requirements and elements with quoted text for spaces`, () => {
+      renderGraph(
+        `
+      requirementDiagram
+          requirement "test req name with spaces" {
+              id: 1
+              text: the test text that is long and takes up a lot of space.
+              risk: high
+              verifymethod: test
+          }
+          element "test entity name that is extra long with spaces" {
+          }
+          `,
+        options
+      );
+    });
+
+    it(`${description}should render requirements and elements with markdown text`, () => {
+      renderGraph(
+        `
+      requirementDiagram
+          requirement "__my bolded name__" {
+              id: 1
+              text: "**Bolded text** _italicized text_"
+              risk: high
+              verifymethod: test
+          }
+          element "*my italicized name*" {
+            type: "**Bolded type** _italicized type_"
+            docref: "*Italicized* __Bolded__"
+          }
+          `,
+        options
+      );
+    });
+
+    it(`${description}should render requirements and elements with markdown text without htmlLabels`, () => {
+      renderGraph(
+        `
+      requirementDiagram
+          requirement "__my bolded name__" {
+              id: 1
+              text: "**Bolded text** _italicized text_"
+              risk: high
+              verifymethod: test
+          }
+          element "*my italicized name*" {
+            type: "**Bolded type** _italicized type_"
+            docref: "*Italicized* __Bolded__"
+          }
+          `,
+        { ...options, htmlLabels: false }
+      );
+    });
+
+    it(`${description}should render a simple Requirement diagram with a title`, () => {
+      imgSnapshotTest(
+        `---
+  title: simple Requirement diagram
+  ---
+    requirementDiagram
+
+    requirement test_req {
+    id: 1
+    text: the test text.
+    risk: high
+    verifymethod: test
+    }
+
+    element test_entity {
+    type: simulation
+    }
+
+    test_entity - satisfies -> test_req
+  `,
+        options
+      );
+    });
+
+    it(`${description}should render a Requirement diagram with TB direction`, () => {
+      imgSnapshotTest(
+        `
+    requirementDiagram
+    direction TB
+
+    requirement test_req {
+    id: 1
+    text: the test text.
+    risk: high
+    verifymethod: test
+    }
+
+    element test_entity {
+    type: simulation
+    }
+
+    test_entity - satisfies -> test_req
+        `,
+        options
+      );
+    });
+
+    it(`${description}should render a Requirement diagram with BT direction`, () => {
+      imgSnapshotTest(
+        `
+      requirementDiagram
+      direction BT
+  
+      requirement test_req {
+      id: 1
+      text: the test text.
+      risk: high
+      verifymethod: test
+      }
+  
+      element test_entity {
+      type: simulation
+      }
+  
+      test_entity - satisfies -> test_req
+          `,
+        options
+      );
+    });
+
+    it(`${description}should render a Requirement diagram with LR direction`, () => {
+      imgSnapshotTest(
+        `
+      requirementDiagram
+      direction LR
+  
+      requirement test_req {
+      id: 1
+      text: the test text.
+      risk: high
+      verifymethod: test
+      }
+  
+      element test_entity {
+      type: simulation
+      }
+  
+      test_entity - satisfies -> test_req
+          `,
+        options
+      );
+    });
+
+    it(`${description}should render a Requirement diagram with RL direction`, () => {
+      imgSnapshotTest(
+        `
+      requirementDiagram
+      direction RL
+  
+      requirement test_req {
+      id: 1
+      text: the test text.
+      risk: high
+      verifymethod: test
+      }
+  
+      element test_entity {
+      type: simulation
+      }
+  
+      test_entity - satisfies -> test_req
+          `,
+        options
+      );
+    });
+
+    it(`${description}should render requirements and elements with styles applied from style statement`, () => {
+      imgSnapshotTest(
+        `
+    requirementDiagram
+
+    requirement test_req {
+    id: 1
+    text: the test text.
+    risk: high
+    verifymethod: test
+    }
+
+    element test_entity {
+    type: simulation
+    }
+
+    test_entity - satisfies -> test_req
+
+    style test_req,test_entity fill:#f9f,stroke:blue, color:grey, font-weight:bold
+        `,
+        options
+      );
+    });
+
+    it(`${description}should render requirements and elements with styles applied from style statement without htmlLabels`, () => {
+      imgSnapshotTest(
+        `
+      requirementDiagram
+  
+      requirement test_req {
+      id: 1
+      text: the test text.
+      risk: high
+      verifymethod: test
+      }
+  
+      element test_entity {
+      type: simulation
+      }
+  
+      test_entity - satisfies -> test_req
+  
+      style test_req,test_entity fill:#f9f,stroke:blue, color:grey, font-weight:bold
+          `,
+        { ...options, htmlLabels: false }
+      );
+    });
+
+    it(`${description}should render requirements and elements with styles applied from class statement`, () => {
+      imgSnapshotTest(
+        `
+requirementDiagram
+  
+      requirement test_req {
+      id: 1
+      text: the test text.
+      risk: high
+      verifymethod: test
+      }
+  
+      element test_entity {
+      type: simulation
+      }
+  
+      test_entity - satisfies -> test_req
+      classDef bold font-weight: bold
+      classDef blue stroke:lightblue, color: #0000FF
+      class test_entity bold
+      class test_req blue, bold
+        `,
+        options
+      );
+    });
+
+    it(`${description}should render requirements and elements with styles applied from class statement without htmlLabels`, () => {
+      imgSnapshotTest(
+        `
+  requirementDiagram
+    
+        requirement test_req {
+        id: 1
+        text: the test text.
+        risk: high
+        verifymethod: test
+        }
+    
+        element test_entity {
+        type: simulation
+        }
+    
+        test_entity - satisfies -> test_req
+        classDef bold font-weight: bold
+        classDef blue stroke:lightblue, color: #0000FF
+        class test_entity bold
+        class test_req blue, bold
+          `,
+        { ...options, htmlLabels: false }
+      );
+    });
+
+    it(`${description}should render requirements and elements with styles applied from classes with shorthand syntax`, () => {
+      imgSnapshotTest(
+        `
+  requirementDiagram
+    
+        requirement test_req:::blue {
+        id: 1
+        text: the test text.
+        risk: high
+        verifymethod: test
+        }
+    
+        element test_entity {
+        type: simulation
+        }
+    
+        test_entity - satisfies -> test_req
+        classDef bold font-weight: bold
+        classDef blue stroke:lightblue, color: #0000FF
+        test_entity:::bold
+          `,
+        options
+      );
+    });
+
+    it(`${description}should render requirements and elements with styles applied from classes with shorthand syntax without htmlLabels`, () => {
+      imgSnapshotTest(
+        `
+  requirementDiagram
+    
+        requirement test_req:::blue {
+        id: 1
+        text: the test text.
+        risk: high
+        verifymethod: test
+        }
+    
+        element test_entity {
+        type: simulation
+        }
+    
+        test_entity - satisfies -> test_req
+        classDef bold font-weight: bold
+        classDef blue stroke:lightblue, color: #0000FF
+        test_entity:::bold
+          `,
+        { ...options, htmlLabels: false }
+      );
+    });
+
+    it(`${description}should render requirements and elements with styles applied from the default class and other styles`, () => {
+      imgSnapshotTest(
+        `
+requirementDiagram
+  
+      requirement test_req:::blue {
+      id: 1
+      text: the test text.
+      risk: high
+      verifymethod: test
+      }
+  
+      element test_entity {
+      type: simulation
+      }
+  
+      test_entity - satisfies -> test_req
+      classDef blue stroke:lightblue, color:blue
+      classDef default fill:pink
+      style test_entity color:green
+        `,
+        options
+      );
+    });
+
+    it(`${description}should render requirements and elements with styles applied from the default class and other styles without htmlLabels`, () => {
+      imgSnapshotTest(
+        `
+  requirementDiagram
+    
+        requirement test_req:::blue {
+        id: 1
+        text: the test text.
+        risk: high
+        verifymethod: test
+        }
+    
+        element test_entity {
+        type: simulation
+        }
+    
+        test_entity - satisfies -> test_req
+        classDef blue stroke:lightblue, color:blue
+        classDef default fill:pink
+        style test_entity color:green
+          `,
+        { ...options, htmlLabels: false }
+      );
+    });
+
+    it(`${description}should render a Requirement diagram with a theme`, () => {
+      imgSnapshotTest(
+        `
+---
+  theme: forest
+---
+  requirementDiagram
+    
+        requirement test_req:::blue {
+        id: 1
+        text: the test text.
+        risk: high
+        verifymethod: test
+        }
+    
+        element test_entity {
+        type: simulation
+        }
+    
+        test_entity - satisfies -> test_req
+          `,
+        options
+      );
+    });
+  });
+});

--- a/docs/syntax/requirementDiagram.md
+++ b/docs/syntax/requirementDiagram.md
@@ -84,6 +84,37 @@ element user_defined_name {
 }
 ```
 
+### Markdown Formatting
+
+In places where user defined text is possible (like names, requirement text, element docref, etc.), you can:
+
+- Surround the text in quotes: `"example text"`
+- Use markdown formatting inside quotes: `"**bold text** and *italics*"`
+
+Example:
+
+```mermaid-example
+requirementDiagram
+
+requirement "__test_req__" {
+    id: 1
+    text: "*italicized text* **bold text**"
+    risk: high
+    verifymethod: test
+}
+```
+
+```mermaid
+requirementDiagram
+
+requirement "__test_req__" {
+    id: 1
+    text: "*italicized text* **bold text**"
+    risk: high
+    verifymethod: test
+}
+```
+
 ### Relationship
 
 Relationships are comprised of a source node, destination node, and relationship type.
@@ -248,6 +279,217 @@ This example uses all features of the diagram.
     test_req5 - refines -> test_req6
     test_entity3 - verifies -> test_req5
     test_req <- copies - test_entity2
+```
+
+## Direction
+
+The diagram can be rendered in different directions using the `direction` statement. Valid values are:
+
+- `TB` - Top to Bottom (default)
+- `BT` - Bottom to Top
+- `LR` - Left to Right
+- `RL` - Right to Left
+
+Example:
+
+```mermaid-example
+requirementDiagram
+
+direction LR
+
+requirement test_req {
+    id: 1
+    text: the test text.
+    risk: high
+    verifymethod: test
+}
+
+element test_entity {
+    type: simulation
+}
+
+test_entity - satisfies -> test_req
+```
+
+```mermaid
+requirementDiagram
+
+direction LR
+
+requirement test_req {
+    id: 1
+    text: the test text.
+    risk: high
+    verifymethod: test
+}
+
+element test_entity {
+    type: simulation
+}
+
+test_entity - satisfies -> test_req
+```
+
+## Styling
+
+Requirements and elements can be styled using direct styling or classes. As a rule of thumb, when applying styles or classes, it accepts a list of requirement or element names and a list of class names allowing multiple assignments at a time (The only exception is the shorthand syntax `:::` which can assign multiple classes but only to one requirement or element at a time).
+
+### Direct Styling
+
+Use the `style` keyword to apply CSS styles directly:
+
+```mermaid-example
+requirementDiagram
+
+requirement test_req {
+    id: 1
+    text: styling example
+    risk: low
+    verifymethod: test
+}
+
+element test_entity {
+    type: simulation
+}
+
+style test_req fill:#ffa,stroke:#000, color: green
+style test_entity fill:#f9f,stroke:#333, color: blue
+```
+
+```mermaid
+requirementDiagram
+
+requirement test_req {
+    id: 1
+    text: styling example
+    risk: low
+    verifymethod: test
+}
+
+element test_entity {
+    type: simulation
+}
+
+style test_req fill:#ffa,stroke:#000, color: green
+style test_entity fill:#f9f,stroke:#333, color: blue
+```
+
+### Class Definitions
+
+Define reusable styles using `classDef`:
+
+```mermaid-example
+requirementDiagram
+
+requirement test_req {
+    id: 1
+    text: "class styling example"
+    risk: low
+    verifymethod: test
+}
+
+element test_entity {
+    type: simulation
+}
+
+classDef important fill:#f96,stroke:#333,stroke-width:4px
+classDef test fill:#ffa,stroke:#000
+```
+
+```mermaid
+requirementDiagram
+
+requirement test_req {
+    id: 1
+    text: "class styling example"
+    risk: low
+    verifymethod: test
+}
+
+element test_entity {
+    type: simulation
+}
+
+classDef important fill:#f96,stroke:#333,stroke-width:4px
+classDef test fill:#ffa,stroke:#000
+```
+
+### Default class
+
+If a class is named default it will be applied to all nodes. Specific styles and classes should be defined afterwards to override the applied default styling.
+
+```
+classDef default fill:#f9f,stroke:#333,stroke-width:4px;
+```
+
+### Applying Classes
+
+Classes can be applied in two ways:
+
+1. Using the `class` keyword:
+
+```
+class test_req,test_entity important
+```
+
+2. Using the shorthand syntax with `:::` either during the definition or afterwards:
+
+```
+requirement test_req:::important {
+    id: 1
+    text: class styling example
+    risk: low
+    verifymethod: test
+}
+```
+
+```
+element test_elem {
+}
+
+test_elem:::myClass
+```
+
+### Combined Example
+
+```mermaid-example
+requirementDiagram
+
+requirement test_req:::important {
+    id: 1
+    text: "class styling example"
+    risk: low
+    verifymethod: test
+}
+
+element test_entity {
+    type: simulation
+}
+
+classDef important font-weight:bold
+
+class test_entity important
+style test_entity fill:#f9f,stroke:#333
+```
+
+```mermaid
+requirementDiagram
+
+requirement test_req:::important {
+    id: 1
+    text: "class styling example"
+    risk: low
+    verifymethod: test
+}
+
+element test_entity {
+    type: simulation
+}
+
+classDef important font-weight:bold
+
+class test_entity important
+style test_entity fill:#f9f,stroke:#333
 ```
 
 <!--- cspell:ignore reqs --->

--- a/packages/mermaid/src/diagrams/requirement/parser/requirementDiagram.jison
+++ b/packages/mermaid/src/diagrams/requirement/parser/requirementDiagram.jison
@@ -22,6 +22,10 @@ accDescr\s*":"\s*                                               { this.begin("ac
 accDescr\s*"{"\s*                                { this.begin("acc_descr_multiline");}
 <acc_descr_multiline>[\}]                       { this.popState(); }
 <acc_descr_multiline>[^\}]*                     return "acc_descr_multiline_value";
+.*direction\s+TB[^\n]*                       return 'direction_tb';
+.*direction\s+BT[^\n]*                       return 'direction_bt';
+.*direction\s+RL[^\n]*                       return 'direction_rl';
+.*direction\s+LR[^\n]*                       return 'direction_lr';
 (\r?\n)+                               return 'NEWLINE';
 \s+                                    /* skip all whitespace */
 \#[^\n]*                               /* skip comments */
@@ -101,7 +105,19 @@ diagram
   | elementDef diagram
   | relationshipDef diagram
   | directive diagram
+  | direction diagram
   | NEWLINE diagram;
+
+direction
+    : direction_tb
+    { yy.setDirection('TB');}
+    | direction_bt
+    { yy.setDirection('BT');}
+    | direction_rl
+    { yy.setDirection('RL');}
+    | direction_lr
+    { yy.setDirection('LR');}
+    ;
 
 requirementDef
   : requirementType requirementName STRUCT_START NEWLINE requirementBody

--- a/packages/mermaid/src/diagrams/requirement/parser/requirementDiagram.spec.js
+++ b/packages/mermaid/src/diagrams/requirement/parser/requirementDiagram.spec.js
@@ -37,7 +37,7 @@ describe('when parsing requirement diagram it...', function () {
 
     let foundReq = requirementDb.getRequirements().get(expectedName);
     expect(foundReq).toBeDefined();
-    expect(foundReq.id).toBe(expectedId);
+    expect(foundReq.requirementId).toBe(expectedId);
     expect(foundReq.text).toBe(expectedText);
 
     expect(requirementDb.getElements().size).toBe(0);
@@ -599,4 +599,251 @@ line 2`;
       expect(reqDiagram.parser.yy.getElements().size).toBe(1);
     });
   }
+
+  it('will accept styling a requirement', function () {
+    const expectedName = 'test_req';
+
+    let lines = [
+      `requirementDiagram`,
+      ``,
+      `requirement ${expectedName} {`,
+      `}`,
+      `style ${expectedName} fill:#f9f,stroke:#333,stroke-width:4px`,
+      ``,
+    ];
+    let doc = lines.join('\n');
+
+    reqDiagram.parser.parse(doc);
+
+    let foundReq = requirementDb.getRequirements().get(expectedName);
+    const styles = foundReq.cssStyles;
+    expect(styles).toEqual(['fill:#f9f', 'stroke:#333', 'stroke-width:4px']);
+  });
+
+  it('will accept styling an element', function () {
+    const expectedName = 'test_element';
+
+    let lines = [
+      `requirementDiagram`,
+      ``,
+      `element ${expectedName} {`,
+      `}`,
+      `style ${expectedName} fill:#f9f,stroke:#333,stroke-width:4px`,
+      ``,
+    ];
+    let doc = lines.join('\n');
+
+    reqDiagram.parser.parse(doc);
+
+    let foundElement = requirementDb.getElements().get(expectedName);
+    const styles = foundElement.cssStyles;
+    expect(styles).toEqual(['fill:#f9f', 'stroke:#333', 'stroke-width:4px']);
+  });
+
+  it('will accept styling multiple things at once', function () {
+    const expectedRequirementName = 'test_requirement';
+    const expectedElementName = 'test_element';
+
+    let lines = [
+      `requirementDiagram`,
+      ``,
+      `requirement ${expectedRequirementName} {`,
+      `}`,
+      `element ${expectedElementName} {`,
+      `}`,
+      `style ${expectedRequirementName},${expectedElementName} fill:#f9f,stroke:#333,stroke-width:4px`,
+      ``,
+    ];
+    let doc = lines.join('\n');
+
+    reqDiagram.parser.parse(doc);
+
+    let foundRequirement = requirementDb.getRequirements().get(expectedRequirementName);
+    const requirementStyles = foundRequirement.cssStyles;
+    expect(requirementStyles).toEqual(['fill:#f9f', 'stroke:#333', 'stroke-width:4px']);
+    let foundElement = requirementDb.getElements().get(expectedElementName);
+    const elementStyles = foundElement.cssStyles;
+    expect(elementStyles).toEqual(['fill:#f9f', 'stroke:#333', 'stroke-width:4px']);
+  });
+
+  it('will accept defining a class', function () {
+    const expectedName = 'myClass';
+
+    let lines = [
+      `requirementDiagram`,
+      ``,
+      `classDef ${expectedName} fill:#f9f,stroke:#333,stroke-width:4px`,
+      ``,
+    ];
+    let doc = lines.join('\n');
+
+    reqDiagram.parser.parse(doc);
+
+    let foundClass = requirementDb.getClasses().get(expectedName);
+    expect(foundClass).toEqual({
+      id: 'myClass',
+      styles: ['fill:#f9f', 'stroke:#333', 'stroke-width:4px'],
+      textStyles: [],
+    });
+  });
+
+  it('will accept defining multiple classes at once', function () {
+    const firstName = 'firstClass';
+    const secondName = 'secondClass';
+
+    let lines = [
+      `requirementDiagram`,
+      ``,
+      `classDef ${firstName},${secondName} fill:#f9f,stroke:#333,stroke-width:4px`,
+      ``,
+    ];
+    let doc = lines.join('\n');
+
+    reqDiagram.parser.parse(doc);
+
+    let firstClass = requirementDb.getClasses().get(firstName);
+    expect(firstClass).toEqual({
+      id: 'firstClass',
+      styles: ['fill:#f9f', 'stroke:#333', 'stroke-width:4px'],
+      textStyles: [],
+    });
+    let secondClass = requirementDb.getClasses().get(secondName);
+    expect(secondClass).toEqual({
+      id: 'secondClass',
+      styles: ['fill:#f9f', 'stroke:#333', 'stroke-width:4px'],
+      textStyles: [],
+    });
+  });
+
+  it('will accept assigning a class via the class statement', function () {
+    const requirementName = 'myReq';
+    const className = 'myClass';
+
+    let lines = [
+      `requirementDiagram`,
+      ``,
+      `requirement ${requirementName} {`,
+      `}`,
+      `classDef ${className} fill:#f9f,stroke:#333,stroke-width:4px`,
+      `class ${requirementName} ${className}`,
+      ``,
+    ];
+    let doc = lines.join('\n');
+
+    reqDiagram.parser.parse(doc);
+
+    let foundRequirement = requirementDb.getRequirements().get(requirementName);
+    expect(foundRequirement.classes).toEqual(['default', className]);
+  });
+
+  it('will accept assigning multiple classes to multiple things via the class statement', function () {
+    const requirementName = 'req';
+    const elementName = 'elem';
+    const firstClassName = 'class1';
+    const secondClassName = 'class2';
+
+    let lines = [
+      `requirementDiagram`,
+      ``,
+      `requirement ${requirementName} {`,
+      `}`,
+      `element ${elementName} {`,
+      `}`,
+      `classDef ${firstClassName},${secondClassName} fill:#f9f,stroke:#333,stroke-width:4px`,
+      `class ${requirementName},${elementName} ${firstClassName},${secondClassName}`,
+      ``,
+    ];
+    let doc = lines.join('\n');
+
+    reqDiagram.parser.parse(doc);
+
+    let requirement = requirementDb.getRequirements().get(requirementName);
+    expect(requirement.classes).toEqual(['default', firstClassName, secondClassName]);
+    let element = requirementDb.getElements().get(elementName);
+    expect(element.classes).toEqual(['default', firstClassName, secondClassName]);
+  });
+
+  it('will accept assigning a class via the shorthand syntax', function () {
+    const requirementName = 'myReq';
+    const className = 'myClass';
+
+    let lines = [
+      `requirementDiagram`,
+      ``,
+      `requirement ${requirementName} {`,
+      `}`,
+      `classDef ${className} fill:#f9f,stroke:#333,stroke-width:4px`,
+      `${requirementName}:::${className}`,
+      ``,
+    ];
+    let doc = lines.join('\n');
+
+    reqDiagram.parser.parse(doc);
+
+    let foundRequirement = requirementDb.getRequirements().get(requirementName);
+    expect(foundRequirement.classes).toEqual(['default', className]);
+  });
+
+  it('will accept assigning multiple classes via the shorthand syntax', function () {
+    const requirementName = 'myReq';
+    const firstClassName = 'class1';
+    const secondClassName = 'class2';
+
+    let lines = [
+      `requirementDiagram`,
+      ``,
+      `requirement ${requirementName} {`,
+      `}`,
+      `classDef ${firstClassName} fill:#f9f,stroke:#333,stroke-width:4px`,
+      `classDef ${secondClassName} color:blue`,
+      `${requirementName}:::${firstClassName},${secondClassName}`,
+      ``,
+    ];
+    let doc = lines.join('\n');
+
+    reqDiagram.parser.parse(doc);
+
+    let foundRequirement = requirementDb.getRequirements().get(requirementName);
+    expect(foundRequirement.classes).toEqual(['default', firstClassName, secondClassName]);
+  });
+
+  it('will accept assigning a class or multiple via the shorthand syntax when defining a requirement or element', function () {
+    const requirementName = 'myReq';
+    const elementName = 'myElem';
+    const firstClassName = 'class1';
+    const secondClassName = 'class2';
+
+    let lines = [
+      `requirementDiagram`,
+      ``,
+      `requirement ${requirementName}:::${firstClassName} {`,
+      `}`,
+      `element ${elementName}:::${firstClassName},${secondClassName} {`,
+      `}`,
+      ``,
+      `classDef ${firstClassName} fill:#f9f,stroke:#333,stroke-width:4px`,
+      `classDef ${secondClassName} color:blue`,
+      ``,
+    ];
+    let doc = lines.join('\n');
+
+    reqDiagram.parser.parse(doc);
+
+    let foundRequirement = requirementDb.getRequirements().get(requirementName);
+    expect(foundRequirement.classes).toEqual(['default', firstClassName]);
+    let foundElement = requirementDb.getElements().get(elementName);
+    expect(foundElement.classes).toEqual(['default', firstClassName, secondClassName]);
+  });
+
+  describe('will parse direction statements and', () => {
+    test.each(['TB', 'BT', 'LR', 'RL'])('will accept direction %s', (directionVal) => {
+      const lines = ['requirementDiagram', '', `direction ${directionVal}`, ''];
+      const doc = lines.join('\n');
+
+      reqDiagram.parser.parse(doc);
+
+      const direction = requirementDb.getDirection();
+      expect(direction).toBe(directionVal);
+    });
+  });
 });

--- a/packages/mermaid/src/diagrams/requirement/requirementDb.spec.ts
+++ b/packages/mermaid/src/diagrams/requirement/requirementDb.spec.ts
@@ -1,0 +1,95 @@
+import requirementDb from './requirementDb.js';
+import { describe, it, expect } from 'vitest';
+import type { RelationshipType } from './types.js';
+
+describe('requirementDb', () => {
+  beforeEach(() => {
+    requirementDb.clear();
+  });
+
+  it('should add a requirement', () => {
+    requirementDb.addRequirement('requirement', 'Requirement');
+    const requirements = requirementDb.getRequirements();
+    expect(requirements.has('requirement')).toBe(true);
+  });
+
+  it('should add an element', () => {
+    requirementDb.addElement('element');
+    const elements = requirementDb.getElements();
+    expect(elements.has('element')).toBe(true);
+  });
+
+  it('should add a relationship', () => {
+    requirementDb.addRelationship('contains' as RelationshipType, 'src', 'dst');
+    const relationships = requirementDb.getRelationships();
+    const relationship = relationships.find(
+      (r) => r.type === 'contains' && r.src === 'src' && r.dst === 'dst'
+    );
+    expect(relationship).toBeDefined();
+  });
+
+  it('should detect single class', () => {
+    requirementDb.defineClass(['a'], ['stroke-width: 8px']);
+    const classes = requirementDb.getClasses();
+
+    expect(classes.has('a')).toBe(true);
+    expect(classes.get('a')?.styles).toEqual(['stroke-width: 8px']);
+  });
+
+  it('should detect many classes', () => {
+    requirementDb.defineClass(['a', 'b'], ['stroke-width: 8px']);
+    const classes = requirementDb.getClasses();
+
+    expect(classes.has('a')).toBe(true);
+    expect(classes.has('b')).toBe(true);
+    expect(classes.get('a')?.styles).toEqual(['stroke-width: 8px']);
+    expect(classes.get('b')?.styles).toEqual(['stroke-width: 8px']);
+  });
+
+  it('should detect direction', () => {
+    requirementDb.setDirection('TB');
+    const direction = requirementDb.getDirection();
+
+    expect(direction).toBe('TB');
+  });
+
+  it('should add styles to a requirement and element', () => {
+    requirementDb.addRequirement('requirement', 'Requirement');
+    requirementDb.setCssStyle(['requirement'], ['color:red']);
+    requirementDb.addElement('element');
+    requirementDb.setCssStyle(['element'], ['stroke-width:4px', 'stroke: yellow']);
+
+    const requirement = requirementDb.getRequirements().get('requirement');
+    const element = requirementDb.getElements().get('element');
+
+    expect(requirement?.cssStyles).toEqual(['color:red']);
+    expect(element?.cssStyles).toEqual(['stroke-width:4px', 'stroke: yellow']);
+  });
+
+  it('should add classes to a requirement and element', () => {
+    requirementDb.addRequirement('requirement', 'Requirement');
+    requirementDb.addElement('element');
+    requirementDb.setClass(['requirement', 'element'], ['myClass']);
+
+    const requirement = requirementDb.getRequirements().get('requirement');
+    const element = requirementDb.getElements().get('element');
+
+    expect(requirement?.classes).toEqual(['default', 'myClass']);
+    expect(element?.classes).toEqual(['default', 'myClass']);
+  });
+
+  it('should add styles to a requirement and element inherited from a class', () => {
+    requirementDb.addRequirement('requirement', 'Requirement');
+    requirementDb.addElement('element');
+    requirementDb.defineClass(['myClass'], ['color:red']);
+    requirementDb.defineClass(['myClass2'], ['stroke-width:4px', 'stroke: yellow']);
+    requirementDb.setClass(['requirement'], ['myClass']);
+    requirementDb.setClass(['element'], ['myClass2']);
+
+    const requirement = requirementDb.getRequirements().get('requirement');
+    const element = requirementDb.getElements().get('element');
+
+    expect(requirement?.cssStyles).toEqual(['color:red']);
+    expect(element?.cssStyles).toEqual(['stroke-width:4px', 'stroke: yellow']);
+  });
+});

--- a/packages/mermaid/src/diagrams/requirement/requirementDb.ts
+++ b/packages/mermaid/src/diagrams/requirement/requirementDb.ts
@@ -8,12 +8,15 @@ import {
   setAccDescription,
   clear as commonClear,
 } from '../common/commonDb.js';
-
-let relations = [];
-let latestRequirement = {};
-let requirements = new Map();
-let latestElement = {};
-let elements = new Map();
+import type {
+  Element,
+  Relation,
+  RelationshipType,
+  Requirement,
+  RequirementType,
+  RiskLevel,
+  VerifyType,
+} from './types.js';
 
 const RequirementType = {
   REQUIREMENT: 'Requirement',
@@ -47,78 +50,108 @@ const Relationships = {
   TRACES: 'traces',
 };
 
-const addRequirement = (name, type) => {
+const getInitialRequirement = (): Requirement => ({
+  id: '',
+  text: '',
+  risk: RiskLevel.LOW_RISK as RiskLevel,
+  verifyMethod: VerifyType.VERIFY_ANALYSIS as VerifyType,
+  name: '',
+  type: RequirementType.REQUIREMENT as RequirementType,
+});
+
+const getInitialElement = (): Element => ({
+  name: '',
+  type: '',
+  docRef: '',
+});
+
+// Update initial declarations
+let relations: Relation[] = [];
+let latestRequirement: Requirement = getInitialRequirement();
+let requirements = new Map<string, Requirement>();
+let latestElement: Element = getInitialElement();
+let elements = new Map<string, Element>();
+
+// Add reset functions
+const resetLatestRequirement = () => {
+  latestRequirement = getInitialRequirement();
+};
+
+const resetLatestElement = () => {
+  latestElement = getInitialElement();
+};
+
+const addRequirement = (name: string, type: RequirementType) => {
   if (!requirements.has(name)) {
     requirements.set(name, {
       name,
       type,
-
       id: latestRequirement.id,
       text: latestRequirement.text,
       risk: latestRequirement.risk,
       verifyMethod: latestRequirement.verifyMethod,
     });
   }
-  latestRequirement = {};
+  resetLatestRequirement();
 
   return requirements.get(name);
 };
 
 const getRequirements = () => requirements;
 
-const setNewReqId = (id) => {
+const setNewReqId = (id: string) => {
   if (latestRequirement !== undefined) {
     latestRequirement.id = id;
   }
 };
 
-const setNewReqText = (text) => {
+const setNewReqText = (text: string) => {
   if (latestRequirement !== undefined) {
     latestRequirement.text = text;
   }
 };
 
-const setNewReqRisk = (risk) => {
+const setNewReqRisk = (risk: RiskLevel) => {
   if (latestRequirement !== undefined) {
     latestRequirement.risk = risk;
   }
 };
 
-const setNewReqVerifyMethod = (verifyMethod) => {
+const setNewReqVerifyMethod = (verifyMethod: VerifyType) => {
   if (latestRequirement !== undefined) {
     latestRequirement.verifyMethod = verifyMethod;
   }
 };
 
-const addElement = (name) => {
+const addElement = (name: string) => {
   if (!elements.has(name)) {
     elements.set(name, {
       name,
       type: latestElement.type,
       docRef: latestElement.docRef,
     });
-    log.info('Added new requirement: ', name);
+    log.info('Added new element: ', name);
   }
-  latestElement = {};
+  resetLatestElement();
 
   return elements.get(name);
 };
 
 const getElements = () => elements;
 
-const setNewElementType = (type) => {
+const setNewElementType = (type: string) => {
   if (latestElement !== undefined) {
     latestElement.type = type;
   }
 };
 
-const setNewElementDocRef = (docRef) => {
+const setNewElementDocRef = (docRef: string) => {
   if (latestElement !== undefined) {
     latestElement.docRef = docRef;
   }
 };
 
-const addRelationship = (type, src, dst) => {
+const addRelationship = (type: RelationshipType, src: string, dst: string) => {
   relations.push({
     type,
     src,
@@ -130,21 +163,19 @@ const getRelationships = () => relations;
 
 const clear = () => {
   relations = [];
-  latestRequirement = {};
+  resetLatestRequirement();
   requirements = new Map();
-  latestElement = {};
+  resetLatestElement();
   elements = new Map();
   commonClear();
 };
 
 export default {
+  Relationships,
   RequirementType,
   RiskLevel,
   VerifyType,
-  Relationships,
-
-  getConfig: () => getConfig().req,
-
+  getConfig: () => getConfig().requirement,
   addRequirement,
   getRequirements,
   setNewReqId,
@@ -155,14 +186,11 @@ export default {
   getAccTitle,
   setAccDescription,
   getAccDescription,
-
   addElement,
   getElements,
   setNewElementType,
   setNewElementDocRef,
-
   addRelationship,
   getRelationships,
-
   clear,
 };

--- a/packages/mermaid/src/diagrams/requirement/requirementDb.ts
+++ b/packages/mermaid/src/diagrams/requirement/requirementDb.ts
@@ -61,7 +61,7 @@ const setDirection = (dir: string) => {
 };
 
 const getInitialRequirement = (): Requirement => ({
-  requirement_id: '',
+  requirementId: '',
   text: '',
   risk: '' as RiskLevel,
   verifyMethod: '' as VerifyType,
@@ -101,7 +101,7 @@ const addRequirement = (name: string, type: RequirementType) => {
     requirements.set(name, {
       name,
       type,
-      requirement_id: latestRequirement.requirement_id,
+      requirementId: latestRequirement.requirementId,
       text: latestRequirement.text,
       risk: latestRequirement.risk,
       verifyMethod: latestRequirement.verifyMethod,
@@ -118,7 +118,7 @@ const getRequirements = () => requirements;
 
 const setNewReqId = (id: string) => {
   if (latestRequirement !== undefined) {
-    latestRequirement.requirement_id = id;
+    latestRequirement.requirementId = id;
   }
 };
 

--- a/packages/mermaid/src/diagrams/requirement/requirementDb.ts
+++ b/packages/mermaid/src/diagrams/requirement/requirementDb.ts
@@ -177,7 +177,6 @@ const getData = () => {
   const config = getConfig();
   const nodes: Node[] = [];
   const edges: Edge[] = [];
-
   for (const requirement of requirements.values()) {
     const node = requirement as unknown as Node;
     node.shape = 'requirementBox';
@@ -195,13 +194,20 @@ const getData = () => {
 
   for (const relation of relations) {
     let counter = 0;
+    const isContains = relation.type === Relationships.CONTAINS;
     const edge: Edge = {
       id: `${relation.src}-${relation.dst}-${counter}`,
       start: requirements.get(relation.src)?.id,
       end: requirements.get(relation.dst)?.id,
-      type: relation.type,
+      label: `&lt;&lt;${relation.type}&gt;&gt;`,
       classes: 'relationshipLine',
-      style: ['fill:none'],
+      style: ['fill:none', isContains ? '' : 'stroke-dasharray: 10,7'],
+      labelpos: 'c',
+      thickness: 'normal',
+      type: 'normal',
+      pattern: isContains ? 'normal' : 'dashed',
+      arrowTypeEnd: isContains ? 'requirement_contains' : 'requirement_arrow',
+      look: config.look,
     };
 
     edges.push(edge);

--- a/packages/mermaid/src/diagrams/requirement/requirementDb.ts
+++ b/packages/mermaid/src/diagrams/requirement/requirementDb.ts
@@ -61,12 +61,12 @@ const setDirection = (dir: string) => {
 };
 
 const getInitialRequirement = (): Requirement => ({
-  id: '',
+  requirement_id: '',
   text: '',
-  risk: RiskLevel.LOW_RISK as RiskLevel,
-  verifyMethod: VerifyType.VERIFY_ANALYSIS as VerifyType,
+  risk: '' as RiskLevel,
+  verifyMethod: '' as VerifyType,
   name: '',
-  type: RequirementType.REQUIREMENT as RequirementType,
+  type: '' as RequirementType,
   cssStyles: [],
   classes: ['default'],
 });
@@ -101,7 +101,7 @@ const addRequirement = (name: string, type: RequirementType) => {
     requirements.set(name, {
       name,
       type,
-      id: latestRequirement.id,
+      requirement_id: latestRequirement.requirement_id,
       text: latestRequirement.text,
       risk: latestRequirement.risk,
       verifyMethod: latestRequirement.verifyMethod,
@@ -118,7 +118,7 @@ const getRequirements = () => requirements;
 
 const setNewReqId = (id: string) => {
   if (latestRequirement !== undefined) {
-    latestRequirement.id = id;
+    latestRequirement.requirement_id = id;
   }
 };
 
@@ -262,6 +262,7 @@ const getData = () => {
   const edges: Edge[] = [];
   for (const requirement of requirements.values()) {
     const node = requirement as unknown as Node;
+    node.id = requirement.name;
     node.cssStyles = requirement.cssStyles;
     node.cssClasses = requirement.classes.join(' ');
     node.shape = 'requirementBox';
@@ -285,8 +286,8 @@ const getData = () => {
     const isContains = relation.type === Relationships.CONTAINS;
     const edge: Edge = {
       id: `${relation.src}-${relation.dst}-${counter}`,
-      start: requirements.get(relation.src)?.id ?? elements.get(relation.src)?.name,
-      end: requirements.get(relation.dst)?.id ?? elements.get(relation.dst)?.name,
+      start: requirements.get(relation.src)?.name ?? elements.get(relation.src)?.name,
+      end: requirements.get(relation.dst)?.name ?? elements.get(relation.dst)?.name,
       label: `&lt;&lt;${relation.type}&gt;&gt;`,
       classes: 'relationshipLine',
       style: ['fill:none', isContains ? '' : 'stroke-dasharray: 10,7'],

--- a/packages/mermaid/src/diagrams/requirement/requirementDb.ts
+++ b/packages/mermaid/src/diagrams/requirement/requirementDb.ts
@@ -66,12 +66,14 @@ const getInitialRequirement = (): Requirement => ({
   verifyMethod: VerifyType.VERIFY_ANALYSIS as VerifyType,
   name: '',
   type: RequirementType.REQUIREMENT as RequirementType,
+  cssStyles: [],
 });
 
 const getInitialElement = (): Element => ({
   name: '',
   type: '',
   docRef: '',
+  cssStyles: [],
 });
 
 // Update initial declarations
@@ -99,6 +101,7 @@ const addRequirement = (name: string, type: RequirementType) => {
       text: latestRequirement.text,
       risk: latestRequirement.risk,
       verifyMethod: latestRequirement.verifyMethod,
+      cssStyles: [],
     });
   }
   resetLatestRequirement();
@@ -138,6 +141,7 @@ const addElement = (name: string) => {
       name,
       type: latestElement.type,
       docRef: latestElement.docRef,
+      cssStyles: [],
     });
     log.info('Added new element: ', name);
   }
@@ -177,6 +181,20 @@ const clear = () => {
   resetLatestElement();
   elements = new Map();
   commonClear();
+};
+
+export const setCssStyle = function (id: string, styles: string[]) {
+  const node = requirements.get(id) ?? elements.get(id);
+  if (!styles || !node) {
+    return;
+  }
+  for (const s of styles) {
+    if (s.includes(',')) {
+      node.cssStyles.push(...s.split(','));
+    } else {
+      node.cssStyles.push(s);
+    }
+  }
 };
 
 const getData = () => {
@@ -251,5 +269,6 @@ export default {
   addRelationship,
   getRelationships,
   clear,
+  setCssStyle,
   getData,
 };

--- a/packages/mermaid/src/diagrams/requirement/requirementDb.ts
+++ b/packages/mermaid/src/diagrams/requirement/requirementDb.ts
@@ -53,6 +53,12 @@ const Relationships = {
   TRACES: 'traces',
 };
 
+let direction = 'TB';
+const getDirection = () => direction;
+const setDirection = (dir: string) => {
+  direction = dir;
+};
+
 const getInitialRequirement = (): Requirement => ({
   id: '',
   text: '',
@@ -215,7 +221,7 @@ const getData = () => {
     counter++;
   }
 
-  return { nodes, edges, other: {}, config };
+  return { nodes, edges, other: {}, config, direction: getDirection() };
 };
 
 export default {
@@ -236,6 +242,8 @@ export default {
   getAccDescription,
   setDiagramTitle,
   getDiagramTitle,
+  getDirection,
+  setDirection,
   addElement,
   getElements,
   setNewElementType,

--- a/packages/mermaid/src/diagrams/requirement/requirementDb.ts
+++ b/packages/mermaid/src/diagrams/requirement/requirementDb.ts
@@ -188,6 +188,7 @@ const getData = () => {
     const node = element as unknown as Node;
     node.shape = 'requirementBox';
     node.look = config.look;
+    node.id = element.name;
 
     nodes.push(node);
   }
@@ -197,8 +198,8 @@ const getData = () => {
     const isContains = relation.type === Relationships.CONTAINS;
     const edge: Edge = {
       id: `${relation.src}-${relation.dst}-${counter}`,
-      start: requirements.get(relation.src)?.id,
-      end: requirements.get(relation.dst)?.id,
+      start: requirements.get(relation.src)?.id ?? elements.get(relation.src)?.name,
+      end: requirements.get(relation.dst)?.id ?? elements.get(relation.dst)?.name,
       label: `&lt;&lt;${relation.type}&gt;&gt;`,
       classes: 'relationshipLine',
       style: ['fill:none', isContains ? '' : 'stroke-dasharray: 10,7'],

--- a/packages/mermaid/src/diagrams/requirement/requirementDb.ts
+++ b/packages/mermaid/src/diagrams/requirement/requirementDb.ts
@@ -1,5 +1,6 @@
 import { getConfig } from '../../diagram-api/diagramAPI.js';
 import { log } from '../../logger.js';
+import type { Node, Edge } from '../../rendering-util/types.js';
 
 import {
   setAccTitle,
@@ -7,6 +8,8 @@ import {
   getAccDescription,
   setAccDescription,
   clear as commonClear,
+  setDiagramTitle,
+  getDiagramTitle,
 } from '../common/commonDb.js';
 import type {
   Element,
@@ -170,6 +173,44 @@ const clear = () => {
   commonClear();
 };
 
+const getData = () => {
+  const config = getConfig();
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
+
+  for (const requirement of requirements.values()) {
+    const node = requirement as unknown as Node;
+    node.shape = 'requirementBox';
+    node.look = config.look;
+    nodes.push(node);
+  }
+
+  for (const element of elements.values()) {
+    const node = element as unknown as Node;
+    node.shape = 'requirementBox';
+    node.look = config.look;
+
+    nodes.push(node);
+  }
+
+  for (const relation of relations) {
+    let counter = 0;
+    const edge: Edge = {
+      id: `${relation.src}-${relation.dst}-${counter}`,
+      start: requirements.get(relation.src)?.id,
+      end: requirements.get(relation.dst)?.id,
+      type: relation.type,
+      classes: 'relationshipLine',
+      style: ['fill:none'],
+    };
+
+    edges.push(edge);
+    counter++;
+  }
+
+  return { nodes, edges, other: {}, config };
+};
+
 export default {
   Relationships,
   RequirementType,
@@ -186,6 +227,8 @@ export default {
   getAccTitle,
   setAccDescription,
   getAccDescription,
+  setDiagramTitle,
+  getDiagramTitle,
   addElement,
   getElements,
   setNewElementType,
@@ -193,4 +236,5 @@ export default {
   addRelationship,
   getRelationships,
   clear,
+  getData,
 };

--- a/packages/mermaid/src/diagrams/requirement/requirementDiagram.ts
+++ b/packages/mermaid/src/diagrams/requirement/requirementDiagram.ts
@@ -3,7 +3,7 @@ import type { DiagramDefinition } from '../../diagram-api/types.js';
 import parser from './parser/requirementDiagram.jison';
 import db from './requirementDb.js';
 import styles from './styles.js';
-import renderer from './requirementRenderer.js';
+import renderer from './requirementRenderer-unified.js';
 
 export const diagram: DiagramDefinition = {
   parser,

--- a/packages/mermaid/src/diagrams/requirement/requirementRenderer-unified.ts
+++ b/packages/mermaid/src/diagrams/requirement/requirementRenderer-unified.ts
@@ -19,9 +19,9 @@ export const draw = async function (text: string, id: string, _version: string, 
   data4Layout.type = diag.type;
   data4Layout.layoutAlgorithm = getRegisteredLayoutAlgorithm(layout);
 
-  data4Layout.nodeSpacing = conf?.nodeSpacing || 50;
-  data4Layout.rankSpacing = conf?.rankSpacing || 50;
-  data4Layout.markers = ['aggregation', 'extension', 'composition', 'dependency', 'lollipop'];
+  data4Layout.nodeSpacing = conf?.nodeSpacing ?? 50;
+  data4Layout.rankSpacing = conf?.rankSpacing ?? 50;
+  data4Layout.markers = ['requirement_contains', 'requirement_arrow'];
   data4Layout.diagramId = id;
   await render(data4Layout, svg);
   const padding = 8;

--- a/packages/mermaid/src/diagrams/requirement/requirementRenderer-unified.ts
+++ b/packages/mermaid/src/diagrams/requirement/requirementRenderer-unified.ts
@@ -1,0 +1,40 @@
+import { getConfig } from '../../diagram-api/diagramAPI.js';
+import { log } from '../../logger.js';
+import { getDiagramElement } from '../../rendering-util/insertElementsForSize.js';
+import { getRegisteredLayoutAlgorithm, render } from '../../rendering-util/render.js';
+import { setupViewPortForSVG } from '../../rendering-util/setupViewPortForSVG.js';
+import type { LayoutData } from '../../rendering-util/types.js';
+import utils from '../../utils.js';
+
+export const draw = async function (text: string, id: string, _version: string, diag: any) {
+  log.info('REF0:');
+  log.info('Drawing requirement diagram (unified)', id);
+  const { securityLevel, state: conf, layout } = getConfig();
+
+  const data4Layout = diag.db.getData() as LayoutData;
+
+  // Create the root SVG - the element is the div containing the SVG element
+  const svg = getDiagramElement(id, securityLevel);
+
+  data4Layout.type = diag.type;
+  data4Layout.layoutAlgorithm = getRegisteredLayoutAlgorithm(layout);
+
+  data4Layout.nodeSpacing = conf?.nodeSpacing || 50;
+  data4Layout.rankSpacing = conf?.rankSpacing || 50;
+  data4Layout.markers = ['aggregation', 'extension', 'composition', 'dependency', 'lollipop'];
+  data4Layout.diagramId = id;
+  await render(data4Layout, svg);
+  const padding = 8;
+  utils.insertTitle(
+    svg,
+    'requirementDiagramTitleText',
+    conf?.titleTopMargin ?? 25,
+    diag.db.getDiagramTitle()
+  );
+
+  setupViewPortForSVG(svg, padding, 'requirementDiagram', conf?.useMaxWidth ?? true);
+};
+
+export default {
+  draw,
+};

--- a/packages/mermaid/src/diagrams/requirement/styles.js
+++ b/packages/mermaid/src/diagrams/requirement/styles.js
@@ -52,6 +52,9 @@ const getStyles = (options) => `
     fill: ${options.nodeTextColor || options.textColor};
     color: ${options.nodeTextColor || options.textColor};
   }
+  .labelBkg {
+    background-color: ${options.edgeLabelBackground};
+  }
 
 `;
 // fill', conf.rect_fill)

--- a/packages/mermaid/src/diagrams/requirement/styles.js
+++ b/packages/mermaid/src/diagrams/requirement/styles.js
@@ -40,6 +40,18 @@ const getStyles = (options) => `
   .relationshipLabel {
     fill: ${options.relationLabelColor};
   }
+  .divider {
+    stroke: ${options.nodeBorder};
+    stroke-width: 1;
+  }
+  .label {
+    font-family: ${options.fontFamily};
+    color: ${options.nodeTextColor || options.textColor};
+  }
+  .label text,span {
+    fill: ${options.nodeTextColor || options.textColor};
+    color: ${options.nodeTextColor || options.textColor};
+  }
 
 `;
 // fill', conf.rect_fill)

--- a/packages/mermaid/src/diagrams/requirement/types.ts
+++ b/packages/mermaid/src/diagrams/requirement/types.ts
@@ -13,7 +13,7 @@ export type VerifyType = 'Analysis' | 'Demonstration' | 'Inspection' | 'Test';
 export interface Requirement {
   name: string;
   type: RequirementType;
-  id: string;
+  requirement_id: string;
   text: string;
   risk: RiskLevel;
   verifyMethod: VerifyType;

--- a/packages/mermaid/src/diagrams/requirement/types.ts
+++ b/packages/mermaid/src/diagrams/requirement/types.ts
@@ -18,6 +18,7 @@ export interface Requirement {
   risk: RiskLevel;
   verifyMethod: VerifyType;
   cssStyles: string[];
+  classes: string[];
 }
 
 export type RelationshipType =
@@ -40,4 +41,11 @@ export interface Element {
   type: string;
   docRef: string;
   cssStyles: string[];
+  classes: string[];
+}
+
+export interface RequirementClass {
+  id: string;
+  styles: string[];
+  textStyles: string[];
 }

--- a/packages/mermaid/src/diagrams/requirement/types.ts
+++ b/packages/mermaid/src/diagrams/requirement/types.ts
@@ -17,6 +17,7 @@ export interface Requirement {
   text: string;
   risk: RiskLevel;
   verifyMethod: VerifyType;
+  cssStyles: string[];
 }
 
 export type RelationshipType =
@@ -38,4 +39,5 @@ export interface Element {
   name: string;
   type: string;
   docRef: string;
+  cssStyles: string[];
 }

--- a/packages/mermaid/src/diagrams/requirement/types.ts
+++ b/packages/mermaid/src/diagrams/requirement/types.ts
@@ -13,7 +13,7 @@ export type VerifyType = 'Analysis' | 'Demonstration' | 'Inspection' | 'Test';
 export interface Requirement {
   name: string;
   type: RequirementType;
-  requirement_id: string;
+  requirementId: string;
   text: string;
   risk: RiskLevel;
   verifyMethod: VerifyType;

--- a/packages/mermaid/src/diagrams/requirement/types.ts
+++ b/packages/mermaid/src/diagrams/requirement/types.ts
@@ -1,0 +1,41 @@
+export type RequirementType =
+  | 'Requirement'
+  | 'Functional Requirement'
+  | 'Interface Requirement'
+  | 'Performance Requirement'
+  | 'Physical Requirement'
+  | 'Design Constraint';
+
+export type RiskLevel = 'Low' | 'Medium' | 'High';
+
+export type VerifyType = 'Analysis' | 'Demonstration' | 'Inspection' | 'Test';
+
+export interface Requirement {
+  name: string;
+  type: RequirementType;
+  id: string;
+  text: string;
+  risk: RiskLevel;
+  verifyMethod: VerifyType;
+}
+
+export type RelationshipType =
+  | 'contains'
+  | 'copies'
+  | 'derives'
+  | 'satisfies'
+  | 'verifies'
+  | 'refines'
+  | 'traces';
+
+export interface Relation {
+  type: RelationshipType;
+  src: string;
+  dst: string;
+}
+
+export interface Element {
+  name: string;
+  type: string;
+  docRef: string;
+}

--- a/packages/mermaid/src/docs/syntax/requirementDiagram.md
+++ b/packages/mermaid/src/docs/syntax/requirementDiagram.md
@@ -61,6 +61,26 @@ element user_defined_name {
 }
 ```
 
+### Markdown Formatting
+
+In places where user defined text is possible (like names, requirement text, element docref, etc.), you can:
+
+- Surround the text in quotes: `"example text"`
+- Use markdown formatting inside quotes: `"**bold text** and *italics*"`
+
+Example:
+
+```mermaid-example
+requirementDiagram
+
+requirement "__test_req__" {
+    id: 1
+    text: "*italicized text* **bold text**"
+    risk: high
+    verifymethod: test
+}
+```
+
 ### Relationship
 
 Relationships are comprised of a source node, destination node, and relationship type.
@@ -155,6 +175,142 @@ This example uses all features of the diagram.
     test_req5 - refines -> test_req6
     test_entity3 - verifies -> test_req5
     test_req <- copies - test_entity2
+```
+
+## Direction
+
+The diagram can be rendered in different directions using the `direction` statement. Valid values are:
+
+- `TB` - Top to Bottom (default)
+- `BT` - Bottom to Top
+- `LR` - Left to Right
+- `RL` - Right to Left
+
+Example:
+
+```mermaid-example
+requirementDiagram
+
+direction LR
+
+requirement test_req {
+    id: 1
+    text: the test text.
+    risk: high
+    verifymethod: test
+}
+
+element test_entity {
+    type: simulation
+}
+
+test_entity - satisfies -> test_req
+```
+
+## Styling
+
+Requirements and elements can be styled using direct styling or classes. As a rule of thumb, when applying styles or classes, it accepts a list of requirement or element names and a list of class names allowing multiple assignments at a time (The only exception is the shorthand syntax `:::` which can assign multiple classes but only to one requirement or element at a time).
+
+### Direct Styling
+
+Use the `style` keyword to apply CSS styles directly:
+
+```mermaid-example
+requirementDiagram
+
+requirement test_req {
+    id: 1
+    text: styling example
+    risk: low
+    verifymethod: test
+}
+
+element test_entity {
+    type: simulation
+}
+
+style test_req fill:#ffa,stroke:#000, color: green
+style test_entity fill:#f9f,stroke:#333, color: blue
+```
+
+### Class Definitions
+
+Define reusable styles using `classDef`:
+
+```mermaid-example
+requirementDiagram
+
+requirement test_req {
+    id: 1
+    text: "class styling example"
+    risk: low
+    verifymethod: test
+}
+
+element test_entity {
+    type: simulation
+}
+
+classDef important fill:#f96,stroke:#333,stroke-width:4px
+classDef test fill:#ffa,stroke:#000
+```
+
+### Default class
+
+If a class is named default it will be applied to all nodes. Specific styles and classes should be defined afterwards to override the applied default styling.
+
+```
+classDef default fill:#f9f,stroke:#333,stroke-width:4px;
+```
+
+### Applying Classes
+
+Classes can be applied in two ways:
+
+1. Using the `class` keyword:
+
+```
+class test_req,test_entity important
+```
+
+2. Using the shorthand syntax with `:::` either during the definition or afterwards:
+
+```
+requirement test_req:::important {
+    id: 1
+    text: class styling example
+    risk: low
+    verifymethod: test
+}
+```
+
+```
+element test_elem {
+}
+
+test_elem:::myClass
+```
+
+### Combined Example
+
+```mermaid-example
+requirementDiagram
+
+requirement test_req:::important {
+    id: 1
+    text: "class styling example"
+    risk: low
+    verifymethod: test
+}
+
+element test_entity {
+    type: simulation
+}
+
+classDef important font-weight:bold
+
+class test_entity important
+style test_entity fill:#f9f,stroke:#333
 ```
 
 <!--- cspell:ignore reqs --->

--- a/packages/mermaid/src/rendering-util/rendering-elements/edgeMarker.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/edgeMarker.ts
@@ -35,6 +35,8 @@ const arrowTypesMap = {
   composition: 'composition',
   dependency: 'dependency',
   lollipop: 'lollipop',
+  requirement_arrow: 'requirement_arrow',
+  requirement_contains: 'requirement_contains',
 } as const;
 
 const addEdgeMarker = (

--- a/packages/mermaid/src/rendering-util/rendering-elements/markers.js
+++ b/packages/mermaid/src/rendering-util/rendering-elements/markers.js
@@ -277,6 +277,43 @@ const barb = (elem, type, id) => {
     .append('path')
     .attr('d', 'M 19,7 L9,13 L14,7 L9,1 Z');
 };
+const requirement_arrow = (elem, type, id) => {
+  elem
+    .append('defs')
+    .append('marker')
+    .attr('id', id + '_' + type + '-requirement_arrowEnd')
+    .attr('refX', 20)
+    .attr('refY', 10)
+    .attr('markerWidth', 20)
+    .attr('markerHeight', 20)
+    .attr('orient', 'auto')
+    .append('path')
+    .attr(
+      'd',
+      `M0,0
+      L20,10
+      M20,10
+      L0,20`
+    );
+};
+const requirement_contains = (elem, type, id) => {
+  const containsNode = elem
+    .append('defs')
+    .append('marker')
+    .attr('id', id + '_' + type + '-requirement_containsEnd')
+    .attr('refX', 20)
+    .attr('refY', 10)
+    .attr('markerWidth', 20)
+    .attr('markerHeight', 20)
+    .attr('orient', 'auto')
+    .append('g');
+
+  containsNode.append('circle').attr('cx', 10).attr('cy', 10).attr('r', 10).attr('fill', 'none');
+
+  containsNode.append('line').attr('x1', 0).attr('x2', 20).attr('y1', 10).attr('y2', 10);
+
+  containsNode.append('line').attr('y1', 0).attr('y2', 20).attr('x1', 10).attr('x2', 10);
+};
 
 // TODO rename the class diagram markers to something shape descriptive and semantic free
 const markers = {
@@ -289,5 +326,7 @@ const markers = {
   circle,
   cross,
   barb,
+  requirement_arrow,
+  requirement_contains,
 };
 export default insertMarkers;

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes.ts
@@ -58,6 +58,7 @@ import { waveEdgedRectangle } from './shapes/waveEdgedRectangle.js';
 import { waveRectangle } from './shapes/waveRectangle.js';
 import { windowPane } from './shapes/windowPane.js';
 import { classBox } from './shapes/classBox.js';
+import { requirementBox } from './shapes/requirementBox.js';
 import { kanbanItem } from './shapes/kanbanItem.js';
 
 type ShapeHandler = <T extends SVGGraphicsElement>(
@@ -476,6 +477,9 @@ const generateShapeMap = () => {
 
     // class diagram
     classBox,
+
+    // Requirement diagram
+    requirementBox,
   } as const;
 
   const entries = [

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/requirementBox.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/requirementBox.ts
@@ -55,7 +55,7 @@ export async function requirementBox<T extends SVGGraphicsElement>(
   if (isRequirementNode) {
     const idHeight = await addText(
       shapeSvg,
-      `${requirementNode.requirement_id ? `Id: ${requirementNode.requirement_id}` : ''}`,
+      `${requirementNode.requirementId ? `Id: ${requirementNode.requirementId}` : ''}`,
       accumulativeHeight,
       node.labelStyle
     );

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/requirementBox.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/requirementBox.ts
@@ -1,0 +1,178 @@
+import { updateNodeBounds } from './util.js';
+import intersect from '../intersect/index.js';
+import type { Node } from '../../types.js';
+import { userNodeOverrides } from './handDrawnShapeStyles.js';
+import rough from 'roughjs';
+import type { D3Selection } from '../../../types.js';
+import { calculateTextWidth, decodeEntities } from '../../../utils.js';
+import { getConfig, sanitizeText } from '../../../diagram-api/diagramAPI.js';
+import { createText } from '../../createText.js';
+import { select } from 'd3';
+import type { Requirement, Element } from '../../../diagrams/requirement/types.js';
+
+export async function requirementBox<T extends SVGGraphicsElement>(
+  parent: D3Selection<T>,
+  node: Node
+) {
+  const requirementNode = node as unknown as Requirement;
+  const elementNode = node as unknown as Element;
+  const config = getConfig().requirement;
+  const PADDING = 20;
+  const GAP = 20;
+  const isRequirementNode = 'id' in node;
+
+  // Add outer g element
+  const shapeSvg = parent
+    .insert('g')
+    .attr('class', '')
+    .attr('id', node.domId ?? node.id);
+
+  let typeHeight;
+  if (isRequirementNode) {
+    typeHeight = await addText(shapeSvg, `&lt;&lt;${requirementNode.type}&gt;&gt;`, 0);
+  } else {
+    typeHeight = await addText(shapeSvg, '&lt;&lt;Element&gt;&gt;', 0);
+  }
+
+  let accumulativeHeight = typeHeight;
+  const nameHeight = await addText(shapeSvg, requirementNode.name, accumulativeHeight);
+  accumulativeHeight += nameHeight + GAP;
+
+  // Requirement
+  if (isRequirementNode) {
+    const idHeight = await addText(shapeSvg, `Id: ${requirementNode.id}`, accumulativeHeight);
+    accumulativeHeight += idHeight;
+    const textHeight = await addText(shapeSvg, `Text: ${requirementNode.text}`, accumulativeHeight);
+    accumulativeHeight += textHeight;
+    const riskHeight = await addText(shapeSvg, `Risk: ${requirementNode.risk}`, accumulativeHeight);
+    accumulativeHeight += riskHeight;
+    await addText(shapeSvg, `Verification: ${requirementNode.verifyMethod}`, accumulativeHeight);
+  } else {
+    // Element
+    const typeHeight = await addText(
+      shapeSvg,
+      `Type: ${elementNode.type ? elementNode.type : 'Not specified'}`,
+      accumulativeHeight
+    );
+    accumulativeHeight += typeHeight;
+    await addText(
+      shapeSvg,
+      `Doc Ref: ${elementNode.docRef ? elementNode.docRef : 'None'}`,
+      accumulativeHeight
+    );
+  }
+
+  const totalWidth = Math.max(
+    (shapeSvg.node()?.getBBox().width ?? 200) + PADDING,
+    config?.rect_min_width ?? 200
+  );
+  const totalHeight = totalWidth;
+  const x = -totalWidth / 2;
+  const y = -totalHeight / 2;
+
+  // Setup roughjs
+  // @ts-ignore TODO: Fix rough typings
+  const rc = rough.svg(shapeSvg);
+  const options = userNodeOverrides(node, {});
+
+  if (node.look !== 'handDrawn') {
+    options.roughness = 0;
+    options.fillStyle = 'solid';
+  }
+
+  // Create and center rectangle
+  const roughRect = rc.rectangle(x, y, totalWidth, totalHeight, options);
+
+  const rect = shapeSvg.insert(() => roughRect, ':first-child');
+  rect.attr('class', 'basic label-container');
+
+  // Re-translate labels now that rect is centered
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  shapeSvg.selectAll('.label').each((_: any, i: number, nodes: any) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const text = select<any, unknown>(nodes[i]);
+
+    const transform = text.attr('transform');
+    let translateX = 0;
+    let translateY = 0;
+    if (transform) {
+      const regex = RegExp(/translate\(([^,]+),([^)]+)\)/);
+      const translate = regex.exec(transform);
+      if (translate) {
+        translateX = parseFloat(translate[1]);
+        translateY = parseFloat(translate[2]);
+      }
+    }
+
+    const newTranslateY = translateY - totalHeight / 2;
+    let newTranslateX = x + PADDING / 2;
+
+    // Keep type and name labels centered.
+    if (i === 0 || i === 1) {
+      newTranslateX = translateX;
+    }
+    // Set the updated transform attribute
+    text.attr('transform', `translate(${newTranslateX}, ${newTranslateY + PADDING})`);
+  });
+
+  // Insert divider line
+  const roughLine = rc.line(
+    x,
+    y + typeHeight + nameHeight + GAP,
+    x + totalWidth,
+    y + typeHeight + nameHeight + GAP,
+    options
+  );
+  shapeSvg.insert(() => roughLine);
+
+  updateNodeBounds(node, rect);
+
+  node.intersect = function (point) {
+    return intersect.rect(node, point);
+  };
+
+  return shapeSvg;
+}
+
+async function addText<T extends SVGGraphicsElement>(
+  parentGroup: D3Selection<T>,
+  inputText: string,
+  yOffset: number,
+  styles: string[] = []
+) {
+  const textEl = parentGroup.insert('g').attr('class', 'label').attr('style', styles.join('; '));
+  const config = getConfig();
+  const useHtmlLabels = config.htmlLabels ?? true;
+
+  const text = await createText(
+    textEl,
+    sanitizeText(decodeEntities(inputText)),
+    {
+      width: calculateTextWidth(inputText, config) + 50, // Add room for error when splitting text into multiple lines
+      classes: 'markdown-node-label',
+      useHtmlLabels,
+    },
+    config
+  );
+  let bbox;
+
+  if (!useHtmlLabels) {
+    const textChild = text.children[0];
+    textChild.textContent = inputText.replaceAll('&gt;', '>').replaceAll('&lt;', '<').trim();
+    // Get the bounding box after the text update
+    bbox = text.getBBox();
+    // Add extra height so it is similar to the html labels
+    bbox.height += 6;
+  } else {
+    const div = text.children[0];
+    const dv = select(text);
+
+    bbox = div.getBoundingClientRect();
+    dv.attr('width', bbox.width);
+    dv.attr('height', bbox.height);
+  }
+
+  // Center text and offset by yOffset
+  textEl.attr('transform', `translate(${-bbox.width / 2},${-bbox.height / 2 + yOffset})`);
+  return bbox.height;
+}

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/requirementBox.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/requirementBox.ts
@@ -199,7 +199,9 @@ async function addText<T extends SVGGraphicsElement>(
 
   if (!useHtmlLabels) {
     const textChild = text.children[0];
-    textChild.textContent = inputText.replaceAll('&gt;', '>').replaceAll('&lt;', '<').trim();
+    for (const child of textChild.children) {
+      child.textContent = child.textContent.replaceAll('&gt;', '>').replaceAll('&lt;', '<');
+    }
     // Get the bounding box after the text update
     bbox = text.getBBox();
     // Add extra height so it is similar to the html labels

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/requirementBox.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/requirementBox.ts
@@ -1,4 +1,4 @@
-import { updateNodeBounds } from './util.js';
+import { getNodeClasses, updateNodeBounds } from './util.js';
 import intersect from '../intersect/index.js';
 import type { Node } from '../../types.js';
 import { styles2String, userNodeOverrides } from './handDrawnShapeStyles.js';
@@ -22,11 +22,12 @@ export async function requirementBox<T extends SVGGraphicsElement>(
   const PADDING = 20;
   const GAP = 20;
   const isRequirementNode = 'verifyMethod' in node;
+  const classes = getNodeClasses(node);
 
   // Add outer g element
   const shapeSvg = parent
     .insert('g')
-    .attr('class', '')
+    .attr('class', classes)
     .attr('id', node.domId ?? node.id);
 
   let typeHeight;

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/requirementBox.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/requirementBox.ts
@@ -55,28 +55,29 @@ export async function requirementBox<T extends SVGGraphicsElement>(
   if (isRequirementNode) {
     const idHeight = await addText(
       shapeSvg,
-      `Id: ${requirementNode.id}`,
+      `${requirementNode.requirement_id ? `Id: ${requirementNode.requirement_id}` : ''}`,
       accumulativeHeight,
       node.labelStyle
     );
+
     accumulativeHeight += idHeight;
     const textHeight = await addText(
       shapeSvg,
-      `Text: ${requirementNode.text}`,
+      `${requirementNode.text ? `Text: ${requirementNode.text}` : ''}`,
       accumulativeHeight,
       node.labelStyle
     );
     accumulativeHeight += textHeight;
     const riskHeight = await addText(
       shapeSvg,
-      `Risk: ${requirementNode.risk}`,
+      `${requirementNode.risk ? `Risk: ${requirementNode.risk}` : ''}`,
       accumulativeHeight,
       node.labelStyle
     );
     accumulativeHeight += riskHeight;
     await addText(
       shapeSvg,
-      `Verification: ${requirementNode.verifyMethod}`,
+      `${requirementNode.verifyMethod ? `Verification: ${requirementNode.verifyMethod}` : ''}`,
       accumulativeHeight,
       node.labelStyle
     );
@@ -84,14 +85,14 @@ export async function requirementBox<T extends SVGGraphicsElement>(
     // Element
     const typeHeight = await addText(
       shapeSvg,
-      `Type: ${elementNode.type ? elementNode.type : 'Not specified'}`,
+      `${elementNode.type ? `Type: ${elementNode.type}` : ''}`,
       accumulativeHeight,
       node.labelStyle
     );
     accumulativeHeight += typeHeight;
     await addText(
       shapeSvg,
-      `Doc Ref: ${elementNode.docRef ? elementNode.docRef : 'None'}`,
+      `${elementNode.docRef ? `Doc Ref: ${elementNode.docRef}` : ''}`,
       accumulativeHeight,
       node.labelStyle
     );
@@ -176,6 +177,9 @@ async function addText<T extends SVGGraphicsElement>(
   yOffset: number,
   style = ''
 ) {
+  if (inputText === '') {
+    return 0;
+  }
   const textEl = parentGroup.insert('g').attr('class', 'label').attr('style', style);
   const config = getConfig();
   const useHtmlLabels = config.htmlLabels ?? true;


### PR DESCRIPTION
## :bookmark_tabs: Summary

Updates the Requirement diagram to the new unified way of rendering including changes to bring it up to par with other diagrams. Styling and classes are now supported as well as changing the direction of the diagram and the hand drawn look.

- New requirementBox shape
- Hand drawn look
- Direction statement to change the direction of the diagram
- Styling now supported via the style statement, classDef and class statements, as well as the shorthand syntax.
- Updated documentation to reflect all new changes

## :straight_ruler: Design Decisions

Before merging a design decision should be made with how the shape is handled in terms of the size and the data it shows inside.

I tried to maintain similarity from before where the shape is always a square and has a default minimum height / width however from my research it seems like the nodes in requirement diagrams scale in height / width based off their text so it would be a smaller rectangle if there was no text inside.

![image](https://github.com/user-attachments/assets/ec3c3232-7416-477b-80b8-4d0081277208)
![image](https://github.com/user-attachments/assets/8defd6f9-4661-472a-9099-d3d8aa861af6)

I can change the box shape to reflect this behavior and if the user wants to resize the shape in Mermaid Chart it's probably best to not force this square look and minimum height / width.

As seen from above, if there is no id, text, type, etc. defined it simply won't show up as text inside the box. In the current version of mermaid it either shows as undefined or other text ("Not specified" or "None"). I can revert it to reflect this behavior again but again from my research I think it's best to not show the text if it wasn't defined.

![image](https://github.com/user-attachments/assets/f3561d1b-1900-4c4a-8132-e1519f33da0e)


### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
