### PR TITLE
Saurabh/fix-node-border-style-for-hand-drawn-shapes

### DIFF
--- a/.changeset/six-planets-rescue.md
+++ b/.changeset/six-planets-rescue.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: node border style for handdrawn shapes

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/handDrawnShapeStyles.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/handDrawnShapeStyles.ts
@@ -104,8 +104,23 @@ export const userNodeOverrides = (node: Node, options: any) => {
       seed: handDrawnSeed,
       strokeWidth: stylesMap.get('stroke-width')?.replace('px', '') || 1.3,
       fillLineDash: [0, 0],
+      strokeLineDash: getStrokeDashArray(stylesMap.get('stroke-dasharray')),
     },
     options
   );
   return result;
+};
+
+const getStrokeDashArray = (strokeDasharrayStyle?: string) => {
+  if (!strokeDasharrayStyle) {
+    return [0, 0];
+  }
+  const dashArray = strokeDasharrayStyle.trim().split(/\s+/).map(Number);
+  if (dashArray.length === 1) {
+    const val = isNaN(dashArray[0]) ? 0 : dashArray[0];
+    return [val, val];
+  }
+  const first = isNaN(dashArray[0]) ? 0 : dashArray[0];
+  const second = isNaN(dashArray[1]) ? 0 : dashArray[1];
+  return [first, second];
 };


### PR DESCRIPTION
## :bookmark_tabs: Summary

- Node borders style `stroke-dasharray` was getting ignored in hand drawn shapes.
- Added a function to get stroke styles.

Resolves #<your issue id here>

## :straight_ruler: Design Decisions

- getStrokeDashArray: a function to get `strokeLineDash` property from roughjs.
- By default if style is not provided it will be `[0, 0]` ie single line.
- `stroke-dasharray` can be a single value or two values eg `stroke-dasharray : 5` or `stroke-dasharray: 5 5`. Handled both cases.

### Note

- We do have a test for `stroke-dasharray` in `flowchart-handDrawn` which was giving single line now it will give proper dashed line.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
