### PR TITLE
6256 - Allow themeVariables to have additional valid CSS colors

### DIFF
--- a/packages/mermaid/src/utils/sanitizeDirective.spec.ts
+++ b/packages/mermaid/src/utils/sanitizeDirective.spec.ts
@@ -1,0 +1,76 @@
+import { sanitizeDirective } from './sanitizeDirective.js';
+
+describe('sanitizeDirective - Theme Variable Validation', () => {
+  it('should allow color names', () => {
+    const input = { themeVariables: { mainBkg: 'green' } };
+    sanitizeDirective(input);
+    expect(input.themeVariables.mainBkg).toBe('green');
+  });
+
+  it('should allow hex colors', () => {
+    const input = { themeVariables: { mainBkg: '#000', actorBkg: '#000000' } };
+    sanitizeDirective(input);
+    expect(input.themeVariables.mainBkg).toBe('#000');
+    expect(input.themeVariables.actorBkg).toBe('#000000');
+  });
+
+  it('should allow rgb colors', () => {
+    const input = { themeVariables: { mainBkg: 'rgb(0, 0, 0)', actorBkg: 'rgba(0, 0, 0, 0.5)'  } };
+    sanitizeDirective(input);
+    expect(input.themeVariables.mainBkg).toBe('rgb(0, 0, 0)');
+    expect(input.themeVariables.actorBkg).toBe('rgba(0, 0, 0, 0.5)');
+  });
+
+  it('should allow hsl colors', () => {
+    const input = { themeVariables: { mainBkg: 'hsl(0, 0%, 0%)',  actorBkg: 'hsla(0, 0%, 0%, 0.5)' } };
+    sanitizeDirective(input);
+    expect(input.themeVariables.mainBkg).toBe('hsl(0, 0%, 0%)');
+    expect(input.themeVariables.actorBkg).toBe('hsla(0, 0%, 0%, 0.5)');
+  });
+
+  it('should allow css variables', () => {
+    const input = { themeVariables: { mainBkg: 'var(--my-color)' } };
+    sanitizeDirective(input);
+    expect(input.themeVariables.mainBkg).toBe('var(--my-color)');
+  });
+
+  it('should allow light-dark function', () => {
+    const input = { themeVariables: { mainBkg: 'light-dark(green, blue)' } };
+    sanitizeDirective(input);
+    expect(input.themeVariables.mainBkg).toBe('light-dark(green, blue)');
+  });
+
+  it('should allow lighten and darken', () => {
+    const input = { themeVariables: { mainBkg: 'lighten(darken(green, 10%), 10%)' } };
+    sanitizeDirective(input);
+    expect(input.themeVariables.mainBkg).toBe('lighten(darken(green, 10%), 10%)');
+  });
+
+  it('should allow relative color syntax', () => {
+    const input = { themeVariables: { 
+        mainBkg: 'oklch(from var(--base-color) calc(l * 1.15) c h)',
+        actorBkg: 'lch(from var(--base-color) calc(l + 20) c h)',
+        actorBorder: 'lch(from var(--base-color) calc(l - 20) c h)',
+        signalColor: 'rgb(from red r g b / alpha)'
+      }};
+    sanitizeDirective(input);
+    expect(input.themeVariables.mainBkg).toBe('oklch(from var(--base-color) calc(l * 1.15) c h)');
+    expect(input.themeVariables.actorBkg).toBe('lch(from var(--base-color) calc(l + 20) c h)');
+    expect(input.themeVariables.actorBorder).toBe('lch(from var(--base-color) calc(l - 20) c h)');
+    expect(input.themeVariables.signalColor).toBe('rgb(from red r g b / alpha)');
+  });
+
+  it('should set invalid input to empty string', () => {
+    const input = { themeVariables: { mainBkg: '{}' } };
+    sanitizeDirective(input);
+    expect(input.themeVariables.mainBkg).toBe('');
+  });
+
+  it('should sanitize unsafe characters', () => {
+    const input = { themeVariables: { mainBkg: '<script>alert("XSS")</script>' } };
+    sanitizeDirective(input);
+    expect(input.themeVariables.mainBkg).toBe('');
+  });
+
+
+});

