### PR TITLE
feat(flowchart): support multiline edge labels using \n

### DIFF
--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
@@ -360,6 +360,11 @@ export const render = async (data4Layout, svg) => {
       graph.setEdge(specialId1, specialId2, edgeMid, nodeId + '-cyclic-special-1');
       graph.setEdge(specialId2, nodeId, edge2, nodeId + '-cyc<lic-special-2');
     } else {
+      // Replace \n with <br/> for multiline edge labels
+      if (typeof edge.label === 'string') {
+        edge.label = edge.label.replace(/\\n/g, '<br/>');
+      }
+
       graph.setEdge(edge.start, edge.end, { ...edge }, edge.id);
     }
   });


### PR DESCRIPTION
## :bookmark_tabs: Summary

Adds support for multiline edge labels in flowcharts by converting `\n` into `<br/>` before rendering.

This enables authors to write:
```
mermaid
graph TD
  A -->|"Line 1\nLine 2"| B
```

Resolves #6436 

## :straight_ruler: Design Decisions

Patches the flowchart layout algorithm (layout-algorithms/dagre/index.ts) to replace \n with <br/> before calling graph.setEdge().

![image](https://github.com/user-attachments/assets/589837ef-15d5-4366-989b-0dca05442fc5)


### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
