### PR TITLE
flowchart: warn when 'click' is used without securityLevel: 'loose' +…

### DIFF
--- a/packages/mermaid/src/diagrams/flowchart/_tests_/click-warning.spec.ts
+++ b/packages/mermaid/src/diagrams/flowchart/_tests_/click-warning.spec.ts
@@ -1,0 +1,30 @@
+import { vi, it, expect } from 'vitest';
+import mermaidAPI from '../../../mermaidAPI.js';
+import { initialize } from '../../../diagram-api/diagramAPI.js';
+import * as logger from '../../../logger.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+it('warns when click is used without securityLevel "loose"', async () => {
+  // Make the mock non-empty to satisfy @typescript-eslint/no-empty-function
+  const warnSpy = vi.spyOn(logger, 'warn').mockImplementation((): void => {
+    return undefined;
+  });
+
+  // Configure Mermaid to a non-loose security level
+  initialize({ securityLevel: 'strict' });
+
+  const diagram = `
+    flowchart LR
+      A-->B
+      click A callback "Tip"
+  `;
+
+  // Render a diagram that uses "click" under strict security
+  await mermaidAPI.render('test-click-warning', diagram);
+
+  // Expect a helpful warning instead of silent failure
+  expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('requires securityLevel: "loose"'));
+});

--- a/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.ts
@@ -20,6 +20,20 @@ export const draw = async function (text: string, id: string, _version: string, 
   log.info('Drawing state diagram (v2)', id);
   const { securityLevel, flowchart: conf, layout } = getConfig();
 
+  // Warn if flowchart uses `click` syntax but securityLevel is not "loose".
+  // This avoids silent failure when users try to use `click` in strict/sandbox modes.
+  try {
+    if (securityLevel !== 'loose') {
+      const CLICK_SYNTAX_RE = /(^|\r?\n)\s*click\s+[\w.:-]+/i;
+      if (CLICK_SYNTAX_RE.test(text)) {
+        log.warn(
+          'Flowchart node "click" requires securityLevel: "loose". ' +
+            'See https://mermaid.js.org/config/usage.html#enabling-click-event-and-tags-in-nodes'
+        );
+      }
+    }
+  } catch {}
+
   // Handle root and document for when rendering in sandbox mode
   let sandboxElement;
   if (securityLevel === 'sandbox') {


### PR DESCRIPTION
… test

## :bookmark_tabs: Summary

Adds validation and tests for click usage in flowcharts.
Validation: Logs a warning when a click directive is used without securityLevel: "loose".
Tests: Added click-warning.spec.ts to ensure the warning is triggered correctly.

Resolves bug #6810.

## :straight_ruler: Design Decisions

Followed existing validation patterns for directive checks.
Decided to warn (instead of throwing an error) so users can understand the limitation without breaking diagrams.
Added tests to prevent regressions and ensure consistent behavior.

### :clipboard: Tasks
Added validation for click.
Added unit tests.
Verified warning appears as expected.
