### PR TITLE
fix: ensure config is correctly picked up from both initialize and frontmatter

### DIFF
--- a/packages/mermaid/src/config.spec.ts
+++ b/packages/mermaid/src/config.spec.ts
@@ -82,6 +82,7 @@ describe('when working with site config', () => {
 describe('getUserDefinedConfig', () => {
   beforeEach(() => {
     configApi.reset();
+    configApi.saveConfigFromInitialize({});
   });
 
   it('should return empty object when no user config is defined', () => {
@@ -106,7 +107,6 @@ describe('getUserDefinedConfig', () => {
 
     expect(configApi.getUserDefinedConfig()).toMatchInlineSnapshot(`
       {
-        "fontFamily": "Arial",
         "fontSize": 14,
         "layout": "elk",
         "theme": "forest",
@@ -128,8 +128,8 @@ describe('getUserDefinedConfig', () => {
       {
         "fontFamily": "Arial",
         "fontSize": 14,
-        "layout": "elk",
-        "theme": "forest",
+        "layout": "dagre",
+        "theme": "dark",
       }
     `);
   });
@@ -152,7 +152,7 @@ describe('getUserDefinedConfig', () => {
       {
         "flowchart": {
           "curve": "basis",
-          "nodeSpacing": 75,
+          "nodeSpacing": 50,
           "rankSpacing": 100,
         },
         "mindmap": {
@@ -196,8 +196,8 @@ describe('getUserDefinedConfig', () => {
     expect(userConfig).toMatchInlineSnapshot(`
       {
         "flowchart": {
-          "curve": "basis",
-          "nodeSpacing": 100,
+          "curve": "linear",
+          "nodeSpacing": 50,
           "rankSpacing": 100,
         },
         "fontSize": 12,

--- a/packages/mermaid/src/config.ts
+++ b/packages/mermaid/src/config.ts
@@ -252,12 +252,12 @@ const checkConfig = (config: MermaidConfig) => {
 export const getUserDefinedConfig = (): MermaidConfig => {
   let userConfig: MermaidConfig = {};
 
-  if (configFromInitialize) {
-    userConfig = assignWithDepth(userConfig, configFromInitialize);
-  }
-
   for (const d of directives) {
     userConfig = assignWithDepth(userConfig, d);
+  }
+
+  if (configFromInitialize) {
+    userConfig = assignWithDepth(userConfig, configFromInitialize);
   }
 
   return userConfig;


### PR DESCRIPTION
## :bookmark_tabs: Summary
The earlier PR addressed part of the issue where getUserDefinedConfig wasn’t correctly handling configs from mermaid.initialize and frontmatter.
However, the merge logic still caused cases where layout from initialize was ignored.
This PR updates the function to merge configs consistently so that:
- If config is provided only via initialize, it is used.
- If config is provided only via frontmatter, it is used.

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [ ] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
