### PR TITLE
Feature: Support multi-line titles using \n and <br> in diagram types

### DIFF
--- a/cypress/timings.json
+++ b/cypress/timings.json
@@ -2,151 +2,211 @@
   "durations": [
     {
       "spec": "cypress/integration/other/configuration.spec.js",
-      "duration": 4989
+      "duration": 5701
     },
     {
       "spec": "cypress/integration/other/external-diagrams.spec.js",
-      "duration": 1382
+      "duration": 2041
     },
     {
       "spec": "cypress/integration/other/ghsa.spec.js",
-      "duration": 3178
+      "duration": 3416
     },
     {
       "spec": "cypress/integration/other/iife.spec.js",
-      "duration": 1372
+      "duration": 1897
     },
     {
       "spec": "cypress/integration/other/interaction.spec.js",
-      "duration": 8998
+      "duration": 11128
     },
     {
       "spec": "cypress/integration/other/rerender.spec.js",
-      "duration": 1249
+      "duration": 1879
     },
     {
       "spec": "cypress/integration/other/xss.spec.js",
-      "duration": 25664
+      "duration": 28815
     },
     {
       "spec": "cypress/integration/rendering/appli.spec.js",
-      "duration": 1928
+      "duration": 2642
     },
     {
       "spec": "cypress/integration/rendering/architecture.spec.ts",
-      "duration": 2330
+      "duration": 103
     },
     {
       "spec": "cypress/integration/rendering/block.spec.js",
-      "duration": 11156
+      "duration": 14912
     },
     {
       "spec": "cypress/integration/rendering/c4.spec.js",
-      "duration": 3418
+      "duration": 4653
+    },
+    {
+      "spec": "cypress/integration/rendering/classDiagram-elk-v3.spec.js",
+      "duration": 35446
+    },
+    {
+      "spec": "cypress/integration/rendering/classDiagram-handDrawn-v3.spec.js",
+      "duration": 33414
     },
     {
       "spec": "cypress/integration/rendering/classDiagram-v2.spec.js",
-      "duration": 14866
+      "duration": 20373
+    },
+    {
+      "spec": "cypress/integration/rendering/classDiagram-v3.spec.js",
+      "duration": 32739
     },
     {
       "spec": "cypress/integration/rendering/classDiagram.spec.js",
-      "duration": 9894
+      "duration": 13359
     },
     {
       "spec": "cypress/integration/rendering/conf-and-directives.spec.js",
-      "duration": 5778
+      "duration": 7905
     },
     {
       "spec": "cypress/integration/rendering/current.spec.js",
-      "duration": 1690
+      "duration": 2060
+    },
+    {
+      "spec": "cypress/integration/rendering/erDiagram-unified.spec.js",
+      "duration": 76749
     },
     {
       "spec": "cypress/integration/rendering/erDiagram.spec.js",
-      "duration": 9144
+      "duration": 12593
     },
     {
       "spec": "cypress/integration/rendering/errorDiagram.spec.js",
-      "duration": 1951
+      "duration": 2862
     },
     {
       "spec": "cypress/integration/rendering/flowchart-elk.spec.js",
-      "duration": 2196
+      "duration": 36233
     },
     {
       "spec": "cypress/integration/rendering/flowchart-handDrawn.spec.js",
-      "duration": 21029
+      "duration": 26615
     },
     {
       "spec": "cypress/integration/rendering/flowchart-shape-alias.spec.ts",
-      "duration": 16087
+      "duration": 21291
     },
     {
       "spec": "cypress/integration/rendering/flowchart-v2.spec.js",
-      "duration": 27465
+      "duration": 37633
     },
     {
       "spec": "cypress/integration/rendering/flowchart.spec.js",
-      "duration": 20035
+      "duration": 26100
     },
     {
       "spec": "cypress/integration/rendering/gantt.spec.js",
-      "duration": 11366
+      "duration": 15342
     },
     {
       "spec": "cypress/integration/rendering/gitGraph.spec.js",
-      "duration": 34025
+      "duration": 44942
     },
     {
       "spec": "cypress/integration/rendering/iconShape.spec.ts",
-      "duration": 185902
+      "duration": 250509
     },
     {
       "spec": "cypress/integration/rendering/imageShape.spec.ts",
-      "duration": 41631
+      "duration": 51267
     },
     {
       "spec": "cypress/integration/rendering/info.spec.ts",
-      "duration": 1736
+      "duration": 2533
     },
     {
       "spec": "cypress/integration/rendering/journey.spec.js",
-      "duration": 2247
+      "duration": 3291
+    },
+    {
+      "spec": "cypress/integration/rendering/kanban.spec.ts",
+      "duration": 6272
     },
     {
       "spec": "cypress/integration/rendering/katex.spec.js",
-      "duration": 2144
+      "duration": 3167
     },
     {
       "spec": "cypress/integration/rendering/marker_unique_id.spec.js",
-      "duration": 1646
+      "duration": 2478
     },
     {
       "spec": "cypress/integration/rendering/mindmap.spec.ts",
-      "duration": 6406
+      "duration": 9253
     },
     {
       "spec": "cypress/integration/rendering/newShapes.spec.ts",
-      "duration": 107219
+      "duration": 133542
+    },
+    {
+      "spec": "cypress/integration/rendering/oldShapes.spec.ts",
+      "duration": 101718
+    },
+    {
+      "spec": "cypress/integration/rendering/packet.spec.ts",
+      "duration": 3473
+    },
+    {
+      "spec": "cypress/integration/rendering/pie.spec.ts",
+      "duration": 4830
+    },
+    {
+      "spec": "cypress/integration/rendering/quadrantChart.spec.js",
+      "duration": 7568
+    },
+    {
+      "spec": "cypress/integration/rendering/radar.spec.js",
+      "duration": 4538
+    },
+    {
+      "spec": "cypress/integration/rendering/requirement.spec.js",
+      "duration": 2124
+    },
+    {
+      "spec": "cypress/integration/rendering/requirementDiagram-unified.spec.js",
+      "duration": 47577
+    },
+    {
+      "spec": "cypress/integration/rendering/sankey.spec.ts",
+      "duration": 5754
+    },
+    {
+      "spec": "cypress/integration/rendering/sequencediagram.spec.js",
+      "duration": 32439
+    },
+    {
+      "spec": "cypress/integration/rendering/stateDiagram-v2.spec.js",
+      "duration": 22649
     },
     {
       "spec": "cypress/integration/rendering/stateDiagram.spec.js",
-      "duration": 15834
+      "duration": 14234
     },
     {
       "spec": "cypress/integration/rendering/theme.spec.js",
-      "duration": 33240
+      "duration": 26318
     },
     {
       "spec": "cypress/integration/rendering/timeline.spec.ts",
-      "duration": 7122
+      "duration": 5931
     },
     {
       "spec": "cypress/integration/rendering/xyChart.spec.js",
-      "duration": 11127
+      "duration": 9627
     },
     {
       "spec": "cypress/integration/rendering/zenuml.spec.js",
-      "duration": 2391
+      "duration": 2735
     }
   ]
 }

