### PR TITLE
Feature/523 Add Style option to sequence diagram actors

### DIFF
--- a/demos/sequence.html
+++ b/demos/sequence.html
@@ -255,13 +255,14 @@
     <pre class="mermaid">
     sequenceDiagram
       participant Pink Alice
-      participant Blue Bob
-      Pink Alice->>Blue Bob: Hello!
-      Blue Bob->>Pink Alice: Hi Alice, what a nice pink color
-      Pink Alice->>Blue Bob: Thanks Bob, I like your color to!
+      participant Purple Bob
+      Pink Alice->>+Purple Bob: Hello!
+      Purple Bob->>+Pink Alice: Hi Alice, what a nice pink color
+      Pink Alice->>-Purple Bob: Thanks Bob, I like your color to!
+      Purple Bob->>-Pink Alice: Thanks Alice!!!
 
       style Pink Alice: fill:pink, stroke:red
-      style Blue Bob: fill:aqua, stroke:blue
+      style Purple Bob: fill:mediumPurple, stroke:purple
     </pre>
     <script type="module">
       import mermaid from './mermaid.esm.mjs';

--- a/demos/sequence.html
+++ b/demos/sequence.html
@@ -249,6 +249,20 @@
       Alice<<->>Bob: Wow, we said that at the same time!
       Bob<<-->>Alice: Bidirectional Arrows are so cool
     </pre>
