### PR TITLE
fix: CodeQL double escape warning

### DIFF
--- a/packages/mermaid/src/diagrams/sequence/sequenceDb.ts
+++ b/packages/mermaid/src/diagrams/sequence/sequenceDb.ts
@@ -372,8 +372,8 @@ export const addLinks = function (actorId: string, text: { text: string }) {
   // JSON.parse the text
   try {
     let sanitizedText = sanitizeText(text.text, getConfig());
-    sanitizedText = sanitizedText.replace(/&amp;/g, '&');
     sanitizedText = sanitizedText.replace(/&equals;/g, '=');
+    sanitizedText = sanitizedText.replace(/&amp;/g, '&');
     const links = JSON.parse(sanitizedText);
     // add the deserialized text to the actor's links field.
     insertLinks(actor, links);
@@ -389,8 +389,8 @@ export const addALink = function (actorId: string, text: { text: string }) {
     const links: Record<string, string> = {};
     let sanitizedText = sanitizeText(text.text, getConfig());
     const sep = sanitizedText.indexOf('@');
-    sanitizedText = sanitizedText.replace(/&amp;/g, '&');
     sanitizedText = sanitizedText.replace(/&equals;/g, '=');
+    sanitizedText = sanitizedText.replace(/&amp;/g, '&');
     const label = sanitizedText.slice(0, sep - 1).trim();
     const link = sanitizedText.slice(sep + 1).trim();
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fix a CodeQL warning related to double unescaping in the SequenceDB "sanitizeText" . 

## :straight_ruler: Design Decisions

N/A

### :clipboard: Tasks

Make sure you

- [X] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
