### PR TITLE
feat: Add optional axis / tick labels for radar chart

### DIFF
--- a/.changeset/calm-kings-double.md
+++ b/.changeset/calm-kings-double.md
@@ -1,0 +1,6 @@
+---
+'mermaid': minor
+'@mermaid-js/parser': minor
+---
+
+Support for optional radar chart tick / axis labels.

--- a/cypress/integration/rendering/radar.spec.js
+++ b/cypress/integration/rendering/radar.spec.js
@@ -45,6 +45,7 @@ describe('radar structure', () => {
 
                 tickLabels{'-1','0','1'}
                 tickLabelsAxis 2
+                tickLabelsOffset 10
             `
     );
     cy.get('svg').should((svg) => {

--- a/cypress/integration/rendering/radar.spec.js
+++ b/cypress/integration/rendering/radar.spec.js
@@ -42,6 +42,9 @@ describe('radar structure', () => {
                 max 8
                 min 0
                 graticule polygon
+
+                tickLabels{'-1','0','1'}
+                tickLabelsAxis 2
             `
     );
     cy.get('svg').should((svg) => {

--- a/demos/radar.html
+++ b/demos/radar.html
@@ -38,6 +38,7 @@
 
         tickLabels{'-1','0','1'}
         tickLabelsAxis 2
+        tickLabelsOffset 10
     </pre
       >
 

--- a/demos/radar.html
+++ b/demos/radar.html
@@ -36,7 +36,7 @@
         min 0
         graticule circle
 
-        tickLabels{'-2','-1','0','1','2'}
+        tickLabels{'-1','0','1'}
         tickLabelsAxis 2
     </pre
       >

--- a/demos/radar.html
+++ b/demos/radar.html
@@ -35,6 +35,9 @@
         max 8
         min 0
         graticule circle
+
+        tickLabels{'-2','-1','0','1','2'}
+        tickLabelsAxis 2
     </pre
       >
 

--- a/docs/syntax/radar.md
+++ b/docs/syntax/radar.md
@@ -74,6 +74,7 @@ radar-beta
 
   tickLabels{'-2','-1','0','1','2'}
   tickLabelsAxis 2
+  tickLabelsOffset 10
 
 ```
 
@@ -93,6 +94,7 @@ radar-beta
 
   tickLabels{'-2','-1','0','1','2'}
   tickLabelsAxis 2
+  tickLabelsOffset 10
 
 ```
 
@@ -151,6 +153,7 @@ radar-beta
 - `ticks`: The ticks keyword is used to define the number of ticks on the graticule. It is the number of concentric circles or polygons drawn to indicate the scale of the radar diagram. If not provided, the default number of ticks is `5`.
 - `tickLabels`: The tickLabels keyword can be used to define labels for each tick. If not provided, no tick labels are rendered.
 - `tickLabelsAxis`: The tickLabelsAxis can be used in conjunction with tickLabels to define where the tick labels should be rendered. The tickLabelsAxis can be any number <= number of axis. If not provided, the default is `null` which render the labels on all axis.
+- `tickLabelsOffset`: The perpendicular offset between the tick label and the axis. If not provided, the default offset is `10` (px).
 
 ```
 radar-beta

--- a/docs/syntax/radar.md
+++ b/docs/syntax/radar.md
@@ -72,6 +72,9 @@ radar-beta
   graticule polygon
   max 5
 
+  tickLabels{'-2','-1','0','1','2'}
+  tickLabelsAxis 2
+
 ```
 
 ```mermaid
@@ -87,6 +90,9 @@ radar-beta
 
   graticule polygon
   max 5
+
+  tickLabels{'-2','-1','0','1','2'}
+  tickLabelsAxis 2
 
 ```
 
@@ -143,6 +149,8 @@ radar-beta
 - `min`: The minimum value for the radar diagram. This is used to scale the radar diagram. If not provided, the minimum value is `0`.
 - `graticule`: The graticule keyword is used to define the type of graticule to be rendered in the radar diagram. The graticule can be `circle` or `polygon`. If not provided, the default graticule is `circle`.
 - `ticks`: The ticks keyword is used to define the number of ticks on the graticule. It is the number of concentric circles or polygons drawn to indicate the scale of the radar diagram. If not provided, the default number of ticks is `5`.
+- `tickLabels`: The tickLabels keyword can be used to define labels for each tick. If not provided, no tick labels are rendered.
+- `tickLabelsAxis`: The tickLabelsAxis can be used in conjunction with tickLabels to define where the tick labels should be rendered. The tickLabelsAxis can be any number <= number of axis. If not provided, the default is `null` which render the labels on all axis.
 
 ```
 radar-beta

--- a/packages/mermaid/src/diagrams/radar/db.ts
+++ b/packages/mermaid/src/diagrams/radar/db.ts
@@ -32,8 +32,8 @@ const defaultOptions: RadarOptions = {
   max: null,
   min: 0,
   graticule: 'circle',
-  showTickLabels: false,
   tickLabels: { labels: [] },
+  tickLabelsAxis: null,
 };
 
 const defaultRadarData: RadarData = {
@@ -111,8 +111,9 @@ const setOptions = (options: Option[]) => {
     max: (optionMap.max?.value as number) ?? defaultOptions.max,
     min: (optionMap.min?.value as number) ?? defaultOptions.min,
     graticule: (optionMap.graticule?.value as 'circle' | 'polygon') ?? defaultOptions.graticule,
-    showTickLabels: (optionMap.showTickLabels?.value as boolean) ?? defaultOptions.showTickLabels,
     tickLabels: (optionMap.tickLabels?.value as TickLabels) ?? defaultOptions.tickLabels,
+    tickLabelsAxis:
+      (optionMap.tickLabelsAxis?.value as number | null) ?? defaultOptions.tickLabelsAxis,
   };
 };
 

--- a/packages/mermaid/src/diagrams/radar/db.ts
+++ b/packages/mermaid/src/diagrams/radar/db.ts
@@ -111,7 +111,14 @@ const setOptions = (options: Option[]) => {
     max: (optionMap.max?.value as number) ?? defaultOptions.max,
     min: (optionMap.min?.value as number) ?? defaultOptions.min,
     graticule: (optionMap.graticule?.value as 'circle' | 'polygon') ?? defaultOptions.graticule,
-    tickLabels: (optionMap.tickLabels?.value as TickLabels) ?? defaultOptions.tickLabels,
+    // this is due to that otherwise $container gets set here via the Options type and
+    //  creates a circular structure which breaks tests
+    tickLabels: {
+      labels: [
+        ...((optionMap.tickLabels?.value as TickLabels)?.labels ??
+          defaultOptions.tickLabels.labels),
+      ],
+    },
     tickLabelsAxis:
       (optionMap.tickLabelsAxis?.value as number | null) ?? defaultOptions.tickLabelsAxis,
   };

--- a/packages/mermaid/src/diagrams/radar/db.ts
+++ b/packages/mermaid/src/diagrams/radar/db.ts
@@ -34,6 +34,7 @@ const defaultOptions: RadarOptions = {
   graticule: 'circle',
   tickLabels: { labels: [] },
   tickLabelsAxis: null,
+  tickLabelsOffset: 10,
 };
 
 const defaultRadarData: RadarData = {
@@ -121,6 +122,8 @@ const setOptions = (options: Option[]) => {
     },
     tickLabelsAxis:
       (optionMap.tickLabelsAxis?.value as number | null) ?? defaultOptions.tickLabelsAxis,
+    tickLabelsOffset:
+      (optionMap.tickLabelsOffset?.value as number) ?? defaultOptions.tickLabelsOffset,
   };
 };
 

--- a/packages/mermaid/src/diagrams/radar/db.ts
+++ b/packages/mermaid/src/diagrams/radar/db.ts
@@ -17,7 +17,14 @@ import type {
   Option,
   Entry,
 } from '../../../../parser/dist/src/language/generated/ast.js';
-import type { RadarAxis, RadarCurve, RadarOptions, RadarDB, RadarData } from './types.js';
+import type {
+  RadarAxis,
+  RadarCurve,
+  RadarOptions,
+  RadarDB,
+  RadarData,
+  TickLabels,
+} from './types.js';
 
 const defaultOptions: RadarOptions = {
   showLegend: true,
@@ -25,6 +32,8 @@ const defaultOptions: RadarOptions = {
   max: null,
   min: 0,
   graticule: 'circle',
+  showTickLabels: false,
+  tickLabels: { labels: [] },
 };
 
 const defaultRadarData: RadarData = {
@@ -102,6 +111,8 @@ const setOptions = (options: Option[]) => {
     max: (optionMap.max?.value as number) ?? defaultOptions.max,
     min: (optionMap.min?.value as number) ?? defaultOptions.min,
     graticule: (optionMap.graticule?.value as 'circle' | 'polygon') ?? defaultOptions.graticule,
+    showTickLabels: (optionMap.showTickLabels?.value as boolean) ?? defaultOptions.showTickLabels,
+    tickLabels: (optionMap.tickLabels?.value as TickLabels) ?? defaultOptions.tickLabels,
   };
 };
 

--- a/packages/mermaid/src/diagrams/radar/radar.spec.ts
+++ b/packages/mermaid/src/diagrams/radar/radar.spec.ts
@@ -1,7 +1,7 @@
 import { it, describe, expect } from 'vitest';
 import { db } from './db.js';
 import { parser } from './parser.js';
-import { relativeRadius, closedRoundCurve } from './renderer.js';
+import { relativeRadius, closedRoundCurve, _getAngleOffset } from './renderer.js';
 import { Diagram } from '../../Diagram.js';
 import mermaidAPI from '../../mermaidAPI.js';
 
@@ -273,6 +273,53 @@ describe('radar diagrams', () => {
         await mermaidAPI.parse(str);
         const diagram = await Diagram.fromText(str);
         await diagram.renderer.draw(str, 'tst', '1.2.3', diagram);
+      });
+    });
+
+    describe('_getAngleOffset', () => {
+      it('should handle angles around -90°', () => {
+        const angle = -Math.PI / 2; // -90 degrees
+        expect(_getAngleOffset(angle)).toEqual({ x: 10, y: 0 });
+      });
+
+      it('should handle angles around -45°', () => {
+        const angle = -Math.PI / 4; // -45 degrees
+        expect(_getAngleOffset(angle)).toEqual({ x: 7.5, y: 7.5 });
+      });
+
+      it('should handle angles around 0°', () => {
+        const angle = 0; // 0 degrees
+        expect(_getAngleOffset(angle)).toEqual({ x: 0, y: 7.5 });
+      });
+
+      it('should handle angles around 45°', () => {
+        const angle = Math.PI / 4; // 45 degrees
+        expect(_getAngleOffset(angle)).toEqual({ x: 10, y: -5 });
+      });
+
+      it('should handle angles around 90°', () => {
+        const angle = Math.PI / 2; // 90 degrees
+        expect(_getAngleOffset(angle)).toEqual({ x: -10, y: 0 });
+      });
+
+      it('should handle angles around 135°', () => {
+        const angle = (3 * Math.PI) / 4; // 135 degrees
+        expect(_getAngleOffset(angle)).toEqual({ x: -7.5, y: -7.5 });
+      });
+
+      it('should handle angles around 180°', () => {
+        const angle = Math.PI; // 180 degrees
+        expect(_getAngleOffset(angle)).toEqual({ x: 0, y: -7.5 });
+      });
+
+      it('should handle angles around 225°', () => {
+        const angle = (5 * Math.PI) / 4; // 225 degrees
+        expect(_getAngleOffset(angle)).toEqual({ x: -7.5, y: 7.5 });
+      });
+
+      it('should handle default case for angles outside defined ranges', () => {
+        const angle = -3 * Math.PI; // -540 degrees
+        expect(_getAngleOffset(angle)).toEqual({ x: 0, y: 0 });
       });
     });
   });

--- a/packages/mermaid/src/diagrams/radar/radar.spec.ts
+++ b/packages/mermaid/src/diagrams/radar/radar.spec.ts
@@ -75,6 +75,10 @@ describe('radar diagrams', () => {
         "max": null,
         "min": 0,
         "showLegend": true,
+        "tickLabels": {
+          "labels": [],
+        },
+        "tickLabelsAxis": null,
         "ticks": 5,
       }
     `);
@@ -87,6 +91,8 @@ describe('radar diagrams', () => {
     graticule polygon
     min 1
     max 10
+    tickLabels {'-4','-3','-2','-1','0','1','2','3','4','5'}
+    tickLabelsAxis 2
     `;
     await expect(parser.parse(str)).resolves.not.toThrow();
     expect(getOptions()).toMatchInlineSnapshot(`
@@ -95,6 +101,21 @@ describe('radar diagrams', () => {
         "max": 10,
         "min": 1,
         "showLegend": false,
+        "tickLabels": {
+          "labels": [
+            "-4",
+            "-3",
+            "-2",
+            "-1",
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+          ],
+        },
+        "tickLabelsAxis": 2,
         "ticks": 10,
       }
     `);
@@ -246,6 +267,8 @@ describe('radar diagrams', () => {
         curve mycurve["My Curve"]{1,2,3}
         curve mycurve2["My Curve 2"]{ C: 1, A: 2, B: 3 }
         graticule polygon
+        tickLabels {'-2','-1','0','1','2'}
+        tickLabelsAxis 2
         `;
         await mermaidAPI.parse(str);
         const diagram = await Diagram.fromText(str);

--- a/packages/mermaid/src/diagrams/radar/radar.spec.ts
+++ b/packages/mermaid/src/diagrams/radar/radar.spec.ts
@@ -1,7 +1,7 @@
 import { it, describe, expect } from 'vitest';
 import { db } from './db.js';
 import { parser } from './parser.js';
-import { relativeRadius, closedRoundCurve, _getAngleOffset } from './renderer.js';
+import { relativeRadius, closedRoundCurve } from './renderer.js';
 import { Diagram } from '../../Diagram.js';
 import mermaidAPI from '../../mermaidAPI.js';
 
@@ -79,6 +79,7 @@ describe('radar diagrams', () => {
           "labels": [],
         },
         "tickLabelsAxis": null,
+        "tickLabelsOffset": 10,
         "ticks": 5,
       }
     `);
@@ -116,6 +117,7 @@ describe('radar diagrams', () => {
           ],
         },
         "tickLabelsAxis": 2,
+        "tickLabelsOffset": 10,
         "ticks": 10,
       }
     `);
@@ -269,57 +271,11 @@ describe('radar diagrams', () => {
         graticule polygon
         tickLabels {'-2','-1','0','1','2'}
         tickLabelsAxis 2
+        tickLabelsOffset 10
         `;
         await mermaidAPI.parse(str);
         const diagram = await Diagram.fromText(str);
         await diagram.renderer.draw(str, 'tst', '1.2.3', diagram);
-      });
-    });
-
-    describe('_getAngleOffset', () => {
-      it('should handle angles around -90°', () => {
-        const angle = -Math.PI / 2; // -90 degrees
-        expect(_getAngleOffset(angle)).toEqual({ x: 10, y: 0 });
-      });
-
-      it('should handle angles around -45°', () => {
-        const angle = -Math.PI / 4; // -45 degrees
-        expect(_getAngleOffset(angle)).toEqual({ x: 7.5, y: 7.5 });
-      });
-
-      it('should handle angles around 0°', () => {
-        const angle = 0; // 0 degrees
-        expect(_getAngleOffset(angle)).toEqual({ x: 0, y: 7.5 });
-      });
-
-      it('should handle angles around 45°', () => {
-        const angle = Math.PI / 4; // 45 degrees
-        expect(_getAngleOffset(angle)).toEqual({ x: 10, y: -5 });
-      });
-
-      it('should handle angles around 90°', () => {
-        const angle = Math.PI / 2; // 90 degrees
-        expect(_getAngleOffset(angle)).toEqual({ x: -10, y: 0 });
-      });
-
-      it('should handle angles around 135°', () => {
-        const angle = (3 * Math.PI) / 4; // 135 degrees
-        expect(_getAngleOffset(angle)).toEqual({ x: -7.5, y: -7.5 });
-      });
-
-      it('should handle angles around 180°', () => {
-        const angle = Math.PI; // 180 degrees
-        expect(_getAngleOffset(angle)).toEqual({ x: 0, y: -7.5 });
-      });
-
-      it('should handle angles around 225°', () => {
-        const angle = (5 * Math.PI) / 4; // 225 degrees
-        expect(_getAngleOffset(angle)).toEqual({ x: -7.5, y: 7.5 });
-      });
-
-      it('should handle default case for angles outside defined ranges', () => {
-        const angle = -3 * Math.PI; // -540 degrees
-        expect(_getAngleOffset(angle)).toEqual({ x: 0, y: 0 });
       });
     });
   });

--- a/packages/mermaid/src/diagrams/radar/renderer.ts
+++ b/packages/mermaid/src/diagrams/radar/renderer.ts
@@ -31,7 +31,15 @@ const draw: DrawDefinition = (_text, id, _version, diagram: Diagram) => {
   drawAxes(g, axes, radius, config);
 
   // 📏 Draw the tick labels
-  drawTickLabels(g, axes, radius, options.ticks, options.tickLabels, options.tickLabelsAxis);
+  drawTickLabels(
+    g,
+    axes,
+    radius,
+    options.ticks,
+    options.tickLabels,
+    options.tickLabelsAxis,
+    options.tickLabelsOffset
+  );
 
   // 📊 Draw the curves
   drawCurves(g, axes, curves, minValue, maxValue, options.graticule, config);
@@ -64,41 +72,6 @@ const drawFrame = (svg: SVG, config: Required<RadarDiagramConfig>): SVGGroup => 
   // g element to center the radar chart
   return svg.append('g').attr('transform', `translate(${center.x}, ${center.y})`);
 };
-
-export function _getAngleOffset(angle: number) {
-  // Convert angle to degrees for easier comparison
-  const degrees = angle * (180 / Math.PI);
-
-  // Define angle ranges with ±22.5° tolerance (45° / 2)
-  if (degrees >= -112.5 && degrees < -67.5) {
-    // Around 12 o'clock (-90°)
-    return { x: 10, y: 0 };
-  } else if (degrees >= -67.5 && degrees < -22.5) {
-    // Around 2 o'clock (-45°)
-    return { x: 7.5, y: 7.5 };
-  } else if (degrees >= -22.5 && degrees < 22.5) {
-    // Around 3 o'clock (0°)
-    return { x: 0, y: 7.5 };
-  } else if (degrees >= 22.5 && degrees < 67.5) {
-    // Around 4 o'clock (45°)
-    return { x: 10, y: -5 };
-  } else if (degrees >= 67.5 && degrees < 112.5) {
-    // Around 6 o'clock (90°)
-    return { x: -10, y: 0 };
-  } else if (degrees >= 112.5 && degrees < 157.5) {
-    // Around 7 o'clock (135°)
-    return { x: -7.5, y: -7.5 };
-  } else if (degrees >= 157.5 && degrees < 202.5) {
-    // Around 9 o'clock (180°)
-    return { x: 0, y: -7.5 };
-  } else if (degrees >= 202.5 && degrees < 247.5) {
-    // Around 10 o'clock (225°)
-    return { x: -7.5, y: 7.5 };
-  }
-
-  // Default offset if no range matches
-  return { x: 0, y: 0 };
-}
 
 const drawGraticule = (
   g: SVGGroup,
@@ -162,7 +135,8 @@ function drawTickLabels(
   radius: number,
   ticks: number,
   tickLabels: TickLabels,
-  tickLabelsAxis: number | null
+  tickLabelsAxis: number | null,
+  tickLabelsOffset: number
 ) {
   const numAxes = axes.length;
   for (let tickIdx = 0; tickIdx < ticks; tickIdx++) {
@@ -173,9 +147,10 @@ function drawTickLabels(
 
     axes.forEach((_, axisIdx) => {
       const angle = (2 * axisIdx * Math.PI) / numAxes - Math.PI / 2;
-      const angleLabelOffsets = _getAngleOffset(angle);
-      const xWithOffset = r * Math.cos(angle) + angleLabelOffsets.x;
-      const yWithOffset = r * Math.sin(angle) + angleLabelOffsets.y;
+
+      const adjustedAngle = r - tickLabelsOffset;
+      const xWithOffset = adjustedAngle * Math.cos(angle) + tickLabelsOffset * Math.sin(angle);
+      const yWithOffset = adjustedAngle * Math.sin(angle) - tickLabelsOffset * Math.cos(angle);
 
       const drawForAxis = tickLabelsAxis === null || axisIdx === tickLabelsAxis - 1;
       if (drawForAxis) {

--- a/packages/mermaid/src/diagrams/radar/renderer.ts
+++ b/packages/mermaid/src/diagrams/radar/renderer.ts
@@ -2,7 +2,7 @@ import type { Diagram } from '../../Diagram.js';
 import type { RadarDiagramConfig } from '../../config.type.js';
 import type { DiagramRenderer, DrawDefinition, SVG, SVGGroup } from '../../diagram-api/types.js';
 import { selectSvgElement } from '../../rendering-util/selectSvgElement.js';
-import type { RadarDB, RadarAxis, RadarCurve } from './types.js';
+import type { RadarDB, RadarAxis, RadarCurve, TickLabels } from './types.js';
 
 const draw: DrawDefinition = (_text, id, _version, diagram: Diagram) => {
   const db = diagram.db as RadarDB;
@@ -25,7 +25,15 @@ const draw: DrawDefinition = (_text, id, _version, diagram: Diagram) => {
   const radius = Math.min(config.width, config.height) / 2;
 
   // 🕸️ Draw graticule
-  drawGraticule(g, axes, radius, options.ticks, options.graticule);
+  drawGraticule(
+    g,
+    axes,
+    radius,
+    options.ticks,
+    options.graticule,
+    options.showTickLabels,
+    options.tickLabels
+  );
 
   // 🪓 Draw the axes
   drawAxes(g, axes, radius, config);
@@ -67,8 +75,46 @@ const drawGraticule = (
   axes: RadarAxis[],
   radius: number,
   ticks: number,
-  graticule: string
+  graticule: string,
+  showTickLabels: boolean,
+  tickLabels: TickLabels
 ) => {
+  if (showTickLabels) {
+    // eslint-disable-next-line
+    console.log(tickLabels);
+    for (let i = 0; i < ticks; i++) {
+      const {
+        labels: { [i]: label },
+      } = tickLabels;
+      const angle = 0;
+      const offset = -i * 20;
+
+      // g.append('line')
+      //   .attr('x1', 0)
+      //   .attr('y1', 0)
+      //   .attr('x2', radius * config.axisScaleFactor * Math.cos(angle))
+      //   .attr('y2', radius * config.axisScaleFactor * Math.sin(angle))
+      //   .attr('class', 'radarAxisLegendLine');
+      // eslint-disable-next-line
+      console.log(radius, i, Math.cos(angle));
+      g.append('text')
+        .text(label)
+        .attr('x', 0)
+        .attr('y', offset)
+        .attr('class', 'radarAxisLegendLabel');
+
+      // if (graticule === 'circle') {
+      //   continue;
+      // } else if (graticule === 'polygon') {
+      //   // const label = tickLabels.labels[i]
+      //   // I am sure that this brings me to hell ...
+      //   const { labels: { [i]: label }} = tickLabels;
+      //   // eslint-disable-next-line
+      //   console.log(label);
+      // }
+    }
+  }
+
   if (graticule === 'circle') {
     // Draw a circle for each tick
     for (let i = 0; i < ticks; i++) {

--- a/packages/mermaid/src/diagrams/radar/renderer.ts
+++ b/packages/mermaid/src/diagrams/radar/renderer.ts
@@ -183,7 +183,7 @@ function drawTickLabels(
           .text(label)
           .attr('x', xWithOffset)
           .attr('y', yWithOffset)
-          .attr('class', 'radarAxisLegendLabel');
+          .attr('class', 'radarAxisTickLabel');
       }
     });
   }

--- a/packages/mermaid/src/diagrams/radar/renderer.ts
+++ b/packages/mermaid/src/diagrams/radar/renderer.ts
@@ -65,7 +65,7 @@ const drawFrame = (svg: SVG, config: Required<RadarDiagramConfig>): SVGGroup => 
   return svg.append('g').attr('transform', `translate(${center.x}, ${center.y})`);
 };
 
-const _getAngleOffset = (angle: number) => {
+export function _getAngleOffset(angle: number) {
   // Convert angle to degrees for easier comparison
   const degrees = angle * (180 / Math.PI);
 
@@ -98,7 +98,7 @@ const _getAngleOffset = (angle: number) => {
 
   // Default offset if no range matches
   return { x: 0, y: 0 };
-};
+}
 
 const drawGraticule = (
   g: SVGGroup,

--- a/packages/mermaid/src/diagrams/radar/styles.ts
+++ b/packages/mermaid/src/diagrams/radar/styles.ts
@@ -78,7 +78,7 @@ export const styles: DiagramStylesProvider = ({ radar }: { radar?: RadarStyleOpt
   .radarAxisLegendLabel {
 		dominant-baseline: middle;
 		text-anchor: middle;
-		font-size: ${radarOptions.axisLabelFontSize}px;
+		font-size: ${(radarOptions.axisLabelFontSize ?? 12) * 1.5}px;
 		color: #ff00ff;
 	}
 	${genIndexStyles(themeVariables, radarOptions)}

--- a/packages/mermaid/src/diagrams/radar/styles.ts
+++ b/packages/mermaid/src/diagrams/radar/styles.ts
@@ -78,7 +78,7 @@ export const styles: DiagramStylesProvider = ({ radar }: { radar?: RadarStyleOpt
   .radarAxisLegendLabel {
 		dominant-baseline: middle;
 		text-anchor: middle;
-		font-size: ${(radarOptions.axisLabelFontSize ?? 12) * 1.5}px;
+		font-size: ${radarOptions.axisLabelFontSize}px;
 		color: #ff00ff;
 	}
 	${genIndexStyles(themeVariables, radarOptions)}

--- a/packages/mermaid/src/diagrams/radar/styles.ts
+++ b/packages/mermaid/src/diagrams/radar/styles.ts
@@ -42,7 +42,6 @@ export const buildRadarStyleOptions = (radar?: RadarStyleOptions) => {
 
 export const styles: DiagramStylesProvider = ({ radar }: { radar?: RadarStyleOptions } = {}) => {
   const { themeVariables, radarOptions } = buildRadarStyleOptions(radar);
-  // TODO: fix
   return `
 	.radarTitle {
 		font-size: ${themeVariables.fontSize};
@@ -71,15 +70,11 @@ export const styles: DiagramStylesProvider = ({ radar }: { radar?: RadarStyleOpt
 		font-size: ${radarOptions.legendFontSize}px;
 		dominant-baseline: hanging;
 	}
-  .radarAxisLegendLine {
-		stroke: #ff00ff;
-		stroke-width: 1;
-	}
-  .radarAxisLegendLabel {
+  .radarAxisTickLabel {
 		dominant-baseline: middle;
 		text-anchor: middle;
 		font-size: ${radarOptions.axisLabelFontSize}px;
-		color: #ff00ff;
+		color: ${radarOptions.axisColor};
 	}
 	${genIndexStyles(themeVariables, radarOptions)}
 	`;

--- a/packages/mermaid/src/diagrams/radar/styles.ts
+++ b/packages/mermaid/src/diagrams/radar/styles.ts
@@ -42,6 +42,7 @@ export const buildRadarStyleOptions = (radar?: RadarStyleOptions) => {
 
 export const styles: DiagramStylesProvider = ({ radar }: { radar?: RadarStyleOptions } = {}) => {
   const { themeVariables, radarOptions } = buildRadarStyleOptions(radar);
+  // TODO: fix
   return `
 	.radarTitle {
 		font-size: ${themeVariables.fontSize};
@@ -69,6 +70,16 @@ export const styles: DiagramStylesProvider = ({ radar }: { radar?: RadarStyleOpt
 		text-anchor: start;
 		font-size: ${radarOptions.legendFontSize}px;
 		dominant-baseline: hanging;
+	}
+  .radarAxisLegendLine {
+		stroke: #ff00ff;
+		stroke-width: 1;
+	}
+  .radarAxisLegendLabel {
+		dominant-baseline: middle;
+		text-anchor: middle;
+		font-size: ${radarOptions.axisLabelFontSize}px;
+		color: #ff00ff;
 	}
 	${genIndexStyles(themeVariables, radarOptions)}
 	`;

--- a/packages/mermaid/src/diagrams/radar/types.ts
+++ b/packages/mermaid/src/diagrams/radar/types.ts
@@ -20,8 +20,8 @@ export interface RadarOptions {
   max: number | null;
   min: number;
   graticule: 'circle' | 'polygon';
-  showTickLabels: boolean;
   tickLabels: TickLabels;
+  tickLabelsAxis: number | null;
 }
 export interface RadarDB extends DiagramDBBase<RadarDiagramConfig> {
   getAxes: () => RadarAxis[];

--- a/packages/mermaid/src/diagrams/radar/types.ts
+++ b/packages/mermaid/src/diagrams/radar/types.ts
@@ -22,6 +22,7 @@ export interface RadarOptions {
   graticule: 'circle' | 'polygon';
   tickLabels: TickLabels;
   tickLabelsAxis: number | null;
+  tickLabelsOffset: number;
 }
 export interface RadarDB extends DiagramDBBase<RadarDiagramConfig> {
   getAxes: () => RadarAxis[];

--- a/packages/mermaid/src/diagrams/radar/types.ts
+++ b/packages/mermaid/src/diagrams/radar/types.ts
@@ -11,12 +11,17 @@ export interface RadarCurve {
   entries: number[];
   label: string;
 }
+export interface TickLabels {
+  labels: string[];
+}
 export interface RadarOptions {
   showLegend: boolean;
   ticks: number;
   max: number | null;
   min: number;
   graticule: 'circle' | 'polygon';
+  showTickLabels: boolean;
+  tickLabels: TickLabels;
 }
 export interface RadarDB extends DiagramDBBase<RadarDiagramConfig> {
   getAxes: () => RadarAxis[];

--- a/packages/mermaid/src/docs/syntax/radar.md
+++ b/packages/mermaid/src/docs/syntax/radar.md
@@ -54,6 +54,7 @@ radar-beta
 
   tickLabels{'-2','-1','0','1','2'}
   tickLabelsAxis 2
+  tickLabelsOffset 10
 
 ```
 
@@ -112,6 +113,7 @@ radar-beta
 - `ticks`: The ticks keyword is used to define the number of ticks on the graticule. It is the number of concentric circles or polygons drawn to indicate the scale of the radar diagram. If not provided, the default number of ticks is `5`.
 - `tickLabels`: The tickLabels keyword can be used to define labels for each tick. If not provided, no tick labels are rendered.
 - `tickLabelsAxis`: The tickLabelsAxis can be used in conjunction with tickLabels to define where the tick labels should be rendered. The tickLabelsAxis can be any number <= number of axis. If not provided, the default is `null` which render the labels on all axis.
+- `tickLabelsOffset`: The perpendicular offset between the tick label and the axis. If not provided, the default offset is `10` (px).
 
 ```
 radar-beta

--- a/packages/mermaid/src/docs/syntax/radar.md
+++ b/packages/mermaid/src/docs/syntax/radar.md
@@ -52,6 +52,9 @@ radar-beta
   graticule polygon
   max 5
 
+  tickLabels{'-2','-1','0','1','2'}
+  tickLabelsAxis 2
+
 ```
 
 ## Details of Syntax
@@ -107,6 +110,8 @@ radar-beta
 - `min`: The minimum value for the radar diagram. This is used to scale the radar diagram. If not provided, the minimum value is `0`.
 - `graticule`: The graticule keyword is used to define the type of graticule to be rendered in the radar diagram. The graticule can be `circle` or `polygon`. If not provided, the default graticule is `circle`.
 - `ticks`: The ticks keyword is used to define the number of ticks on the graticule. It is the number of concentric circles or polygons drawn to indicate the scale of the radar diagram. If not provided, the default number of ticks is `5`.
+- `tickLabels`: The tickLabels keyword can be used to define labels for each tick. If not provided, no tick labels are rendered.
+- `tickLabelsAxis`: The tickLabelsAxis can be used in conjunction with tickLabels to define where the tick labels should be rendered. The tickLabelsAxis can be any number <= number of axis. If not provided, the default is `null` which render the labels on all axis.
 
 ```
 radar-beta

--- a/packages/parser/src/language/radar/radar.langium
+++ b/packages/parser/src/language/radar/radar.langium
@@ -49,7 +49,13 @@ Option:
         | name='max' value=NUMBER
         | name='min' value=NUMBER
         | name='graticule' value=GRATICULE
+        | name='showTickLabels' value=BOOLEAN
+        | name='tickLabels' value=TickLabels
     )
 ;   
 
 terminal GRATICULE returns string: 'circle' | 'polygon';
+
+TickLabels:
+    '{' NEWLINE* labels+=STRING (',' NEWLINE* labels+=STRING)* NEWLINE* '}'
+;

--- a/packages/parser/src/language/radar/radar.langium
+++ b/packages/parser/src/language/radar/radar.langium
@@ -49,8 +49,8 @@ Option:
         | name='max' value=NUMBER
         | name='min' value=NUMBER
         | name='graticule' value=GRATICULE
-        | name='showTickLabels' value=BOOLEAN
         | name='tickLabels' value=TickLabels
+        | name='tickLabelsAxis' value=NUMBER
     )
 ;   
 

--- a/packages/parser/src/language/radar/radar.langium
+++ b/packages/parser/src/language/radar/radar.langium
@@ -51,6 +51,7 @@ Option:
         | name='graticule' value=GRATICULE
         | name='tickLabels' value=TickLabels
         | name='tickLabelsAxis' value=NUMBER
+        | name='tickLabelsOffset' value=NUMBER
     )
 ;   
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

I added two new optional options for the radar chart. This enables to set tick labels and render them on one or all axis of the radar chart.

Resolves #6473

## :straight_ruler: Design Decisions

```
...other chart definitions

  axis A, B, C

  ticks 3
  tickLabels{'-1','0','1'}
  tickLabelsAxis 2
```

This add the labels: `-1, 0 and 1` to the intersections points of axis and ticks of the axis B.

```
...other chart definitions

  axis A, B, C

  ticks 3
  tickLabels{'-1','0','1'}
```

This add the labels: `-1, 0 and 1` to the intersections points of axis and ticks of all defined axis.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
