### PR TITLE
Feature/6129 sankey custom color

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,0 @@
-#!/usr/bin/env sh
-NODE_OPTIONS="--max_old_space_size=8192" pnpm run pre-commit

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ USER 0:0
 RUN corepack enable \
     && corepack enable pnpm
 
-RUN apk add --no-cache git~=2.43.4 \
+RUN apk add --no-cache git>=2.43.4 \
     && git config --add --system safe.directory /mermaid
 
 ENV NODE_OPTIONS="--max_old_space_size=8192"

--- a/packages/mermaid/src/config.type.ts
+++ b/packages/mermaid/src/config.type.ts
@@ -1482,6 +1482,13 @@ export interface SankeyDiagramConfig extends BaseDiagramConfig {
    *
    */
   suffix?: string;
+  /**
+   * Custom colors for nodes in the sankey diagram.
+   * Keys are node IDs and values are color strings.
+   */
+  colors?: {
+    [key: string]: string;
+  };
 }
 /**
  * The object containing configurations specific for packet diagrams.

--- a/packages/mermaid/src/config.type.ts
+++ b/packages/mermaid/src/config.type.ts
@@ -1483,11 +1483,11 @@ export interface SankeyDiagramConfig extends BaseDiagramConfig {
    */
   suffix?: string;
   /**
-   * Custom colors for nodes in the sankey diagram.
-   * Keys are node IDs and values are color strings.
+   * Custom colors for nodes in the sankey diagram. Keys are node IDs and values are color strings.
+   *
    */
   colors?: {
-    [key: string]: string;
+    [k: string]: string;
   };
 }
 /**

--- a/packages/mermaid/src/diagrams/sankey/sankeyRenderer.ts
+++ b/packages/mermaid/src/diagrams/sankey/sankeyRenderer.ts
@@ -1,5 +1,6 @@
 import type { Diagram } from '../../Diagram.js';
 import { getConfig, defaultConfig } from '../../diagram-api/diagramAPI.js';
+import { log } from '../../logger.js';
 import {
   select as d3select,
   scaleOrdinal as d3scaleOrdinal,
@@ -103,7 +104,7 @@ export const draw = function (text: string, id: string, _version: string, diagOb
 
   // Get color scheme for the graph
   const colorScheme = d3scaleOrdinal(d3schemeTableau10);
-  const customColors = conf?.colors || {};
+  const customColors = conf?.colors ?? {};
 
   // Create rectangles for nodes
   svg
@@ -124,7 +125,16 @@ export const draw = function (text: string, id: string, _version: string, diagOb
       return d.y1 - d.y0;
     })
     .attr('width', (d: any) => d.x1 - d.x0)
-    .attr('fill', (d: any) => customColors[d.id] || colorScheme(d.id));
+    .attr('fill', (d: any) => {
+  log.debug('Node color debug:', {
+    id: d.id,
+    customColor: customColors[d.id],
+    fallbackColor: colorScheme(d.id),
+    allCustomColors: customColors,
+    fullConfig: conf
+  });
+  return customColors[d.id] || colorScheme(d.id);
+});
 
   const getText = ({ id, value }: { id: string; value: number }) => {
     if (!showValues) {

--- a/packages/mermaid/src/diagrams/sankey/sankeyRenderer.ts
+++ b/packages/mermaid/src/diagrams/sankey/sankeyRenderer.ts
@@ -1,6 +1,5 @@
 import type { Diagram } from '../../Diagram.js';
 import { getConfig, defaultConfig } from '../../diagram-api/diagramAPI.js';
-import { log } from '../../logger.js';
 import {
   select as d3select,
   scaleOrdinal as d3scaleOrdinal,
@@ -125,16 +124,7 @@ export const draw = function (text: string, id: string, _version: string, diagOb
       return d.y1 - d.y0;
     })
     .attr('width', (d: any) => d.x1 - d.x0)
-    .attr('fill', (d: any) => {
-  log.debug('Node color debug:', {
-    id: d.id,
-    customColor: customColors[d.id],
-    fallbackColor: colorScheme(d.id),
-    allCustomColors: customColors,
-    fullConfig: conf
-  });
-  return customColors[d.id] || colorScheme(d.id);
-});
+    .attr('fill', (d: any) => {return customColors[d.id] || colorScheme(d.id);});
 
   const getText = ({ id, value }: { id: string; value: number }) => {
     if (!showValues) {

--- a/packages/mermaid/src/diagrams/sankey/sankeyRenderer.ts
+++ b/packages/mermaid/src/diagrams/sankey/sankeyRenderer.ts
@@ -103,6 +103,7 @@ export const draw = function (text: string, id: string, _version: string, diagOb
 
   // Get color scheme for the graph
   const colorScheme = d3scaleOrdinal(d3schemeTableau10);
+  const customColors = conf?.colors || {};
 
   // Create rectangles for nodes
   svg
@@ -123,7 +124,7 @@ export const draw = function (text: string, id: string, _version: string, diagOb
       return d.y1 - d.y0;
     })
     .attr('width', (d: any) => d.x1 - d.x0)
-    .attr('fill', (d: any) => colorScheme(d.id));
+    .attr('fill', (d: any) => customColors[d.id] || colorScheme(d.id));
 
   const getText = ({ id, value }: { id: string; value: number }) => {
     if (!showValues) {
@@ -171,12 +172,12 @@ export const draw = function (text: string, id: string, _version: string, diagOb
     gradient
       .append('stop')
       .attr('offset', '0%')
-      .attr('stop-color', (d: any) => colorScheme(d.source.id));
+      .attr('stop-color', (d: any) => customColors[d.source.id] || colorScheme(d.source.id));
 
     gradient
       .append('stop')
       .attr('offset', '100%')
-      .attr('stop-color', (d: any) => colorScheme(d.target.id));
+      .attr('stop-color', (d: any) => customColors[d.target.id] || colorScheme(d.target.id));
   }
 
   let coloring: any;
@@ -185,10 +186,10 @@ export const draw = function (text: string, id: string, _version: string, diagOb
       coloring = (d: any) => d.uid;
       break;
     case 'source':
-      coloring = (d: any) => colorScheme(d.source.id);
+      coloring = (d: any) => customColors[d.source.id] || colorScheme(d.source.id);
       break;
     case 'target':
-      coloring = (d: any) => colorScheme(d.target.id);
+      coloring = (d: any) => customColors[d.target.id] || colorScheme(d.target.id);
       break;
     default:
       coloring = linkColor;

--- a/packages/mermaid/src/schemas/config.schema.yaml
+++ b/packages/mermaid/src/schemas/config.schema.yaml
@@ -2150,6 +2150,13 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
           The suffix to use for values
         type: string
         default: ''
+      colors:
+        description: |
+          Custom colors for nodes in the sankey diagram. Keys are node IDs and values are color strings.
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
 
   PacketDiagramConfig:
     title: Packet Diagram Config

--- a/packages/mermaid/src/utils/sanitizeDirective.ts
+++ b/packages/mermaid/src/utils/sanitizeDirective.ts
@@ -23,11 +23,17 @@ export const sanitizeDirective = (args: any): void => {
   // Sanitize each key if an object
   for (const key of Object.keys(args)) {
     log.debug('Checking key', key);
+    // Skip configKeys check for Sankey colors object and its contents
+    if (key === 'colors' && args.colors && typeof args.colors === 'object') {
+      log.debug('Preserving Sankey colors object and its contents');
+      continue;
+    }
+
     if (
       key.startsWith('__') ||
       key.includes('proto') ||
       key.includes('constr') ||
-      !configKeys.has(key) ||
+      (!configKeys.has(key) && key !== 'colors') ||
       args[key] == null
     ) {
       log.debug('sanitize deleting key: ', key);


### PR DESCRIPTION
## :bookmark_tabs: Summary

It will give the option to choose the color for Sankey nodes

Resolves #6129

## :straight_ruler: Design Decisions

The implementation adds a `color` section under the configuration so that the user can specify the color of the node

Example:

```
config:
  sankey:
    showValues: false
    colors:
      source: "#ff0000"
      target1: "#0000ff"
      target2: "#00ff00"
---
sankey-beta
source,target1,40
source,target2,60
```

<img width="626" alt="Image" src="https://github.com/user-attachments/assets/8c20d2ed-2e0a-48fd-837e-a894165c7234" />

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
