### PR TITLE
fix: Handle langium data loss warning

### DIFF
--- a/packages/mermaid/src/diagrams/common/populateCommonDb.ts
+++ b/packages/mermaid/src/diagrams/common/populateCommonDb.ts
@@ -2,13 +2,13 @@ import type { DiagramAST } from '@mermaid-js/parser';
 import type { DiagramDB } from '../../diagram-api/types.js';
 
 export function populateCommonDb(ast: DiagramAST, db: DiagramDB) {
-  if (ast.accDescr) {
-    db.setAccDescription?.(ast.accDescr);
+  if (ast.accDescr?.length > 0) {
+    db.setAccDescription?.(ast.accDescr.pop() ?? '');
   }
-  if (ast.accTitle) {
-    db.setAccTitle?.(ast.accTitle);
+  if (ast.accTitle?.length > 0) {
+    db.setAccTitle?.(ast.accTitle.pop() ?? '');
   }
-  if (ast.title) {
-    db.setDiagramTitle?.(ast.title);
+  if (ast.title?.length > 0) {
+    db.setDiagramTitle?.(ast.title.pop() ?? '');
   }
 }

--- a/packages/parser/src/language/common/common.langium
+++ b/packages/parser/src/language/common/common.langium
@@ -8,7 +8,7 @@ fragment EOL returns string:
 ;
 
 fragment TitleAndAccessibilities:
-  ((accDescr=ACC_DESCR | accTitle=ACC_TITLE | title=TITLE) EOL)+
+  ((accDescr+=ACC_DESCR | accTitle+=ACC_TITLE | title+=TITLE) EOL)+
 ;
 
 terminal BOOLEAN returns boolean: 'true' | 'false';

--- a/packages/parser/src/language/common/tokenBuilder.ts
+++ b/packages/parser/src/language/common/tokenBuilder.ts
@@ -1,6 +1,5 @@
 import type { GrammarAST, Stream, TokenBuilderOptions } from 'langium';
 import type { TokenType } from 'chevrotain';
-
 import { DefaultTokenBuilder } from 'langium';
 
 export abstract class AbstractMermaidTokenBuilder extends DefaultTokenBuilder {

--- a/packages/parser/src/language/common/valueConverter.ts
+++ b/packages/parser/src/language/common/valueConverter.ts
@@ -1,6 +1,5 @@
 import type { CstNode, GrammarAST, ValueType } from 'langium';
 import { DefaultValueConverter } from 'langium';
-
 import { accessibilityDescrRegex, accessibilityTitleRegex, titleRegex } from './matcher.js';
 
 const rulesRegexes: Record<string, RegExp> = {
@@ -31,14 +30,12 @@ export abstract class AbstractMermaidValueConverter extends DefaultValueConverte
   ): ValueType {
     let value: ValueType | undefined = this.runCommonConverter(rule, input, cstNode);
 
-    if (value === undefined) {
-      value = this.runCustomConverter(rule, input, cstNode);
-    }
-    if (value === undefined) {
-      return super.runConverter(rule, input, cstNode);
+    value ??= this.runCustomConverter(rule, input, cstNode);
+    if (value !== undefined) {
+      return value;
     }
 
-    return value;
+    return super.runConverter(rule, input, cstNode);
   }
 
   private runCommonConverter(

--- a/packages/parser/tests/architecture.test.ts
+++ b/packages/parser/tests/architecture.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest';
-
 import { Architecture } from '../src/language/index.js';
 import { expectNoErrorsOrAlternatives, architectureParse as parse } from './test-util.js';
 
@@ -33,7 +32,7 @@ describe('architecture', () => {
       expect(result.value.$type).toBe(Architecture);
 
       const { title } = result.value;
-      expect(title).toBe('sample title');
+      expect(title).toEqual(['sample title']);
     });
 
     it.each([
@@ -48,7 +47,7 @@ describe('architecture', () => {
       expect(result.value.$type).toBe(Architecture);
 
       const { title } = result.value;
-      expect(title).toBe('sample title');
+      expect(title).toEqual(['sample title']);
     });
 
     it('should handle regular architecture + title + accTitle + accDescr', () => {
@@ -62,9 +61,9 @@ describe('architecture', () => {
       expect(result.value.$type).toBe(Architecture);
 
       const { title, accTitle, accDescr } = result.value;
-      expect(title).toBe('sample title');
-      expect(accTitle).toBe('sample accTitle');
-      expect(accDescr).toBe('sample accDescr');
+      expect(title).toEqual(['sample title']);
+      expect(accTitle).toEqual(['sample accTitle']);
+      expect(accDescr).toEqual(['sample accDescr']);
     });
 
     it('should handle regular architecture + title + accTitle + multi-line accDescr', () => {
@@ -80,9 +79,9 @@ describe('architecture', () => {
       expect(result.value.$type).toBe(Architecture);
 
       const { title, accTitle, accDescr } = result.value;
-      expect(title).toBe('sample title');
-      expect(accTitle).toBe('sample accTitle');
-      expect(accDescr).toBe('sample accDescr');
+      expect(title).toEqual(['sample title']);
+      expect(accTitle).toEqual(['sample accTitle']);
+      expect(accDescr).toEqual(['sample accDescr']);
     });
   });
 });

--- a/packages/parser/tests/gitGraph.test.ts
+++ b/packages/parser/tests/gitGraph.test.ts
@@ -166,14 +166,14 @@ describe('Parsing CherryPicking Statements', () => {
   describe('Parsing with Accessibility Titles and Descriptions', () => {
     it('should parse accessibility titles', () => {
       const result = parse(`gitGraph\n  accTitle: Accessible Graph\n  commit\n`);
-      expect(result.value.accTitle).toBe('Accessible Graph');
+      expect(result.value.accTitle).toEqual(['Accessible Graph']);
     });
 
     it('should parse multiline accessibility descriptions', () => {
       const result = parse(
         `gitGraph\n  accDescr {\n    Detailed description\n    across multiple lines\n  }\n  commit\n`
       );
-      expect(result.value.accDescr).toBe('Detailed description\nacross multiple lines');
+      expect(result.value.accDescr).toEqual(['Detailed description\nacross multiple lines']);
     });
   });
 
@@ -189,7 +189,7 @@ describe('Parsing CherryPicking Statements', () => {
         merge feature tag:"v1.0"
         cherry-pick id:"feat1" tag:"critical fix"
       `);
-      expect(result.value.accTitle).toBe('Complex Example');
+      expect(result.value.accTitle).toEqual(['Complex Example']);
       expect(result.value.statements[0].$type).toBe('Commit');
       expect(result.value.statements[1].$type).toBe('Branch');
       expect(result.value.statements[2].$type).toBe('Commit');

--- a/packages/parser/tests/pie.test.ts
+++ b/packages/parser/tests/pie.test.ts
@@ -49,7 +49,7 @@ describe('pie', () => {
         expect(result.value.$type).toBe(Pie);
 
         const { title } = result.value;
-        expect(title).toBe('sample title');
+        expect(title).toEqual(['sample title']);
       });
 
       it.each([
@@ -69,7 +69,7 @@ describe('pie', () => {
         expect(result.value.$type).toBe(Pie);
 
         const { title } = result.value;
-        expect(title).toBe('sample title');
+        expect(title).toEqual(['sample title']);
       });
     });
 
@@ -85,7 +85,7 @@ describe('pie', () => {
 
         const { showData, title } = result.value;
         expect(showData).toBeTruthy();
-        expect(title).toBe('sample title');
+        expect(title).toEqual(['sample title']);
       });
 
       it.each([
@@ -106,7 +106,7 @@ describe('pie', () => {
 
         const { showData, title } = result.value;
         expect(showData).toBeTruthy();
-        expect(title).toBe('sample title');
+        expect(title).toEqual(['sample title']);
       });
     });
   });
@@ -166,7 +166,7 @@ describe('pie', () => {
       expect(result.value.$type).toBe(Pie);
 
       const { title, sections } = result.value;
-      expect(title).toBe('sample wow');
+      expect(title).toEqual(['sample wow']);
 
       expect(sections[0].label).toBe('GitHub');
       expect(sections[0].value).toBe(100);
@@ -200,7 +200,7 @@ describe('pie', () => {
       expect(result.value.$type).toBe(Pie);
 
       const { accTitle, sections } = result.value;
-      expect(accTitle).toBe('sample wow');
+      expect(accTitle).toEqual(['sample wow']);
 
       expect(sections[0].label).toBe('GitHub');
       expect(sections[0].value).toBe(100);
@@ -218,7 +218,7 @@ describe('pie', () => {
       expect(result.value.$type).toBe(Pie);
 
       const { accDescr, sections } = result.value;
-      expect(accDescr).toBe('sample wow');
+      expect(accDescr).toEqual(['sample wow']);
 
       expect(sections[0].label).toBe('GitHub');
       expect(sections[0].value).toBe(100);
@@ -238,7 +238,7 @@ describe('pie', () => {
       expect(result.value.$type).toBe(Pie);
 
       const { accDescr, sections } = result.value;
-      expect(accDescr).toBe('sample wow');
+      expect(accDescr).toEqual(['sample wow']);
 
       expect(sections[0].label).toBe('GitHub');
       expect(sections[0].value).toBe(100);

--- a/packages/parser/tests/radar.test.ts
+++ b/packages/parser/tests/radar.test.ts
@@ -35,7 +35,7 @@ describe('radar', () => {
       expect(result.value.$type).toBe(Radar);
 
       const { title } = result.value;
-      expect(title).toBe('My Title');
+      expect(title).toEqual(['My Title']);
     });
 
     it.each([
@@ -47,7 +47,7 @@ describe('radar', () => {
       expect(result.value.$type).toBe(Radar);
 
       const { accDescr } = result.value;
-      expect(accDescr).toBe('My Accessible Description');
+      expect(accDescr).toEqual(['My Accessible Description']);
     });
 
     it.each([
@@ -59,7 +59,7 @@ describe('radar', () => {
       expect(result.value.$type).toBe(Radar);
 
       const { accTitle } = result.value;
-      expect(accTitle).toBe('My Accessible Title');
+      expect(accTitle).toEqual(['My Accessible Title']);
     });
 
     it.each([
@@ -75,9 +75,9 @@ describe('radar', () => {
       expect(result.value.$type).toBe(Radar);
 
       const { title, accDescr, accTitle } = result.value;
-      expect(title).toBe('My Title');
-      expect(accDescr).toBe('My Accessible Description');
-      expect(accTitle).toBe('My Accessible Title');
+      expect(title).toEqual(['My Title']);
+      expect(accDescr).toEqual(['My Accessible Description']);
+      expect(accTitle).toEqual(['My Accessible Title']);
     });
   });
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

It's not an issue to actually lose the data, as we're just taking the last value anyways. But having the warnings clog up the console means we might miss actual warnings.

## I would rather not merge this, need a better approach.

Resolves #<your issue id here>

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [ ] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
