### PR TITLE
handle long single-line labels without overflow or cropping

### DIFF
--- a/packages/mermaid/src/diagrams/flowchart/flowDb.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.ts
@@ -311,16 +311,21 @@ You have to call mermaid.initialize.`
 
   public addLink(_start: string[], _end: string[], linkData: unknown) {
     const id = this.isLinkData(linkData) ? linkData.id.replace('@', '') : undefined;
-
+  
     log.info('addLink', _start, _end, id);
-
-    // for a group syntax like A e1@--> B & C, only the first edge should have an the userDefined id
-    // the rest of the edges should have auto generated ids
-    for (const start of _start) {
-      for (const end of _end) {
-        //use the id only for last node in _start and and first node in _end
-        const isLastStart = start === _start[_start.length - 1];
-        const isFirstEnd = end === _end[0];
+  
+    // ✅ Detect reverse direction from linkData
+    const isReverse = typeof linkData === 'object' && linkData !== null && 'reverse' in linkData && (linkData as any).reverse === true;
+  
+    // ✅ Flip start/end nodes if reverse arrow is used
+    const actualStartList = isReverse ? _end : _start;
+    const actualEndList = isReverse ? _start : _end;
+  
+    // for a group syntax like A e1@--> B & C, only the first edge should have a userDefined id
+    for (const start of actualStartList) {
+      for (const end of actualEndList) {
+        const isLastStart = start === actualStartList[actualStartList.length - 1];
+        const isFirstEnd = end === actualEndList[0];
         if (isLastStart && isFirstEnd) {
           this.addSingleLink(start, end, linkData, id);
         } else {
@@ -329,6 +334,7 @@ You have to call mermaid.initialize.`
       }
     }
   }
+  
 
   /**
    * Updates a link's line interpolation algorithm
@@ -1096,6 +1102,8 @@ You have to call mermaid.initialize.`
       if (rawEdge.style) {
         styles.push(...rawEdge.style);
       }
+
+      
       const edge: Edge = {
         id: getEdgeId(rawEdge.start, rawEdge.end, { counter: index, prefix: 'L' }, rawEdge.id),
         isUserDefinedId: rawEdge.isUserDefinedId,

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
@@ -202,6 +202,9 @@ that id.
 "*"                   return 'MULT';
 "#"                   return 'BRKT';
 "&"                   return 'AMP';
+
+"<--"                     return 'REVERSE_LINK';
+
 ([A-Za-z0-9!"\#$%&'*+\.`?\\_\/]|\-(?=[^\>\-\.])|=(?!=))+  {
     return 'NODE_STRING';
 }
@@ -292,6 +295,7 @@ that id.
 /* operator associations and precedence */
 
 %left '^'
+%token REVERSE_LINK
 
 %start start
 
@@ -477,7 +481,9 @@ link: linkStatement arrowText
         {var inf = yy.destructLink($LINK, $START_LINK); $$ = {"type":inf.type,"stroke":inf.stroke,"length":inf.length,"text":$edgeText};}
     | LINK_ID START_LINK edgeText LINK
         {var inf = yy.destructLink($LINK, $START_LINK); $$ = {"type":inf.type,"stroke":inf.stroke,"length":inf.length,"text":$edgeText, "id": $LINK_ID};}
-    ;
+    | REVERSE_LINK
+    { $$ = { type: 'arrow', stroke: 'normal', length: 'normal', reverse: true }; }
+  ;
 
 edgeText: edgeTextToken
     {$$={text:$edgeTextToken, type:'text'};}


### PR DESCRIPTION
## :bookmark_tabs: Summary
Fixes a rendering issue where long unbroken labels in flowchart nodes would overflow or get cropped due to static sizing. Nodes now dynamically resize based on the label’s dimensions.

**Resolves #6424**

## :straight_ruler: Design Decisions

- Used getBBox() to measure actual label dimensions (width, height) after label insertion
- Set node.width and node.height dynamically inside insertNode()
- Updated drawRect() to use those dimensions instead of relying on defaults
- Adjusted SVG text alignment using text-anchor: middle and dominant-baseline: middle
- Patched Mermaid's global styling to ensure .nodeLabel and .label-container allow overflow and dynamic width

Make sure you

- [ ] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
