### PR TITLE
Fix for Gantt end date

### DIFF
--- a/packages/mermaid/src/diagrams/gantt/ganttDb.js
+++ b/packages/mermaid/src/diagrams/gantt/ganttDb.js
@@ -608,11 +608,9 @@ const compileTasks = function () {
       );
       if (rawTasks[pos].endTime) {
         rawTasks[pos].processed = true;
-        rawTasks[pos].manualEndTime = dayjs(
-          rawTasks[pos].raw.endTime.data,
-          'YYYY-MM-DD',
-          true
-        ).isValid();
+        const formattedDate = dateFormat?.trim ? dateFormat.trim() : '';
+        rawTasks[pos].manualEndTime =
+          formattedDate && dayjs(rawTasks[pos].raw.endTime.data, formattedDate, true).isValid();
         checkTaskDates(rawTasks[pos], dateFormat, excludes, includes);
       }
     }

--- a/packages/mermaid/src/diagrams/gantt/ganttDb.spec.ts
+++ b/packages/mermaid/src/diagrams/gantt/ganttDb.spec.ts
@@ -282,6 +282,74 @@ describe('when using the ganttDb', function () {
     expect(tasks[0].task).toEqual('test1');
   });
 
+  it('end date should not be stretched when using YYYY-MM-DD HH:mm:ss format with excludes', function () {
+    ganttDb.setDateFormat('YYYY-MM-DD HH:mm:ss');
+    ganttDb.setExcludes('weekends');
+    ganttDb.addSection('datetime fixed end');
+    ganttDb.addTask(
+      'fixed datetime end across weekends',
+      'id1, 2025-09-01 10:00:00, 2025-09-25 15:00:00'
+    );
+
+    const tasks = ganttDb.getTasks();
+
+    expect(tasks[0].startTime).toEqual(
+      dayjs('2025-09-01 10:00:00', 'YYYY-MM-DD HH:mm:ss').toDate()
+    );
+    expect(tasks[0].endTime).toEqual(dayjs('2025-09-25 15:00:00', 'YYYY-MM-DD HH:mm:ss').toDate());
+    expect(tasks[0].renderEndTime).toBeNull();
+  });
+
+  it('end date should not be stretched when using YYYY-MM-DD hh:mm format with excludes', function () {
+    ganttDb.setDateFormat('YYYY-MM-DD hh:mm');
+    ganttDb.setExcludes('weekends');
+    ganttDb.addSection('datetime fixed end');
+    ganttDb.addTask(
+      'fixed datetime end across weekends',
+      'id1, 2025-09-01 10:00, 2025-09-25 12:00'
+    );
+
+    const tasks = ganttDb.getTasks();
+
+    expect(tasks[0].startTime).toEqual(dayjs('2025-09-01 10:00', 'YYYY-MM-DD hh:mm').toDate());
+    expect(tasks[0].endTime).toEqual(dayjs('2025-09-25 12:00', 'YYYY-MM-DD hh:mm').toDate());
+    expect(tasks[0].renderEndTime).toBeNull();
+  });
+
+  // preserves behavior prior to YYYY-MM-DD HH:mm:ss exclude fix
+  it('end date should extend when using a duration and excludes', function () {
+    ganttDb.setDateFormat('YYYY-MM-DD HH:mm:ss');
+    ganttDb.setExcludes('weekends');
+
+    ganttDb.addSection('datetime + duration');
+    ganttDb.addTask('duration over weekend', 'id, 2025-09-01 10:00:00, 7d');
+
+    const tasks = ganttDb.getTasks();
+
+    expect(tasks[0].startTime).toEqual(
+      dayjs('2025-09-01 10:00:00', 'YYYY-MM-DD HH:mm:ss').toDate()
+    );
+    expect(tasks[0].endTime).toEqual(dayjs('2025-09-10 10:00:00', 'YYYY-MM-DD HH:mm:ss').toDate());
+    expect(tasks[0].renderEndTime).toEqual(
+      dayjs('2025-09-10 10:00:00', 'YYYY-MM-DD HH:mm:ss').toDate()
+    );
+  });
+
+  // preserves behavior prior to YYYY-MM-DD HH:mm:ss exclude fix
+  it('end date using YYYY-MM-DD format should not be extended when using excludes', function () {
+    ganttDb.setDateFormat('YYYY-MM-DD');
+    ganttDb.setExcludes('weekends');
+
+    ganttDb.addSection('datetime fixed end');
+    ganttDb.addTask('fixed datetime end across weekends', 'id, 2025-09-01 , 2025-09-25');
+
+    const tasks = ganttDb.getTasks();
+
+    expect(tasks[0].startTime).toEqual(dayjs('2025-09-01', 'YYYY-MM-DD').toDate());
+    expect(tasks[0].endTime).toEqual(dayjs('2025-09-25', 'YYYY-MM-DD').toDate());
+    expect(tasks[0].renderEndTime).toBeNull();
+  });
+
   it('should maintain the order in which tasks are created', function () {
     ganttDb.setAccTitle('Project Execution');
     ganttDb.setDateFormat('YYYY-MM-DD');


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fix for Gantt end date when using YYYY-MM-DD HH:mm:ss or similar date format in combination with excludes. Also some tests.

Resolves #6884

## :straight_ruler: Design Decisions

Changed a check for setting the manualEndTime, allowing more date formats to work properly. While preserving the previous behaviour for YYYY-MM-DD and durations (7d etc).

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
