### PR TITLE
Fix tooltip br tags

### DIFF
--- a/packages/mermaid/src/diagrams/class/classDb.ts
+++ b/packages/mermaid/src/diagrams/class/classDb.ts
@@ -503,7 +503,7 @@ export class ClassDB implements DiagramDB {
           .text(el.attr('title'))
           .style('left', window.scrollX + rect.left + (rect.right - rect.left) / 2 + 'px')
           .style('top', window.scrollY + rect.top - 14 + document.body.scrollTop + 'px');
-        tooltipElem.html(tooltipElem.html().replace(/&lt;br\/&gt;/g, '<br/>'));
+        tooltipElem.html(tooltipElem.html().replace(/&lt;br\s*\/?&gt;/gi, '<br/>'));
         el.classed('hover', true);
       })
       .on('mouseout', (event: MouseEvent) => {

--- a/packages/mermaid/src/diagrams/flowchart/flowDb.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.ts
@@ -599,7 +599,7 @@ You have to call mermaid.initialize.`
           .text(el.attr('title'))
           .style('left', window.scrollX + rect.left + (rect.right - rect.left) / 2 + 'px')
           .style('top', window.scrollY + rect.bottom + 'px');
-        tooltipElem.html(tooltipElem.html().replace(/&lt;br\/&gt;/g, '<br/>'));
+        tooltipElem.html(tooltipElem.html().replace(/&lt;br\s*\/?&gt;/gi, '<br/>'));
         el.classed('hover', true);
       })
       .on('mouseout', (e: MouseEvent) => {


### PR DESCRIPTION
## Summary
- allow both `<br>` and `<br/>` in flowchart and class diagram tooltips

## Testing
- `pnpm lint:fix`
- `NODE_OPTIONS=--max_old_space_size=4096 pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68574761da088332bb5a49c72e55501f