### PR TITLE
fix: prevent duplicate ID generation in fast multi-block renders

### DIFF
--- a/docs/config/setup/mermaid/interfaces/DetailedError.md
+++ b/docs/config/setup/mermaid/interfaces/DetailedError.md
@@ -10,7 +10,7 @@
 
 # Interface: DetailedError
 
-Defined in: [packages/mermaid/src/utils.ts:783](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/utils.ts#L783)
+Defined in: [packages/mermaid/src/utils.ts:829](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/utils.ts#L829)
 
 ## Properties
 
@@ -18,7 +18,7 @@ Defined in: [packages/mermaid/src/utils.ts:783](https://github.com/mermaid-js/me
 
 > `optional` **error**: `any`
 
-Defined in: [packages/mermaid/src/utils.ts:788](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/utils.ts#L788)
+Defined in: [packages/mermaid/src/utils.ts:834](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/utils.ts#L834)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [packages/mermaid/src/utils.ts:788](https://github.com/mermaid-js/me
 
 > **hash**: `any`
 
-Defined in: [packages/mermaid/src/utils.ts:786](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/utils.ts#L786)
+Defined in: [packages/mermaid/src/utils.ts:832](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/utils.ts#L832)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [packages/mermaid/src/utils.ts:786](https://github.com/mermaid-js/me
 
 > `optional` **message**: `string`
 
-Defined in: [packages/mermaid/src/utils.ts:789](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/utils.ts#L789)
+Defined in: [packages/mermaid/src/utils.ts:835](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/utils.ts#L835)
 
 ---
 
@@ -42,4 +42,4 @@ Defined in: [packages/mermaid/src/utils.ts:789](https://github.com/mermaid-js/me
 
 > **str**: `string`
 
-Defined in: [packages/mermaid/src/utils.ts:784](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/utils.ts#L784)
+Defined in: [packages/mermaid/src/utils.ts:830](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/utils.ts#L830)

--- a/packages/mermaid/src/utils.ts
+++ b/packages/mermaid/src/utils.ts
@@ -62,6 +62,48 @@ const d3CurveTypes = {
 
 const directiveWithoutOpen =
   /\s*(?:(\w+)(?=:):|(\w+))\s*(?:(\w+)|((?:(?!}%{2}).|\r?\n)*))?\s*(?:}%{2})?/gi;
+const TimeProvider = {
+  _canUsePerformanceNow: false,
+  _lastTimestamp: 0,
+  _initialized: false,
+  _incrementStep: 1,
+
+  _initialize: function() {
+      if (this._initialized) {
+          return;
+      }
+
+      if (window.performance && typeof window.performance.now === 'function' &&
+          window.performance.timing && typeof window.performance.timing.navigationStart === 'number') {
+          this._canUsePerformanceNow = true;
+          this._lastTimestamp = window.performance.timeOrigin * 1e3;
+      } else {
+          this._canUsePerformanceNow = false;
+          this._lastTimestamp = Date.now()  * 1e3;
+      }
+      this._initialized = true;
+  },
+
+  _getRawTimestamp: function() {
+      if (this._canUsePerformanceNow) {
+        return Math.floor((window.performance.timeOrigin + window.performance.now()) * 1e3);
+      } else {
+        return Date.now() * 1e3;
+      }
+  },
+
+  getTimestamp: function() {
+      this._initialize();
+      const rawTimestamp = this._getRawTimestamp();
+
+      if (rawTimestamp <= this._lastTimestamp) {
+          this._lastTimestamp += this._incrementStep;
+      } else {
+          this._lastTimestamp = rawTimestamp;
+      }
+      return this._lastTimestamp;
+  }
+};
 /**
  * Detects the init config object from the text
  *
@@ -759,7 +801,7 @@ export class InitIDGenerator {
     // TODO: Seed is only used for length?
     // v11: Use the actual value of seed string to generate an initial value for count.
     this.count = seed ? seed.length : 0;
-    this.next = deterministic ? () => this.count++ : () => Date.now();
+    this.next = deterministic ? () => this.count++ : () => TimeProvider.getTimestamp();
   }
 }
 

--- a/packages/mermaid/src/utils.ts
+++ b/packages/mermaid/src/utils.ts
@@ -68,41 +68,45 @@ const TimeProvider = {
   _initialized: false,
   _incrementStep: 1,
 
-  _initialize: function() {
-      if (this._initialized) {
-          return;
-      }
+  _initialize: function () {
+    if (this._initialized) {
+      return;
+    }
 
-      if (window.performance && typeof window.performance.now === 'function' &&
-          window.performance.timing && typeof window.performance.timing.navigationStart === 'number') {
-          this._canUsePerformanceNow = true;
-          this._lastTimestamp = window.performance.timeOrigin * 1e3;
-      } else {
-          this._canUsePerformanceNow = false;
-          this._lastTimestamp = Date.now()  * 1e3;
-      }
-      this._initialized = true;
+    if (
+      window.performance &&
+      typeof window.performance.now === 'function' &&
+      window.performance.timing &&
+      typeof window.performance.timing.navigationStart === 'number'
+    ) {
+      this._canUsePerformanceNow = true;
+      this._lastTimestamp = window.performance.timeOrigin * 1e3;
+    } else {
+      this._canUsePerformanceNow = false;
+      this._lastTimestamp = Date.now() * 1e3;
+    }
+    this._initialized = true;
   },
 
-  _getRawTimestamp: function() {
-      if (this._canUsePerformanceNow) {
-        return Math.floor((window.performance.timeOrigin + window.performance.now()) * 1e3);
-      } else {
-        return Date.now() * 1e3;
-      }
+  _getRawTimestamp: function () {
+    if (this._canUsePerformanceNow) {
+      return Math.floor((window.performance.timeOrigin + window.performance.now()) * 1e3);
+    } else {
+      return Date.now() * 1e3;
+    }
   },
 
-  getTimestamp: function() {
-      this._initialize();
-      const rawTimestamp = this._getRawTimestamp();
+  getTimestamp: function () {
+    this._initialize();
+    const rawTimestamp = this._getRawTimestamp();
 
-      if (rawTimestamp <= this._lastTimestamp) {
-          this._lastTimestamp += this._incrementStep;
-      } else {
-          this._lastTimestamp = rawTimestamp;
-      }
-      return this._lastTimestamp;
-  }
+    if (rawTimestamp <= this._lastTimestamp) {
+      this._lastTimestamp += this._incrementStep;
+    } else {
+      this._lastTimestamp = rawTimestamp;
+    }
+    return this._lastTimestamp;
+  },
 };
 /**
  * Detects the init config object from the text

--- a/packages/mermaid/src/utils.ts
+++ b/packages/mermaid/src/utils.ts
@@ -805,7 +805,9 @@ export class InitIDGenerator {
     // TODO: Seed is only used for length?
     // v11: Use the actual value of seed string to generate an initial value for count.
     this.count = seed ? seed.length : 0;
-    this.next = deterministic ? () => this.count++ : () => TimeProvider.getTimestamp();
+    this.next = deterministic
+      ? () => this.count++
+      : () => Number.parseInt(`${Date.now()}${this.count++}`);
   }
 }
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fix duplicate ID generation when rendering multiple Mermaid blocks quickly.

## :straight_ruler: Design Decisions

This fix changes the ID generation to use microsecond-level timestamps instead of milliseconds, greatly reducing the chance of duplicate IDs.  
Additionally, if a duplicate ID is detected, an incremental counter is added to ensure uniqueness.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
