### PR TITLE
Move requirements containment arrow to edge start

### DIFF
--- a/packages/mermaid/src/diagrams/requirement/requirementDb.ts
+++ b/packages/mermaid/src/diagrams/requirement/requirementDb.ts
@@ -328,7 +328,7 @@ export class RequirementDB implements DiagramDB {
         thickness: 'normal',
         type: 'normal',
         pattern: isContains ? 'normal' : 'dashed',
-        arrowTypeEnd: isContains ? 'requirement_contains' : 'requirement_arrow',
+        arrowTypeStart: isContains ? 'requirement_contains' : 'requirement_arrow',
         look: config.look,
       };
 

--- a/packages/mermaid/src/diagrams/requirement/requirementDb.ts
+++ b/packages/mermaid/src/diagrams/requirement/requirementDb.ts
@@ -328,7 +328,8 @@ export class RequirementDB implements DiagramDB {
         thickness: 'normal',
         type: 'normal',
         pattern: isContains ? 'normal' : 'dashed',
-        arrowhead: isContains ? 'requirement_contains' : 'requirement_arrow',
+        arrowTypeStart: isContains ? 'requirement_contains' : '',
+        arrowTypeEnd: isContains ? '' : 'requirement_arrow',
         look: config.look,
       };
 

--- a/packages/mermaid/src/diagrams/requirement/requirementDb.ts
+++ b/packages/mermaid/src/diagrams/requirement/requirementDb.ts
@@ -328,7 +328,7 @@ export class RequirementDB implements DiagramDB {
         thickness: 'normal',
         type: 'normal',
         pattern: isContains ? 'normal' : 'dashed',
-        arrowTypeStart: isContains ? 'requirement_contains' : 'requirement_arrow',
+        arrowhead: isContains ? 'requirement_contains' : 'requirement_arrow',
         look: config.look,
       };
 

--- a/packages/mermaid/src/rendering-util/rendering-elements/markers.js
+++ b/packages/mermaid/src/rendering-util/rendering-elements/markers.js
@@ -423,19 +423,19 @@ const requirement_contains = (elem, type, id) => {
   const containsNode = elem
     .append('defs')
     .append('marker')
-    .attr('id', id + '_' + type + '-requirement_containsEnd')
-    .attr('refX', 20)
+    .attr('id', id + '_' + type + '-requirement_containsStart')
+    .attr('refX', 0)
     .attr('refY', 10)
     .attr('markerWidth', 20)
     .attr('markerHeight', 20)
     .attr('orient', 'auto')
     .append('g');
 
-  containsNode.append('circle').attr('cx', 10).attr('cy', 10).attr('r', 10).attr('fill', 'none');
+  containsNode.append('circle').attr('cx', 10).attr('cy', 10).attr('r', 9).attr('fill', 'none');
 
-  containsNode.append('line').attr('x1', 0).attr('x2', 20).attr('y1', 10).attr('y2', 10);
+  containsNode.append('line').attr('x1', 1).attr('x2', 19).attr('y1', 10).attr('y2', 10);
 
-  containsNode.append('line').attr('y1', 0).attr('y2', 20).attr('x1', 10).attr('x2', 10);
+  containsNode.append('line').attr('y1', 1).attr('y2', 19).attr('x1', 10).attr('x2', 10);
 };
 
 // TODO rename the class diagram markers to something shape descriptive and semantic free


### PR DESCRIPTION
## :bookmark_tabs: Summary

This moves the containment arrowhead (`⨁`) to the start of the edge. It also slightly tweaks the geometry to avoid clipping.

Resolves #6380

## :straight_ruler: Design Decisions

The [example](https://mermaid.js.org/syntax/requirementDiagram.html#larger-example) from the documentation with slight zoom demonstrates the position and clipping.

![image](https://github.com/user-attachments/assets/b3c57885-bcdd-487e-b423-6144232090d1)

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
