### PR TITLE
Feature/818 add remove delay to until after and Fix/5867

### DIFF
--- a/.changeset/clean-breads-drop.md
+++ b/.changeset/clean-breads-drop.md
@@ -1,0 +1,5 @@
+---
+'mermaid': major
+---
+
+Extend usage of after/until to start and end date and add delay

--- a/.changeset/clean-breads-drop.md
+++ b/.changeset/clean-breads-drop.md
@@ -2,4 +2,6 @@
 'mermaid': major
 ---
 
-Extend usage of after/until to start and end date and add delay
+feat: Extend usage of after/until to start and end date
+feat: Add a possible delay (duration)(positive of negative) to dates defined with after/until
+fix: Resolve task end issue when until and excludes are used.

--- a/docs/syntax/gantt.md
+++ b/docs/syntax/gantt.md
@@ -145,6 +145,36 @@ After processing the tags, the remaining metadata items are interpreted as follo
 > **Note**
 > Support for keyword `until` was added in (v10.9.0+). This can be used to define a task which is running until some other specific task or milestone starts.
 
+::: info
+starting from (v\<MERMAID_RELEASE_VERSION>+) `until` and `after`can be used as `startdate` or/and `enddate`. `until` will relate to the **earliest start** date of
+the provided tasks identifiers and `after` will relate to the **latest end** date of the provided tasks.
+
+Moreover positive and negative delay (as duration) can be added in front of after/until keyword. E.g `1d after task2` or `-3w until task1` or `+1.5d after id1`
+
+```mermaid-example
+gantt
+tickInterval 1day
+ref 1 : 2025-01-01, 2d
+ref 2 : 2025-02-01, 2d
+task1: after task1, until task2
+task2: until task1, after task2
+task3: -1d after task1, +1d until task2
+task4: -1d until task1, +1d after task2
+```
+
+```mermaid
+gantt
+tickInterval 1day
+ref 1 : 2025-01-01, 2d
+ref 2 : 2025-02-01, 2d
+task1: after task1, until task2
+task2: until task1, after task2
+task3: -1d after task1, +1d until task2
+task4: -1d until task1, +1d after task2
+```
+
+:::
+
 For simplicity, the table does not show the use of multiple tasks listed with the `after` keyword. Here is an example of how to use it and how it's interpreted:
 
 ```mermaid-example

--- a/packages/mermaid/src/diagrams/gantt/ganttDb.js
+++ b/packages/mermaid/src/diagrams/gantt/ganttDb.js
@@ -320,7 +320,7 @@ const getStartDate = function (prevTime, dateFormat, str) {
  */
 const parseDuration = function (str) {
   // cspell:disable-next-line
-  const statement = /^(\d+(?:\.\d+)?)([Mdhmswy]|ms)$/.exec(str.trim());
+  const statement = /^([+-]?\d+(?:\.\d+)?)([Mdhmswy]|ms)$/.exec(str.trim());
   if (statement !== null) {
     return [Number.parseFloat(statement[1]), statement[2]];
   }
@@ -330,7 +330,8 @@ const parseDuration = function (str) {
 
 const manageUntilAfter = function (str) {
   // test for until
-  const RePattern = /^(?<type>until|after)\s+(?<ids>[\d\w- ]+)/;
+  const RePattern =
+    /^(?<delay>[+-]?\d+(?:\.\d+)?(?:ms|[Mdhmswy])\s+)?(?<type>until|after)\s+(?<ids>[\d\w- ]+)/;
   const reStatement = RePattern.exec(str);
 
   if (reStatement !== null) {
@@ -351,6 +352,17 @@ const manageUntilAfter = function (str) {
           limitTaskStamp = task.endTime;
         }
       }
+    }
+    if (reStatement.groups.delay) {
+      const [durationValue, durationUnit] = parseDuration(reStatement.groups.delay);
+      let endStamp = dayjs(limitTaskStamp);
+      if (!Number.isNaN(durationValue)) {
+        const newTimeStamp = endStamp.add(durationValue, durationUnit);
+        if (newTimeStamp.isValid()) {
+          endStamp = newTimeStamp;
+        }
+      }
+      limitTaskStamp = endStamp.toDate();
     }
 
     if (limitTask) {

--- a/packages/mermaid/src/diagrams/gantt/ganttDb.spec.ts
+++ b/packages/mermaid/src/diagrams/gantt/ganttDb.spec.ts
@@ -62,15 +62,16 @@ describe('when using the ganttDb', function () {
 
   // prettier-ignore
   it.each(convert`
