### PR TITLE
chore: run cspell on lint staged for markdown files

### DIFF
--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -7,5 +7,6 @@ export default {
     'prettier --write',
   ],
   '.cspell/*.txt': ['tsx scripts/fixCSpell.ts'],
+  '**/*.md': ['pnpm dlx cspell'],
   '**/*.jison': ['pnpm -w run lint:jison'],
 };

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -7,6 +7,6 @@ export default {
     'prettier --write',
   ],
   '.cspell/*.txt': ['tsx scripts/fixCSpell.ts'],
-  '**/*.md': ['pnpm dlx cspell'],
+  '**/*.md': ['pnpm cspell'],
   '**/*.jison': ['pnpm -w run lint:jison'],
 };


### PR DESCRIPTION
## :bookmark_tabs: Summary

Run cspell on markdown files on lint staged.

Resolves #4119 

## :straight_ruler: Design Decisions

Although eslint supports code linting in markdown, it doesn't check other parts of it. It is advised to not use cspell and eslint together at once.

> Due to the nature of how files are parsed, the cspell command line tool and this eslint plugin will give different results. It is recommended that either eslint or cspell checks a file, but not both.

I noticed that eslint cspell isn't used for markdown files, so I used cspell cli that uses it's own config file. I tested it and there aren't any spelling issues in markdowns.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
