### PR TITLE
Bug/direction parsing

### DIFF
--- a/.changeset/common-roses-think.md
+++ b/.changeset/common-roses-think.md
@@ -1,0 +1,5 @@
+---
+'@mermaid-js/parser': patch
+---
+
+fix: parsing of the keyword direction so that it is only detected at the beginning of an expression.

--- a/.changeset/slow-clouds-think.md
+++ b/.changeset/slow-clouds-think.md
@@ -1,0 +1,5 @@
+---
+'@mermaid-js/parser': patch
+---
+
+fix: add `direction TD` in flowchart

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow-direction.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow-direction.spec.js
@@ -44,6 +44,22 @@ describe('when parsing directions', function () {
     expect(subgraph.id).toBe('A');
     expect(subgraph.dir).toBe('BT');
   });
+  it('should handle a subgraph with TB direction with TD direction', function () {
+    const res = flow.parser.parse(`flowchart TB
+    subgraph A
+      direction TDI write anything and it's ignored
+      a --> b
+    end`);
+
+    const subgraphs = flow.parser.yy.getSubGraphs();
+    expect(subgraphs.length).toBe(1);
+    const subgraph = subgraphs[0];
+    expect(subgraph.nodes.length).toBe(2);
+    expect(subgraph.nodes[0]).toBe('b');
+    expect(subgraph.nodes[1]).toBe('a');
+    expect(subgraph.id).toBe('A');
+    expect(subgraph.dir).toBe('TB');
+  });
   it('should use the last defined direction', function () {
     const res = flow.parser.parse(`flowchart TB
     subgraph A

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow-direction.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow-direction.spec.js
@@ -47,16 +47,19 @@ describe('when parsing directions', function () {
   it('should handle a subgraph with TB direction with TD direction', function () {
     const res = flow.parser.parse(`flowchart TB
     subgraph A
-      direction TDI write anything and it's ignored
-      a --> b
+      direction TD
+      direction RL@--> a
+      a --> b["direction LR"]
     end`);
 
     const subgraphs = flow.parser.yy.getSubGraphs();
     expect(subgraphs.length).toBe(1);
     const subgraph = subgraphs[0];
-    expect(subgraph.nodes.length).toBe(2);
-    expect(subgraph.nodes[0]).toBe('b');
-    expect(subgraph.nodes[1]).toBe('a');
+    expect(subgraph.nodes.length).toBe(3);
+    expect(subgraph.nodes[0]).toBe('a');
+    expect(subgraph.nodes[1]).toBe('direction');
+    expect(subgraph.nodes[2]).toBe('b');
+    expect(flow.parser.yy.getVertices().get('b').text).toBe('direction LR');
     expect(subgraph.id).toBe('A');
     expect(subgraph.dir).toBe('TB');
   });

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
@@ -137,6 +137,7 @@ that id.
 <dir>\s*"v"              { this.popState();  return 'DIR'; }
 
 .*direction\s+TB[^\n]*       return 'direction_tb';
+.*direction\s+TD[^\n]*       return 'direction_tb';
 .*direction\s+BT[^\n]*       return 'direction_bt';
 .*direction\s+RL[^\n]*       return 'direction_rl';
 .*direction\s+LR[^\n]*       return 'direction_lr';

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
@@ -136,11 +136,11 @@ that id.
 <dir>\s*"^"              { this.popState();  return 'DIR'; }
 <dir>\s*"v"              { this.popState();  return 'DIR'; }
 
-.*direction\s+TB[^\n]*       return 'direction_tb';
-.*direction\s+TD[^\n]*       return 'direction_tb';
-.*direction\s+BT[^\n]*       return 'direction_bt';
-.*direction\s+RL[^\n]*       return 'direction_rl';
-.*direction\s+LR[^\n]*       return 'direction_lr';
+direction\s+TB\s*(?=[\n;]|$)       return 'direction_tb';
+direction\s+TD\s*(?=[\n;]|$)       return 'direction_tb';
+direction\s+BT\s*(?=[\n;]|$)       return 'direction_bt';
+direction\s+RL\s*(?=[\n;]|$)       return 'direction_rl';
+direction\s+LR\s*(?=[\n;]|$)       return 'direction_lr';
 
 [^\s\"]+\@(?=[^\{\"])               { return 'LINK_ID'; }
 [0-9]+                       return 'NUM';


### PR DESCRIPTION
## :bookmark_tabs: Summary

add `direction TD` in accordance with documentation and fix the regex that ignores all characters before or after a direction, which could hide syntax errors or remove parts of the graph.

Before correction, this line is a **valid** direction:
```mmd
bla bla direction RLblablabla
```

This is not a graph.
```mmd
direction LR@--> up
```

Neither that
```mmd
a --> b["direction LRTB"]
```

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
