### PR TITLE
test(e2e): fix Cypress config for Node.JS v20.19.0

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,8 +1,8 @@
 import eyesPlugin from '@applitools/eyes-cypress';
 import { registerArgosTask } from '@argos-ci/cypress/task';
-import coverage from '@cypress/code-coverage/task';
+import coverage from '@cypress/code-coverage/task.js';
 import { defineConfig } from 'cypress';
-import { addMatchImageSnapshotPlugin } from 'cypress-image-snapshot/plugin';
+import { addMatchImageSnapshotPlugin } from 'cypress-image-snapshot/plugin.js';
 import cypressSplit from 'cypress-split';
 
 export default eyesPlugin(


### PR DESCRIPTION
## :bookmark_tabs: Summary

Node.JS v20.19.0 breaks `import '@cypress/code-coverage/task'` in the `cypress.config.ts` for some reason (this is probably due to the new `experimental-require-module` feature that is enabled by default in Node.JS v20.19.0).

As a work-around, we can change this to `@cypress/code-coverage/task.js` and `cypress-image-snapshot/plugin.js'`.

See: https://github.com/cypress-io/code-coverage/pull/940
See: https://nodejs.org/en/blog/release/v20.19.0

## :straight_ruler: Design Decisions

The reason why we don't need to update `@argos-ci/cypress/task` is because they've set their `exports` in the `package.json` file:

https://github.com/argos-ci/argos-javascript/blob/af931a704908a48f49f375f92f23924a39792c7e/packages/cypress/package.json#L30-L43

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
  - Test only change
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
  - Test only change
