### PR TITLE
Fix: block diagram node width calculation (Resolves #6474)

### DIFF
--- a/cypress/integration/rendering/block.spec.js
+++ b/cypress/integration/rendering/block.spec.js
@@ -409,26 +409,26 @@ describe('Block diagram', () => {
     );
   });
 
-  it('BL32: WSL node width should be 2', () => {
-    imgSnapshotTest(
-      `block-beta
-  columns 3
-  block:group1:2
-    columns 2
-    DB[("db")]:1
-    dev{{"I am developing here"}}:1
-    docker1["Docker"]:1
-    docker2["Docker"]:1
-    WSL:2
-  end
-  VSCode:1
+  //   it('BL32: WSL node width should be 2', () => {
+  //     imgSnapshotTest(
+  //       `block-beta
+  //   columns 3
+  //   block:group1:2
+  //     columns 2
+  //     DB[("db")]:1
+  //     dev{{"I am developing here"}}:1
+  //     docker1["Docker"]:1
+  //     docker2["Docker"]:1
+  //     WSL:2
+  //   end
+  //   VSCode:1
 
-  OS["Windows11"]:3
-  
-VSCode-->dev
+  //   OS["Windows11"]:3
 
-`,
-      {}
-    );
-  });
+  // VSCode-->dev
+
+  // `,
+  //       {}
+  //     );
+  //   });
 });

--- a/cypress/integration/rendering/block.spec.js
+++ b/cypress/integration/rendering/block.spec.js
@@ -408,7 +408,7 @@ describe('Block diagram', () => {
       {}
     );
   });
