### PR TITLE
Fix: Wrong link to d3-shape documentation in Flowchart docs

### DIFF
--- a/docs/syntax/flowchart.md
+++ b/docs/syntax/flowchart.md
@@ -1792,8 +1792,7 @@ graph LR
 ```
 
 For a full list of available curves, including an explanation of custom curves, refer to
-the [Shapes](https://github.com/d3/d3-shape/blob/main/README.md#curves) documentation in the
-[d3-shape](https://github.com/d3/d3-shape/) project.
+the [Shapes](https://d3js.org/d3-shape/curve) documentation in the [d3-shape](https://github.com/d3/d3-shape/) project.
 
 ### Styling a node
 

--- a/packages/mermaid/src/docs/syntax/flowchart.md
+++ b/packages/mermaid/src/docs/syntax/flowchart.md
@@ -1135,8 +1135,7 @@ graph LR
 ```
 
 For a full list of available curves, including an explanation of custom curves, refer to
-the [Shapes](https://github.com/d3/d3-shape/blob/main/README.md#curves) documentation in the
-[d3-shape](https://github.com/d3/d3-shape/) project.
+the [Shapes](https://d3js.org/d3-shape/curve) documentation in the [d3-shape](https://github.com/d3/d3-shape/) project.
 
 ### Styling a node
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

This PR fixes a link in the documentation: Right now, the link just points unhelpfully to the project's GitHub README (I assume, in the past there was more documentation there). I changed it to the project's documentation page describing the different curves.

(I edited by "Edit this page on GitHub", so I have a default branch name, sry :blush: )

~~Resolves #<your issue id here>~~

## :straight_ruler: Design Decisions

~~Describe the way your implementation works or what design decisions you made if applicable.~~

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
