### PR TITLE
Fix timeline title wrapping issue (#6393)

### DIFF
--- a/packages/mermaid/src/diagrams/timeline/timelineRenderer.ts
+++ b/packages/mermaid/src/diagrams/timeline/timelineRenderer.ts
@@ -205,7 +205,7 @@ export const draw = function (text: string, id: string, version: string, diagObj
       .attr('y', 10) // Adjust vertical position as needed
       .attr('width', box.width - 2 * LEFT_MARGIN) // Width of the foreignObject
       .attr('height', 100); // Set a reasonable height for wrapping
-  
+
     // Append a div inside the foreignObject for proper HTML rendering
     foreignObject
       .append('xhtml:div') // Use xhtml namespace for HTML elements inside SVG
@@ -216,7 +216,7 @@ export const draw = function (text: string, id: string, version: string, diagObj
       .style('text-align', 'center') // Center-align the text
       .text(title); // Set the title text
   }
-  
+
   //5. Draw the diagram
   depthY = hasSections ? maxSectionHeight + maxTaskHeight + 150 : maxTaskHeight + 100;
 

--- a/packages/mermaid/src/diagrams/timeline/timelineRenderer.ts
+++ b/packages/mermaid/src/diagrams/timeline/timelineRenderer.ts
@@ -199,14 +199,24 @@ export const draw = function (text: string, id: string, version: string, diagObj
   log.debug('bounds', box);
 
   if (title) {
-    svg
-      .append('text')
-      .text(title)
-      .attr('x', box.width / 2 - LEFT_MARGIN)
-      .attr('font-size', '4ex')
-      .attr('font-weight', 'bold')
-      .attr('y', 20);
+    const foreignObject = svg
+      .append('foreignObject')
+      .attr('x', LEFT_MARGIN) // Adjust position as needed
+      .attr('y', 10) // Adjust vertical position as needed
+      .attr('width', box.width - 2 * LEFT_MARGIN) // Width of the foreignObject
+      .attr('height', 100); // Set a reasonable height for wrapping
+  
+    // Append a div inside the foreignObject for proper HTML rendering
+    foreignObject
+      .append('xhtml:div') // Use xhtml namespace for HTML elements inside SVG
+      .attr('xmlns', 'http://www.w3.org/1999/xhtml') // Explicitly set XHTML namespace
+      .style('font-size', '16px') // Match font size with Mermaid's theme
+      .style('word-wrap', 'break-word') // Ensure long words wrap properly
+      .style('white-space', 'normal') // Allow normal wrapping behavior
+      .style('text-align', 'center') // Center-align the text
+      .text(title); // Set the title text
   }
+  
   //5. Draw the diagram
   depthY = hasSections ? maxSectionHeight + maxTaskHeight + 150 : maxTaskHeight + 100;
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

This pull request resolves the issue where timeline titles do not wrap correctly when the text is too long. The problem caused layout issues, such as overflowing or shrinking diagrams, making them unreadable. The fix ensures that timeline titles break into multiple lines and maintain consistent diagram layouts.

Resolves #[#6393](https://github.com/mermaid-js/mermaid/pull/6394#top)

## :straight_ruler: Design Decisions

1. Identified the Problem

- Found that the title was rendered using an SVG <text> element, which does not support automatic text wrapping.

2.Introduced <foreignObject> for Wrapping

Replaced the <text> element with <foreignObject> to enable proper wrapping using HTML/CSS.
**Updated Code:**


```
if (title) {
  const foreignObject = svg
    .append('foreignObject')
    .attr('x', LEFT_MARGIN) // Adjust position as needed
    .attr('y', TOP_MARGIN) // Adjust vertical position as needed
    .attr('width', diagramWidth - LEFT_MARGIN * 2) // Set width
    .attr('height', WRAPPING_HEIGHT); // Define height for wrapping

  foreignObject
    .append('xhtml:div') // Use xhtml namespace for HTML inside SVG
    .style('font-size', `${conf.fontSize || '16px'}`)
    .style('word-wrap', 'break-word')
    .style('white-space', 'normal')
    .style('text-align', 'center')
    .text(title);
}
```

3. Applied CSS Styling for Wrapping

- word-wrap: break-word; Ensures long words break into multiple lines.
- white-space: normal; Allows natural line breaks.
- text-align: center; Centers the title for better readability.

4. Tested with Long Titles

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
