### PR TITLE
Fix: Remove unexpected spaces in Block Diagram

### DIFF
--- a/.changeset/lovely-queens-own.md
+++ b/.changeset/lovely-queens-own.md
@@ -1,0 +1,8 @@
+---
+'mermaid': patch
+---
+
+fix(block): overflowing blocks no longer affect later lines
+
+This may change the layout of block diagrams that have overflowing lines
+(i.e. block diagrams that use up more columns that the `columns` specifier).

--- a/cypress/integration/rendering/block.spec.js
+++ b/cypress/integration/rendering/block.spec.js
@@ -384,4 +384,17 @@ describe('Block diagram', () => {
       {}
     );
   });
+
+  it('BL30: block should overflow if too wide for columns', () => {
+    imgSnapshotTest(
+      `block-beta
+  columns 2
+  fit:2
+  overflow:3
+  short:1
+  also_overflow:2
+`,
+      {}
+    );
+  });
 });

--- a/packages/mermaid/src/diagrams/block/layout.ts
+++ b/packages/mermaid/src/diagrams/block/layout.ts
@@ -270,7 +270,11 @@ function layoutBlocks(block: Block, db: BlockDB) {
       if (child.children) {
         layoutBlocks(child, db);
       }
-      columnPos += child?.widthInColumns ?? 1;
+      let columnsFilled = child?.widthInColumns ?? 1;
+      if (columns > 0) {
+        columnsFilled = Math.min(columnsFilled, columns - (columnPos % columns));
+      }
+      columnPos += columnsFilled;
       log.debug('abc88 columnsPos', child, columnPos);
     }
   }

--- a/packages/mermaid/src/diagrams/block/layout.ts
+++ b/packages/mermaid/src/diagrams/block/layout.ts
@@ -272,6 +272,7 @@ function layoutBlocks(block: Block, db: BlockDB) {
       }
       let columnsFilled = child?.widthInColumns ?? 1;
       if (columns > 0) {
+        // Make sure overflowing lines do not affect later lines
         columnsFilled = Math.min(columnsFilled, columns - (columnPos % columns));
       }
       columnPos += columnsFilled;


### PR DESCRIPTION
## :bookmark_tabs: Summary

Remove unexpected spaces in Block Diagram.

Resolves #6633

e.g.
- columns 1
https://www.mermaidchart.com/play#pako:eNqrVkrOT0lVslJKyslPztZNSi1JjMlTAILk_JzS3LxiBUMI19EKynCyMoIwnK2MIQwXKxMIwxUm4gZT425lqFQLAHetGZ4
![column1](https://github.com/user-attachments/assets/9585fd30-af14-4c3e-8b92-14496ea4e8b3)

- columns 2
https://www.mermaidchart.com/play#pako:eNqrVkrOT0lVslJKyslPztZNSi1JjMlTAILk_JzS3LxiBSMI19HKEMJwsoKKOFsZQxguViYQhitMxA2mxt3KUKkWAHfvGZ8
![column2](https://github.com/user-attachments/assets/49f3e0eb-cca8-4015-9347-6f18253a98a9)

## :straight_ruler: Design Decisions

- The width of the block that extends beyond the column is no longer included in the position calculation.
- If necessary, add an error message stating that the columns and block widths do not match.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
