### PR TITLE
6369 mirror edge color on arrowhead

### DIFF
--- a/.changeset/vast-nails-stay.md
+++ b/.changeset/vast-nails-stay.md
@@ -1,0 +1,5 @@
+---
+'mermaid': minor
+---
+
+The arrowhead color should match the color of the edge. Creates a unique clone of the arrow marker with the appropriate color.

--- a/cypress/integration/rendering/flowchart.spec.js
+++ b/cypress/integration/rendering/flowchart.spec.js
@@ -895,7 +895,7 @@ graph TD
     imgSnapshotTest(
       `
       graph TD
-        classDef default fill:#a34,stroke:#000,stroke-width:4px,color:#fff 
+        classDef default fill:#a34,stroke:#000,stroke-width:4px,color:#fff
         hello --> default
       `,
       { htmlLabels: true, flowchart: { htmlLabels: true }, securityLevel: 'loose' }
@@ -910,6 +910,23 @@ graph TD
       hello --> default
 
       style default stroke:#000,stroke-width:4px
+    `,
+      {
+        flowchart: { htmlLabels: true },
+        securityLevel: 'loose',
+      }
+    );
+  });
+  it('#6369: edge color should affect arrow head', () => {
+    imgSnapshotTest(
+      `
+    flowchart LR
+        A --> B
+        A --> C
+        C --> D
+
+        linkStyle 0 stroke:#D50000
+        linkStyle 2 stroke:#D50000
     `,
       {
         flowchart: { htmlLabels: true },

--- a/packages/mermaid/src/rendering-util/rendering-elements/edgeMarker.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/edgeMarker.ts
@@ -15,28 +15,29 @@ export const addEdgeMarkers = (
   edge: Pick<EdgeData, 'arrowTypeStart' | 'arrowTypeEnd'>,
   url: string,
   id: string,
-  diagramType: string
+  diagramType: string,
+  strokeColor?: string
 ) => {
   if (edge.arrowTypeStart) {
-    addEdgeMarker(svgPath, 'start', edge.arrowTypeStart, url, id, diagramType);
+    addEdgeMarker(svgPath, 'start', edge.arrowTypeStart, url, id, diagramType, strokeColor);
   }
   if (edge.arrowTypeEnd) {
-    addEdgeMarker(svgPath, 'end', edge.arrowTypeEnd, url, id, diagramType);
+    addEdgeMarker(svgPath, 'end', edge.arrowTypeEnd, url, id, diagramType, strokeColor);
   }
 };
 
 const arrowTypesMap = {
-  arrow_cross: 'cross',
-  arrow_point: 'point',
-  arrow_barb: 'barb',
-  arrow_circle: 'circle',
-  aggregation: 'aggregation',
-  extension: 'extension',
-  composition: 'composition',
-  dependency: 'dependency',
-  lollipop: 'lollipop',
-  requirement_arrow: 'requirement_arrow',
-  requirement_contains: 'requirement_contains',
+  arrow_cross: { type: 'cross', fill: false },
+  arrow_point: { type: 'point', fill: true },
+  arrow_barb: { type: 'barb', fill: true },
+  arrow_circle: { type: 'circle', fill: false },
+  aggregation: { type: 'aggregation', fill: false },
+  extension: { type: 'extension', fill: false },
+  composition: { type: 'composition', fill: true },
+  dependency: { type: 'dependency', fill: true },
+  lollipop: { type: 'lollipop', fill: false },
+  requirement_arrow: { type: 'requirement_arrow', fill: false },
+  requirement_contains: { type: 'requirement_contains', fill: false },
 } as const;
 
 const addEdgeMarker = (
@@ -45,15 +46,55 @@ const addEdgeMarker = (
   arrowType: string,
   url: string,
   id: string,
-  diagramType: string
+  diagramType: string,
+  strokeColor?: string
 ) => {
-  const endMarkerType = arrowTypesMap[arrowType as keyof typeof arrowTypesMap];
+  const arrowTypeInfo = arrowTypesMap[arrowType as keyof typeof arrowTypesMap];
 
-  if (!endMarkerType) {
+  if (!arrowTypeInfo) {
     log.warn(`Unknown arrow type: ${arrowType}`);
     return; // unknown arrow type, ignore
   }
 
+  const endMarkerType = arrowTypeInfo.type;
   const suffix = position === 'start' ? 'Start' : 'End';
-  svgPath.attr(`marker-${position}`, `url(${url}#${id}_${diagramType}-${endMarkerType}${suffix})`);
+  const originalMarkerId = `${id}_${diagramType}-${endMarkerType}${suffix}`;
+
+  // If stroke color is specified and non-empty, create or use a colored variant of the marker
+  if (strokeColor && strokeColor.trim() !== '') {
+    // Create a sanitized color value for use in IDs
+    const colorId = strokeColor.replace(/[^\dA-Za-z]/g, '_');
+    const coloredMarkerId = `${originalMarkerId}_${colorId}`;
+
+    // Check if the colored marker already exists
+    if (!document.getElementById(coloredMarkerId)) {
+      // Get the original marker
+      const originalMarker = document.getElementById(originalMarkerId);
+      if (originalMarker) {
+        // Clone the marker and create colored version
+        const coloredMarker = originalMarker.cloneNode(true) as Element;
+        coloredMarker.id = coloredMarkerId;
+
+        // Apply colors to the paths inside the marker
+        const paths = coloredMarker.querySelectorAll('path, circle, line');
+        paths.forEach((path) => {
+          path.setAttribute('stroke', strokeColor);
+
+          // Apply fill only to markers that should be filled
+          if (arrowTypeInfo.fill) {
+            path.setAttribute('fill', strokeColor);
+          }
+        });
+
+        // Add the new colored marker to the defs section
+        originalMarker.parentNode?.appendChild(coloredMarker);
+      }
+    }
+
+    // Use the colored marker
+    svgPath.attr(`marker-${position}`, `url(${url}#${coloredMarkerId})`);
+  } else {
+    // Always use the original marker for unstyled edges
+    svgPath.attr(`marker-${position}`, `url(${url}#${originalMarkerId})`);
+  }
 };

--- a/packages/mermaid/src/rendering-util/rendering-elements/edges.js
+++ b/packages/mermaid/src/rendering-util/rendering-elements/edges.js
@@ -509,6 +509,7 @@ export const insertEdge = function (elem, edge, clusterDb, diagramType, startNod
   let svgPath;
   let linePath = lineFunction(lineData);
   const edgeStyles = Array.isArray(edge.style) ? edge.style : [edge.style];
+  let strokeColor = edgeStyles.find((style) => style.startsWith('stroke:'));
 
   if (edge.look === 'handDrawn') {
     const rc = rough.svg(elem);
@@ -539,18 +540,18 @@ export const insertEdge = function (elem, edge, clusterDb, diagramType, startNod
     if (edge.animation) {
       animationClass = ' edge-animation-' + edge.animation;
     }
+
+    const pathStyle = stylesFromClasses ? stylesFromClasses + ';' + styles + ';' : styles;
     svgPath = elem
       .append('path')
       .attr('d', linePath)
       .attr('id', edge.id)
       .attr(
         'class',
-        ' ' +
-          strokeClasses +
-          (edge.classes ? ' ' + edge.classes : '') +
-          (animationClass ? animationClass : '')
+        ' ' + strokeClasses + (edge.classes ? ' ' + edge.classes : '') + (animationClass ?? '')
       )
-      .attr('style', stylesFromClasses ? stylesFromClasses + ';' + styles + ';' : styles);
+      .attr('style', pathStyle);
+    strokeColor = pathStyle.match(/stroke:([^;]+)/)?.[1];
   }
 
   // DEBUG code, DO NOT REMOVE
@@ -587,7 +588,7 @@ export const insertEdge = function (elem, edge, clusterDb, diagramType, startNod
   log.info('arrowTypeStart', edge.arrowTypeStart);
   log.info('arrowTypeEnd', edge.arrowTypeEnd);
 
-  addEdgeMarkers(svgPath, edge, url, id, diagramType);
+  addEdgeMarkers(svgPath, edge, url, id, diagramType, strokeColor);
 
   let paths = {};
   if (pointsHasChanged) {


### PR DESCRIPTION
## :bookmark_tabs: Summary

The arrowhead color should match the color of the edge.

* Enhanced marker handling: Arrows now properly match the edge color instead of using default colors
* Dynamic marker creation: Creates colored variants of markers when needed
* Improved reusability: Same-colored arrows reuse the same marker definitions
* Smart fill behavior: Configurable fill behavior for different arrow types


Resolves #6369 


## :straight_ruler: Design Decisions

Instead of using CSS to style existing markers (which had inconsistent browser support), this implementation:
* Detects when an edge has a custom stroke color
* Creates a unique clone of the arrow marker with the appropriate color
* Applies stroke/fill directly to SVG element attributes
* References the colored marker variant from the edge

This ensures styling consistency across all browsers and prevents side effects between different edges.
### :clipboard: Tasks

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
