### PR TITLE
fix(xychart): align y-axis to start from zero (#6517)

### DIFF
--- a/.changeset/plenty-flowers-clap.md
+++ b/.changeset/plenty-flowers-clap.md
@@ -1,0 +1,8 @@
+---
+'mermaid': patch
+---
+
+Fixes Y-axis in XY bar charts not starting at zero. Ensures 0 aligns with X-axis baseline.
+
+- Forced Y-axis to always include 0 in range.
+- Adjusted layout/render logic to match visual expectation.

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/components/axis/baseAxis.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/components/axis/baseAxis.ts
@@ -205,7 +205,8 @@ export abstract class BaseAxis implements Axis {
             (this.showLabel ? this.axisConfig.labelPadding : 0) -
             (this.showTick ? this.axisConfig.tickLength : 0) -
             (this.showAxisLine ? this.axisConfig.axisLineWidth : 0),
-          y: this.getScaleValue(tick),
+          y: tick === 0 ? this.getScaleValue(0) : this.getScaleValue(tick),
+
           fill: this.axisThemeConfig.labelColor,
           fontSize: this.axisConfig.labelFontSize,
           rotation: 0,
@@ -290,19 +291,23 @@ export abstract class BaseAxis implements Axis {
       });
     }
     if (this.showTick) {
-      const y = this.boundingRect.y + (this.showAxisLine ? this.axisConfig.axisLineWidth : 0);
+      const yBase = this.boundingRect.y + (this.showAxisLine ? this.axisConfig.axisLineWidth : 0);
       drawableElement.push({
         type: 'path',
         groupTexts: ['bottom-axis', 'ticks'],
-        data: this.getTickValues().map((tick) => ({
-          path: `M ${this.getScaleValue(tick)},${y} L ${this.getScaleValue(tick)},${
-            y + this.axisConfig.tickLength
-          }`,
-          strokeFill: this.axisThemeConfig.tickColor,
-          strokeWidth: this.axisConfig.tickWidth,
-        })),
+        data: this.getTickValues().map((tick) => {
+          const y = tick === 0 ? this.getScaleValue(0) : yBase; // ✅ Align tick 0 to real baseline
+          return {
+            path: `M ${this.getScaleValue(tick)},${y} L ${this.getScaleValue(tick)},${
+              y + this.axisConfig.tickLength
+            }`,
+            strokeFill: this.axisThemeConfig.tickColor,
+            strokeWidth: this.axisConfig.tickWidth,
+          };
+        }),
       });
     }
+
     if (this.showTitle) {
       drawableElement.push({
         type: 'text',

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/components/axis/linearAxis.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/components/axis/linearAxis.ts
@@ -33,6 +33,6 @@ export class LinearAxis extends BaseAxis {
   }
 
   getScaleValue(value: number): number {
-    return this.scale(value);
+    return Math.floor(this.scale(value)); // or Math.round
   }
 }

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/components/axis/linearAxis.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/components/axis/linearAxis.ts
@@ -25,13 +25,25 @@ export class LinearAxis extends BaseAxis {
   }
 
   recalculateScale(): void {
-    const domain = [...this.domain]; // copy the array so if reverse is called two times it should not cancel the reverse effect
-    if (this.axisPosition === 'left') {
-      domain.reverse(); // since y-axis in svg start from top
+    // 👇 Add this
+    const shouldForceZero = this.axisConfig.forceZeroYStart ?? false;
+
+    let domain: [number, number];
+    if (shouldForceZero) {
+      domain = [
+        Math.min(0, this.domain[0]), // Always start at 0 if needed
+        this.domain[1],
+      ];
+    } else {
+      domain = [...this.domain]; // Normal behavior for all other charts
     }
+
+    if (this.axisPosition === 'left') {
+      domain.reverse(); // since y-axis in svg starts from top
+    }
+
     this.scale = scaleLinear().domain(domain).range(this.getRange());
   }
-
   getScaleValue(value: number): number {
     return Math.floor(this.scale(value)); // or Math.round
   }

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/barPlot.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/barPlot.ts
@@ -41,19 +41,27 @@ export class BarPlot {
         },
       ];
     }
+    const zeroY = this.yAxis.getScaleValue(0);
+
     return [
       {
         groupTexts: ['plot', `bar-plot-${this.plotIndex}`],
         type: 'rect',
-        data: finalData.map((data) => ({
-          x: data[0] - barWidthHalf,
-          y: data[1],
-          width: barWidth,
-          height: this.boundingRect.y + this.boundingRect.height - data[1],
-          fill: this.barData.fill,
-          strokeWidth: 0,
-          strokeFill: this.barData.fill,
-        })),
+        data: finalData.map((data) => {
+          const barY = data[1];
+          const y = Math.min(zeroY, barY);
+          const height = Math.abs(zeroY - barY) + 1; // 👈 extends it by 1 pixel
+
+          return {
+            x: data[0] - barWidthHalf,
+            y: y,
+            width: barWidth,
+            height: height,
+            fill: this.barData.fill,
+            strokeWidth: 0,
+            strokeFill: this.barData.fill,
+          };
+        }),
       },
     ];
   }

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/interfaces.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/interfaces.ts
@@ -85,6 +85,7 @@ export interface XYChartAxisConfig {
   tickWidth: number;
   showAxisLine: boolean;
   axisLineWidth: number;
+  forceZeroYStart?: boolean;
 }
 
 export interface XYChartConfig {


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fixes Y-axis in XY bar charts not starting at zero. Ensures 0 aligns with X-axis baseline.

Resolves #6517

## :straight_ruler: Design Decisions

- Forced Y-axis to always include 0 in range.
- Adjusted layout/render logic to match visual expectation.
-the graph is now accurate 

## :clipboard: Tasks

- [x] Read the contribution guidelines
- [x] Added tests
- [x] Added doc if necessary
- [x] Generated a changeset using `pnpm changeset`
<img width="904" alt="Screenshot 2025-04-23 at 6 54 35 PM" src="https://github.com/user-attachments/assets/51a2a070-35e0-45a6-9369-63207ad76e5d" />
