### PR TITLE
Fix: Apply proper styling for Mermaid ER diagrams

### DIFF
--- a/.changeset/curly-coats-tell.md
+++ b/.changeset/curly-coats-tell.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+Fix stroke styles for ER diagram to correctly apply path and row-specific styles

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/erBox.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/erBox.ts
@@ -40,7 +40,7 @@ export async function erBox<T extends SVGGraphicsElement>(parent: D3Selection<T>
   let TEXT_PADDING = config.er?.entityPadding ?? 6;
 
   const { cssStyles } = node;
-  const { labelStyles } = styles2String(node);
+  const { labelStyles, nodeStyles } = styles2String(node);
 
   // Draw rect if no attributes are found
   if (entityNode.attributes.length === 0 && node.label) {
@@ -294,6 +294,18 @@ export async function erBox<T extends SVGGraphicsElement>(parent: D3Selection<T>
   }
 
   updateNodeBounds(node, rect);
+
+  if (nodeStyles && node.look !== 'handDrawn') {
+    const allStyle = nodeStyles.split(';');
+    const strokeStyles = allStyle
+      ?.filter((e) => {
+        return e.includes('stroke');
+      })
+      ?.map((s) => `${s}`)
+      .join('; ');
+    shapeSvg.selectAll('path').attr('style', strokeStyles ?? '');
+    shapeSvg.selectAll('.row-rect-even path').attr('style', nodeStyles);
+  }
 
   node.intersect = function (point) {
     return intersect.rect(node, point);


### PR DESCRIPTION
## :bookmark_tabs: Summary

- This fix ensures that stroke styles are correctly applied to `path` and `.row-rect-even path` elements 
- Filters out stroke-related styles from the full node styles and applies them selectively


## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [ ] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
