### PR TITLE
build: change mermaid live preview to use pnpm

### DIFF
--- a/scripts/editor.bash
+++ b/scripts/editor.bash
@@ -11,7 +11,6 @@ pushd packages/mermaid
 # Append commit hash to version
 jq ".version = .version + \"+${COMMIT_REF:0:7}\"" package.json > package.tmp.json
 mv package.tmp.json package.json
-yarn link
 popd
 
 pnpm run -r clean
@@ -26,13 +25,14 @@ cd mermaid-live-editor
 git clean -xdf
 rm -rf docs/
 
-# We have to use npm instead of yarn because it causes trouble in netlify
+# Tells PNPM that mermaid-live-editor is not part of this workspace
+touch pnpm-workspace.yaml
+
 # Install dependencies
-yarn install
+pnpm install --frozen-lockfile
 
 # Link local mermaid to live editor
-yarn link mermaid     
+pnpm link ../packages/mermaid
 
 # Force Build the site
-yarn run build
-
+pnpm run build


### PR DESCRIPTION
## :bookmark_tabs: Summary

Right now, the netlify build seems to be failing since we're ignoring the `mermaid-live-editor` lockfile.

This is causing errors with broken dependencies.

Switching to `pnpm`, which the `mermaid-live-editor` uses, fixes these issues!

### Example of failing logs

https://app.netlify.com/projects/mermaid-js/deploys/68c400ebf012d900086056b6

```
8:18:43 PM: [vite]: Rollup failed to resolve import "@internationalized/date" from "/opt/build/repo/mermaid-live-editor/node_modules/bits-ui/dist/bits/calendar/components/calendar.svelte".
8:18:43 PM: This is most likely unintended because it can break your application at runtime.
8:18:43 PM: If you do want to externalize this module explicitly add it to
8:18:43 PM: `build.rollupOptions.external`
8:18:43 PM:     at viteLog (file:///opt/build/repo/mermaid-live-editor/node_modules/vite/dist/node/chunks/dep-M_KD0XSK.js:34340:57)
8:18:43 PM:     at file:///opt/build/repo/mermaid-live-editor/node_modules/vite/dist/node/chunks/dep-M_KD0XSK.js:34378:73
8:18:43 PM:     at onwarn (file:///opt/build/repo/mermaid-live-editor/node_modules/@sveltejs/kit/src/exports/vite/index.js:943:9)
8:18:43 PM:     at file:///opt/build/repo/mermaid-live-editor/node_modules/vite/dist/node/chunks/dep-M_KD0XSK.js:34378:28
8:18:43 PM:     at onRollupLog (file:///opt/build/repo/mermaid-live-editor/node_modules/vite/dist/node/chunks/dep-M_KD0XSK.js:34373:3)
8:18:43 PM:     at onLog (file:///opt/build/repo/mermaid-live-editor/node_modules/vite/dist/node/chunks/dep-M_KD0XSK.js:34169:4)
8:18:43 PM:     at file:///opt/build/repo/mermaid-live-editor/node_modules/rollup/dist/es/shared/node-entry.js:20911:32
8:18:43 PM:     at Object.logger [as onLog] (file:///opt/build/repo/mermaid-live-editor/node_modules/rollup/dist/es/shared/node-entry.js:22797:9)
8:18:43 PM:     at ModuleLoader.handleInvalidResolvedId (file:///opt/build/repo/mermaid-live-editor/node_modules/rollup/dist/es/shared/node-entry.js:21541:26)
8:18:43 PM:     at file:///opt/build/repo/mermaid-live-editor/node_modules/rollup/dist/es/shared/node-entry.js:21499:26
```

## :straight_ruler: Design Decisions

I've had to use `touch pnpm-workspace.yaml` to create a new PNPM workspace.

Ideally one would be added to https://github.com/mermaid-js/mermaid-live-editor, but then the `touch pnpm-workspace.yaml` would do nothing, so it's safe to keep it.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
