### PR TITLE
4838: Log warning for duplicate commit IDs in gitGraph

### DIFF
--- a/.changeset/full-donuts-give.md
+++ b/.changeset/full-donuts-give.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: Log a warning when duplicate commit IDs are encountered in gitGraph to help identify and debug rendering issues caused by non-unique IDs.

--- a/cypress/integration/rendering/gitGraph.spec.js
+++ b/cypress/integration/rendering/gitGraph.spec.js
@@ -1569,37 +1569,4 @@ gitGraph TB:
       {}
     );
   });
-  it('77:should render gitGraph with duplicate commit IDs and log warnings', () => {
-    imgSnapshotTest(
-      `gitGraph
-     commit id:"initial commit"
-     commit id:"work on first release"
-     commit id:"design freeze from here"
-     branch v1-rc
-     checkout v1-rc
-     commit id:"bugfix 1"
-     commit id:"bigfix 2" tag:"v1.0.1"
-     branch FORK-v1.0-MDR
-     checkout FORK-v1.0-MDR
-     commit id:"working on MDR"
-     checkout v1-rc
-     commit id:"minor design changes for MDR" tag:"v1.0.2"
-     checkout FORK-v1.0-MDR
-     merge v1-rc
-     checkout main
-     commit id:"new feature for v1.1…"
-     checkout FORK-v1.0-MDR
-     commit id:"working on MDR"
-     commit id:"finishing MDR"
-     branch v1.0-MDR
-     checkout v1.0-MDR
-     commit id:"brush up release" tag:"v1.0.2-MDR"
-     checkout v1-rc
-     commit id:"bugfix without MDR"
-     checkout main
-     commit id:"work on v1.1"`,
-      {}
-    );
-    cy.log('Warning: Commit ID "working on MDR" already exists');
-  });
 });

--- a/cypress/integration/rendering/gitGraph.spec.js
+++ b/cypress/integration/rendering/gitGraph.spec.js
@@ -1569,4 +1569,37 @@ gitGraph TB:
       {}
     );
   });
+  it('77:should render gitGraph with duplicate commit IDs and log warnings', () => {
+    imgSnapshotTest(
+      `gitGraph
+     commit id:"initial commit"
+     commit id:"work on first release"
+     commit id:"design freeze from here"
+     branch v1-rc
+     checkout v1-rc
+     commit id:"bugfix 1"
+     commit id:"bigfix 2" tag:"v1.0.1"
+     branch FORK-v1.0-MDR
+     checkout FORK-v1.0-MDR
+     commit id:"working on MDR"
+     checkout v1-rc
+     commit id:"minor design changes for MDR" tag:"v1.0.2"
+     checkout FORK-v1.0-MDR
+     merge v1-rc
+     checkout main
+     commit id:"new feature for v1.1…"
+     checkout FORK-v1.0-MDR
+     commit id:"working on MDR"
+     commit id:"finishing MDR"
+     branch v1.0-MDR
+     checkout v1.0-MDR
+     commit id:"brush up release" tag:"v1.0.2-MDR"
+     checkout v1-rc
+     commit id:"bugfix without MDR"
+     checkout main
+     commit id:"work on v1.1"`,
+      {}
+    );
+    cy.log('Warning: Commit ID "working on MDR" already exists');
+  });
 });

--- a/packages/mermaid/src/diagrams/git/gitGraph.spec.ts
+++ b/packages/mermaid/src/diagrams/git/gitGraph.spec.ts
@@ -1349,12 +1349,12 @@ describe('when parsing a gitGraph', function () {
      commit id:"work on v1.1"
   `;
 
-    const spyOn = vi.spyOn(log, 'warn').mockImplementation(() => undefined);
+    const logWarnSpy = vi.spyOn(log, 'warn').mockImplementation(() => undefined);
 
     await parser.parse(str);
 
-    expect(spyOn).toHaveBeenCalledWith('Commit ID working on MDR already exists');
+    expect(logWarnSpy).toHaveBeenCalledWith('Commit ID working on MDR already exists');
 
-    spyOn.mockRestore();
+    logWarnSpy.mockRestore();
   });
 });

--- a/packages/mermaid/src/diagrams/git/gitGraphAst.ts
+++ b/packages/mermaid/src/diagrams/git/gitGraphAst.ts
@@ -125,6 +125,9 @@ export const commit = function (commitDB: CommitDB) {
   };
   state.records.head = newCommit;
   log.info('main branch', config.mainBranchName);
+  if (state.records.commits.has(newCommit.id)) {
+    log.warn(`Commit ID ${newCommit.id} already exists`);
+  }
   state.records.commits.set(newCommit.id, newCommit);
   state.records.branches.set(state.records.currBranch, newCommit.id);
   log.debug('in pushCommit ' + newCommit.id);


### PR DESCRIPTION
## :bookmark_tabs: Summary

This PR adds a warning log when duplicate commit IDs are encountered in gitGraph. Duplicate commit IDs can lead to incorrect or broken rendering, particularly affecting the chronological layout of commits
Resolves #4838

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [ ] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
