### PR TITLE
docs: add MIT license to `examples` metadata

### DIFF
--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Mermaid examples package",
   "author": "Sidharth Vinod",
+  "license": "MIT",
   "type": "module",
   "module": "./dist/mermaid-examples.core.mjs",
   "types": "./dist/mermaid.d.ts",


### PR DESCRIPTION

## :bookmark_tabs: Summary

Adding the MIT license documentation so the published package metadata accurately reflects the license. The MIT license is currently included in the package distribution https://www.npmjs.com/package/@mermaid-js/examples?activeTab=code, but not documented in the metadata. This causes npmjs.com to display the license as "none"

### Screenshots

<img width="1195" height="779" alt="Screenshot 2025-09-15 at 5 20 41 PM" src="https://github.com/user-attachments/assets/ccd767c5-727d-4de0-8b5c-7d3913a062ed" />

### :clipboard: Tasks

Make sure you

- [ ] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
