### PR TITLE
Fix: Adjust pie chart title to prevent cropping

### DIFF
--- a/cypress/integration/rendering/pie.spec.ts
+++ b/cypress/integration/rendering/pie.spec.ts
@@ -82,4 +82,40 @@ describe('pie chart', () => {
       `
     );
   });
+  describe('title wrapping', () => {
+    it('should render a pie chart with a short title', () => {
+      cy.renderGraph(`
+        pie title Short Title
+        "A" : 60
+        "B" : 40
+      `);
+    });
+  
+    it('should render a pie chart with a medium-length title that wraps into two lines', () => {
+      cy.renderGraph(`
+        pie title This is a medium title that should wrap nicely
+        "A" : 50
+        "B" : 30
+        "C" : 20
+      `);
+    });
+  
+    it('should render a pie chart with a very long title that wraps into multiple lines without overlapping the pie', () => {
+      cy.renderGraph(`
+        pie title This is a very long pie chart title that should properly wrap into multiple lines and not overlap with the pie chart even if it is extremely verbose
+        "A" : 45
+        "B" : 35
+        "C" : 20
+      `);
+    });
+  
+    it('should render a small pie chart with a long title', () => {
+      cy.renderGraph(`
+        %%{ init: { "themeVariables": { "pieOuterStrokeWidth": "1px" }, "pie": { "textPosition": 0.5 } } }%%
+        pie title Small Pie with Long Title that should wrap
+        "A" : 100
+      `);
+    });
+  });
+  
 });

--- a/cypress/integration/rendering/pie.spec.ts
+++ b/cypress/integration/rendering/pie.spec.ts
@@ -82,40 +82,4 @@ describe('pie chart', () => {
       `
     );
   });
-  describe('title wrapping', () => {
-    it('should render a pie chart with a short title', () => {
-      cy.renderGraph(`
-        pie title Short Title
-        "A" : 60
-        "B" : 40
-      `);
-    });
-  
-    it('should render a pie chart with a medium-length title that wraps into two lines', () => {
-      cy.renderGraph(`
-        pie title This is a medium title that should wrap nicely
-        "A" : 50
-        "B" : 30
-        "C" : 20
-      `);
-    });
-  
-    it('should render a pie chart with a very long title that wraps into multiple lines without overlapping the pie', () => {
-      cy.renderGraph(`
-        pie title This is a very long pie chart title that should properly wrap into multiple lines and not overlap with the pie chart even if it is extremely verbose
-        "A" : 45
-        "B" : 35
-        "C" : 20
-      `);
-    });
-  
-    it('should render a small pie chart with a long title', () => {
-      cy.renderGraph(`
-        %%{ init: { "themeVariables": { "pieOuterStrokeWidth": "1px" }, "pie": { "textPosition": 0.5 } } }%%
-        pie title Small Pie with Long Title that should wrap
-        "A" : 100
-      `);
-    });
-  });
-  
 });

--- a/cypress/integration/rendering/pie.spec.ts
+++ b/cypress/integration/rendering/pie.spec.ts
@@ -82,4 +82,30 @@ describe('pie chart', () => {
       `
     );
   });
+  it('renders short title without shrink or wrap', () => {
+    imgSnapshotTest(`
+      pie
+        title Short
+        "A" : 60
+        "B" : 40
+    `);
+  });
+
+  it('shrinks font size for medium long title', () => {
+    imgSnapshotTest(`
+      pie
+        title Short
+        "A" : 60
+        "B" : 40
+    `);
+  });
+
+  it('wraps very long title into multiple lines', () => {
+    imgSnapshotTest(`
+      pie
+        title Short
+        "A" : 60
+        "B" : 40
+    `);
+  });
 });

--- a/cypress/integration/rendering/pie.spec.ts
+++ b/cypress/integration/rendering/pie.spec.ts
@@ -79,9 +79,22 @@ describe('pie chart', () => {
       `pie showData
         "Dogs": 50
         "Cats": 25
-      `
+      `,
+      {
+        pie: {
+          useMaxWidth: true,
+        },
+        themeVariables: {
+          fontFamily: 'Arial, sans-serif',
+          fontSize: '16px',
+          pieOuterStrokeWidth: '1px',
+          legendTextColor: '#000',
+          pieStrokeColor: '#000',
+        },
+      }
     );
   });
