### PR TITLE
wip: Add optInMarkdownLabels config setting

### DIFF
--- a/docs/config/setup/mermaid/interfaces/MermaidConfig.md
+++ b/docs/config/setup/mermaid/interfaces/MermaidConfig.md
@@ -312,6 +312,17 @@ Defined in: [packages/mermaid/src/config.type.ts:195](https://github.com/mermaid
 
 ---
 
+### optInMarkdownLabels?
+
+> `optional` **optInMarkdownLabels**: `boolean`
+
+Defined in: [packages/mermaid/src/config.type.ts:217](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L217)
+
+Only process markdown for labels enclosed in double-quote-backtick delimiters, e.g. "`_markdown label_`".
+This can be useful when upgrading from mermaid 10 to 11, as version 11 started interpreting labels as markdown by default.
+
+---
+
 ### packet?
 
 > `optional` **packet**: `PacketDiagramConfig`

--- a/packages/mermaid/src/config.type.ts
+++ b/packages/mermaid/src/config.type.ts
@@ -209,6 +209,13 @@ export interface MermaidConfig {
    *
    */
   suppressErrorRendering?: boolean;
+  /**
+   * This option controls the rendering of label text. The default behavior
+   * is to treat all labels as markdown to be rendered. Setting this value to
+   * true means labels will not be rendered as markdown unless they
+   * are enclosed in double-quote-backtick delimiters, e.g. "`_markdown label_`".
+   */
+  optInMarkdownLabels?: boolean;
 }
 /**
  * The object containing configurations specific for flowcharts

--- a/packages/mermaid/src/config.type.ts
+++ b/packages/mermaid/src/config.type.ts
@@ -210,10 +210,9 @@ export interface MermaidConfig {
    */
   suppressErrorRendering?: boolean;
   /**
-   * This option controls the rendering of label text. The default behavior
-   * is to treat all labels as markdown to be rendered. Setting this value to
-   * true means labels will not be rendered as markdown unless they
-   * are enclosed in double-quote-backtick delimiters, e.g. "`_markdown label_`".
+   * Only process markdown for labels enclosed in double-quote-backtick delimiters, e.g. "`_markdown label_`".
+   * This can be useful when upgrading from mermaid 10 to 11, as version 11 started interpreting labels as markdown by default.
+   *
    */
   optInMarkdownLabels?: boolean;
 }

--- a/packages/mermaid/src/diagrams/flowchart/flowDb.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.ts
@@ -997,6 +997,7 @@ You have to call mermaid.initialize.`
         id: vertex.id,
         label: vertex.text,
         labelStyle: '',
+        labelType: vertex.labelType,
         parentId,
         padding: config.flowchart?.padding || 8,
         cssStyles: vertex.styles,

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow-node-data.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow-node-data.spec.js
@@ -412,4 +412,21 @@ describe('when parsing directions', function () {
     expect(data4Layout.nodes[1].label).toEqual('labe for n4');
     expect(data4Layout.nodes[2].label).toEqual('labe for n5');
   });
+
+  it(' should include labelType in nodes', function () {
+    const res = flow.parser.parse(`flowchart TB
+      A["\`**foo**\`"] --> B[bar]
+      `);
+
+    const data4Layout = flow.parser.yy.getData();
+    expect(data4Layout.nodes.length).toBe(2);
+
+    expect(data4Layout.nodes[0].shape).toEqual('squareRect');
+    expect(data4Layout.nodes[0].label).toEqual('**foo**');
+    expect(data4Layout.nodes[0].labelType).toEqual('markdown');
+
+    expect(data4Layout.nodes[1].shape).toEqual('squareRect');
+    expect(data4Layout.nodes[1].label).toEqual('bar');
+    expect(data4Layout.nodes[1].labelType).toEqual('text');
+  });
 });

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow.spec.js
@@ -237,4 +237,32 @@ with a second line`
       }).not.toThrow();
     });
   }
+
+  it(`should parse labels without markdown delimiters as text`, function () {
+    const flowChart = `
+    graph TB
+      a[foo]
+    `;
+    flow.parser.parse(flowChart);
+    const vert = flow.parser.yy.getVertices();
+    const edges = flow.parser.yy.getEdges();
+
+    expect(vert.get('a').id).toBe('a');
+    expect(vert.get('a').text).toBe('foo');
+    expect(vert.get('a').labelType).toBe('text');
+  });
+
+  it(`should parse markdown labels`, function () {
+    const flowChart = `
+    graph TB
+      a["\`foo\`"]
+    `;
+    flow.parser.parse(flowChart);
+    const vert = flow.parser.yy.getVertices();
+    const edges = flow.parser.yy.getEdges();
+
+    expect(vert.get('a').id).toBe('a');
+    expect(vert.get('a').text).toBe('foo');
+    expect(vert.get('a').labelType).toBe('markdown');
+  });
 });