--- a/packages/mermaid/src/diagrams/common/common.ts
+++ b/packages/mermaid/src/diagrams/common/common.ts
@@ -2,7 +2,7 @@ import DOMPurify from 'dompurify';
 import type { MermaidConfig } from '../../config.type.js';
 
 // Remove and ignore br:s
-export const lineBreakRegex = /<br\s*\/?>/gi;
+export const lineBreakRegex = /<br\s*\/?>|\n/gi;
 
 /**
  * Gets the rows of lines in a string

--- a/packages/mermaid/src/diagrams/common/svgDrawCommon.ts
+++ b/packages/mermaid/src/diagrams/common/svgDrawCommon.ts
@@ -65,8 +65,6 @@ export const drawBackgroundRect = (element: SVG | SVGGroup, bounds: Bound): void
 };
 
 export const drawText = (element: SVG | SVGGroup, textData: TextData): D3TextElement => {
-  const nText: string = textData.text.replace(lineBreakRegex, ' ');
-
   const textElem: D3TextElement = element.append('text');
   textElem.attr('x', textData.x);
   textElem.attr('y', textData.y);
@@ -77,9 +75,15 @@ export const drawText = (element: SVG | SVGGroup, textData: TextData): D3TextEle
     textElem.attr('class', textData.class);
   }
 
-  const tspan: D3TSpanElement = textElem.append('tspan');
-  tspan.attr('x', textData.x + textData.textMargin * 2);
-  tspan.text(nText);
+  const normalizedText = textData.text.replace(/\\n/g, '\n');
+  const lines = normalizedText.split(lineBreakRegex);
+
+  lines.forEach((line, i) => {
+    const tspan: D3TSpanElement = textElem.append('tspan');
+    tspan.attr('x', textData.x + textData.textMargin * 2);
+    tspan.attr('dy', i === 0 ? '0' : '1.2em');
+    tspan.text(line);
+  });
 
   return textElem;
 };

--- a/packages/mermaid/src/diagrams/state/parser/stateDiagram.jison
+++ b/packages/mermaid/src/diagrams/state/parser/stateDiagram.jison
@@ -46,6 +46,10 @@
 
 %%
 
+"click"                     return 'CLICK';
+"href"                      return 'HREF';
+\"[^"]*\"                   return 'STRING';   // or use /"[^"]*"/ if preferred
+
 "default"             return 'DEFAULT';
 
 .*direction\s+TB[^\n]*                                      return 'direction_tb';
@@ -246,8 +250,26 @@ statement
     | direction
     | acc_title acc_title_value  { $$=$2.trim();yy.setAccTitle($$); }
     | acc_descr acc_descr_value  { $$=$2.trim();yy.setAccDescription($$); }
-    | acc_descr_multiline_value { $$=$1.trim();yy.setAccDescription($$); }    ;
-
+    | acc_descr_multiline_value { $$=$1.trim();yy.setAccDescription($$); }    
+    | CLICK idStatement STRING STRING NL
+    {
+        $$ = {
+            stmt: "click",
+            id: $2,
+            url: $3,
+            tooltip: $4
+        };
+    }
+    | CLICK idStatement HREF STRING NL
+    {
+        $$ = {
+            stmt: "click",
+            id: $2,
+            url: $4,
+            tooltip: ""
+        };
+    }
+    ;
 
 classDefStatement
     : classDef CLASSDEF_ID CLASSDEF_STYLEOPTS {

--- a/packages/mermaid/src/diagrams/state/stateDb.js
+++ b/packages/mermaid/src/diagrams/state/stateDb.js
@@ -65,6 +65,8 @@ export class StateDB {
   constructor(version) {
     this.clear();
 
+    this.links = new Map();
+
     this.version = version;
 
     // Needed for JISON since it only supports direct properties
@@ -125,6 +127,11 @@ export class StateDB {
    * @type {number}
    */
   dividerCnt = 0;
