### PR TITLE
6617: Support Per-Link Curve Styling in Flowcharts

### DIFF
--- a/.changeset/lemon-masks-unite.md
+++ b/.changeset/lemon-masks-unite.md
@@ -1,0 +1,5 @@
+---
+'mermaid': minor
+---
+
+feat: Added support for per link curve styling in flowchart diagram using edge ids

--- a/packages/mermaid/src/diagrams/flowchart/flowDb.spec.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.spec.ts
@@ -125,4 +125,43 @@ describe('flow db getData', () => {
     const { edges } = flowDb.getData();
     expect(edges[0].curve).toBe('basis');
   });
+
+  it('should support modifying interpolate using edge id syntax', () => {
+    flowDb.addVertex('A', { text: 'A', type: 'text' }, undefined, [], [], '', {}, undefined);
+    flowDb.addVertex('B', { text: 'B', type: 'text' }, undefined, [], [], '', {}, undefined);
+    flowDb.addVertex('C', { text: 'C', type: 'text' }, undefined, [], [], '', {}, undefined);
+    flowDb.addVertex('D', { text: 'D', type: 'text' }, undefined, [], [], '', {}, undefined);
+    flowDb.addLink(['A'], ['B'], {});
+    flowDb.addLink(['A'], ['C'], { id: 'e2' });
+    flowDb.addLink(['B'], ['D'], { id: 'e3' });
+    flowDb.addLink(['C'], ['D'], {});
+    flowDb.updateLinkInterpolate(['default'], 'stepBefore');
+    flowDb.updateLinkInterpolate([0], 'basis');
+    flowDb.addVertex(
+      'e2',
+      { text: 'Shouldnt be used', type: 'text' },
+      undefined,
+      [],
+      [],
+      '',
+      {},
+      ' curve: monotoneX '
+    );
+    flowDb.addVertex(
+      'e3',
+      { text: 'Shouldnt be used', type: 'text' },
+      undefined,
+      [],
+      [],
+      '',
+      {},
+      ' curve: catmullRom '
+    );
+
+    const { edges } = flowDb.getData();
+    expect(edges[0].curve).toBe('basis');
+    expect(edges[1].curve).toBe('monotoneX');
+    expect(edges[2].curve).toBe('catmullRom');
+    expect(edges[3].curve).toBe('stepBefore');
+  });
 });

--- a/packages/mermaid/src/diagrams/flowchart/flowDb.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.ts
@@ -139,6 +139,9 @@ export class FlowDB implements DiagramDB {
       if (edgeDoc?.animation !== undefined) {
         edge.animation = edgeDoc.animation;
       }
+      if (edgeDoc?.curve !== undefined) {
+        edge.interpolate = edgeDoc.curve;
+      }
       return;
     }
 

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow-lines.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow-lines.spec.js
@@ -37,6 +37,59 @@ describe('[Lines] when parsing', () => {
     expect(edges[1].interpolate).toBe('cardinal');
   });
 
+  it('should handle edge curve properties using edge ID', function () {
+    const res = flow.parser.parse(
+      'graph TD\n' +
+        'A e1@-->B\n' +
+        'A uniqueName@-->C\n' +
+        'e1@{curve: basis}\n' +
+        'uniqueName@{curve: cardinal}'
+    );
+
+    const vert = flow.parser.yy.getVertices();
+    const edges = flow.parser.yy.getEdges();
+
+    expect(edges[0].interpolate).toBe('basis');
+    expect(edges[1].interpolate).toBe('cardinal');
+  });
+
+  it('should handle edge curve properties using edge ID but without overriding default', function () {
+    const res = flow.parser.parse(
+      'graph TD\n' +
+        'A e1@-->B\n' +
+        'A-->C\n' +
+        'linkStyle default interpolate linear\n' +
+        'e1@{curve: stepAfter}'
+    );
+
+    const vert = flow.parser.yy.getVertices();
+    const edges = flow.parser.yy.getEdges();
+
+    expect(edges[0].interpolate).toBe('stepAfter');
+    expect(edges.defaultInterpolate).toBe('linear');
+  });
+
+  it('should handle edge curve properties using edge ID mixed with line interpolation', function () {
+    const res = flow.parser.parse(
+      'graph TD\n' +
+        'A e1@-->B-->D\n' +
+        'A-->C e4@-->D-->E\n' +
+        'linkStyle default interpolate linear\n' +
+        'linkStyle 1 interpolate basis\n' +
+        'e1@{curve: monotoneX}\n' +
+        'e4@{curve: stepBefore}'
+    );
+
+    const vert = flow.parser.yy.getVertices();
+    const edges = flow.parser.yy.getEdges();
+
+    expect(edges[0].interpolate).toBe('monotoneX');
+    expect(edges[1].interpolate).toBe('basis');
+    expect(edges.defaultInterpolate).toBe('linear');
+    expect(edges[3].interpolate).toBe('stepBefore');
+    expect(edges.defaultInterpolate).toBe('linear');
+  });
+
   it('should handle line interpolation multi-numbered definitions', function () {
     const res = flow.parser.parse(
       'graph TD\n' + 'A-->B\n' + 'A-->C\n' + 'linkStyle 0,1 interpolate basis'

--- a/packages/mermaid/src/types.ts
+++ b/packages/mermaid/src/types.ts
@@ -16,6 +16,19 @@ export interface NodeMetaData {
 export interface EdgeMetaData {
   animation?: 'fast' | 'slow';
   animate?: boolean;
+  curve?:
+    | 'basis'
+    | 'bumpX'
+    | 'bumpY'
+    | 'cardinal'
+    | 'catmullRom'
+    | 'linear'
+    | 'monotoneX'
+    | 'monotoneY'
+    | 'natural'
+    | 'step'
+    | 'stepAfter'
+    | 'stepBefore';
 }
 import type { MermaidConfig } from './config.type.js';
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

This PR introduces support for per link curve styling in flowcharts by making use of edge id as explained in this [comment](https://github.com/mermaid-js/mermaid/issues/6617#issuecomment-2955468195)
> ```
> flowchart LR
>   A e1@--> B
> ```
> 
> This could then easily be combined with attributes for the edge:
> `e1@{ curve: linear }`

Resolves #6617 

## :straight_ruler: Design Decisions

The ability to add per link curve styles is added in the same way animate works for flowcharts

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Examples:
```
graph TD
A e1@-->B e2@-->C
A e3@-->D e4@-->C
e1@{ curve: linear }
e2@{ curve: catmullRom }
e3@{ curve: stepBefore }
e4@{ curve: stepAfter }
```

<img width="254" height="305" alt="image" src="https://github.com/user-attachments/assets/0edbe8f4-9921-4603-b7c2-cfcf23a51f66" />
