### PR TITLE
Fix incorrect `style="undefined;"` output in some Mermaid diagrams

### DIFF
--- a/.changeset/gold-shoes-camp.md
+++ b/.changeset/gold-shoes-camp.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+Fix incorrect `style="undefined;"` output in some Mermaid diagrams

--- a/.changeset/gold-shoes-camp.md
+++ b/.changeset/gold-shoes-camp.md
@@ -2,4 +2,4 @@
 'mermaid': patch
 ---
 
-Fix incorrect `style="undefined;"` output in some Mermaid diagrams
+fix: Remove incorrect `style="undefined;"` attributes in some Mermaid diagrams

--- a/packages/mermaid/src/rendering-util/rendering-elements/edges.js
+++ b/packages/mermaid/src/rendering-util/rendering-elements/edges.js
@@ -562,7 +562,7 @@ export const insertEdge = function (elem, edge, clusterDb, diagramType, startNod
   }
   let svgPath;
   let linePath = lineFunction(lineData);
-  const edgeStyles = Array.isArray(edge.style) ? edge.style : [edge.style];
+  const edgeStyles = Array.isArray(edge.style) ? edge.style : edge.style ? [edge.style] : [];
   let strokeColor = edgeStyles.find((style) => style?.startsWith('stroke:'));
 
   if (edge.look === 'handDrawn') {


### PR DESCRIPTION
## :bookmark_tabs: Summary

I noticed that some diagrams, e.g. the below:

```
erDiagram
        XXX ||--o| YYY: zzz
```

end up with `style="undefined;" in their SVG output, inside .edgePaths (perhaps other places). This change prevents that.

## :straight_ruler: Design Decisions

### :clipboard: Tasks

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- ~:notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.~
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

I have not added any tests - I am not particularly sure where/how would be the best place to, but happy to give a go with direction.