+
+    <hr />
+
+    <pre class="mermaid">
+    sequenceDiagram
+      participant Pink Alice
+      participant Blue Bob
+      Pink Alice->>Blue Bob: Hello!
+      Blue Bob->>Pink Alice: Hi Alice, what a nice pink color
+      Pink Alice->>Blue Bob: Thanks Bob, I like your color to!
+
+      style Pink Alice: fill:pink, stroke:red
+      style Blue Bob: fill:aqua, stroke:blue
+    </pre>
     <script type="module">
       import mermaid from './mermaid.esm.mjs';
       mermaid.initialize({

--- a/packages/mermaid/src/diagrams/sequence/parser/sequenceDiagram.jison
+++ b/packages/mermaid/src/diagrams/sequence/parser/sequenceDiagram.jison
@@ -57,6 +57,7 @@
 "details"                                                       return 'details';
 "over"                                                          return 'over';
 "note"                                                          return 'note';
+"style"                                                         return 'style';
 "activate"                                                      { this.begin('ID'); return 'activate'; }
 "deactivate"                                                    { this.begin('ID'); return 'deactivate'; }
 "title"\s[^#\n;]+                                               return 'title';
@@ -84,7 +85,7 @@ accDescr\s*"{"\s*                                { this.begin("acc_descr_multili
 \-\-[x]                                                         return 'DOTTED_CROSS';
 \-[\)]                                                          return 'SOLID_POINT';
 \-\-[\)]                                                        return 'DOTTED_POINT';
-":"(?:(?:no)?wrap:)?[^#\n;]+                                    return 'TXT';
+":"(?:(?:no)?wrap:)?[^\n;]+                                     return 'TXT';
 "+"                                                             return '+';
 "-"                                                             return '-';
 <<EOF>>                                                         return 'NEWLINE';
@@ -143,6 +144,7 @@ statement
 	| 'activate' actor 'NEWLINE' {$$={type: 'activeStart', signalType: yy.LINETYPE.ACTIVE_START, actor: $2.actor};}
 	| 'deactivate' actor 'NEWLINE' {$$={type: 'activeEnd', signalType: yy.LINETYPE.ACTIVE_END, actor: $2.actor};}
 	| note_statement 'NEWLINE'
+	| style_statement 'NEWLINE'
 	| links_statement 'NEWLINE'
 	| link_statement 'NEWLINE'
 	| properties_statement 'NEWLINE'
@@ -258,6 +260,13 @@ link_statement
 		$$ = [$2, {type:'addALink', actor:$2.actor, text:$3}];
   }
 	;
+
+style_statement
+    : 'style' actor text2                              
+		{
+		$$ = [$2, {type:'setCssStyle', actor:$2.actor, text:$3}];
+		}
+    ;
 
 properties_statement
 	: 'properties' actor text2

--- a/packages/mermaid/src/diagrams/sequence/parser/sequenceDiagram.jison
+++ b/packages/mermaid/src/diagrams/sequence/parser/sequenceDiagram.jison
@@ -262,10 +262,10 @@ link_statement
 	;
 
 style_statement
-    : 'style' actor text2                              
-		{
+    : 'style' actor text2
+	{
 		$$ = [$2, {type:'setCssStyle', actor:$2.actor, text:$3}];
-		}
+  }
     ;
 
 properties_statement

--- a/packages/mermaid/src/diagrams/sequence/sequenceDb.ts
+++ b/packages/mermaid/src/diagrams/sequence/sequenceDb.ts
@@ -98,6 +98,7 @@ export const addActor = function (
     actorCnt: null,
     rectData: null,
     type: type ?? 'participant',
+    style: '',
   });
   if (state.records.prevActor) {
     const prevActorInRecords = state.records.actors.get(state.records.prevActor);
@@ -478,6 +479,11 @@ export const getActorProperty = function (actor: Actor, key: string) {
   return undefined;
 };
 
+export const setCssStyle = function (actorId: string, text: { text: string }) {
+  const actor = getActor(actorId);
+  actor.style = text.text.replaceAll(',', ';');
+};
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-redundant-type-constituents
 export const apply = function (param: any | AddMessageParams | AddMessageParams[]) {
   if (Array.isArray(param)) {
@@ -624,6 +630,9 @@ export const apply = function (param: any | AddMessageParams | AddMessageParams[
       case 'breakEnd':
         addSignal(undefined, undefined, undefined, param.signalType);
         break;
+      case 'setCssStyle':
+        setCssStyle(param.actor, param.text);
+        break;
     }
   }
 };
@@ -665,4 +674,5 @@ export default {
   getAccDescription,
   hasAtLeastOneBox,
   hasAtLeastOneBoxWithTitle,
+  setCssStyle,
 };

--- a/packages/mermaid/src/diagrams/sequence/sequenceRenderer.ts
+++ b/packages/mermaid/src/diagrams/sequence/sequenceRenderer.ts
@@ -836,6 +836,7 @@ export const draw = async function (_text: string, id: string, _version: string,
    * @param verticalPos - The vertical position of the message.
    */
   function activeEnd(msg: any, verticalPos: number) {
+    const actor = actors.get(msg.from);
     const activationData = bounds.endActivation(msg);
     if (activationData.starty + 18 > verticalPos) {
       activationData.starty = verticalPos - 6;
@@ -846,7 +847,8 @@ export const draw = async function (_text: string, id: string, _version: string,
       activationData,
       verticalPos,
       conf,
-      actorActivations(msg.from).length
+      actorActivations(msg.from).length,
+      actor.style
     );
 
     bounds.insert(activationData.startx, verticalPos - 10, activationData.stopx, verticalPos);

--- a/packages/mermaid/src/diagrams/sequence/svgDraw.js
+++ b/packages/mermaid/src/diagrams/sequence/svgDraw.js
@@ -348,6 +348,7 @@ const drawActorTypeParticipant = function (elem, actor, conf, isFooter) {
       .attr('class', 'actor-line 200')
       .attr('stroke-width', '0.5px')
       .attr('stroke', '#999')
+      .attr('style', actor.style)
       .attr('name', actor.name);
 
     g = boxplusLineGroup.append('g');
@@ -378,6 +379,7 @@ const drawActorTypeParticipant = function (elem, actor, conf, isFooter) {
   rect.rx = 3;
   rect.ry = 3;
   rect.name = actor.name;
+  rect.attrs = { style: actor.style };
   const rectElem = drawRect(g, rect);
   actor.rectData = rect;
 

--- a/packages/mermaid/src/diagrams/sequence/svgDraw.js
+++ b/packages/mermaid/src/diagrams/sequence/svgDraw.js
@@ -548,8 +548,9 @@ export const anchorElement = function (elem) {
  * @param {any} verticalPos - Precise y coordinate of bottom activation box edge.
  * @param {any} conf - Sequence diagram config object.
  * @param {any} actorActivations - Number of activations on the actor.
+ * @param {string} style - CSS style of this actor.
  */
-export const drawActivation = function (elem, bounds, verticalPos, conf, actorActivations) {
+export const drawActivation = function (elem, bounds, verticalPos, conf, actorActivations, style) {
   const rect = svgDrawCommon.getNoteRect();
   const g = bounds.anchored;
   rect.x = bounds.startx;
@@ -557,6 +558,7 @@ export const drawActivation = function (elem, bounds, verticalPos, conf, actorAc
   rect.class = 'activation' + (actorActivations % 3); // Will evaluate to 0, 1 or 2
   rect.width = bounds.stopx - bounds.startx;
   rect.height = verticalPos - bounds.starty;
+  rect.attrs = { style };
   drawRect(g, rect);
 };
 

--- a/packages/mermaid/src/diagrams/sequence/types.ts
+++ b/packages/mermaid/src/diagrams/sequence/types.ts
@@ -17,6 +17,7 @@ export interface Actor {
   actorCnt: number | null;
   rectData: unknown;
   type: string;
+  style: string;
 }
 
 export interface Message {


### PR DESCRIPTION
## :bookmark_tabs: Summary

As described in https://github.com/mermaid-js/mermaid/issues/523, it would be nice if we could style the actors of the sequence diagram. Basic styling makes larger sequence diagrams easier to read, and is for many users (including me) a reason to use other tools instead of mermaid.

This PR introduces the `style` keyword, allowing users to add style to specific actors of the sequence diagram.

Example:
```
    sequenceDiagram
      Pink Alice->>+Purple Bob: Hello!
      Purple Bob->>+Pink Alice: Hi Alice, what a nice pink color
      Pink Alice->>-Purple Bob: Thanks Bob, I like your color to!
      Purple Bob->>-Pink Alice: Thanks Alice!!!

      style Pink Alice: fill:pink,stroke:red
      style Purple Bob: fill:mediumPurple,stroke:purple
```

Output:
<img width="402" alt="image" src="https://github.com/user-attachments/assets/f5168862-def5-4591-9413-29ca30e86523" />


Resolves #523 

## :straight_ruler: Design Decisions

First time contributing to the mermaid codebase, so not very familiar yet. Let me know if you think this solution makes sense.

This PR makes the following changes:
1. Add `style` keyword to sequence diagram JISON definition.
2. As defined in the `style_statement` this keyword takes in the actor, and the text after the `:` and passes it to the `setCssStyle` function.
3. Added `setCssStyle` function to `sequenceDb.ts`. This function retrieves the actor based on its ID and then sets its `style` attribute to the defined style (e.g. `fill:pink, stroke:red`). We replace `,` by `;` so that the defined style becomes valid CSS.
4. This `actor.style` attribute is then accessed in `sequenceRender.ts` and `svgDraw.ts` and passed to the `rect` objects by setting `rect.attr` to `{ style }`. 

Haven't added any tests / docs yet. First wanted to get some feedback 😄 

### :clipboard: Tasks

Make sure you

- [ ] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.


