### PR TITLE
build: stop using `cypress/browsers` for Applitools

### DIFF
--- a/.github/workflows/e2e-applitools.yml
+++ b/.github/workflows/e2e-applitools.yml
@@ -23,9 +23,6 @@ env:
 jobs:
   e2e-applitools:
     runs-on: ubuntu-latest
-    container:
-      image: cypress/browsers:node-20.11.0-chrome-121.0.6167.85-1-ff-120.0-edge-121.0.2277.83-1
-      options: --user 1001
     steps:
       - if: ${{ ! env.USE_APPLI }}
         name: Warn if not using Applitools


### PR DESCRIPTION
## :bookmark_tabs: Summary

The Applitools workflow in `.github/workflows/e2e-applitools.yml` is failing with the following error:
    
> Your configFile threw an error from: cypress.config.js
>
> We stopped running your tests because your config file crashed.
>
> Error: connect ECONNREFUSED 127.0.0.1:21077
>     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1611:16)

Running this in GitHub Actions instead of in the `cypress/browsers` docker image fixes this issue.

I've tested this in https://github.com/mermaid-js/mermaid/actions/runs/17232726852/job/48890317715 and it seems to work!

## :straight_ruler: Design Decisions

N/A

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
  - Not needed.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
  - Not needed.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
  - Build/CI only change
