### PR TITLE
Make elk not force node model order, but strongly consider it instead

### DIFF
--- a/packages/mermaid-layout-elk/src/render.ts
+++ b/packages/mermaid-layout-elk/src/render.ts
@@ -766,7 +766,7 @@ export const render = async (
     id: 'root',
     layoutOptions: {
       'elk.hierarchyHandling': 'INCLUDE_CHILDREN',
-      'elk.layered.crossingMinimization.forceNodeModelOrder': true,
+      'elk.layered.considerModelOrder.strategy': 'NODES_AND_EDGES',
       'elk.algorithm': algorithm,
       'nodePlacement.strategy': data4Layout.config.elk?.nodePlacementStrategy,
       'elk.layered.mergeEdges': data4Layout.config.elk?.mergeEdges,


### PR DESCRIPTION
## :bookmark_tabs: Summary

This improves the ordering in models with crossings that can be resolved by reordering nodes. It keeps the node order to still avoid #6647, the initial fix of which caused this regression to be introduced. Perhaps the `forceNodeModelOrder` config should be exposed in the mermaid-elk API?

[See this example on the ELK Editor.](https://rtsys.informatik.uni-kiel.de/elklive/elkgraph.html?compressedContent=IYGw5g9gTglgLgCwLYC4AEJgE8CmUcAmAUAPQloDGUEAzjTAHZgCyjMSMAXsHDBAwDoAZtAo4AchAI5mUnCADyUaVHRwoAVxxEK-eitnTFyvAJrqeOMFnTiFAEQCiAZQD6AQXH3Xj+wHEXIlJyABUEGBo0CLQAI2ACNAB3BBwGNA16JjQRKDFJaUN5JRU1TRwBIIY5NAYABjQAbwxgGPk0ACJa9rQAXyIq6Rr3RubWkA7gbr6BnBqARhHMMY65qf7qhgAmRZa29s21mZqADR3l9uPDjYAhM72Yq8GGa+GmpfuBVd71p+vbt9243aMQEB2+R2epwB5wAWmsiIQwLM6mgALQAPiGaARBCRNXqGPmQURyIWhK2xNxyOG5OulLxzzRmOe7hxDNutLpbORLyZNWux25-I5zMFQq2fIYYuCaGuGjgaEQ0RoCAgGhACVaaAA1jgAA4KxCzGjAJDlGUASQV+GgKkicAgaAAzAAaNAAFjdczd2xgQkoehgBjkxhUZgscCsNjQdnEjjQAAppEJgOq4ABKSrVABu9Whe1zj1m2YW+aBJaLaGz2zLHWrlezTru5adDfdzbr7vhJKrBMxJaFub51cHfarTtHw-dRCAA) Before and after images below.

<img width="357" height="199" alt="elk previously" src="https://github.com/user-attachments/assets/47af2887-392b-4a30-a927-f11c7cb115d2" />

<img width="242" height="309" alt="elk updated" src="https://github.com/user-attachments/assets/eda2cd91-2ae7-4d62-bbdb-8f582cbbe2d1" />

## :straight_ruler: Design Decisions

Removed the `forceNodeModelOrder`, i.e. set it to false, to allow elk to choose optimal node order, and set `considerModelOrder.strategy': 'NODES_AND_EDGES'` instead to guide order where it does not matter. [See the docs](https://eclipse.dev/elk/reference/options/org-eclipse-elk-layered-considerModelOrder-strategy.html) and the section on crossing minimization [in this blog post](https://eclipse.dev/elk/blog/posts/2023/23-01-09-constraining-the-model.html).

### :clipboard: Tasks

I have not been able to generate a changeset, for some reason I'm failing at `pnpm` install failing to locate the roughjs.patch /shrug. Must be my env that's messed up, sorry!