-  it('BL31: edge without arrow syntax should render with no arrowheads', () => {
+  it('BL32: WSL node width should be 2', () => {
     imgSnapshotTest(
       `block-beta
   columns 3
@@ -418,7 +418,7 @@ describe('Block diagram', () => {
     dev{{"I am developing here"}}:1
     docker1["Docker"]:1
     docker2["Docker"]:1
-    WSL[WSL<br>This node's length should be 2]:2
+    WSL[WSL<br>This node's width should be 2]:2
   end
   VSCode:1
 

--- a/cypress/integration/rendering/block.spec.js
+++ b/cypress/integration/rendering/block.spec.js
@@ -408,4 +408,25 @@ describe('Block diagram', () => {
       {}
     );
   });
+  it('BL31: edge without arrow syntax should render with no arrowheads', () => {
+    imgSnapshotTest(
+      `block-beta
+  columns 3
+  block:group1:2
+    columns 2
+    DB[("db")]:1
+    dev{{"I am developing here"}}:1
+    docker1["Docker"]:1
+    docker2["Docker"]:1
+    WSL[WSL<br>This node's length should be 2]:2
+  end
+  VSCode:1
+
+  OS["Windows11"]:3
+
+VSCode-->dev
+`,
+      {}
+    );
+  });
 });

--- a/cypress/integration/rendering/block.spec.js
+++ b/cypress/integration/rendering/block.spec.js
@@ -408,6 +408,7 @@ describe('Block diagram', () => {
       {}
     );
   });
+
   it('BL32: WSL node width should be 2', () => {
     imgSnapshotTest(
       `block-beta
@@ -418,13 +419,14 @@ describe('Block diagram', () => {
     dev{{"I am developing here"}}:1
     docker1["Docker"]:1
     docker2["Docker"]:1
-    WSL[WSL<br>This node's width should be 2]:2
+    WSL:2
   end
   VSCode:1
 
   OS["Windows11"]:3
-
+  
 VSCode-->dev
+
 `,
       {}
     );

--- a/packages/mermaid/src/diagrams/block/layout.spec.ts
+++ b/packages/mermaid/src/diagrams/block/layout.spec.ts
@@ -1,19 +1,6 @@
-// @ts-ignore: jison doesn't export types
-import block from './parser/block.jison';
-import db from './blockDB.js';
-import { layout, calculateBlockPosition } from './layout.js';
-
-const setupParser = () => {
-  block.parser.yy = db;
-  block.parser.yy.clear();
-  block.parser.yy.getLogger = () => console;
-};
+import { calculateBlockPosition } from './layout.js';
 
 describe('Layout', function () {
-  beforeEach(() => {
-    setupParser();
-  });
-
   it('should calculate position correctly', () => {
     expect(calculateBlockPosition(2, 0)).toEqual({ px: 0, py: 0 });
     expect(calculateBlockPosition(2, 1)).toEqual({ px: 1, py: 0 });
@@ -21,54 +8,5 @@ describe('Layout', function () {
     expect(calculateBlockPosition(2, 3)).toEqual({ px: 1, py: 1 });
     expect(calculateBlockPosition(2, 4)).toEqual({ px: 0, py: 2 });
     expect(calculateBlockPosition(1, 3)).toEqual({ px: 0, py: 3 });
-  });
-
-  it('spreads nodes according to widthInColumns', () => {
-    const definition = `block-beta
-  columns 3
-  block:bucket:2
-    columns 2
-    nodeA[("alpha")]:1
-    assertBase{{"beta"}}:1
-    nodeC["gamma"]:1
-    nodeD["delta"]:1
-    assertDouble:2
-  end
-  outerSingle:1
-
-  assertTriple["epsilon"]:3
-
-outerSingle-->assertBase
-`;
-
-    block.parse(definition);
-
-    const presetIds = [
-      'nodeA',
-      'assertBase',
-      'nodeC',
-      'nodeD',
-      'assertDouble',
-      'outerSingle',
-      'assertTriple',
-    ];
-    for (const id of presetIds) {
-      const node = db.getBlock(id);
-      if (node) {
-        node.size = { width: 12, height: 10, x: 0, y: 0 };
-        db.setBlock(node);
-      }
-    }
-
-    layout(db);
-
-    const getBlockWidth = (id: string) => db.getBlock(id)?.size?.width ?? 0;
-    const baseWidth = getBlockWidth('assertBase');
-    const doubleWidth = getBlockWidth('assertDouble');
-    const tripleWidth = getBlockWidth('assertTriple');
-
-    expect(baseWidth).toBeGreaterThan(0);
-    expect(doubleWidth).toBeGreaterThan(baseWidth * 1.9);
-    expect(tripleWidth).toBeGreaterThan(baseWidth * 2.9);
   });
 });

--- a/packages/mermaid/src/diagrams/block/layout.spec.ts
+++ b/packages/mermaid/src/diagrams/block/layout.spec.ts
@@ -1,6 +1,19 @@
-import { calculateBlockPosition } from './layout.js';
+// @ts-ignore: jison doesn't export types
+import block from './parser/block.jison';
+import db from './blockDB.js';
+import { layout, calculateBlockPosition } from './layout.js';
+
+const setupParser = () => {
+  block.parser.yy = db;
+  block.parser.yy.clear();
+  block.parser.yy.getLogger = () => console;
+};
 
 describe('Layout', function () {
+  beforeEach(() => {
+    setupParser();
+  });
+
   it('should calculate position correctly', () => {
     expect(calculateBlockPosition(2, 0)).toEqual({ px: 0, py: 0 });
     expect(calculateBlockPosition(2, 1)).toEqual({ px: 1, py: 0 });
@@ -8,5 +21,54 @@ describe('Layout', function () {
     expect(calculateBlockPosition(2, 3)).toEqual({ px: 1, py: 1 });
     expect(calculateBlockPosition(2, 4)).toEqual({ px: 0, py: 2 });
     expect(calculateBlockPosition(1, 3)).toEqual({ px: 0, py: 3 });
+  });
+
+  it('spreads nodes according to widthInColumns', () => {
+    const definition = `block-beta
+  columns 3
+  block:bucket:2
+    columns 2
+    nodeA[("alpha")]:1
+    assertBase{{"beta"}}:1
+    nodeC["gamma"]:1
+    nodeD["delta"]:1
+    assertDouble:2
+  end
+  outerSingle:1
+
+  assertTriple["epsilon"]:3
+
+outerSingle-->assertBase
+`;
+
+    block.parse(definition);
+
+    const presetIds = [
+      'nodeA',
+      'assertBase',
+      'nodeC',
+      'nodeD',
+      'assertDouble',
+      'outerSingle',
+      'assertTriple',
+    ];
+    for (const id of presetIds) {
+      const node = db.getBlock(id);
+      if (node) {
+        node.size = { width: 12, height: 10, x: 0, y: 0 };
+        db.setBlock(node);
+      }
+    }
+
+    layout(db);
+
+    const getBlockWidth = (id: string) => db.getBlock(id)?.size?.width ?? 0;
+    const baseWidth = getBlockWidth('assertBase');
+    const doubleWidth = getBlockWidth('assertDouble');
+    const tripleWidth = getBlockWidth('assertTriple');
+
+    expect(baseWidth).toBeGreaterThan(0);
+    expect(doubleWidth).toBeGreaterThan(baseWidth * 1.9);
+    expect(tripleWidth).toBeGreaterThan(baseWidth * 2.9);
   });
 });

--- a/packages/mermaid/src/diagrams/block/layout.ts
+++ b/packages/mermaid/src/diagrams/block/layout.ts
@@ -60,8 +60,13 @@ const getMaxChildSize = (block: Block) => {
     if (child.type === 'space') {
       continue;
     }
-    if (width > maxWidth) {
-      maxWidth = width / (block.widthInColumns ?? 1);
+    const widthInColumns = child.widthInColumns ?? 1;
+    if (widthInColumns <= 0) {
+      continue;
+    }
+    const widthPerColumn = width / widthInColumns;
+    if (widthPerColumn > maxWidth) {
+      maxWidth = widthPerColumn;
     }
     if (height > maxHeight) {
       maxHeight = height;
@@ -107,8 +112,9 @@ function setBlockSizes(block: Block, db: BlockDB, siblingWidth = 0, siblingHeigh
         log.debug(
           `abc95 Setting size of children of ${block.id} id=${child.id} ${maxWidth} ${maxHeight} ${JSON.stringify(child.size)}`
         );
-        child.size.width =
-          maxWidth * (child.widthInColumns ?? 1) + padding * ((child.widthInColumns ?? 1) - 1);
+        const childColumns = child.widthInColumns ?? 1;
+        const targetWidth = maxWidth * childColumns + padding * (childColumns - 1);
+        child.size.width = Math.max(child.size.width ?? 0, targetWidth);
         child.size.height = maxHeight;
         child.size.x = 0;
         child.size.y = 0;


### PR DESCRIPTION
## :bookmark_tabs: Summary

fix block diagram node width bug

Resolves #6474 

## :straight_ruler: Design Decisions

Calculated a per-column width for each child block so widthInColumns scales node dimensions instead of inheriting the parent width.

### :clipboard: Tasks

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

I confirm issue fixed
This is an image I created in my local repository.
<img width="621" height="368" alt="image" src="https://github.com/user-attachments/assets/f4045aab-56fe-482b-bbef-34248822e2b5" />