--- a/packages/mermaid/src/utils/sanitizeDirective.spec.ts
+++ b/packages/mermaid/src/utils/sanitizeDirective.spec.ts
@@ -15,14 +15,16 @@ describe('sanitizeDirective - Theme Variable Validation', () => {
   });
 
   it('should allow rgb colors', () => {
-    const input = { themeVariables: { mainBkg: 'rgb(0, 0, 0)', actorBkg: 'rgba(0, 0, 0, 0.5)'  } };
+    const input = { themeVariables: { mainBkg: 'rgb(0, 0, 0)', actorBkg: 'rgba(0, 0, 0, 0.5)' } };
     sanitizeDirective(input);
     expect(input.themeVariables.mainBkg).toBe('rgb(0, 0, 0)');
     expect(input.themeVariables.actorBkg).toBe('rgba(0, 0, 0, 0.5)');
   });
 
   it('should allow hsl colors', () => {
-    const input = { themeVariables: { mainBkg: 'hsl(0, 0%, 0%)',  actorBkg: 'hsla(0, 0%, 0%, 0.5)' } };
+    const input = {
+      themeVariables: { mainBkg: 'hsl(0, 0%, 0%)', actorBkg: 'hsla(0, 0%, 0%, 0.5)' },
+    };
     sanitizeDirective(input);
     expect(input.themeVariables.mainBkg).toBe('hsl(0, 0%, 0%)');
     expect(input.themeVariables.actorBkg).toBe('hsla(0, 0%, 0%, 0.5)');
@@ -47,12 +49,14 @@ describe('sanitizeDirective - Theme Variable Validation', () => {
   });
 
   it('should allow relative color syntax', () => {
-    const input = { themeVariables: { 
+    const input = {
+      themeVariables: {
         mainBkg: 'oklch(from var(--base-color) calc(l * 1.15) c h)',
         actorBkg: 'lch(from var(--base-color) calc(l + 20) c h)',
         actorBorder: 'lch(from var(--base-color) calc(l - 20) c h)',
-        signalColor: 'rgb(from red r g b / alpha)'
-      }};
+        signalColor: 'rgb(from red r g b / alpha)',
+      },
+    };
     sanitizeDirective(input);
     expect(input.themeVariables.mainBkg).toBe('oklch(from var(--base-color) calc(l * 1.15) c h)');
     expect(input.themeVariables.actorBkg).toBe('lch(from var(--base-color) calc(l + 20) c h)');
@@ -71,6 +75,4 @@ describe('sanitizeDirective - Theme Variable Validation', () => {
     sanitizeDirective(input);
     expect(input.themeVariables.mainBkg).toBe('');
   });
-
-
 });

--- a/packages/mermaid/src/utils/sanitizeDirective.ts
+++ b/packages/mermaid/src/utils/sanitizeDirective.ts
@@ -54,7 +54,7 @@ export const sanitizeDirective = (args: any): void => {
   if (args.themeVariables) {
     for (const k of Object.keys(args.themeVariables)) {
       const val = args.themeVariables[k];
-      if (val?.match && !val.match(/^[\d \-*+/"#%(),.;A-Za-z]+$/)) {
+      if (val?.match && !val.match(/^[\d "#%()*+,./;A-Za-z\-]+$/)) {
         args.themeVariables[k] = '';
       }
     }

--- a/packages/mermaid/src/utils/sanitizeDirective.ts
+++ b/packages/mermaid/src/utils/sanitizeDirective.ts
@@ -54,7 +54,7 @@ export const sanitizeDirective = (args: any): void => {
   if (args.themeVariables) {
     for (const k of Object.keys(args.themeVariables)) {
       const val = args.themeVariables[k];
-      if (val?.match && !val.match(/^[\d "#%(),.;A-Za-z]+$/)) {
+      if (val?.match && !val.match(/^[\d \-*+/"#%(),.;A-Za-z]+$/)) {
         args.themeVariables[k] = '';
       }
     }

--- a/packages/mermaid/src/utils/sanitizeDirective.ts
+++ b/packages/mermaid/src/utils/sanitizeDirective.ts
@@ -54,7 +54,7 @@ export const sanitizeDirective = (args: any): void => {
   if (args.themeVariables) {
     for (const k of Object.keys(args.themeVariables)) {
       const val = args.themeVariables[k];
-      if (val?.match && !val.match(/^[\d "#%()*+,./;A-Za-z\-]+$/)) {
+      if (val?.match && !val.match(/^[\d "#%()*+,./;A-Za-z-]+$/)) {
         args.themeVariables[k] = '';
       }
     }


### PR DESCRIPTION
## :bookmark_tabs: Summary

This is to resolve the recent issue I submitted. Before this PR there are several color options that can't be used without the sanitization stripping them out. After the PR, you should be able to set a themeVariable to:
* var(--some-css-var)
* light-dark(var(--lightColor), var(--darkColor))
* lighten(var(--someColor), 10%)
* oklch(from var(--base-color) calc(1 * 1.15) c h)

For me, this will enable easy theming of the diagrams based on user selection of light mode or dark mode, but in general it should open up a lot of theming possibilities for everybody I think.

This is my first PR on a major project, so apologies if  I make any mistakes :) 

Resolves #6256 

## :straight_ruler: Design Decisions

The only change here was to the regular expression, I tried to do the bare minimum to allow the CSS. Dashes were added which covers most of the features above, I also added the ability to do `*`, `+`, `/` 

### :clipboard: Tasks

Make sure you

- [✅  ] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [✅  ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
