### PR TITLE
6691: update packet diagram to use new class-based DB approach

### DIFF
--- a/.changeset/vast-buses-see.md
+++ b/.changeset/vast-buses-see.md
@@ -1,5 +1,5 @@
 ---
-'mermaid': minor
+'mermaid': patch
 ---
 
 chore: Update packet diagram to use new class-based database structure

--- a/.changeset/vast-buses-see.md
+++ b/.changeset/vast-buses-see.md
@@ -1,0 +1,5 @@
+---
+'mermaid': minor
+---
+
+chore: Update packet diagram to use new class-based database structure

--- a/packages/mermaid/src/diagrams/packet/db.ts
+++ b/packages/mermaid/src/diagrams/packet/db.ts
@@ -1,6 +1,7 @@
 import { getConfig as commonGetConfig } from '../../config.js';
 import type { PacketDiagramConfig } from '../../config.type.js';
 import DEFAULT_CONFIG from '../../defaultConfig.js';
+import type { DiagramDB } from '../../diagram-api/types.js';
 import { cleanAndMerge } from '../../utils.js';
 import {
   clear as commonClear,
@@ -11,49 +12,42 @@ import {
   setAccTitle,
   setDiagramTitle,
 } from '../common/commonDb.js';
-import type { PacketDB, PacketData, PacketWord } from './types.js';
-
-const defaultPacketData: PacketData = {
-  packet: [],
-};
-
-let data: PacketData = structuredClone(defaultPacketData);
-
+import type { PacketWord } from './types.js';
 const DEFAULT_PACKET_CONFIG: Required<PacketDiagramConfig> = DEFAULT_CONFIG.packet;
 
-const getConfig = (): Required<PacketDiagramConfig> => {
-  const config = cleanAndMerge({
-    ...DEFAULT_PACKET_CONFIG,
-    ...commonGetConfig().packet,
-  });
-  if (config.showBits) {
-    config.paddingY += 10;
+export class PacketDB implements DiagramDB {
+  private packet: PacketWord[] = [];
+
+  public getConfig() {
+    const config = cleanAndMerge({
+      ...DEFAULT_PACKET_CONFIG,
+      ...commonGetConfig().packet,
+    });
+    if (config.showBits) {
+      config.paddingY += 10;
+    }
+    return config;
   }
-  return config;
-};
 
-const getPacket = (): PacketWord[] => data.packet;
-
-const pushWord = (word: PacketWord) => {
-  if (word.length > 0) {
-    data.packet.push(word);
+  public getPacket() {
+    return this.packet;
   }
-};
 
-const clear = () => {
-  commonClear();
-  data = structuredClone(defaultPacketData);
-};
+  public pushWord(word: PacketWord) {
+    if (word.length > 0) {
+      this.packet.push(word);
+    }
+  }
 
-export const db: PacketDB = {
-  pushWord,
-  getPacket,
-  getConfig,
-  clear,
-  setAccTitle,
-  getAccTitle,
-  setDiagramTitle,
-  getDiagramTitle,
-  getAccDescription,
-  setAccDescription,
-};
+  public clear() {
+    commonClear();
+    this.packet = [];
+  }
+
+  public setAccTitle = setAccTitle;
+  public getAccTitle = getAccTitle;
+  public setDiagramTitle = setDiagramTitle;
+  public getDiagramTitle = getDiagramTitle;
+  public getAccDescription = getAccDescription;
+  public setAccDescription = setAccDescription;
+}

--- a/packages/mermaid/src/diagrams/packet/diagram.ts
+++ b/packages/mermaid/src/diagrams/packet/diagram.ts
@@ -1,12 +1,14 @@
 import type { DiagramDefinition } from '../../diagram-api/types.js';
-import { db } from './db.js';
+import { PacketDB } from './db.js';
 import { parser } from './parser.js';
 import { renderer } from './renderer.js';
 import { styles } from './styles.js';
 
 export const diagram: DiagramDefinition = {
   parser,
-  db,
+  get db() {
+    return new PacketDB();
+  },
   renderer,
   styles,
 };

--- a/packages/mermaid/src/diagrams/packet/packet.spec.ts
+++ b/packages/mermaid/src/diagrams/packet/packet.spec.ts
@@ -1,24 +1,26 @@
 import { it, describe, expect } from 'vitest';
-import { db } from './db.js';
+import { PacketDB } from './db.js';
 import { parser } from './parser.js';
 
-const { clear, getPacket, getDiagramTitle, getAccTitle, getAccDescription } = db;
-
 describe('packet diagrams', () => {
+  let db: PacketDB;
   beforeEach(() => {
-    clear();
+    db = new PacketDB();
+    if (parser.parser) {
+      parser.parser.yy = db;
+    }
   });
 
   it('should handle a packet-beta definition', async () => {
     const str = `packet-beta`;
     await expect(parser.parse(str)).resolves.not.toThrow();
-    expect(getPacket()).toMatchInlineSnapshot('[]');
+    expect(db.getPacket()).toMatchInlineSnapshot('[]');
   });
 
   it('should handle a packet definition', async () => {
     const str = `packet`;
     await expect(parser.parse(str)).resolves.not.toThrow();
-    expect(getPacket()).toMatchInlineSnapshot('[]');
+    expect(db.getPacket()).toMatchInlineSnapshot('[]');
   });
 
   it('should handle diagram with data and title', async () => {
@@ -29,10 +31,10 @@ describe('packet diagrams', () => {
     0-10: "test"
     `;
     await expect(parser.parse(str)).resolves.not.toThrow();
-    expect(getDiagramTitle()).toMatchInlineSnapshot('"Packet diagram"');
-    expect(getAccTitle()).toMatchInlineSnapshot('"Packet accTitle"');
-    expect(getAccDescription()).toMatchInlineSnapshot('"Packet accDescription"');
-    expect(getPacket()).toMatchInlineSnapshot(`
+    expect(db.getDiagramTitle()).toMatchInlineSnapshot('"Packet diagram"');
+    expect(db.getAccTitle()).toMatchInlineSnapshot('"Packet accTitle"');
+    expect(db.getAccDescription()).toMatchInlineSnapshot('"Packet accDescription"');
+    expect(db.getPacket()).toMatchInlineSnapshot(`
       [
         [
           {
@@ -52,7 +54,7 @@ describe('packet diagrams', () => {
     11: "single"
     `;
     await expect(parser.parse(str)).resolves.not.toThrow();
-    expect(getPacket()).toMatchInlineSnapshot(`
+    expect(db.getPacket()).toMatchInlineSnapshot(`
       [
         [
           {
@@ -78,7 +80,7 @@ describe('packet diagrams', () => {
     +16: "word"
     `;
     await expect(parser.parse(str)).resolves.not.toThrow();
-    expect(getPacket()).toMatchInlineSnapshot(`
+    expect(db.getPacket()).toMatchInlineSnapshot(`
       [
         [
           {
@@ -104,7 +106,7 @@ describe('packet diagrams', () => {
     +16: "word"
     `;
     await expect(parser.parse(str)).resolves.not.toThrow();
-    expect(getPacket()).toMatchInlineSnapshot(`
+    expect(db.getPacket()).toMatchInlineSnapshot(`
       [
         [
           {
@@ -130,7 +132,7 @@ describe('packet diagrams', () => {
     11-90: "multiple"
     `;
     await expect(parser.parse(str)).resolves.not.toThrow();
-    expect(getPacket()).toMatchInlineSnapshot(`
+    expect(db.getPacket()).toMatchInlineSnapshot(`
       [
         [
           {
@@ -172,7 +174,7 @@ describe('packet diagrams', () => {
     17-63: "multiple"
     `;
     await expect(parser.parse(str)).resolves.not.toThrow();
-    expect(getPacket()).toMatchInlineSnapshot(`
+    expect(db.getPacket()).toMatchInlineSnapshot(`
       [
         [
           {


### PR DESCRIPTION
## :bookmark_tabs: Summary

1. Migrated the `db` implementation for Packet diagrams from a plain object to a `PacketDB` class.
      - `PacketDB` now implements the `DiagramDB` interface for consistency and type safety.
      - Moved diagram DB instantiation inside a `get db()` accessor to allow fresh instance creation per parse.
      - Updated parser logic to:
        - Accept an instance of `PacketDB`.
        - Perform runtime checks to validate the instance.
      - Improved import grouping and readability across files.
2. Cleanups & Minor Improvements
    - Centralized all `commonDb` exports into grouped imports.
    - Removed unnecessary shared state by encapsulating state inside the `PacketDB` class.
    - Enhanced maintainability and future extensibility.

Resolves #6691

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
