### PR TITLE
build: fix `mermaid-zenuml` IIFE build and add changesets

### DIFF
--- a/.changeset/honest-trees-dress.md
+++ b/.changeset/honest-trees-dress.md
@@ -1,0 +1,7 @@
+---
+'@mermaid-js/mermaid-zenuml': patch
+---
+
+chore: bump minimum ZenUML version to 3.23.28
+
+commit: 9d06d8f31e7f12af9e9e092214f907f2dc93ad75

--- a/.changeset/yellow-mirrors-change.md
+++ b/.changeset/yellow-mirrors-change.md
@@ -1,0 +1,7 @@
+---
+'@mermaid-js/mermaid-zenuml': patch
+---
+
+fix(zenuml): limit `peerDependencies` to Mermaid v10 and v11
+
+commit: 0ad44c12feead9d20c6a870a49327ada58d6e657

--- a/.esbuild/build.ts
+++ b/.esbuild/build.ts
@@ -34,6 +34,19 @@ const buildPackage = async (entryName: keyof typeof packageOptions) => {
       { ...iifeOptions, minify: true, metafile: shouldVisualize }
     );
   }
+  if (entryName === 'mermaid-zenuml') {
+    const iifeOptions: MermaidBuildOptions = {
+      ...commonOptions,
+      format: 'iife',
+      globalName: 'mermaid-zenuml',
+    };
+    buildConfigs.push(
+      // mermaid-zenuml.js
+      { ...iifeOptions },
+      // mermaid-zenuml.min.js
+      { ...iifeOptions, minify: true, metafile: shouldVisualize }
+    );
+  }
 
   const results = await Promise.all(buildConfigs.map((option) => build(getBuildConfig(option))));
 

--- a/.esbuild/util.ts
+++ b/.esbuild/util.ts
@@ -58,6 +58,7 @@ export const getBuildConfig = (options: MermaidBuildOptions): BuildOptions => {
     format,
     minify,
     options: { name, file, packageName },
+    globalName = 'mermaid',
   } = options;
   const external: string[] = ['require', 'fs', 'path'];
   const outFileName = getFileName(name, options);
@@ -68,6 +69,7 @@ export const getBuildConfig = (options: MermaidBuildOptions): BuildOptions => {
     },
     metafile,
     minify,
+    globalName,
     logLevel: 'info',
     chunkNames: `chunks/${outFileName}/[name]-[hash]`,
     define: {
@@ -89,11 +91,12 @@ export const getBuildConfig = (options: MermaidBuildOptions): BuildOptions => {
   if (format === 'iife') {
     output.format = 'iife';
     output.splitting = false;
-    output.globalName = '__esbuild_esm_mermaid';
+    const originalGlobalName = output.globalName ?? 'mermaid';
+    output.globalName = `__esbuild_esm_mermaid_nm[${JSON.stringify(originalGlobalName)}]`;
     // Workaround for removing the .default access in esbuild IIFE.
     // https://github.com/mermaid-js/mermaid/pull/4109#discussion_r1292317396
     output.footer = {
-      js: 'globalThis.mermaid = globalThis.__esbuild_esm_mermaid.default;',
+      js: `globalThis[${JSON.stringify(originalGlobalName)}] = globalThis.${output.globalName}.default;`,
     };
     output.outExtension = { '.js': '.js' };
   } else {


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fixes the `mermaid-zenuml` IIFE build and prepares for the v0.2.1 release of it.

As part of our migration from Vite to ESBuild, we seemed to have broken it.

I've updated the ESBuild scripts to support multiple IIFE bundles/entry-points. And I've also added changeset entries for https://github.com/mermaid-js/mermaid/commit/9d06d8f31e7f12af9e9e092214f907f2dc93ad75 and https://github.com/mermaid-js/mermaid/commit/0ad44c12feead9d20c6a870a49327ada58d6e657 so that we can correctly make a v0.2.1 release!

Fixes https://github.com/mermaid-js/zenuml-core/issues/169#issuecomment-2781217436 (raised by @MrCoder)

## :straight_ruler: Design Decisions

Instead of making a unique dummy `globalThis` to handle the ESM default export issue, I've changed Mermaid to use `globalThis.__esbuild_esm_mermaid_nm["mermaid"]` so that mermaid-zenuml can use `globalThis.__esbuild_esm_mermaid_nm["mermaid-zenuml"]`.

I had to rename the var from `globalThis.__esbuild_esm_mermaid` to `globalThis.__esbuild_esm_mermaid_nm` avoid conflicts in case somebody is using an older version of Mermaid with a newer version of Mermaid-ZenUML.

ESBuild will automatically merge objects using this syntax, see https://esbuild.github.io/api/#global-name

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
