### PR TITLE
feat(flowchart): add inheritDir option for subgraph direction

### DIFF
--- a/cypress/integration/rendering/flowchart.spec.js
+++ b/cypress/integration/rendering/flowchart.spec.js
@@ -934,4 +934,43 @@ graph TD
       }
     );
   });
+  it('68: should honor subgraph direction when inheritDir is false', () => {
+    imgSnapshotTest(
+      `
+      %%{init: {"flowchart": { "inheritDir": false }}}%%
+      flowchart TB
+        direction LR
+        subgraph A
+          direction TB
+          a --> b
+        end
+        subgraph B
+          c --> d
+        end
+      `,
+      {
+        fontFamily: 'courier',
+      }
+    );
+  });
+
+  it('69: should inherit global direction when inheritDir is true', () => {
+    imgSnapshotTest(
+      `
+      %%{init: {"flowchart": { "inheritDir": true }}}%%
+      flowchart TB
+        direction LR
+        subgraph A
+          direction TB
+          a --> b
+        end
+        subgraph B
+          c --> d
+        end
+      `,
+      {
+        fontFamily: 'courier',
+      }
+    );
+  });
 });

--- a/docs/config/setup/defaultConfig/variables/configKeys.md
+++ b/docs/config/setup/defaultConfig/variables/configKeys.md
@@ -12,4 +12,4 @@
 
 > `const` **configKeys**: `Set`<`string`>
 
