### PR TITLE
6611: Block diagram shows incorrect arrow direction

### DIFF
--- a/.changeset/strong-dryers-pay.md
+++ b/.changeset/strong-dryers-pay.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: correctly render non-directional lines for '---' in block diagrams

--- a/cypress/integration/rendering/block.spec.js
+++ b/cypress/integration/rendering/block.spec.js
@@ -408,14 +408,4 @@ describe('Block diagram', () => {
       {}
     );
   });
-  it('BL32: edge with arrow syntax should render with arrowheads', () => {
-    imgSnapshotTest(
-      `block-beta
-  a
-  b
-  a --> b
-`,
-      {}
-    );
-  });
 });

--- a/cypress/integration/rendering/block.spec.js
+++ b/cypress/integration/rendering/block.spec.js
@@ -397,4 +397,25 @@ describe('Block diagram', () => {
       {}
     );
   });
+
+  it('BL31: edge without arrow syntax should render with no arrowheads', () => {
+    imgSnapshotTest(
+      `block-beta
+  a
+  b
+  a --- b
+`,
+      {}
+    );
+  });
+  it('BL32: edge with arrow syntax should render with arrowheads', () => {
+    imgSnapshotTest(
+      `block-beta
+  a
+  b
+  a --> b
+`,
+      {}
+    );
+  });
 });

--- a/packages/mermaid/src/diagrams/block/blockDB.ts
+++ b/packages/mermaid/src/diagrams/block/blockDB.ts
@@ -238,13 +238,15 @@ export function edgeTypeStr2Type(typeStr: string): string {
 }
 
 export function edgeStrToEdgeData(typeStr: string): string {
-  switch (typeStr.trim()) {
-    case '--x':
+  switch (typeStr.replace(/^[\s-]+|[\s-]+$/g, '')) {
+    case 'x':
       return 'arrow_cross';
-    case '--o':
+    case 'o':
       return 'arrow_circle';
-    default:
+    case '>':
       return 'arrow_point';
+    default:
+      return '';
   }
 }
 


### PR DESCRIPTION

## :bookmark_tabs: Summary

This PR updates the block diagram rendering logic to correctly interpret `---` as a non-directional line, ensuring that arrows are **not added** for this syntax.

Resolves #6611

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
