### PR TITLE
Fix <br> not working in tooltips anymore

### DIFF
--- a/.changeset/chatty-hands-bake.md
+++ b/.changeset/chatty-hands-bake.md
@@ -1,0 +1,11 @@
+---
+'mermaid': patch
+---
+
+fix(flowchart,class): fix newline handling in tooltips
+
+`<br>`, `<br/>`, and newlines in tooltips for flowchart and class diagrams now
+all work as newlines, even after changes in Firefox 140 and Chrome 136.
+
+author: @jrobichaud
+author: @aloisklink

--- a/packages/mermaid/src/diagrams/class/classDb.ts
+++ b/packages/mermaid/src/diagrams/class/classDb.ts
@@ -349,7 +349,11 @@ export class ClassDB implements DiagramDB {
   public setTooltip(ids: string, tooltip?: string) {
     ids.split(',').forEach((id) => {
       if (tooltip !== undefined) {
-        this.classes.get(id)!.tooltip = sanitizeText(tooltip);
+        tooltip = sanitizeText(tooltip);
+        // Backwards compatibility. No need to support variations with spaces in them,
+        // since older versions only supported exactly `<br>` and `<br/>`.
+        tooltip = tooltip.replaceAll('<br>', '\n').replaceAll('<br/>', '\n');
+        this.classes.get(id)!.tooltip = tooltip;
       }
     });
   }
@@ -499,11 +503,11 @@ export class ClassDB implements DiagramDB {
         const rect = this.getBoundingClientRect();
 
         tooltipElem.transition().duration(200).style('opacity', '.9');
+        // use `.innerText` instead of `.text()` to convert \n to line breaks
+        tooltipElem.node()!.innerText = el.attr('title');
         tooltipElem
-          .text(el.attr('title'))
           .style('left', window.scrollX + rect.left + (rect.right - rect.left) / 2 + 'px')
           .style('top', window.scrollY + rect.top - 14 + document.body.scrollTop + 'px');
-        tooltipElem.html(tooltipElem.html().replace(/&lt;br\/&gt;/g, '<br/>'));
         el.classed('hover', true);
       })
       .on('mouseout', (event: MouseEvent) => {

--- a/packages/mermaid/src/diagrams/class/classDb.ts
+++ b/packages/mermaid/src/diagrams/class/classDb.ts
@@ -350,6 +350,9 @@ export class ClassDB implements DiagramDB {
     ids.split(',').forEach((id) => {
       if (tooltip !== undefined) {
         tooltip = sanitizeText(tooltip);
+        // Backwards compatibility. Now that we're using `.innerText` instead of `.textContents`,
+        // we need to scrub out any raw LF or CRs in the contents.
+        tooltip = tooltip.replaceAll('\n', ' ').replaceAll('\r', ' ');
         // Backwards compatibility. No need to support variations with spaces in them,
         // since older versions only supported exactly `<br>` and `<br/>`.
         tooltip = tooltip.replaceAll('<br>', '\n').replaceAll('<br/>', '\n');

--- a/packages/mermaid/src/diagrams/flowchart/flowDb.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.ts
@@ -453,6 +453,10 @@ You have to call mermaid.initialize.`
       return;
     }
     tooltip = this.sanitizeText(tooltip);
+
+    // Backwards compatibility. No need to support variations with spaces in them,
+    // since older versions only supported exactly `<br>` and `<br/>`.
+    tooltip = tooltip.replaceAll('<br>', '\n').replaceAll('<br/>', '\n');
     for (const id of ids.split(',')) {
       this.tooltips.set(this.version === 'gen-1' ? this.lookUpDomId(id) : id, tooltip);
     }
@@ -574,7 +578,7 @@ You have to call mermaid.initialize.`
   }
 
   private setupToolTips(element: Element) {
-    let tooltipElem = select('.mermaidTooltip');
+    let tooltipElem = select<HTMLDivElement, unknown>('.mermaidTooltip');
     // @ts-ignore TODO: fix this
     if ((tooltipElem._groups || tooltipElem)[0][0] === null) {
       // @ts-ignore TODO: fix this
@@ -599,11 +603,11 @@ You have to call mermaid.initialize.`
         const rect = (e.currentTarget as Element)?.getBoundingClientRect();
 
         tooltipElem.transition().duration(200).style('opacity', '.9');
+        // use `.innerText` instead of `.text()` to convert \n to line breaks
+        tooltipElem.node()!.innerText = el.attr('title');
         tooltipElem
-          .text(el.attr('title'))
           .style('left', window.scrollX + rect.left + (rect.right - rect.left) / 2 + 'px')
           .style('top', window.scrollY + rect.bottom + 'px');
-        tooltipElem.html(tooltipElem.html().replace(/&lt;br\/&gt;/g, '<br/>'));
         el.classed('hover', true);
       })
       .on('mouseout', (e: MouseEvent) => {

--- a/packages/mermaid/src/diagrams/flowchart/flowDb.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.ts
@@ -453,7 +453,9 @@ You have to call mermaid.initialize.`
       return;
     }
     tooltip = this.sanitizeText(tooltip);
-
+    // Backwards compatibility. Now that we're using `.innerText` instead of `.textContents`,
+    // we need to scrub out any raw LF or CRs in the contents.
+    tooltip = tooltip.replaceAll('\n', ' ').replaceAll('\r', ' ');
     // Backwards compatibility. No need to support variations with spaces in them,
     // since older versions only supported exactly `<br>` and `<br/>`.
     tooltip = tooltip.replaceAll('<br>', '\n').replaceAll('<br/>', '\n');


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fix `<br>` in tooltips not working anymore. `<br>` evaluated as text are not working anymore since Chrome 136 and Firefox 140.

Resolves #6631

## :straight_ruler: Design Decisions

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
