### PR TITLE
fix:  flowchart newline escaping in labels

### DIFF
--- a/packages/mermaid/src/diagrams/flowchart/flowDb.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.ts
@@ -168,7 +168,7 @@ export class FlowDB implements DiagramDB {
       if (txt.startsWith('"') && txt.endsWith('"')) {
         txt = txt.substring(1, txt.length - 1);
       }
-      txt = txt.replace(/\\\s*\n/g, '\n');
+      txt = txt.replace(/\\\n/g, '\n');
       vertex.text = txt;
     } else {
       if (vertex.text === undefined) {


### PR DESCRIPTION
- Fixed flowchart labels not properly handling backslash-newline escaping. Previously, `\ ` sequences were displayed literally instead of creating actual line breaks in node labels.

Resolves #7045

## :straight_ruler: Design Decisions

- Added a single regex replacement in the `addVertex` method to process backslash-newline escaping before text rendering. The fix handles all three label formats (square brackets, double quotes, and backticks) consistently by replacing `\ ` patterns with actual newlines after quote stripping but before storing the text for rendering.
