### PR TITLE
add build:vite script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,13 @@
     "git graph"
   ],
   "scripts": {
+    "clean": "pnpm run -r clean ",
     "build": "pnpm build:esbuild && pnpm build:types",
-    "build:esbuild": "pnpm run -r clean && tsx .esbuild/build.ts",
+    "build:esbuild": "pnpm clean && tsx .esbuild/build.ts",
     "build:mermaid": "pnpm build:esbuild --mermaid",
     "build:viz": "pnpm build:esbuild --visualize",
+    "build:vite": "tsx .vite/build.ts",
+    "release": "pnpm clean && pnpm build:vite",
     "build:types": "pnpm --filter mermaid types:build-config && tsx .build/types.ts",
     "build:types:watch": "tsc -p ./packages/mermaid/tsconfig.json --emitDeclarationOnly --watch",
     "dev": "tsx .esbuild/server.ts",
@@ -127,7 +130,7 @@
     "tsx": "^4.7.3",
     "typescript": "~5.7.3",
     "typescript-eslint": "^8.31.1",
-    "vite": "^6.1.1",
+    "vite": "6.3.4",
     "vite-plugin-istanbul": "^7.0.0",
     "vitest": "^3.0.6"
   },

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -8,11 +8,12 @@
     "Sidharth Vinod (https://sidharth.dev)"
   ],
   "homepage": "https://github.com/mermaid-js/mermaid/tree/develop/packages/mermaid/parser/#readme",
+  "module": "./dist/mermaid-parser.esm.mjs",
   "types": "dist/src/index.d.ts",
   "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/mermaid-parser.core.mjs",
+      "import": "./dist/mermaid-parser.esm.mjs",
       "types": "./dist/src/index.d.ts"
     }
   },


### PR DESCRIPTION
## :bookmark_tabs: Summary

Brief description about the content of your PR.

esbuild output size: 15.5M
vite       output size: 5.1M

esbuild output use ES2022 syntax, not compitable with IOS 15 safari
use vite will transform to ES2018, which is defined in tsconfig.json "compilerOptions": {"target": "ES2018"}, no static initialization blocks will be generated

Resolves #6529 
Usage: 
pnpm run release
reference mermaid.esm.mjs
```html
  <html lang="en">
      <head>
        <meta charset="utf-8" />
      </head>
      <body>
        <script type="module">
          import mermaid from 'The/Path/In/Your/Package/mermaid.esm.mjs';
          mermaid.initialize({ startOnLoad: true });
        </script>
      </body>
  </html>
```


## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
