### PR TITLE
fix(flowchart): make subgraphs inherit global graph direction by default

### DIFF
--- a/packages/mermaid/src/diagrams/flowchart/flowDb.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.ts
@@ -686,7 +686,8 @@ You have to call mermaid.initialize.`
       nodes: nodeList,
       title: title.trim(),
       classes: [],
-      dir,
+      dir: dir ?? this.getDirection(),
+
       labelType: _title.type,
     };
 

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow-direction.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow-direction.spec.js
@@ -26,7 +26,7 @@ describe('when parsing directions', function () {
     expect(subgraph.nodes[0]).toBe('b');
     expect(subgraph.nodes[1]).toBe('a');
     expect(subgraph.id).toBe('A');
-    expect(subgraph.dir).toBe(undefined);
+    expect(subgraph.dir).toBe('TB');
   });
   it('should handle a subgraph with a direction', function () {
     const res = flow.parser.parse(`flowchart TB


### PR DESCRIPTION


## :bookmark_tabs: Summary

Fixes an issue where subgraphs in flowcharts always default to `TD` (top-down) layout, ignoring the global graph direction (`LR`, `RL`, `BT`).

Resolves #6428 

## :straight_ruler: Design Decisions

Modified `flowDb.ts` to assign `dir = getDirection()` when the subgraph's direction is not explicitly set.

**before
![image](https://github.com/user-attachments/assets/26288420-a2c5-4ed6-a906-783e0f69df0b)

**after
 
![image](https://github.com/user-attachments/assets/0a06e278-35ac-442a-8171-4cedf62dc16f)



### :clipboard: Tasks

Make sure you

- [x ] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ x] :computer: have added necessary unit/e2e tests.
- [x ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
