### PR TITLE
fix(sequenceDiagram): allow empty message after colon (Fixes #6518)

### DIFF
--- a/.changeset/sixty-deer-tell.md
+++ b/.changeset/sixty-deer-tell.md
@@ -1,0 +1,5 @@
+---
+'mermaid': major
+---
+
+fix: allow sequence diagram arrows with a trailing colon but no message

--- a/packages/mermaid/src/diagrams/sequence/parser/sequenceDiagram.jison
+++ b/packages/mermaid/src/diagrams/sequence/parser/sequenceDiagram.jison
@@ -84,7 +84,8 @@ accDescr\s*"{"\s*                                { this.begin("acc_descr_multili
 \-\-[x]                                                         return 'DOTTED_CROSS';
 \-[\)]                                                          return 'SOLID_POINT';
 \-\-[\)]                                                        return 'DOTTED_POINT';
-":"(?:(?:no)?wrap:)?[^#\n;]+                                    return 'TXT';
+":"(?:(?:no)?wrap:)?[^#\n;]*                                    return 'TXT';
+":"                             								return 'TXT';
 "+"                                                             return '+';
 "-"                                                             return '-';
 <<EOF>>                                                         return 'NEWLINE';

--- a/packages/mermaid/src/diagrams/sequence/sequenceDiagram.spec.js
+++ b/packages/mermaid/src/diagrams/sequence/sequenceDiagram.spec.js
@@ -2022,4 +2022,20 @@ describe('sequence db class', () => {
       expect(Object.hasOwn(sequenceDb, fun)).toBe(true);
     }
   });
+  // This test verifies that messages with a colon but no content (e.g., "Alice->>Bob:")
+  // are correctly parsed as valid messages with an empty string as the message content.
+
+  it('should parse a message with a trailing colon but no content', async () => {
+    const diagram = await Diagram.fromText(`
+sequenceDiagram
+Alice->>Bob:
+Bob->>Alice:Got it!
+`);
+
+    const messages = diagram.db.getMessages();
+    expect(messages.length).toBe(2);
+    expect(messages[0].message).toBe('');
+    expect(messages[0].from).toBe('Alice');
+    expect(messages[0].to).toBe('Bob');
+  });
 });


### PR DESCRIPTION
## :bookmark_tabs: Summary

This pull request fixes an issue where sequence diagram arrows with a trailing colon but no message (e.g., `B ->> A:`) would fail to parse. The grammar previously required at least one character after the colon, which was unnecessarily restrictive.

Resolves #6518

---

## :straight_ruler: Design Decisions

The lexer rule for `TXT` was too strict, requiring one or more characters after the colon. This PR modifies the rule to allow zero or more characters (`*` instead of `+`), and adds a fallback pattern to match a standalone colon.

### 🔧 Lexer Fix

```jison
":"(?:(?:no)?wrap:)?[^#\n;]*                                    return 'TXT';
":"                                                             return 'TXT';
```
This enables syntax such as:
```
sequenceDiagram
A ->> B:
B ->> A: response
```

which now parses correctly.

No changes were needed in the parser or rendering logic since TXT is already processed safely as an optional message.

## :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [MERMAID_RELEASE_VERSION](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running pnpm changeset and following the prompts. Changesets that add features should be minor and those that fix bugs should be patch. Please prefix changeset messages with feat:, fix:, or chore:.