+  /**
+   * @private
+   * @type {Map<string, { url: string, tooltip: string }>}
+   */
+  links = new Map();
 
   static relationType = {
     AGGREGATION: 0,
@@ -278,6 +285,9 @@ export class StateDB {
         case STMT_APPLYCLASS:
           this.setCssClass(item.id.trim(), item.styleClass);
           break;
+        case 'click':
+          this.addLink(item.id, item.url, item.tooltip);
+          break;
       }
     });
 
@@ -406,6 +416,7 @@ export class StateDB {
     this.startEndCount = 0;
     this.classes = newClassesList();
     if (!saveCommon) {
+      this.links = new Map();
       commonClear();
     }
   }
@@ -568,6 +579,25 @@ export class StateDB {
   getDividerId() {
     this.dividerCnt++;
     return 'divider-id-' + this.dividerCnt;
+  }
+
+  /**
+   * Adds a clickable link to a state.
+   * @param {string} stateId
+   * @param {string} url
+   * @param {string} tooltip
+   */
+  addLink(stateId, url, tooltip = '') {
+    this.links.set(stateId, { url, tooltip });
+    log.warn('Adding link', stateId, url, tooltip);
+  }
+
+  /**
+   * Get all registered links.
+   * @returns {Map<string, { url: string, tooltip: string }>}
+   */
+  getLinks() {
+    return this.links;
   }
 
   /**

--- a/packages/mermaid/src/diagrams/state/stateRenderer-v3-unified.ts
+++ b/packages/mermaid/src/diagrams/state/stateRenderer-v3-unified.ts
@@ -67,6 +67,61 @@ export const draw = async function (text: string, id: string, _version: string, 
   data4Layout.diagramId = id;
   // console.log('REF1:', data4Layout);
   await render(data4Layout, svg);
+
+  // Inject clickable links after nodes are rendered
+  try {
+    const links: Map<string, { url: string; tooltip: string }> =
+      typeof diag.db.getLinks === 'function' ? diag.db.getLinks() : new Map();
+
+    type StateKey = string | { id: string };
+
+    links.forEach((linkInfo, key: StateKey) => {
+      const stateId = typeof key === 'string' ? key : typeof key?.id === 'string' ? key.id : '';
+
+      if (!stateId) {
+        log.warn('⚠️ Invalid or missing stateId from key:', JSON.stringify(key));
+        return;
+      }
+
+      const allNodes = svg.node()?.querySelectorAll('g');
+      let matchedElem: SVGGElement | undefined;
+
+      allNodes?.forEach((g: SVGGElement) => {
+        const text = g.textContent?.trim();
+        if (text === stateId) {
+          matchedElem = g;
+        }
+      });
+
+      if (!matchedElem) {
+        log.warn('⚠️ Could not find node matching text:', stateId);
+        return;
+      }
+
+      const parent = matchedElem.parentNode;
+      if (!parent) {
+        log.warn('⚠️ Node has no parent, cannot wrap:', stateId);
+        return;
+      }
+
+      const a = document.createElementNS('http://www.w3.org/2000/svg', 'a');
+      const cleanedUrl = linkInfo.url.replace(/^"+|"+$/g, ''); // remove leading/trailing quotes
+      a.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', cleanedUrl);
+      a.setAttribute('target', '_blank');
+      if (linkInfo.tooltip) {
+        const tooltip = linkInfo.tooltip.replace(/^"+|"+$/g, '');
+        a.setAttribute('title', tooltip);
+      }
+
+      parent.replaceChild(a, matchedElem);
+      a.appendChild(matchedElem);
+
+      log.info('🔗 Wrapped node in <a> tag for:', stateId, linkInfo.url);
+    });
+  } catch (err) {
+    log.error('❌ Error injecting clickable links:', err);
+  }
+
   const padding = 8;
   utils.insertTitle(
     svg,

--- a/packages/mermaid/src/rendering-util/createText.ts
+++ b/packages/mermaid/src/rendering-util/createText.ts
@@ -169,10 +169,10 @@ function updateTextContentAndStyles(tspan: any, wrappedLine: MarkdownWord[]) {
       .attr('class', 'text-inner-tspan')
       .attr('font-weight', word.type === 'strong' ? 'bold' : 'normal');
     if (index === 0) {
-      innerTspan.text(word.content);
+      innerTspan.text(decodeEntities(word.content));
     } else {
       // TODO: check what joiner to use.
-      innerTspan.text(' ' + word.content);
+      innerTspan.text(' ' + decodeEntities(word.content));
     }
   });
 }

--- a/packages/mermaid/src/rendering-util/createText.ts
+++ b/packages/mermaid/src/rendering-util/createText.ts
@@ -169,10 +169,10 @@ function updateTextContentAndStyles(tspan: any, wrappedLine: MarkdownWord[]) {
       .attr('class', 'text-inner-tspan')
       .attr('font-weight', word.type === 'strong' ? 'bold' : 'normal');
     if (index === 0) {
-      innerTspan.text(decodeEntities(word.content));
+      innerTspan.text(word.content);
     } else {
       // TODO: check what joiner to use.
-      innerTspan.text(' ' + decodeEntities(word.content));
+      innerTspan.text(' ' + word.content);
     }
   });
 }

--- a/packages/mermaid/src/utils.ts
+++ b/packages/mermaid/src/utils.ts
@@ -33,6 +33,7 @@ import memoize from 'lodash-es/memoize.js';
 import merge from 'lodash-es/merge.js';
 import { directiveRegex } from './diagram-api/regexes.js';
 import type { D3Element, Point, TextDimensionConfig, TextDimensions } from './types.js';
+import { drawText } from './diagrams/common/svgDrawCommon.js';
 
 export const ZERO_WIDTH_SPACE = '\u200b';
 
@@ -820,17 +821,18 @@ export const insertTitle = (
   if (!title) {
     return;
   }
+
   const bounds = parent.node()?.getBBox();
-  if (!bounds) {
-    return;
-  }
-  parent
-    .append('text')
-    .text(title)
-    .attr('text-anchor', 'middle')
-    .attr('x', bounds.x + bounds.width / 2)
-    .attr('y', -titleTopMargin)
-    .attr('class', cssClass);
+  const centerX = bounds ? bounds.x + bounds.width / 2 : 100;
+
+  drawText(parent, {
+    text: title,
+    x: centerX,
+    y: -titleTopMargin,
+    class: cssClass,
+    anchor: 'middle',
+    textMargin: 0,
+  });
 };
 
 /**

--- a/packages/mermaid/src/utils.ts
+++ b/packages/mermaid/src/utils.ts
@@ -922,13 +922,7 @@ export const encodeEntities = function (text: string): string {
  * @returns
  */
 export const decodeEntities = function (text: string): string {
-  return text
-    .replace(/ﬂ°°/g, '&#')
-    .replace(/ﬂ°/g, '&')
-    .replace(/¶ß/g, ';')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&amp;/g, '&');
+  return text.replace(/ﬂ°°/g, '&#').replace(/ﬂ°/g, '&').replace(/¶ß/g, ';');
 };
 
 export const isString = (value: unknown): value is string => {

--- a/packages/mermaid/src/utils.ts
+++ b/packages/mermaid/src/utils.ts
@@ -922,7 +922,13 @@ export const encodeEntities = function (text: string): string {
  * @returns
  */
 export const decodeEntities = function (text: string): string {
-  return text.replace(/ﬂ°°/g, '&#').replace(/ﬂ°/g, '&').replace(/¶ß/g, ';');
+  return text
+    .replace(/ﬂ°°/g, '&#')
+    .replace(/ﬂ°/g, '&')
+    .replace(/¶ß/g, ';')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
 };
 
 export const isString = (value: unknown): value is string => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   roughjs:
-    hash: 3543d47108cb41b68ec6a671c0e1f9d0cfe2ce524fea5b0992511ae84c3c6b64
+    hash: vxb6t6fqvzyhwhtjiliqr25jyq
     path: patches/roughjs.patch
 
 importers:
@@ -267,7 +267,7 @@ importers:
         version: 15.0.7
       roughjs:
         specifier: ^4.6.6
-        version: 4.6.6(patch_hash=3543d47108cb41b68ec6a671c0e1f9d0cfe2ce524fea5b0992511ae84c3c6b64)
+        version: 4.6.6(patch_hash=vxb6t6fqvzyhwhtjiliqr25jyq)
       stylis:
         specifier: ^4.3.6
         version: 4.3.6
@@ -19289,7 +19289,7 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.34.8
       fsevents: 2.3.3
 
-  roughjs@4.6.6(patch_hash=3543d47108cb41b68ec6a671c0e1f9d0cfe2ce524fea5b0992511ae84c3c6b64):
+  roughjs@4.6.6(patch_hash=vxb6t6fqvzyhwhtjiliqr25jyq):
     dependencies:
       hachure-fill: 0.5.2
       path-data-parser: 0.1.0
@@ -20365,35 +20365,6 @@ snapshots:
       - postcss
       - supports-color
       - vue
-
-  unocss@0.59.4(postcss@8.4.41)(rollup@4.21.1)(vite@5.4.2(@types/node@22.5.1)(terser@5.33.0)):
-    dependencies:
-      '@unocss/astro': 0.59.4(rollup@4.21.1)(vite@5.4.2(@types/node@22.5.1)(terser@5.33.0))
-      '@unocss/cli': 0.59.4(rollup@4.21.1)
-      '@unocss/core': 0.59.4
-      '@unocss/extractor-arbitrary-variants': 0.59.4
-      '@unocss/postcss': 0.59.4(postcss@8.4.41)
-      '@unocss/preset-attributify': 0.59.4
-      '@unocss/preset-icons': 0.59.4
-      '@unocss/preset-mini': 0.59.4
-      '@unocss/preset-tagify': 0.59.4
-      '@unocss/preset-typography': 0.59.4
-      '@unocss/preset-uno': 0.59.4
-      '@unocss/preset-web-fonts': 0.59.4
-      '@unocss/preset-wind': 0.59.4
-      '@unocss/reset': 0.59.4
-      '@unocss/transformer-attributify-jsx': 0.59.4
-      '@unocss/transformer-attributify-jsx-babel': 0.59.4
-      '@unocss/transformer-compile-class': 0.59.4
-      '@unocss/transformer-directives': 0.59.4
-      '@unocss/transformer-variant-group': 0.59.4
-      '@unocss/vite': 0.59.4(rollup@4.21.1)(vite@5.4.2(@types/node@22.5.1)(terser@5.33.0))
-    optionalDependencies:
-      vite: 5.4.2(@types/node@22.5.1)(terser@5.33.0)
-    transitivePeerDependencies:
-      - postcss
-      - rollup
-      - supports-color
 
   unpipe@1.0.0: {}
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

This PR adds native multi-line title rendering support across all diagrams that accept titles. It allows users to use both `\n` and `<br>` inside their diagram titles (flowchart, state, ...)

Resolves #6324 

## :straight_ruler: Design Decisions

- `drawText()` was updated to always support multi-line rendering using `<tspan>` elements.
- A shared `lineBreakRegex(/<br\s*\/?>|\n/gi)` is used to detect line breaks.
- Escaped `\n` from YAML frontmatter is converted to real newlines using `.replace(/\\n/g, '\n')`.
- `insertTitle()` was refactored to use `drawText()` to enable consistent rendering across diagram types.

![image](https://github.com/user-attachments/assets/9408d03f-1f97-4976-8bb1-2f75b0dfa9d9)
![image](https://github.com/user-attachments/assets/657f8a9b-d5c8-4a27-8e9c-e660aef1cbcc)
![image](https://github.com/user-attachments/assets/8d6e7839-a815-4a7c-a961-57648962b2a5)


### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
