### PR TITLE
fix: restore curve type configuration functionality for flowcharts 

### DIFF
--- a/.changeset/curve-interpolation-fix.md
+++ b/.changeset/curve-interpolation-fix.md
@@ -1,0 +1,9 @@
+---
+'mermaid': minor
+---
+
+fix: restore curve type configuration functionality for flowcharts. This fixes the issue where curve type settings were not being applied when configured through any of the following methods:
+
+- Config
+- Init directive (%%{ init: { 'flowchart': { 'curve': '...' } } }%%)
+- LinkStyle command (linkStyle default interpolate ...)

--- a/packages/mermaid/src/config.type.ts
+++ b/packages/mermaid/src/config.type.ts
@@ -262,7 +262,19 @@ export interface FlowchartDiagramConfig extends BaseDiagramConfig {
    * Defines how mermaid renders curves for flowcharts.
    *
    */
-  curve?: 'basis' | 'linear' | 'cardinal';
+  curve?:
+    | 'basis'
+    | 'bumpX'
+    | 'bumpY'
+    | 'cardinal'
+    | 'catmullRom'
+    | 'linear'
+    | 'monotoneX'
+    | 'monotoneY'
+    | 'natural'
+    | 'step'
+    | 'stepAfter'
+    | 'stepBefore';
   /**
    * Represents the padding between the labels and the shape
    *

--- a/packages/mermaid/src/diagrams/flowchart/flowDb.spec.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.spec.ts
@@ -98,3 +98,31 @@ describe('flow db class', () => {
     }
   });
 });
+
+describe('flow db getData', () => {
+  let flowDb: FlowDB;
+  beforeEach(() => {
+    flowDb = new FlowDB();
+  });
+
+  it('should use defaultInterpolate for edges without specific interpolate', () => {
+    flowDb.addVertex('A', { text: 'A', type: 'text' }, undefined, [], [], '', {}, undefined);
+    flowDb.addVertex('B', { text: 'B', type: 'text' }, undefined, [], [], '', {}, undefined);
+    flowDb.addLink(['A'], ['B'], {});
+    flowDb.updateLinkInterpolate(['default'], 'stepBefore');
+
+    const { edges } = flowDb.getData();
+    expect(edges[0].curve).toBe('stepBefore');
+  });
+
+  it('should prioritize edge-specific interpolate over defaultInterpolate', () => {
+    flowDb.addVertex('A', { text: 'A', type: 'text' }, undefined, [], [], '', {}, undefined);
+    flowDb.addVertex('B', { text: 'B', type: 'text' }, undefined, [], [], '', {}, undefined);
+    flowDb.addLink(['A'], ['B'], {});
+    flowDb.updateLinkInterpolate(['default'], 'stepBefore');
+    flowDb.updateLinkInterpolate([0], 'basis');
+
+    const { edges } = flowDb.getData();
+    expect(edges[0].curve).toBe('basis');
+  });
+});

--- a/packages/mermaid/src/diagrams/flowchart/flowDb.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.ts
@@ -252,6 +252,7 @@ export class FlowDB implements DiagramDB {
       labelType: 'text',
       classes: [],
       isUserDefinedId: false,
+      interpolate: this.edges.defaultInterpolate,
     };
     log.info('abc78 Got edge...', edge);
     const linkTextObj = type.text;
@@ -1124,6 +1125,7 @@ You have to call mermaid.initialize.`
         look: config.look,
         animate: rawEdge.animate,
         animation: rawEdge.animation,
+        curve: rawEdge.interpolate || this.edges.defaultInterpolate || config.flowchart?.curve,
       };
 
       edges.push(edge);

--- a/packages/mermaid/src/rendering-util/rendering-elements/edges.js
+++ b/packages/mermaid/src/rendering-util/rendering-elements/edges.js
@@ -6,7 +6,22 @@ import utils from '../../utils.js';
 import { getLineFunctionsWithOffset } from '../../utils/lineWithOffset.js';
 import { getSubGraphTitleMargins } from '../../utils/subGraphTitleMargins.js';
 
-import { curveBasis, curveLinear, curveCardinal, line, select } from 'd3';
+import {
+  curveBasis,
+  curveLinear,
+  curveCardinal,
+  curveBumpX,
+  curveBumpY,
+  curveCatmullRom,
+  curveMonotoneX,
+  curveMonotoneY,
+  curveNatural,
+  curveStep,
+  curveStepAfter,
+  curveStepBefore,
+  line,
+  select,
+} from 'd3';
 import rough from 'roughjs';
 import createLabel from './createLabel.js';
 import { addEdgeMarkers } from './edgeMarker.ts';
@@ -483,6 +498,33 @@ export const insertEdge = function (elem, edge, clusterDb, diagramType, startNod
       break;
     case 'cardinal':
       curve = curveCardinal;
+      break;
+    case 'bumpX':
+      curve = curveBumpX;
+      break;
+    case 'bumpY':
+      curve = curveBumpY;
+      break;
+    case 'catmullRom':
+      curve = curveCatmullRom;
+      break;
+    case 'monotoneX':
+      curve = curveMonotoneX;
+      break;
+    case 'monotoneY':
+      curve = curveMonotoneY;
+      break;
+    case 'natural':
+      curve = curveNatural;
+      break;
+    case 'step':
+      curve = curveStep;
+      break;
+    case 'stepAfter':
+      curve = curveStepAfter;
+      break;
+    case 'stepBefore':
+      curve = curveStepBefore;
       break;
     default:
       curve = curveBasis;

--- a/packages/mermaid/src/schemas/config.schema.yaml
+++ b/packages/mermaid/src/schemas/config.schema.yaml
@@ -2066,7 +2066,21 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
         description: |
           Defines how mermaid renders curves for flowcharts.
         type: string
-        enum: ['basis', 'linear', 'cardinal']
+        enum:
+          [
+            'basis',
+            'bumpX',
+            'bumpY',
+            'cardinal',
+            'catmullRom',
+            'linear',
+            'monotoneX',
+            'monotoneY',
+            'natural',
+            'step',
+            'stepAfter',
+            'stepBefore',
+          ]
         default: 'basis'
       padding:
         description: |


### PR DESCRIPTION
This pull request addresses the issue with curve type settings not being applied correctly for flowcharts in Mermaid. The changes include restoring the curve type configuration functionality and adding support for additional curve types.

Fixes and Enhancements:

* [`.changeset/curve-interpolation-fix.md`](diffhunk://#diff-008baba2b52ce5920c449816d8115e7a2b88cacd80feadfb48654ec79730cf62R1-R9): Documented the fix for restoring curve type configuration functionality for flowcharts. This ensures that curve type settings are applied correctly when configured through various methods.

Codebase Updates:

* [`packages/mermaid/src/config.type.ts`](diffhunk://#diff-6af9e024e230dc5cf5a564b3bf3a10c4eed59900316e31c1f1c5f5a80386c388L265-R277): Expanded the `curve` property in `FlowchartDiagramConfig` to include additional curve types such as 'bumpX', 'bumpY', 'catmullRom', 'monotoneX', 'monotoneY', 'natural', 'step', 'stepAfter', and 'stepBefore'.
* [`packages/mermaid/src/diagrams/flowchart/flowDb.spec.ts`](diffhunk://#diff-a6ca1fb3b57540d65a03168086dc4de04c31cc1823d9437296a6859ba54f7c1cR101-R128): Added tests to verify that the default and edge-specific interpolation settings are applied correctly.

Implementation Details:

* [`packages/mermaid/src/diagrams/flowchart/flowDb.ts`](diffhunk://#diff-24cf16277fd88c600b7d11fc1b9dc550c467ae0674ea73b4604e659086e4ec55R255): Updated the `FlowDB` class to ensure that the `interpolate` property is correctly set for edges, and that the curve type is determined based on edge-specific or default settings. [[1]](diffhunk://#diff-24cf16277fd88c600b7d11fc1b9dc550c467ae0674ea73b4604e659086e4ec55R255) [[2]](diffhunk://#diff-24cf16277fd88c600b7d11fc1b9dc550c467ae0674ea73b4604e659086e4ec55R1128)
* [`packages/mermaid/src/rendering-util/rendering-elements/edges.js`](diffhunk://#diff-3aad9809facdb1009147cb27062c1c80d03c5d5991c2a9d426e26d69dac52b8aL9-R24): Imported additional curve functions from `d3` and updated the `insertEdge` function to handle the new curve types. [[1]](diffhunk://#diff-3aad9809facdb1009147cb27062c1c80d03c5d5991c2a9d426e26d69dac52b8aL9-R24) [[2]](diffhunk://#diff-3aad9809facdb1009147cb27062c1c80d03c5d5991c2a9d426e26d69dac52b8aR502-R528)

Schema Update:

* [`packages/mermaid/src/schemas/config.schema.yaml`](diffhunk://#diff-36889d8ba1a3921f4cbcbc11784a46fef8f62694be0fdd8887f788076675b0f7L2069-R2083): Updated the JSON schema to include the new curve types in the `enum` for flowchart curve configuration.

Resolves #6193 

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [X] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [X] :computer: have added necessary unit/e2e tests.
- [X] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [X] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
