### PR TITLE
fix: add classLiteral to the language for class diagram namespace

### DIFF
--- a/.changeset/rare-women-fly.md
+++ b/.changeset/rare-women-fly.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: Add escaped class literal name on namespace

--- a/cypress/integration/rendering/classDiagram.spec.js
+++ b/cypress/integration/rendering/classDiagram.spec.js
@@ -512,4 +512,17 @@ describe('Class diagram', () => {
       );
     });
   });
+
+  it('should handle backticks for namespace and class names', () => {
+    imgSnapshotTest(
+      `
+      classDiagram
+          namespace \`A::B\` {
+              class \`IPC::Sender\`
+          }
+          RenderProcessHost --|> \`IPC::Sender\`
+      `,
+      {}
+    );
+  });
 });

--- a/packages/mermaid/src/diagrams/class/parser/class.spec.js
+++ b/packages/mermaid/src/diagrams/class/parser/class.spec.js
@@ -15,4 +15,12 @@ describe('class diagram', function () {
       expect(() => parser.parse(`classDiagram\nnamespace ${prop} {\n\tclass A\n}`)).not.toThrow();
     });
   });
+
+  describe('backtick escaping', function () {
+    it('should handle backtick-quoted namespace names', function () {
+      expect(() =>
+        parser.parse(`classDiagram\nnamespace \`A::B\` {\n\tclass \`IPC::Sender\`\n}`)
+      ).not.toThrow();
+    });
+  });
 });

--- a/packages/mermaid/src/diagrams/class/parser/classDiagram.jison
+++ b/packages/mermaid/src/diagrams/class/parser/classDiagram.jison
@@ -242,6 +242,7 @@ classLabel
 
 namespaceName
     : alphaNumToken { $$=$1; }
+    | classLiteralName { $$=$1; }
     | alphaNumToken DOT namespaceName { $$=$1+'.'+$3; }
     | alphaNumToken namespaceName { $$=$1+$2; }
     ;


### PR DESCRIPTION
## :bookmark_tabs: Summary

This PR adds `classLiteralName` on the class diagram's language. This allows backticks on namespace label which seems reasonable to do.

I have also added a test case to not throw if backticks used on the namespace for class diagrams.

Now, this is valid syntax.

```
classDiagram
    namespace `A::B` {
        class `IPC::Sender`
    }
    RenderProcessHost --|> `IPC::Sender`
```

Outputs to:

<img width="209" height="294" alt="image" src="https://github.com/user-attachments/assets/6f61ad82-8c0d-4010-80f3-9a925f571c9f" />


Resolves #6815  

## :straight_ruler: Design Decisions

This is a straightforward change to add `classLiteralName` in the language definition of namespace.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
