### PR TITLE
Set custom font family for legend in user diagrams.

### DIFF
--- a/packages/mermaid/src/diagrams/user-journey/styles.js
+++ b/packages/mermaid/src/diagrams/user-journey/styles.js
@@ -14,7 +14,6 @@ const getStyles = (options) =>
   .legend {
     fill: ${options.textColor};
     font-family: ${options.fontFamily};
-    font-size: ${options.textSize};
   }
 
   .label text {

--- a/packages/mermaid/src/diagrams/user-journey/styles.js
+++ b/packages/mermaid/src/diagrams/user-journey/styles.js
@@ -13,6 +13,8 @@ const getStyles = (options) =>
 
   .legend {
     fill: ${options.textColor};
+    font-family: ${options.fontFamily};
+    font-size: ${options.textSize};
   }
 
   .label text {


### PR DESCRIPTION
## :bookmark_tabs: Summary

Before there was an issue where the font family for the legend in user journey diagrams defaulted to the system font-family, resulting in inconsistent styling.

With this change, users can now define a custom font family for the legend in user journey diagrams through the Mermaid configuration.

## :straight_ruler: Design Decisions

Updated styles.js for user journey diagrams to include font-family and font-size for legends. Previously, no font-family was set, so the system's default font-family was used. Now, custom font-family can be applied through Mermaid's configuration.

## :clipboard: Tasks

Make sure you

- [X] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