--- a/packages/mermaid/src/rendering-util/createText.ts
+++ b/packages/mermaid/src/rendering-util/createText.ts
@@ -204,6 +204,7 @@ export const createText = async (
     isNode = true,
     width = 200,
     addSvgBackground = false,
+    labelType = 'text',
   } = {},
   config?: MermaidConfig
 ) => {
@@ -218,14 +219,15 @@ export const createText = async (
     'addSvgBackground: ',
     addSvgBackground,
     'optInMarkdownLabels: ',
-    optInMarkdownLabels
+    optInMarkdownLabels,
+    'labelType: ',
+    labelType
   );
   if (useHtmlLabels) {
     // TODO: addHtmlLabel accepts a labelStyle. Do we possibly have that?
     let labelMaker = (text, config) => {
-      const match = text.match(/^"`(.*)`"$/);
-      if (match) {
-        return markdownToHTML(match[1], config);
+      if (labelType === 'markdown') {
+        return markdownToHTML(text, config);
       } else {
         return `<span class="${classes}">${text}</span>`;
       }

--- a/packages/mermaid/src/rendering-util/createText.ts
+++ b/packages/mermaid/src/rendering-util/createText.ts
@@ -200,6 +200,7 @@ export const createText = async (
     isTitle = false,
     classes = '',
     useHtmlLabels = true,
+    optInMarkdownLabels = false,
     isNode = true,
     width = 200,
     addSvgBackground = false,
@@ -215,12 +216,24 @@ export const createText = async (
     useHtmlLabels,
     isNode,
     'addSvgBackground: ',
-    addSvgBackground
+    addSvgBackground,
+    'optInMarkdownLabels: ',
+    optInMarkdownLabels
   );
   if (useHtmlLabels) {
     // TODO: addHtmlLabel accepts a labelStyle. Do we possibly have that?
-
-    const htmlText = markdownToHTML(text, config);
+    let labelMaker = (text, config) => {
+      const match = text.match(/^"`(.*)`"$/);
+      if (match) {
+        return markdownToHTML(match[1], config);
+      } else {
+        return `<span class="${classes}">${text}</span>`;
+      }
+    };
+    if (!optInMarkdownLabels) {
+      labelMaker = markdownToHTML;
+    }
+    const htmlText = labelMaker(text, config);
     const decodedReplacedText = replaceIconSubstring(decodeEntities(htmlText));
 
     //for Katex the text could contain escaped characters, \\relax that should be transformed to \relax

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/util.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/util.ts
@@ -15,7 +15,6 @@ export const labelHelper = async <T extends SVGGraphicsElement>(
   let cssClasses;
   const config = getConfig();
   const useHtmlLabels = node.useHtmlLabels || evaluate(config?.htmlLabels);
-  const optInMarkdownLabels = evaluate(config?.optInMarkdownLabels);
 
   if (!_classes) {
     cssClasses = 'node default';
@@ -43,16 +42,20 @@ export const labelHelper = async <T extends SVGGraphicsElement>(
     label = typeof node.label === 'string' ? node.label : node.label[0];
   }
 
-  const text = await createText(labelEl, sanitizeText(decodeEntities(label), getConfig()), {
-    useHtmlLabels,
-    optInMarkdownLabels,
-    width: node.width || getConfig().flowchart?.wrappingWidth,
-    // @ts-expect-error -- This is currently not used. Should this be `classes` instead?
-    cssClasses: 'markdown-node-label',
-    style: node.labelStyle,
-    addSvgBackground: !!node.icon || !!node.img,
-    labelType: node.labelType,
-  });
+  const text = await createText(
+    labelEl,
+    sanitizeText(decodeEntities(label), getConfig()),
+    {
+      useHtmlLabels,
+      width: node.width || getConfig().flowchart?.wrappingWidth,
+      // @ts-expect-error -- This is currently not used. Should this be `classes` instead?
+      cssClasses: 'markdown-node-label',
+      style: node.labelStyle,
+      addSvgBackground: !!node.icon || !!node.img,
+      labelType: node.labelType,
+    },
+    config
+  );
   // Get the size of the label
   let bbox = text.getBBox();
   const halfPadding = (node?.padding ?? 0) / 2;

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/util.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/util.ts
@@ -51,6 +51,7 @@ export const labelHelper = async <T extends SVGGraphicsElement>(
     cssClasses: 'markdown-node-label',
     style: node.labelStyle,
     addSvgBackground: !!node.icon || !!node.img,
+    labelType: node.labelType,
   });
   // Get the size of the label
   let bbox = text.getBBox();

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/util.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/util.ts
@@ -13,7 +13,10 @@ export const labelHelper = async <T extends SVGGraphicsElement>(
   _classes?: string
 ) => {
   let cssClasses;
-  const useHtmlLabels = node.useHtmlLabels || evaluate(getConfig()?.htmlLabels);
+  const config = getConfig();
+  const useHtmlLabels = node.useHtmlLabels || evaluate(config?.htmlLabels);
+  const optInMarkdownLabels = evaluate(config?.optInMarkdownLabels);
+
   if (!_classes) {
     cssClasses = 'node default';
   } else {
@@ -42,6 +45,7 @@ export const labelHelper = async <T extends SVGGraphicsElement>(
 
   const text = await createText(labelEl, sanitizeText(decodeEntities(label), getConfig()), {
     useHtmlLabels,
+    optInMarkdownLabels,
     width: node.width || getConfig().flowchart?.wrappingWidth,
     // @ts-expect-error -- This is currently not used. Should this be `classes` instead?
     cssClasses: 'markdown-node-label',

--- a/packages/mermaid/src/schemas/config.schema.yaml
+++ b/packages/mermaid/src/schemas/config.schema.yaml
@@ -311,6 +311,12 @@ properties:
     description: |
       Suppresses inserting 'Syntax error' diagram in the DOM.
       This is useful when you want to control how to handle syntax errors in your application.
+  optInMarkdownLabels:
+    type: boolean
+    default: false
+    description: |
+      Only process markdown for labels enclosed in double-quote-backtick delimiters, e.g. "`_markdown label_`".
+      This can be useful when upgrading from mermaid 10 to 11, as version 11 started interpreting labels as markdown by default.
 
 $defs: # JSON Schema definition (maybe we should move these to a separate file)
   BaseDiagramConfig:


### PR DESCRIPTION
## :bookmark_tabs: Summary

This is a quick strawman implementation of the direction I'm proposing to resolve #6275.

Resolves #6275

Examples of types of labels causing issues in an external project:

<img width="749" alt="image" src="https://github.com/user-attachments/assets/ae6e9aa0-c450-4ef8-9851-1bb10d0a8b21" />

After applying new config setting with these changes:
<img width="592" alt="image" src="https://github.com/user-attachments/assets/d4e20afe-8990-472c-a13d-2d268077197e" />


## :straight_ruler: Design Decisions

I've added an `optInMarkdownLabels` config setting. It defaults to false, but when enabled (either in frontmatter, or in a call to initialize), it turns off the auto-markdown processing for node labels.

The primary goal is to provide a less intrusive upgrade path from Mermaid 10 to 11. Users who encounter markdown issues in their node rendering when upgrading to Mermaid 11 could set `optInMarkdownLabels` to false in order restore a closer approximation of the 10.x behavior. I'm not claiming this PR will ever guarantee no rendering changes in the upgrade from 10 to 11, but it will certainly provide a fix for the `Unsupported markdown` issues that can be accidentally encountered during the upgrade.

There are many issues to solve before the implementation could be considered for merge. I'm sharing the early draft just as a conversation point, to see if this approach would be acceptable if the following issues were resolved.

- [ ] Need to examine closer whether my new opt-in label maker effectively captures the behavior of the old 10.7 labels. This initial sketch just wraps the text in a span.
- [ ] Currently, the expected double-quote-backtick delimiter is being removed before the text is sent to the label node. I haven't found where that's happening.
- [ ] I've only defaulted the `useHtmlLabels` path, which calls `markdownToHTML`. I should probably update the `markdownToLines` path for `useHtmlLabels=false` as well.
- [ ] No existing unit tests have been run to verify I haven't broken anything.
- [ ] No new unit tests have been written to verify the new behavior.

### :clipboard: Tasks

Make sure you

- [ ] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