-    testName                                                                             | section     | taskName   | taskData                       | expStartDate            | expEndDate                       | expId      | expTask
-    ${'should handle fixed dates'}                                                       | ${'testa1'} | ${'test1'} | ${'id1,2013-01-01,2013-01-12'} | ${new Date(2013, 0, 1)} | ${new Date(2013, 0, 12)}         | ${'id1'}   | ${'test1'}
-    ${'should handle duration (days) instead of fixed date to determine end date'}       | ${'testa1'} | ${'test1'} | ${'id1,2013-01-01,2d'}         | ${new Date(2013, 0, 1)} | ${new Date(2013, 0, 3)}          | ${'id1'}   | ${'test1'}
-    ${'should handle duration (hours) instead of fixed date to determine end date'}      | ${'testa1'} | ${'test1'} | ${'id1,2013-01-01,2h'}         | ${new Date(2013, 0, 1)} | ${new Date(2013, 0, 1, 2)}       | ${'id1'}   | ${'test1'}
-    ${'should handle duration (minutes) instead of fixed date to determine end date'}    | ${'testa1'} | ${'test1'} | ${'id1,2013-01-01,2m'}         | ${new Date(2013, 0, 1)} | ${new Date(2013, 0, 1, 0, 2)}    | ${'id1'}   | ${'test1'}
-    ${'should handle duration (seconds) instead of fixed date to determine end date'}    | ${'testa1'} | ${'test1'} | ${'id1,2013-01-01,2s'}         | ${new Date(2013, 0, 1)} | ${new Date(2013, 0, 1, 0, 0, 2)} | ${'id1'}   | ${'test1'}
-    ${'should handle duration (weeks) instead of fixed date to determine end date'}      | ${'testa1'} | ${'test1'} | ${'id1,2013-01-01,2w'}         | ${new Date(2013, 0, 1)} | ${new Date(2013, 0, 15)}         | ${'id1'}   | ${'test1'}
-    ${'should handle fixed dates without id'}                                            | ${'testa1'} | ${'test1'} | ${'2013-01-01,2013-01-12'}     | ${new Date(2013, 0, 1)} | ${new Date(2013, 0, 12)}         | ${'task1'} | ${'test1'}
-    ${'should handle duration instead of a fixed date to determine end date without id'} | ${'testa1'} | ${'test1'} | ${'2013-01-01,4d'}             | ${new Date(2013, 0, 1)} | ${new Date(2013, 0, 5)}          | ${'task1'} | ${'test1'}
+    testName                                                                             | section     | taskName   | taskData                       | expStartDate            | expEndDate                         | expId      | expTask
+    ${'should handle fixed dates'}                                                       | ${'testa1'} | ${'test1'} | ${'id1,2013-01-01,2013-01-12'} | ${new Date(2013, 0, 1)} | ${new Date(2013, 0, 12)}           | ${'id1'}   | ${'test1'}
+    ${'should handle duration (days) instead of fixed date to determine end date'}       | ${'testa1'} | ${'test1'} | ${'id1,2013-01-01,2d'}         | ${new Date(2013, 0, 1)} | ${new Date(2013, 0, 3)}            | ${'id1'}   | ${'test1'}
+    ${'should handle duration (hours) instead of fixed date to determine end date'}      | ${'testa1'} | ${'test1'} | ${'id1,2013-01-01,2h'}         | ${new Date(2013, 0, 1)} | ${new Date(2013, 0, 1, 2)}         | ${'id1'}   | ${'test1'}
+    ${'should handle duration (minutes) instead of fixed date to determine end date'}    | ${'testa1'} | ${'test1'} | ${'id1,2013-01-01,2m'}         | ${new Date(2013, 0, 1)} | ${new Date(2013, 0, 1, 0, 2)}      | ${'id1'}   | ${'test1'}
+    ${'should handle duration (seconds) instead of fixed date to determine end date'}    | ${'testa1'} | ${'test1'} | ${'id1,2013-01-01,2s'}         | ${new Date(2013, 0, 1)} | ${new Date(2013, 0, 1, 0, 0, 2)}   | ${'id1'}   | ${'test1'}
+    ${'should handle duration (weeks) instead of fixed date to determine end date'}      | ${'testa1'} | ${'test1'} | ${'id1,2013-01-01,2w'}         | ${new Date(2013, 0, 1)} | ${new Date(2013, 0, 15)}           | ${'id1'}   | ${'test1'}
+    ${'should handle duration (miliseconds) instead of fixed date to determine end date'}| ${'testa1'} | ${'test1'} | ${'id1,2013-01-01,2ms'}        | ${new Date(2013, 0, 1)} | ${new Date(2013, 0, 1, 0, 0, 0, 2)}| ${'id1'}   | ${'test1'}
+    ${'should handle fixed dates without id'}                                            | ${'testa1'} | ${'test1'} | ${'2013-01-01,2013-01-12'}     | ${new Date(2013, 0, 1)} | ${new Date(2013, 0, 12)}           | ${'task1'} | ${'test1'}
+    ${'should handle duration instead of a fixed date to determine end date without id'} | ${'testa1'} | ${'test1'} | ${'2013-01-01,4d'}             | ${new Date(2013, 0, 1)} | ${new Date(2013, 0, 5)}            | ${'task1'} | ${'test1'}
   `)('$testName', ({ section, taskName, taskData, expStartDate, expEndDate, expId, expTask }) => {
     ganttDb.setDateFormat('YYYY-MM-DD');
     ganttDb.addSection(section);
@@ -84,12 +85,46 @@ describe('when using the ganttDb', function () {
 
   // prettier-ignore
   it.each(convert`
