### PR TITLE
fix: trim the direction string in flowchart

### DIFF
--- a/.changeset/smart-humans-cover.md
+++ b/.changeset/smart-humans-cover.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: Update flowchart direction TD's behavior to be the same as TB

--- a/packages/mermaid/src/diagrams/flowchart/flowDb.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.ts
@@ -403,7 +403,8 @@ You have to call mermaid.initialize.`
    *
    */
   public setDirection(dir: string) {
-    this.direction = dir;
+    this.direction = dir.trim();
+
     if (/.*</.exec(this.direction)) {
       this.direction = 'RL';
     }


### PR DESCRIPTION
## :bookmark_tabs: Summary

This PR fixes the wrong behavior of direction `TD` which should've behaved like `TB`.

In `flowDb.ts`, the method `setDirection` takes `dir` string argument representing the direction. The data received had an extra space `' '` before the direction identifier, e.g. `" TD"`. There is a check if the direction is `TD`, convert it to `TB` with strict equality check. 

Resolves #6681 

## :straight_ruler: Design Decisions

In `flowDb.ts`, the method `setDirection` takes `dir` string argument representing the direction. The data received had an extra space `' '` before the direction identifier, e.g. `" TD"`. There is a check if the direction is `TD`, convert it to `TB` with strict equality check. Thus, `" TD" === "TD"` is always false, hence not converted to "TB" as shown below.

```typescript
if (this.direction === 'TD') {
      this.direction = 'TB';
    }
```

To fix this, trimming the string is the best way instead of changing the right hand side of the equality check or using another condition.

```diff
-    this.direction = dir;
+    this.direction = dir.trim();
```


### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
