### PR TITLE
6619: Prevent title from overlapping with box top border in Safari

### DIFF
--- a/.changeset/tangy-ghosts-watch.md
+++ b/.changeset/tangy-ghosts-watch.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: adjust sequence diagram title positioning to prevent overlap with top border in Safari

--- a/packages/mermaid/src/diagrams/sequence/svgDraw.js
+++ b/packages/mermaid/src/diagrams/sequence/svgDraw.js
@@ -524,7 +524,7 @@ export const drawBox = function (elem, box, conf) {
       box.name,
       g,
       box.x,
-      box.y + (box.textMaxHeight || 0) / 2,
+      box.y + conf.boxTextMargin + (box.textMaxHeight || 0) / 2,
       box.width,
       0,
       { class: 'text' },


### PR DESCRIPTION
## :bookmark_tabs: Summary

This PR fixes a Safari-specific rendering issue in sequence diagrams where the diagram title overlaps or collides with the top border of the box.

Resolves #6619

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
