### PR TITLE
add noteshub.app to exclusions for certificate errors

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -52,6 +52,9 @@ exclude = [
 # Swimm returns 404, even though the link is valid
 "https://docs.swimm.io",
 
+# Certificate Error
+"https://noteshub.app",
+
 # Timeout
 "https://huehive.co",
 "https://foswiki.org",


### PR DESCRIPTION
## :bookmark_tabs: Summary
This pull request updates the `.github/lychee.toml` file to exclude additional URLs from link checking due to certificate errors.

Changes to exclusions:

* [`.github/lychee.toml`](diffhunk://#diff-1ee4bb8ae9dc685b5e17713ba7c4ed2c29a7a4ab8a3b5d480434970c2529efefR55-R57): Added `"https://noteshub.app"` to the `exclude` list to prevent link checking due to a certificate error.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
