### PR TITLE
Fix sequenceDiagram regex performance

### DIFF
--- a/packages/mermaid/src/diagrams/sequence/parser/sequenceDiagram.jison
+++ b/packages/mermaid/src/diagrams/sequence/parser/sequenceDiagram.jison
@@ -33,7 +33,7 @@
 "actor"                                                   		{ this.begin('ID'); return 'participant_actor'; }
 "create"                                                        return 'create';
 "destroy"                                                       { this.begin('ID'); return 'destroy'; }
-<ID>[^\<->\->:\n,;]+?([\-]*[^\<->\->:\n,;]+?)*?(?=((?!\n)\s)+"as"(?!\n)\s|[#\n;]|$)     { yytext = yytext.trim(); this.begin('ALIAS'); return 'ACTOR'; }
+<ID>[^\-<>:\n,;]+?[^<>:\n,;]*?(?=((?!\n)\s)+"as"(?!\n)\s|[#\n;]|$)     { yytext = yytext.trim(); this.begin('ALIAS'); return 'ACTOR'; }
 <ALIAS>"as"                                                     { this.popState(); this.popState(); this.begin('LINE'); return 'AS'; }
 <ALIAS>(?:)                                                     { this.popState(); this.popState(); return 'NEWLINE'; }
 "loop"                                                          { this.begin('LINE'); return 'loop'; }


### PR DESCRIPTION
## :bookmark_tabs: Summary

I have an interactive Mermaid diagram editor embedded in my app, and one of the users reported that after accidentally copy-pasting an invalidly formatted Mermaid diagram, the page hung and became unresponsive.

After some research, I found that the problem originated from the Jison lexer for sequenceDiagram. The regex used to identify ACTORs was causing catastrophic backtracking, resulting in very poor performance. This PR aims to resolve this specific performance issue by limiting the backtracking.

You can see an example of the problematic behavior in the [mermaid live editor](https://mermaid.live/edit#pako:eNptkM9OhDAQh1-lO1fLhj9bYHtYY_Tg-giGSwMDNCktdtvoSnh3C7gmGnvq_Ob7ZtJOUJsGgcMF3zzqGp-k6KwYyCisk7UchXbkQckafyUvptdbHJ1Od0vFyTMqZdYOJb15J8IiuRp_X2kSzh94w2qhF4T0KCwZ8BtdelFAo9UJg-VmU3JejZUO2u5__ExaREU6i8LtgEJnZQPcWY8UBrSDWEqYFrkC1-OAFfBwbbAVXrkKKj0HLbzz1ZjhZlrjux54K9QlVH5shLv91U9qUTdoH43XDvixWGcAn-ADeMLYPkuPLM3iNM5zVmQUrsDzZB-zPC1DeGDZISlnCp_r1nhfFmz-AqGzgok) – one of the example diagrams, with multiple line breaks removed, that causes the regex to block the main thread.

## :straight_ruler: Design Decisions

Original regex: 
`[^\<->\->:\n,;]+?([\-]*[^\<->\->:\n,;]+?)*?(?=((?!\n)\s)+"as"(?!\n)\s|[#\n;]|$)`

Let's break it in three parts: 
1.  `[^\<->\->:\n,;]+?`
It's doesn't cause any real problems, but `\<->\->` is a redundant definition and `\-<>` does exactly the same job inside the character range (`[]`), so I changed it a bit to `[^\-<>:\n,;]+?`
2. `([\-]*[^\<->\->:\n,;]+?)*?`
That's the main issue, double lazy operators at `+?)*?)` scale exponentially and cause all the aforementioned perfomance issues. 
`[\-]*` – allows zero/many hyphens
`[^\<->\->:\n,;]+?` – allows all characters except prohibited range one or more times (with ? operator trying to take as little as possible)
`(...)*?` – allows to repeat that block zero/many times

This code block was added in PR #3524 to support hyphens in participant names (e.g. `my-name-here`), and it can be rewritten much more simply as `[^<>:\n,;]*?` – same as the first part, while additionally allowing hyphens `-`.

3. `(?=((?!\n)\s)+"as"(?!\n)\s|[#\n;]|$)` – I didnt' touch this part at all

Final regex: 
`[^\-<>:\n,;]+?[^<>:\n,;]*?(?=((?!\n)\s)+"as"(?!\n)\s|[#\n;]|$)`

P.S. I’d be happy to add any tests, but I couldn’t figure out what could be done except for time limits on parsing certain valid/invalid diagram definitions. However, I consider these generally unstable, as they depend on the machine running the tests. I've checked that all of the current examples from the docs are being parsed correctly and none of the e2e/unit tests was affected by this change

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