-    section     | taskName1  | taskName2  | taskData1              | taskData2             | expStartDate2                                | expEndDate2              | expId2     | expTask2
-    ${'testa1'} | ${'test1'} | ${'test2'} | ${'id1,2013-01-01,2w'} | ${'id2,after id1,1d'} | ${new Date(2013, 0, 15)}                     | ${undefined}             | ${'id2'}   | ${'test2'}
-    ${'testa1'} | ${'test1'} | ${'test2'} | ${'id1,2013-01-01,2w'} | ${'id2,after id3,1d'} | ${new Date(new Date().setHours(0, 0, 0, 0))} | ${undefined}             | ${'id2'}   | ${'test2'}
-    ${'testa1'} | ${'test1'} | ${'test2'} | ${'id1,2013-01-01,2w'} | ${'after id1,1d'}     | ${new Date(2013, 0, 15)}                     | ${undefined}             | ${'task1'} | ${'test2'}
-    ${'testa1'} | ${'test1'} | ${'test2'} | ${'id1,2013-01-01,2w'} | ${'2013-01-26'}       | ${new Date(2013, 0, 15)}                     | ${new Date(2013, 0, 26)} | ${'task1'} | ${'test2'}
-    ${'testa1'} | ${'test1'} | ${'test2'} | ${'id1,2013-01-01,2w'} | ${'2d'}               | ${new Date(2013, 0, 15)}                     | ${new Date(2013, 0, 17)} | ${'task1'} | ${'test2'}
+  testName                              | taskName    | taskData                              | expStartDate              | expEndDate                 | expId     | expTask
+  ${'start after, end until'}           | ${'test1'}  | ${'id4,after id1, until id3'}         | ${new Date(2025, 0, 15)}  | ${new Date(2025, 1, 29)}   | ${'id4'}  | ${'test1'}
+  ${'start after, end until several id'}| ${'test1'}  | ${'id4,after id1, until id2 id3'}     | ${new Date(2025, 0, 15)}  | ${new Date(2025, 0, 32)}   | ${'id4'}  | ${'test1'}
+  ${'start until, end after'}           | ${'test1'}  | ${'id4,until id2, after id2'}         | ${new Date(2025, 1, 1)}   | ${new Date(2025, 1, 3)}    | ${'id4'}  | ${'test1'}
+  ${'start after, end until +delay'}    | ${'test1'}  | ${'id4, 1d after id1, +3d until id3'} | ${new Date(2025, 0, 16)}  | ${new Date(2025, 2, 4)}    | ${'id4'}  | ${'test1'}
+  ${'start after, end until -delay'}    | ${'test1'}  | ${'-1d after id1, -3d until id3'}     | ${new Date(2025, 0, 14)}  | ${new Date(2025, 1, 26)}   | ${'task1'}| ${'test1'}
+  `)(
+    '$testName',
+    ({
+      taskName,
+      taskData,
+      expStartDate,
+      expEndDate,
+      expId,
+      expTask,
+    }) => {
+      ganttDb.setDateFormat('YYYY-MM-DD');
+      ganttDb.addSection('section test');
+      ganttDb.addTask('t1', 'id1,2025-01-01,2w');
+      ganttDb.addTask('t2', 'id2,2025-02-01,2d');
+      ganttDb.addTask('t3', 'milestone,id3,2025-03-01,0d');
+      ganttDb.addTask(taskName, taskData);
+      const tasks = ganttDb.getTasks();
+      expect(tasks[3].startTime).toEqual(expStartDate);
+      expect(tasks[3].endTime).toEqual(expEndDate);
+      expect(tasks[3].id).toEqual(expId);
+      expect(tasks[3].task).toEqual(expTask);
+    }
+  );
+
+  // prettier-ignore
+  it.each(convert`
+  testName                                      | section     | taskName1  | taskName2  | taskData1              | taskData2                | expStartDate2                                | expEndDate2              | expId2     | expTask2
+  ${'should handle after with known id'}        | ${'testa1'} | ${'test1'} | ${'test2'} | ${'id1,2013-01-01,2w'} | ${'id2,after id1,1d'}    | ${new Date(2013, 0, 15)}                     | ${undefined}             | ${'id2'}   | ${'test2'}
+  ${'should handle delay with after'}           | ${'testa1'} | ${'test1'} | ${'test2'} | ${'id1,2013-01-01,2w'} | ${'id2,1d after id1,1d'} | ${new Date(2013, 0, 16)}                     | ${undefined}             | ${'id2'}   | ${'test2'}
+  ${'should handle negativedelay with after'}   | ${'testa1'} | ${'test1'} | ${'test2'} | ${'id1,2013-01-01,2w'} | ${'id2,-1d after id1,1d'}| ${new Date(2013, 0, 14)}                     | ${undefined}             | ${'id2'}   | ${'test2'}
+  ${'should handle after with unknown id'}      | ${'testa1'} | ${'test1'} | ${'test2'} | ${'id1,2013-01-01,2w'} | ${'id2,after id3,1d'}    | ${new Date(new Date().setHours(0, 0, 0, 0))} | ${undefined}             | ${'id2'}   | ${'test2'}
+  ${'after with known id + its id auto defined'}| ${'testa1'} | ${'test1'} | ${'test2'} | ${'id1,2013-01-01,2w'} | ${'after id1,1d'}        | ${new Date(2013, 0, 15)}                     | ${undefined}             | ${'task1'} | ${'test2'}
+  ${'should handle end as a date'}              | ${'testa1'} | ${'test1'} | ${'test2'} | ${'id1,2013-01-01,2w'} | ${'2013-01-26'}          | ${new Date(2013, 0, 15)}                     | ${new Date(2013, 0, 26)} | ${'task1'} | ${'test2'}
+  ${'should handle end as duration'}            | ${'testa1'} | ${'test1'} | ${'test2'} | ${'id1,2013-01-01,2w'} | ${'2d'}                  | ${new Date(2013, 0, 15)}                     | ${new Date(2013, 0, 17)} | ${'task1'} | ${'test2'}
   `)(
     '$testName',
     ({

--- a/packages/mermaid/src/diagrams/gantt/ganttDb.spec.ts
+++ b/packages/mermaid/src/diagrams/gantt/ganttDb.spec.ts
@@ -459,13 +459,13 @@ describe('when using the ganttDb', function () {
 
     expect(tasks[0].startTime).toEqual(dayjs('2019-09-30', 'YYYY-MM-DD').toDate());
     expect(tasks[0].endTime).toEqual(dayjs('2019-10-11', 'YYYY-MM-DD').toDate());
-    expect(tasks[1].renderEndTime).toBeNull(); // Fixed end
+    expect(tasks[0].renderEndTime).toEqual(dayjs('2019-10-11', 'YYYY-MM-DD').toDate());
     expect(tasks[0].id).toEqual('id1');
     expect(tasks[0].task).toEqual('test1');
 
     expect(tasks[1].startTime).toEqual(dayjs('2019-10-11', 'YYYY-MM-DD').toDate());
     expect(tasks[1].endTime).toEqual(dayjs('2019-10-31', 'YYYY-MM-DD').toDate());
-    expect(tasks[1].renderEndTime).toBeNull(); // Fixed end
+    expect(tasks[1].renderEndTime).toEqual(dayjs('2019-10-31', 'YYYY-MM-DD').toDate());
     expect(tasks[1].id).toEqual('id2');
     expect(tasks[1].task).toEqual('test2');
   });

--- a/packages/mermaid/src/diagrams/gantt/ganttDb.spec.ts
+++ b/packages/mermaid/src/diagrams/gantt/ganttDb.spec.ts
@@ -280,7 +280,7 @@ describe('when using the ganttDb', function () {
 
     expect(tasks[3].startTime).toEqual(dayjs('2019-02-01', 'YYYY-MM-DD').toDate());
     expect(tasks[3].endTime).toEqual(dayjs('2019-02-20', 'YYYY-MM-DD').toDate());
-    expect(tasks[3].renderEndTime).toBeNull(); // Fixed end
+    expect(tasks[3].renderEndTime).toEqual(dayjs('2019-02-20', 'YYYY-MM-DD').toDate());
     expect(tasks[3].id).toEqual('id4');
     expect(tasks[3].task).toEqual('test4');
 
@@ -313,6 +313,7 @@ describe('when using the ganttDb', function () {
 
     expect(tasks[0].startTime).toEqual(dayjs('2024-02-28', 'YYYY-MM-DD').toDate());
     expect(tasks[0].endTime).toEqual(dayjs('2024-03-04', 'YYYY-MM-DD').toDate());
+    expect(tasks[0].renderEndTime).toEqual(dayjs('2024-03-04', 'YYYY-MM-DD').toDate());
     expect(tasks[0].id).toEqual('id1');
     expect(tasks[0].task).toEqual('test1');
   });
@@ -519,7 +520,7 @@ describe('when using the ganttDb', function () {
 
       expect(tasks[1].startTime).toEqual(dayjs('2019-02-01', 'YYYY-MM-DD').toDate());
       expect(tasks[1].endTime).toEqual(dayjs('2019-02-04', 'YYYY-MM-DD').toDate());
-      expect(tasks[1].renderEndTime).toBeNull(); // Fixed end
+      expect(tasks[1].renderEndTime).toEqual(dayjs('2019-02-04', 'YYYY-MM-DD').toDate());
       expect(tasks[1].manualEndTime).toBeTruthy();
       expect(tasks[1].id).toEqual('id2');
       expect(tasks[1].task).toEqual('test2');
@@ -539,5 +540,34 @@ describe('when using the ganttDb', function () {
     ganttDb.setDateFormat('YYYYMMDD');
     ganttDb.addTask('test1', 'id1,202304,1d');
     expect(() => ganttDb.getTasks()).toThrowError('Invalid date:202304');
+  });
+
+  it('until should work with excludes', function () {
+    ganttDb.setDateFormat('YYYY-MM-DD');
+    ganttDb.setExcludes('2025-04-02 2025-04-03 2025-04-04');
+    ganttDb.addSection('section1');
+    ganttDb.addTask('test1', 'id1, 2025-03-31, 3d');
+    ganttDb.addTask('test2', 'id2, until id1, 3d until id1');
+    ganttDb.addTask('test3', 'id3, until id1, after id1');
+
+    const tasks = ganttDb.getTasks();
+
+    expect(tasks[0].startTime).toEqual(dayjs('2025-03-31', 'YYYY-MM-DD').toDate());
+    expect(tasks[0].endTime).toEqual(dayjs('2025-04-06', 'YYYY-MM-DD').toDate());
+    expect(tasks[0].renderEndTime).toEqual(dayjs('2025-04-06', 'YYYY-MM-DD').toDate());
+    expect(tasks[0].id).toEqual('id1');
+    expect(tasks[0].task).toEqual('test1');
+
+    expect(tasks[1].startTime).toEqual(dayjs('2025-03-31', 'YYYY-MM-DD').toDate());
+    expect(tasks[1].endTime).toEqual(dayjs('2025-04-06', 'YYYY-MM-DD').toDate());
+    expect(tasks[1].renderEndTime).toEqual(dayjs('2025-04-06', 'YYYY-MM-DD').toDate());
+    expect(tasks[1].id).toEqual('id2');
+    expect(tasks[1].task).toEqual('test2');
+
+    expect(tasks[2].startTime).toEqual(dayjs('2025-03-31', 'YYYY-MM-DD').toDate());
+    expect(tasks[2].endTime).toEqual(dayjs('2025-04-06', 'YYYY-MM-DD').toDate());
+    expect(tasks[2].renderEndTime).toEqual(dayjs('2025-04-06', 'YYYY-MM-DD').toDate());
+    expect(tasks[2].id).toEqual('id3');
+    expect(tasks[2].task).toEqual('test3');
   });
 });

--- a/packages/mermaid/src/docs/syntax/gantt.md
+++ b/packages/mermaid/src/docs/syntax/gantt.md
@@ -95,6 +95,25 @@ After processing the tags, the remaining metadata items are interpreted as follo
 Support for keyword `until` was added in (v10.9.0+). This can be used to define a task which is running until some other specific task or milestone starts.
 ```
 
