### PR TITLE
`layout-elk` package documentation misleading version

### DIFF
--- a/packages/mermaid-layout-elk/README.md
+++ b/packages/mermaid-layout-elk/README.md
@@ -54,7 +54,7 @@ mermaid.registerLayoutLoaders(elkLayouts);
 ```html
 <script type="module">
   import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-  import elkLayouts from 'https://cdn.jsdelivr.net/npm/@mermaid-js/layout-elk@11/dist/mermaid-layout-elk.esm.min.mjs';
+  import elkLayouts from 'https://cdn.jsdelivr.net/npm/@mermaid-js/layout-elk@0/dist/mermaid-layout-elk.esm.min.mjs';
 
   mermaid.registerLayoutLoaders(elkLayouts);
 </script>


### PR DESCRIPTION
## :bookmark_tabs: Summary

It shows `layout-elk@11` in CDN code snippet while this package is currently on v0.1.7.

https://github.com/mermaid-js/mermaid/blob/1c1d7d03005cb109bf37cf20bdef224c54f7ee42/packages/mermaid-layout-elk/package.json#L3
