### PR TITLE
Fix: Support `direction TD` in Subgraphs

### DIFF
--- a/.changeset/early-rules-agree.md
+++ b/.changeset/early-rules-agree.md
@@ -1,0 +1,5 @@
+---
+'mermaid': major
+---
+
+Fixed parsing issue when using direction TD inside subgraph would throw parse error or be ignored

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
@@ -137,6 +137,7 @@ that id.
 <dir>\s*"v"              { this.popState();  return 'DIR'; }
 
 .*direction\s+TB[^\n]*       return 'direction_tb';
+.*direction\s+TD[^\n]*       return 'direction_td';
 .*direction\s+BT[^\n]*       return 'direction_bt';
 .*direction\s+RL[^\n]*       return 'direction_rl';
 .*direction\s+LR[^\n]*       return 'direction_lr';
@@ -620,6 +621,8 @@ alphaNum
 direction
     : direction_tb
     { $$={stmt:'dir', value:'TB'};}
+    | direction_td
+    { $$ = { stmt: 'dir', value: 'TD' }; }
     | direction_bt
     { $$={stmt:'dir', value:'BT'};}
     | direction_rl

--- a/packages/mermaid/src/diagrams/flowchart/parser/subgraph.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/subgraph.spec.js
@@ -309,4 +309,21 @@ describe('when parsing subgraphs', function () {
     expect(subgraphA.nodes).toContain('a');
     expect(subgraphA.nodes).not.toContain('c');
   });
+  it('should correctly parse direction TD inside a subgraph', function () {
+    const res = flow.parser.parse(`
+      graph LR
+        subgraph WithTD
+          direction TD
+          A1 --> A2
+        end
+    `);
+
+    const subgraphs = flow.parser.yy.getSubGraphs();
+    expect(subgraphs.length).toBe(1);
+    const subgraph = subgraphs[0];
+
+    expect(subgraph.dir).toBe('TD');
+    expect(subgraph.nodes).toContain('A1');
+    expect(subgraph.nodes).toContain('A2');
+  });
 });


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fixes a parsing issue where using `direction TD` inside a subgraph would throw a parse error or be ignored.
This change ensures that subgraph-local directions (`TD`, `BT`, `RL`, `LR`, etc.) are fully supported in the grammar and properly rendered.

Resolves #6338 

## :straight_ruler: Design Decisions

- Updated the `flow.jison` grammar to allow `direction TD` and other directions inside subgraphs.

![image](https://github.com/user-attachments/assets/706c5b80-c780-4bb3-8533-6809e48eaf84)


### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.