### PR TITLE
fix(mindmap): decode <, >, and & characters in node labels

### DIFF
--- a/packages/mermaid/src/rendering-util/createText.ts
+++ b/packages/mermaid/src/rendering-util/createText.ts
@@ -169,10 +169,10 @@ function updateTextContentAndStyles(tspan: any, wrappedLine: MarkdownWord[]) {
       .attr('class', 'text-inner-tspan')
       .attr('font-weight', word.type === 'strong' ? 'bold' : 'normal');
     if (index === 0) {
-      innerTspan.text(word.content);
+      innerTspan.text(decodeEntities(word.content));
     } else {
       // TODO: check what joiner to use.
-      innerTspan.text(' ' + word.content);
+      innerTspan.text(' ' + decodeEntities(word.content));
     }
   });
 }

--- a/packages/mermaid/src/utils.ts
+++ b/packages/mermaid/src/utils.ts
@@ -922,7 +922,13 @@ export const encodeEntities = function (text: string): string {
  * @returns
  */
 export const decodeEntities = function (text: string): string {
-  return text.replace(/ﬂ°°/g, '&#').replace(/ﬂ°/g, '&').replace(/¶ß/g, ';');
+  return text
+    .replace(/ﬂ°°/g, '&#')
+    .replace(/ﬂ°/g, '&')
+    .replace(/¶ß/g, ';')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
 };
 
 export const isString = (value: unknown): value is string => {


### PR DESCRIPTION
## :bookmark_tabs: Summary

This PR fixes issue #6396 by decoding the characters `<`, `>` and `&` that were incorrectly rendered as `&lt;`, `&gt;`, and `&amp;` in mindmap node labels.

Resolves #6396 

## :straight_ruler: Design Decisions

- Used the existing `decodeEntities()` function to decode text when rendering tspan elements in `createText.ts`.

Verified manually in the dev environment with the following:

```
mermaid
mindmap
  root((Symbols))
    LessThan["A < B"]
    GreaterThan["A > B"]
    Amp["A & B"]
```
screenshots : 
![image](https://github.com/user-attachments/assets/501786e8-6832-4b2b-a2dc-cee9173b64d4)
![image](https://github.com/user-attachments/assets/465e40ef-abbf-48f3-b971-6e1df8d1464c)



### :clipboard: Tasks

Make sure you

- [x ] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ x] :computer: have added necessary unit/e2e tests.
- [x ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