+
   it('renders short title without shrink or wrap', () => {
     imgSnapshotTest(`
       pie

--- a/cypress/integration/rendering/pie.spec.ts
+++ b/cypress/integration/rendering/pie.spec.ts
@@ -91,21 +91,29 @@ describe('pie chart', () => {
     `);
   });
 
-  it('shrinks font size for medium long title', () => {
-    imgSnapshotTest(`
-      pie
-        title Short
-        "A" : 60
-        "B" : 40
-    `);
+  it('should render a pie chart with a medium-length title', () => {
+    renderGraph(
+      `pie title Distribution of Pets in Urban Areas
+        "Dogs": 50
+        "Cats": 30
+        "Birds": 20
+      `
+    );
+    cy.get('svg').should('exist');
+    cy.get('text').contains('Distribution of Pets in Urban Areas').should('exist');
   });
 
-  it('wraps very long title into multiple lines', () => {
-    imgSnapshotTest(`
-      pie
-        title Short
-        "A" : 60
-        "B" : 40
-    `);
+  it('should render a pie chart with a long title without clipping', () => {
+    renderGraph(
+      `pie title Analysis of the Distribution of Various Pet Species Across Different Metropolitan Regions
+        "Dogs": 50
+        "Cats": 30
+        "Birds": 20
+      `
+    );
+    cy.get('.pieTitleText tspan').then(($tspans) => {
+      const titleText = [...$tspans].map((el) => el.textContent).join(' ');
+      expect(titleText).to.include('Analysis of the Distribution');
+    });
   });
 });

--- a/packages/mermaid/src/diagrams/pie/pie.spec.ts
+++ b/packages/mermaid/src/diagrams/pie/pie.spec.ts
@@ -138,6 +138,14 @@ describe('pie', () => {
         `);
       }).rejects.toThrowError();
     });
+    it('should reject pie sections with negative integers', async () => {
+      await expect(async () => {
+        await parser.parse(`pie
+        "ash" : -40
+        "bat" : 60
+        `);
+      }).rejects.toThrowError();
+    });
 
     it('should handle unsafe properties', async () => {
       await expect(

--- a/packages/mermaid/src/diagrams/pie/pieRenderer.ts
+++ b/packages/mermaid/src/diagrams/pie/pieRenderer.ts
@@ -36,7 +36,6 @@ const createPieArcs = (sections: Sections): d3.PieArcDatum<D3Section>[] => {
  * @param diagObj - A standard diagram containing the DB and the text and type etc of the diagram.
  */
 
-
 export const draw: DrawDefinition = (text, id, _version, diagObj) => {
   log.debug('rendering pie chart\n' + text);
   const db = diagObj.db as PieDB;
@@ -53,7 +52,8 @@ export const draw: DrawDefinition = (text, id, _version, diagObj) => {
     const lines: string[] = [];
     let currentLine = '';
 
-    const tempText = svg.append('text')
+    const tempText = svg
+      .append('text')
       .attr('class', 'temp-title-text')
       .style('font-size', '8px')
       .style('visibility', 'hidden')
@@ -166,48 +166,45 @@ export const draw: DrawDefinition = (text, id, _version, diagObj) => {
   const minFontSize = 8; // Set a minimum font size
   const maxAvailableWidth = pieWidth - MARGIN;
 
-  const titleElement = titleGroup
-    .append('text')
-    .text(titleText)
-    .attr('x', 0)
-    .attr('y', -(height - 100) / 2)
-    .attr('class', 'pieTitleText')
-    .style('text-anchor', 'middle');
+  const titleElement = svg
+  .append('text')
+  .text(titleText)
+  .attr('x', pieWidth / 2)
+  .attr('y', 30) // <-- fixed: always near top
+  .attr('class', 'pieTitleText')
+  .style('text-anchor', 'middle');
 
-    let titleFits = false;
+  let titleFits = false;
 
-    while (!titleFits && fontSize > minFontSize) {
-      titleElement.style('font-size', `${fontSize}px`);
-      titleFits = (titleElement.node() as SVGGraphicsElement)?.getBBox()?.width <= maxAvailableWidth;
-      if (!titleFits) {
-        fontSize -= 1;
-      }
-    }
-    
+  while (!titleFits && fontSize > minFontSize) {
+    titleElement.style('font-size', `${fontSize}px`);
+    titleFits = (titleElement.node() as SVGGraphicsElement)?.getBBox()?.width <= maxAvailableWidth;
     if (!titleFits) {
-      // Title still too long even after shrinking: split into multiple lines
-      titleElement.remove(); // Remove the single-line title
-    
-      const lines = splitTitleIntoLines(titleText, maxAvailableWidth);
-    
-      const titleGroup = svg.append('g');
-      const TITLE_START_Y = 10;
-      const LINE_SPACING = 10;
-      
-      lines.forEach((line, i) => {
-        titleGroup
-          .append('text')
-          .text(line)
-          .attr('x', pieWidth / 2) // center horizontally!
-          .attr('y', TITLE_START_Y + i * LINE_SPACING)
-          .attr('class', 'pieTitleText')
-          .style('text-anchor', 'middle')
-          .style('font-size', `${minFontSize}px`);
-      });
-      
-      
+      fontSize -= 1;
     }
-    
+  }
+
+  if (!titleFits) {
+    // Title still too long even after shrinking: split into multiple lines
+    titleElement.remove(); // Remove the single-line title
+
+    const lines = splitTitleIntoLines(titleText, maxAvailableWidth);
+
+    const titleGroup = svg.append('g');
+    const TITLE_START_Y = 10;
+    const LINE_SPACING = 10;
+
+    lines.forEach((line, i) => {
+      titleGroup
+        .append('text')
+        .text(line)
+        .attr('x', pieWidth / 2) // center horizontally!
+        .attr('y', TITLE_START_Y + i * LINE_SPACING)
+        .attr('class', 'pieTitleText')
+        .style('text-anchor', 'middle')
+        .style('font-size', `${minFontSize}px`);
+    });
+  }
 
   // Add the legends/annotations for each section
   const legend = group

--- a/packages/mermaid/src/diagrams/pie/pieRenderer.ts
+++ b/packages/mermaid/src/diagrams/pie/pieRenderer.ts
@@ -167,12 +167,12 @@ export const draw: DrawDefinition = (text, id, _version, diagObj) => {
   const maxAvailableWidth = pieWidth - MARGIN;
 
   const titleElement = svg
-  .append('text')
-  .text(titleText)
-  .attr('x', pieWidth / 2)
-  .attr('y', 30) // <-- fixed: always near top
-  .attr('class', 'pieTitleText')
-  .style('text-anchor', 'middle');
+    .append('text')
+    .text(titleText)
+    .attr('x', pieWidth / 2)
+    .attr('y', 30) // <-- fixed: always near top
+    .attr('class', 'pieTitleText')
+    .style('text-anchor', 'middle');
 
   let titleFits = false;
 
@@ -190,7 +190,6 @@ export const draw: DrawDefinition = (text, id, _version, diagObj) => {
 
     const lines = splitTitleIntoLines(titleText, maxAvailableWidth);
 
-    const titleGroup = svg.append('g');
     const TITLE_START_Y = 10;
     const LINE_SPACING = 10;
 

--- a/packages/mermaid/src/diagrams/pie/pieRenderer.ts
+++ b/packages/mermaid/src/diagrams/pie/pieRenderer.ts
@@ -125,12 +125,30 @@ export const draw: DrawDefinition = (text, id, _version, diagObj) => {
     .style('text-anchor', 'middle')
     .attr('class', 'slice');
 
-  group
+  const titleGroup = group.append('g');
+  const titleText = db.getDiagramTitle();
+
+  // Adjust title font size dynamically
+  let fontSize = 25; // Start with a larger font size
+  const minFontSize = 8; // Set a minimum font size
+  const maxAvailableWidth = pieWidth - MARGIN;
+
+  const titleElement = titleGroup
     .append('text')
-    .text(db.getDiagramTitle())
+    .text(titleText)
     .attr('x', 0)
     .attr('y', -(height - 50) / 2)
-    .attr('class', 'pieTitleText');
+    .attr('class', 'pieTitleText')
+    .style('text-anchor', 'middle');
+
+  // Reduce font size dynamically until it fits
+  while (
+    (titleElement.node() as SVGGraphicsElement)?.getBBox()?.width > maxAvailableWidth &&
+    fontSize > minFontSize
+  ) {
+    fontSize -= 1;
+    titleElement.style('font-size', `${fontSize}px`);
+  }
 
   // Add the legends/annotations for each section
   const legend = group

--- a/packages/mermaid/src/diagrams/pie/pieRenderer.ts
+++ b/packages/mermaid/src/diagrams/pie/pieRenderer.ts
@@ -32,8 +32,8 @@ const createTitle = (
   fontSize: number,
   pieWidth: number
 ): d3.Selection<SVGTextElement, unknown, Element | null, unknown> => {
-
-  const tempTitle = svg.append<SVGTextElement>('text')
+  const tempTitle = svg
+    .append<SVGTextElement>('text')
     .attr('x', pieWidth / 2)
     .attr('y', 30)
     .attr('class', 'pieTitleText')
@@ -42,7 +42,8 @@ const createTitle = (
     .style('font-size', fontSize + 'px');
 
   lines.forEach((line, idx) => {
-    tempTitle.append('tspan')
+    tempTitle
+      .append('tspan')
       .attr('x', pieWidth / 2)
       .attr('dy', idx === 0 ? 0 : '1.2em')
       .text(line);
@@ -50,8 +51,6 @@ const createTitle = (
 
   return tempTitle;
 };
-
-
 
 /**
  * Draws a Pie Chart with the data given in text.
@@ -152,53 +151,50 @@ export const draw: DrawDefinition = (text, id, _version, diagObj) => {
     .style('text-anchor', 'middle')
     .attr('class', 'slice');
 
-    const titleText = db.getDiagramTitle();
-    let titleHeight = 0;
-    const TITLE_MARGIN = 10;
-    let extraMargin = 0;
-    
-    if (titleText) {
-      const maxAvailableWidth = pieWidth - MARGIN;
-      let fontSize = 25;
-      const minFontSize = 10;
-      const titleWrapConfig = {
-        fontFamily: 'Arial',
-        fontWeight: 400,
-        joinWith: '<br/>'
-      };
-    
-      let wrappedTitle = wrapLabel(titleText, maxAvailableWidth, {
-        ...titleWrapConfig,
-        fontSize
-      });
-    
-      let lines = wrappedTitle.split('<br/>');
-      let tempTitle = createTitle(svg, lines, fontSize, pieWidth);
-      let bbox = (tempTitle.node() as SVGGraphicsElement)?.getBBox();
-    
-      while (bbox && bbox.width > maxAvailableWidth && fontSize > minFontSize) {
-        fontSize -= 1;
-        tempTitle.remove();
-        wrappedTitle = wrapLabel(titleText, maxAvailableWidth, {
-          ...titleWrapConfig,
-          fontSize
-        });
-        lines = wrappedTitle.split('<br/>');
-        tempTitle = createTitle(svg, lines, fontSize, pieWidth);
-        bbox = (tempTitle.node() as SVGGraphicsElement)?.getBBox();
-      }
-    
-      titleHeight = bbox?.height || 0;
-      extraMargin = lines.length * 3;
-    }
-    
-group.attr(
-  'transform',
-  `translate(${pieWidth / 2}, ${height / 2 + titleHeight + TITLE_MARGIN + extraMargin})`
-);
+  const titleText = db.getDiagramTitle();
+  let titleHeight = 0;
+  const TITLE_MARGIN = 10;
+  let extraMargin = 0;
 
-  
-  
+  if (titleText) {
+    const maxAvailableWidth = pieWidth - MARGIN;
+    let fontSize = 25;
+    const minFontSize = 10;
+    const titleWrapConfig = {
+      fontFamily: 'Arial',
+      fontWeight: 400,
+      joinWith: '<br/>',
+    };
+
+    let wrappedTitle = wrapLabel(titleText, maxAvailableWidth, {
+      ...titleWrapConfig,
+      fontSize,
+    });
+
+    let lines = wrappedTitle.split('<br/>');
+    let tempTitle = createTitle(svg, lines, fontSize, pieWidth);
+    let bbox = (tempTitle.node() as SVGGraphicsElement)?.getBBox();
+
+    while (bbox && bbox.width > maxAvailableWidth && fontSize > minFontSize) {
+      fontSize -= 1;
+      tempTitle.remove();
+      wrappedTitle = wrapLabel(titleText, maxAvailableWidth, {
+        ...titleWrapConfig,
+        fontSize,
+      });
+      lines = wrappedTitle.split('<br/>');
+      tempTitle = createTitle(svg, lines, fontSize, pieWidth);
+      bbox = (tempTitle.node() as SVGGraphicsElement)?.getBBox();
+    }
+
+    titleHeight = bbox?.height || 0;
+    extraMargin = lines.length * 3;
+  }
+
+  group.attr(
+    'transform',
+    `translate(${pieWidth / 2}, ${height / 2 + titleHeight + TITLE_MARGIN + extraMargin})`
+  );
 
   // Add the legends/annotations for each section
   const legend = group

--- a/packages/mermaid/src/diagrams/pie/pieRenderer.ts
+++ b/packages/mermaid/src/diagrams/pie/pieRenderer.ts
@@ -152,55 +152,46 @@ export const draw: DrawDefinition = (text, id, _version, diagObj) => {
     .style('text-anchor', 'middle')
     .attr('class', 'slice');
 
-  const titleText = db.getDiagramTitle();
-  const maxAvailableWidth = pieWidth - MARGIN;
-  let fontSize = 25;
-  const minFontSize = 10;
-  const titleWrapConfig = {
-    fontFamily: 'Arial',
-    fontWeight: 400,
-    joinWith: '<br/>'
-  };
-  
-
-  // Start wrapping immediately
-  let wrappedTitle = wrapLabel(titleText, maxAvailableWidth, {
-    ...titleWrapConfig,
-    fontSize
-  });
-  
-
-  let lines = wrappedTitle.split('<br/>');
-
-  // Create temporary text to measure
-  let tempTitle = createTitle(svg, lines, fontSize, pieWidth);
-
-
-
-  let bbox = (tempTitle.node() as SVGGraphicsElement)?.getBBox();
-
-  // Shrink if even the wrapped version is too wide
-  while (bbox && bbox.width > maxAvailableWidth && fontSize > minFontSize) {
-    fontSize -= 1;
-    tempTitle.remove();
-
-    // Re-wrap at smaller font size
-    wrappedTitle = wrapLabel(titleText, maxAvailableWidth, {
-  ...titleWrapConfig,
-  fontSize
-});
-
-    lines = wrappedTitle.split('<br/>');
-
-    // Redraw
-    tempTitle = createTitle(svg, lines, fontSize, pieWidth);
-
-
-    bbox = (tempTitle.node() as SVGGraphicsElement)?.getBBox();
-  }
-  const titleHeight = bbox?.height || 0;
-  const TITLE_MARGIN = 10; // add extra margin between title and pie
-  const extraMargin = lines.length * 3; 
+    const titleText = db.getDiagramTitle();
+    let titleHeight = 0;
+    const TITLE_MARGIN = 10;
+    let extraMargin = 0;
+    
+    if (titleText) {
+      const maxAvailableWidth = pieWidth - MARGIN;
+      let fontSize = 25;
+      const minFontSize = 10;
+      const titleWrapConfig = {
+        fontFamily: 'Arial',
+        fontWeight: 400,
+        joinWith: '<br/>'
+      };
+    
+      let wrappedTitle = wrapLabel(titleText, maxAvailableWidth, {
+        ...titleWrapConfig,
+        fontSize
+      });
+    
+      let lines = wrappedTitle.split('<br/>');
+      let tempTitle = createTitle(svg, lines, fontSize, pieWidth);
+      let bbox = (tempTitle.node() as SVGGraphicsElement)?.getBBox();
+    
+      while (bbox && bbox.width > maxAvailableWidth && fontSize > minFontSize) {
+        fontSize -= 1;
+        tempTitle.remove();
+        wrappedTitle = wrapLabel(titleText, maxAvailableWidth, {
+          ...titleWrapConfig,
+          fontSize
+        });
+        lines = wrappedTitle.split('<br/>');
+        tempTitle = createTitle(svg, lines, fontSize, pieWidth);
+        bbox = (tempTitle.node() as SVGGraphicsElement)?.getBBox();
+      }
+    
+      titleHeight = bbox?.height || 0;
+      extraMargin = lines.length * 3;
+    }
+    
 group.attr(
   'transform',
   `translate(${pieWidth / 2}, ${height / 2 + titleHeight + TITLE_MARGIN + extraMargin})`


### PR DESCRIPTION
**Summary**
Fixes pie chart title rendering by dynamically reducing font size when the title exceeds available space, ensuring it fits without being cropped.
_Resolves #6242_

**Design Decisions**
Added logic to measure title width using getBBox().

- Introduced a loop to reduce font size (down to a minimum) until the title fits within pieWidth - margin.

- Applied the fix only after title rendering to avoid runtime errors.

- Used .style('font-size', ${fontSize}px) for dynamic font updates.


### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
n about the content of your PR.