+::: info
+starting from (v\<MERMAID_RELEASE_VERSION>+) `until` and `after`can be used as `startdate` or/and `enddate`. `until` will relate to the **earliest start** date of
+the provided tasks identifiers and `after` will relate to the **latest end** date of the provided tasks.
+
+Moreover positive and negative delay (as duration) can be added in front of after/until keyword. E.g `1d after task2` or `-3w until task1` or `+1.5d after id1`
+
+```mermaid-example
+gantt
+tickInterval 1day
+ref 1 : 2025-01-01, 2d
+ref 2 : 2025-02-01, 2d
+task1: after task1, until task2
+task2: until task1, after task2
+task3: -1d after task1, +1d until task2
+task4: -1d until task1, +1d after task2
+```
+
+:::
+
 For simplicity, the table does not show the use of multiple tasks listed with the `after` keyword. Here is an example of how to use it and how it's interpreted:
 
 ```mermaid-example


### PR DESCRIPTION
## :bookmark_tabs: Summary

Possibility to define a task start an end date relative to others is extended in this work:

- after and until keywords can now be used for start date **and** end date
- when after/until is used it is now possible to add a delay (in form of a duration). For example: 5 days after the end of task1 `5d after task1`

Working on that subject forced me to solve the duration issue when until is used with excluded dates #5867

Resolves #818
Resolves #5867

## :straight_ruler: Design Decisions

A dedicated function have been created to manage after/until keywords which is called by _getStartDate_ and _getEndDate_.

_fixTaskDates_ and _checkTaskDates_ usage is restricted to date definition where duration is used to help resolve the duration issue when exclude is used.

`task.renderEndTime` is always defined to help resolve issue #5867

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