-Defined in: [packages/mermaid/src/defaultConfig.ts:274](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/defaultConfig.ts#L274)
+Defined in: [packages/mermaid/src/defaultConfig.ts:279](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/defaultConfig.ts#L279)

--- a/docs/config/setup/defaultConfig/variables/configKeys.md
+++ b/docs/config/setup/defaultConfig/variables/configKeys.md
@@ -12,4 +12,4 @@
 
 > `const` **configKeys**: `Set`<`string`>
 
-Defined in: [packages/mermaid/src/defaultConfig.ts:279](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/defaultConfig.ts#L279)
+Defined in: [packages/mermaid/src/defaultConfig.ts:278](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/defaultConfig.ts#L278)

--- a/packages/mermaid/src/config.type.ts
+++ b/packages/mermaid/src/config.type.ts
@@ -226,12 +226,6 @@ export interface FlowchartDiagramConfig extends BaseDiagramConfig {
    * Defines a top/bottom margin for subgraph titles
    *
    */
-  /**
-   * If true, subgraphs without explicit direction will inherit the global graph direction (e.g., LR, TB, RL, BT).
-   * Defaults to `false` to preserve legacy layout behavior.
-   */
-  inheritDir?: boolean;
-
   subGraphTitleMargin?: {
     top?: number;
     bottom?: number;
@@ -301,12 +295,17 @@ export interface FlowchartDiagramConfig extends BaseDiagramConfig {
    *
    */
   wrappingWidth?: number;
+  /**
+   * If true, subgraphs without explicit direction will inherit the global graph direction
+   * (e.g., LR, TB, RL, BT). Defaults to false to preserve legacy layout behavior.
+   *
+   */
+  inheritDir?: boolean;
 }
 /**
  * This interface was referenced by `MermaidConfig`'s JSON-Schema
  * via the `definition` "BaseDiagramConfig".
  */
-
 export interface BaseDiagramConfig {
   useWidth?: number;
   /**

--- a/packages/mermaid/src/config.type.ts
+++ b/packages/mermaid/src/config.type.ts
@@ -226,6 +226,12 @@ export interface FlowchartDiagramConfig extends BaseDiagramConfig {
    * Defines a top/bottom margin for subgraph titles
    *
    */
+  /**
+   * If true, subgraphs without explicit direction will inherit the global graph direction (e.g., LR, TB, RL, BT).
+   * Defaults to `false` to preserve legacy layout behavior.
+   */
+  inheritDir?: boolean;
+
   subGraphTitleMargin?: {
     top?: number;
     bottom?: number;
@@ -300,6 +306,7 @@ export interface FlowchartDiagramConfig extends BaseDiagramConfig {
  * This interface was referenced by `MermaidConfig`'s JSON-Schema
  * via the `definition` "BaseDiagramConfig".
  */
+
 export interface BaseDiagramConfig {
   useWidth?: number;
   /**

--- a/packages/mermaid/src/defaultConfig.ts
+++ b/packages/mermaid/src/defaultConfig.ts
@@ -71,6 +71,10 @@ const config: RequiredDeep<MermaidConfig> = {
         fontWeight: this.personFontWeight,
       };
     },
+    flowchart: {
+      ...defaultConfigJson.flowchart,
+      inheritDir: false, // default to legacy behavior
+    },
 
     external_personFont: function () {
       return {

--- a/packages/mermaid/src/diagrams/flowchart/flowDb.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.ts
@@ -651,7 +651,8 @@ You have to call mermaid.initialize.`
       const prims: any = { boolean: {}, number: {}, string: {} };
       const objs: any[] = [];
 
-      let dir; //  = undefined; direction.trim();
+      let dir: string | undefined;
+
       const nodeList = a.filter(function (item) {
         const type = typeof item;
         if (item.stmt && item.stmt === 'dir') {
@@ -670,7 +671,16 @@ You have to call mermaid.initialize.`
       return { nodeList, dir };
     };
 
-    const { nodeList, dir } = uniq(list.flat());
+    const result = uniq(list.flat());
+    const nodeList = result.nodeList;
+    let dir = result.dir;
+    const flowchartConfig = getConfig().flowchart ?? {};
+    dir =
+      dir ??
+      (flowchartConfig.inheritDir
+        ? (this.getDirection() ?? (getConfig() as any).direction ?? undefined)
+        : undefined);
+
     if (this.version === 'gen-1') {
       for (let i = 0; i < nodeList.length; i++) {
         nodeList[i] = this.lookUpDomId(nodeList[i]);
@@ -681,6 +691,7 @@ You have to call mermaid.initialize.`
     title = title || '';
     title = this.sanitizeText(title);
     this.subCount = this.subCount + 1;
+
     const subGraph = {
       id: id,
       nodes: nodeList,

--- a/packages/mermaid/src/schemas/config.schema.yaml
+++ b/packages/mermaid/src/schemas/config.schema.yaml
@@ -2105,6 +2105,13 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
         type: number
         default: 200
 
+      inheritDir:
+        type: boolean
+        default: false
+        description: |
+          If true, subgraphs without explicit direction will inherit the global graph direction
+          (e.g., LR, TB, RL, BT). Defaults to false to preserve legacy layout behavior.
+
   SankeyLinkColor:
     description: |
       Picks the color of the sankey diagram links, using the colors of the source and/or target of the links.


### PR DESCRIPTION
## :bookmark_tabs: Summary

resolves #6492 

This PR introduces a new flowchart configuration option that enables optional inheritance of global direction by subgraphs.

Currently, subgraphs do not inherit the global direction (e.g., LR, TB) of the parent flowchart. This behavior was intentionally designed to allow space-efficient diagrams through alternating layout directions across nested subgraphs.

However, in some scenarios, users may prefer a uniform direction across all levels — especially in linear or consistent hierarchical structures. Until now, there was no configuration-based way to achieve this

Solution
This PR adds a new config option:


```
flowchart: {
  inheritDir: true | false // default: false
}
```

When inheritDir: true:

Subgraphs that do not specify their own dir will inherit the global graph direction.

![image](https://github.com/user-attachments/assets/86ed881c-650e-4cf6-9b5b-389e675133fd)


When inheritDir: false (default):

Subgraphs behave as before — alternating direction is preserved for optimal layout.
![image](https://github.com/user-attachments/assets/db4ed7e7-8b45-4258-887e-e809c56e0a1e)


⚠️ This ensures zero impact on existing diagrams unless the new option is explicitly enabled.

## :straight_ruler: Design Decisions

Updated FlowDB.ts to:

Respect flowchart.inheritDir inside addSubGraph().

If no dir is explicitly set for a subgraph, it will inherit this.getDirection() only when inheritDir is true.

Clean, minimal, and fully backward-compatible.

Added test case in flowchart.spec.js

Validated via example.html with both inheritDir: true and inheritDir: false. (screenshots)

@ashishjain0512 

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
