### PR TITLE
Fix: Properly decode <, >, and & in mindmap node labels

### DIFF
--- a/packages/mermaid/src/rendering-util/createText.ts
+++ b/packages/mermaid/src/rendering-util/createText.ts
@@ -169,10 +169,10 @@ function updateTextContentAndStyles(tspan: any, wrappedLine: MarkdownWord[]) {
       .attr('class', 'text-inner-tspan')
       .attr('font-weight', word.type === 'strong' ? 'bold' : 'normal');
     if (index === 0) {
-      innerTspan.text(word.content);
+      innerTspan.text(decodeEntities(word.content));
     } else {
       // TODO: check what joiner to use.
-      innerTspan.text(' ' + word.content);
+      innerTspan.text(' ' + decodeEntities(word.content));
     }
   });
 }

--- a/packages/mermaid/src/utils.ts
+++ b/packages/mermaid/src/utils.ts
@@ -922,7 +922,13 @@ export const encodeEntities = function (text: string): string {
  * @returns
  */
 export const decodeEntities = function (text: string): string {
-  return text.replace(/ﬂ°°/g, '&#').replace(/ﬂ°/g, '&').replace(/¶ß/g, ';');
+  return text
+    .replace(/ﬂ°°/g, '&#')
+    .replace(/ﬂ°/g, '&')
+    .replace(/¶ß/g, ';')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
 };
 
 export const isString = (value: unknown): value is string => {


### PR DESCRIPTION
## :bookmark_tabs: Summary

This pull request fixes a rendering bug in Mermaid mindmap diagrams where characters like `<`, `>`, and `&` were incorrectly displayed as `&lt;`, `&gt;`, and `&amp;` inside SVG <tspan> elements.

This issue occurred because `.text()` in D3/SVG escapes HTML entities even when the decoded content is passed in. This PR addresses it by decoding these entities right before rendering.

Resolves #6396 

## :straight_ruler: Design Decisions

Modified `decodeEntities()` function in `utils.ts` to replace common HTML entities (`&lt;, &gt;, &amp;`) with their correct characters.

Applied `decodeEntities()` immediately before inserting text content into `<tspan>` elements via `.text()` in the `updateTextContentAndStyles()` function of `createText.ts`.

This approach ensures that the final text rendered in the SVG node is accurate and unescaped while maintaining full safety.

### Screenshots
**Before**
![image](https://github.com/user-attachments/assets/6161219d-da30-4857-905e-36109057e113)

**After**
![image](https://github.com/user-attachments/assets/fdc8bfe6-3d32-4162-a5bb-ef661cdcb30f)

### :clipboard: Tasks

Make sure you

- [ ] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
