### PR TITLE
feat: #7059. Flowchart: material icons in labels.

### DIFF
--- a/.changeset/gentle-onions-tap.md
+++ b/.changeset/gentle-onions-tap.md
@@ -1,0 +1,5 @@
+---
+'mermaid': minor
+---
+
+Flowchart: Render material icons in labels.

--- a/packages/mermaid/src/rendering-util/createText.spec.ts
+++ b/packages/mermaid/src/rendering-util/createText.spec.ts
@@ -60,4 +60,54 @@ describe('replaceIconSubstring', () => {
     const expected = sanitizeText(staticBellIconPack.icons.bell.body);
     expect(output).toContain(expected);
   });
+
+  describe('logos/mdi/symbols iconsets', () => {
+    it('converts logos icon notations to HTML tags', async () => {
+      const input = 'Check out these logos: logos:react and logos:nodejs';
+      const output = await replaceIconSubstring(input);
+      const expected = `Check out these logos: <i class='logos react'></i> and <i class='logos nodejs'></i>`;
+      expect(output).toEqual(expected);
+    });
+
+    it('converts mdi icon notations to HTML tags', async () => {
+      const input = 'Material design icons: mdi:home and mdi:account-circle';
+      const output = await replaceIconSubstring(input);
+      const expected = `Material design icons: <i class='mdi home'></i> and <i class='mdi account-circle'></i>`;
+      expect(output).toEqual(expected);
+    });
+
+    it('converts symbols icon notations to HTML tags', async () => {
+      const input = 'Symbols: symbols:arrow-upward and symbols:check';
+      const output = await replaceIconSubstring(input);
+      const expected = `Symbols: <i class='symbols arrow-upward'></i> and <i class='symbols check'></i>`;
+      expect(output).toEqual(expected);
+    });
+
+    it('handles mixed icon types in one string', async () => {
+      const input = 'Mixed icons: fa:fa-user, logos:github, mdi:home, symbols:star';
+      const output = await replaceIconSubstring(input);
+      const expected = `Mixed icons: <i class='fa fa-user'></i>, <i class='logos github'></i>, <i class='mdi home'></i>, <i class='symbols star'></i>`;
+      expect(output).toEqual(expected);
+    });
+
+    it('handles multiple logos icons in one string', async () => {
+      const input = 'Logos: logos:react, logos:vue, logos:angular';
+      const output = await replaceIconSubstring(input);
+      const expected = `Logos: <i class='logos react'></i>, <i class='logos vue'></i>, <i class='logos angular'></i>`;
+      expect(output).toEqual(expected);
+    });
+
+    it('handles icons with hyphens and underscores', async () => {
+      const input = 'Complex names: logos:visual-studio-code and mdi:account_circle';
+      const output = await replaceIconSubstring(input);
+      const expected = `Complex names: <i class='logos visual-studio-code'></i> and <i class='mdi account_circle'></i>`;
+      expect(output).toEqual(expected);
+    });
+
+    it('handles strings with no new iconset notations', async () => {
+      const input = 'This string has no new icons';
+      const output = await replaceIconSubstring(input);
+      expect(output).toEqual(input); // No change expected
+    });
+  });
 });

--- a/packages/mermaid/src/rendering-util/createText.spec.ts
+++ b/packages/mermaid/src/rendering-util/createText.spec.ts
@@ -61,6 +61,56 @@ describe('replaceIconSubstring', () => {
     const expected = sanitizeText(staticBellIconPack.icons.bell.body);
     expect(output).toContain(expected);
   });
+
+  describe('logos/mdi/symbols iconsets', () => {
+    it('converts logos icon notations to HTML tags', async () => {
+      const input = 'Check out these logos: logos:react and logos:nodejs';
+      const output = await replaceIconSubstring(input);
+      const expected = `Check out these logos: <i class='logos react'></i> and <i class='logos nodejs'></i>`;
+      expect(output).toEqual(expected);
+    });
+
+    it('converts mdi icon notations to HTML tags', async () => {
+      const input = 'Material design icons: mdi:home and mdi:account-circle';
+      const output = await replaceIconSubstring(input);
+      const expected = `Material design icons: <i class='mdi home'></i> and <i class='mdi account-circle'></i>`;
+      expect(output).toEqual(expected);
+    });
+
+    it('converts symbols icon notations to HTML tags', async () => {
+      const input = 'Symbols: symbols:arrow-upward and symbols:check';
+      const output = await replaceIconSubstring(input);
+      const expected = `Symbols: <i class='symbols arrow-upward'></i> and <i class='symbols check'></i>`;
+      expect(output).toEqual(expected);
+    });
+
+    it('handles mixed icon types in one string', async () => {
+      const input = 'Mixed icons: fa:fa-user, logos:github, mdi:home, symbols:star';
+      const output = await replaceIconSubstring(input);
+      const expected = `Mixed icons: <i class='fa fa-user'></i>, <i class='logos github'></i>, <i class='mdi home'></i>, <i class='symbols star'></i>`;
+      expect(output).toEqual(expected);
+    });
+
+    it('handles multiple logos icons in one string', async () => {
+      const input = 'Logos: logos:react, logos:vue, logos:angular';
+      const output = await replaceIconSubstring(input);
+      const expected = `Logos: <i class='logos react'></i>, <i class='logos vue'></i>, <i class='logos angular'></i>`;
+      expect(output).toEqual(expected);
+    });
+
+    it('handles icons with hyphens and underscores', async () => {
+      const input = 'Complex names: logos:visual-studio-code and mdi:account_circle';
+      const output = await replaceIconSubstring(input);
+      const expected = `Complex names: <i class='logos visual-studio-code'></i> and <i class='mdi account_circle'></i>`;
+      expect(output).toEqual(expected);
+    });
+
+    it('handles strings with no new iconset notations', async () => {
+      const input = 'This string has no new icons';
+      const output = await replaceIconSubstring(input);
+      expect(output).toEqual(input); // No change expected
+    });
+  });
 });
 
 describe('createText', () => {

--- a/packages/mermaid/src/rendering-util/createText.spec.ts
+++ b/packages/mermaid/src/rendering-util/createText.spec.ts
@@ -1,7 +1,8 @@
 import { select } from 'd3';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { sanitizeText } from '../diagram-api/diagramAPI.js';
 import mermaid from '../mermaid.js';
+import { clearIconPacks } from './icons.js';
 import { createText, replaceIconSubstring } from './createText.js';
 
 describe('replaceIconSubstring', () => {
@@ -63,6 +64,10 @@ describe('replaceIconSubstring', () => {
   });
 
   describe('generic Iconify icon tokens', () => {
+    afterEach(() => {
+      clearIconPacks();
+    });
+
     it('leaves unregistered generic icon tokens as literal text', async () => {
       const input = 'Check out these logos: logos:react and logos:nodejs';
       const output = await replaceIconSubstring(input);

--- a/packages/mermaid/src/rendering-util/createText.spec.ts
+++ b/packages/mermaid/src/rendering-util/createText.spec.ts
@@ -62,53 +62,66 @@ describe('replaceIconSubstring', () => {
     expect(output).toContain(expected);
   });
 
-  describe('logos/mdi/symbols iconsets', () => {
-    it('converts logos icon notations to HTML tags', async () => {
+  describe('generic Iconify icon tokens', () => {
+    it('leaves unregistered generic icon tokens as literal text', async () => {
       const input = 'Check out these logos: logos:react and logos:nodejs';
       const output = await replaceIconSubstring(input);
-      const expected = `Check out these logos: <i class='logos react'></i> and <i class='logos nodejs'></i>`;
-      expect(output).toEqual(expected);
+      expect(output).toEqual(input);
     });
 
-    it('converts mdi icon notations to HTML tags', async () => {
+    it('leaves unregistered mdi tokens as literal text', async () => {
       const input = 'Material design icons: mdi:home and mdi:account-circle';
       const output = await replaceIconSubstring(input);
-      const expected = `Material design icons: <i class='mdi home'></i> and <i class='mdi account-circle'></i>`;
-      expect(output).toEqual(expected);
+      expect(output).toEqual(input);
     });
 
-    it('converts symbols icon notations to HTML tags', async () => {
+    it('leaves unregistered symbols tokens as literal text', async () => {
       const input = 'Symbols: symbols:arrow-upward and symbols:check';
       const output = await replaceIconSubstring(input);
-      const expected = `Symbols: <i class='symbols arrow-upward'></i> and <i class='symbols check'></i>`;
-      expect(output).toEqual(expected);
+      expect(output).toEqual(input);
     });
 
-    it('handles mixed icon types in one string', async () => {
-      const input = 'Mixed icons: fa:fa-user, logos:github, mdi:home, symbols:star';
+    it('replaces a registered generic icon token with SVG', async () => {
+      const mockIconPack = {
+        prefix: 'mypack',
+        icons: {
+          myicon: {
+            body: '<circle cx="50" cy="50" r="40"/>',
+            width: 100,
+            height: 100,
+          },
+        },
+      };
+      mermaid.registerIconPacks([
+        {
+          name: 'mypack',
+          loader: () => Promise.resolve(mockIconPack),
+        },
+      ]);
+      const input = 'Icon here: mypack:myicon';
       const output = await replaceIconSubstring(input);
-      const expected = `Mixed icons: <i class='fa fa-user'></i>, <i class='logos github'></i>, <i class='mdi home'></i>, <i class='symbols star'></i>`;
-      expect(output).toEqual(expected);
+      expect(output).toContain('<circle');
+      expect(output).not.toContain('mypack:myicon');
     });
 
-    it('handles multiple logos icons in one string', async () => {
-      const input = 'Logos: logos:react, logos:vue, logos:angular';
+    it('FA icons fall back to <i> tags while unregistered generic tokens stay as literal text', async () => {
+      const input = 'Mixed: fa:fa-user and logos:github';
       const output = await replaceIconSubstring(input);
-      const expected = `Logos: <i class='logos react'></i>, <i class='logos vue'></i>, <i class='logos angular'></i>`;
-      expect(output).toEqual(expected);
+      expect(output).toContain("<i class='fa fa-user'></i>");
+      expect(output).toContain('logos:github');
+      expect(output).not.toContain("<i class='logos github'></i>");
     });
 
-    it('handles icons with hyphens and underscores', async () => {
-      const input = 'Complex names: logos:visual-studio-code and mdi:account_circle';
+    it('handles icon names with hyphens and underscores as literal text when unregistered', async () => {
+      const input = 'Complex names: mdi:account-circle and mdi:account_circle';
       const output = await replaceIconSubstring(input);
-      const expected = `Complex names: <i class='logos visual-studio-code'></i> and <i class='mdi account_circle'></i>`;
-      expect(output).toEqual(expected);
+      expect(output).toEqual(input);
     });
 
-    it('handles strings with no new iconset notations', async () => {
+    it('handles strings with no icon tokens', async () => {
       const input = 'This string has no new icons';
       const output = await replaceIconSubstring(input);
-      expect(output).toEqual(input); // No change expected
+      expect(output).toEqual(input);
     });
   });
 });

--- a/packages/mermaid/src/rendering-util/createText.ts
+++ b/packages/mermaid/src/rendering-util/createText.ts
@@ -262,8 +262,16 @@ export async function replaceIconSubstring(
   config: MermaidConfig = {}
 ): Promise<string> {
   const pendingReplacements: Promise<string>[] = [];
-  // cspell: disable-next-line
-  text.replace(/(fa[bklrs]?):fa-([\w-]+)/g, (fullMatch, prefix, iconName) => {
+
+  // Define icon regex patterns
+  const iconPatterns = [
+    // cspell: disable-next-line
+    /(fa[bklrs]?):fa-([\w-]+)/g, // FontAwesome icons
+    /(logos|mdi|symbols):([\w-]+)/g, // Other icon types
+  ];
+
+  // Helper function to process icon replacements
+  const processIconMatch = (fullMatch: string, prefix: string, iconName: string) => {
     pendingReplacements.push(
       (async () => {
         const registeredIconName = `${prefix}:${iconName}`;
@@ -275,11 +283,24 @@ export async function replaceIconSubstring(
       })()
     );
     return fullMatch;
+  };
+
+  // Process each icon pattern
+  iconPatterns.forEach((pattern) => {
+    text.replace(pattern, (fullMatch, prefix, iconName) => {
+      return processIconMatch(fullMatch, prefix, iconName);
+    });
   });
 
   const replacements = await Promise.all(pendingReplacements);
-  // cspell: disable-next-line
-  return text.replace(/(fa[bklrs]?):fa-([\w-]+)/g, () => replacements.shift() ?? '');
+
+  // Apply replacements using the same patterns
+  let result = text;
+  iconPatterns.forEach((pattern) => {
+    result = result.replace(pattern, () => replacements.shift() ?? '');
+  });
+
+  return result;
 }
 
 // Note when using from flowcharts converting the API isNode means classes should be set accordingly. When using htmlLabels => to set classes to 'nodeLabel' when isNode=true otherwise 'edgeLabel'

--- a/packages/mermaid/src/rendering-util/createText.ts
+++ b/packages/mermaid/src/rendering-util/createText.ts
@@ -275,6 +275,9 @@ export async function replaceIconSubstring(
   const GENERIC_ICON_PATTERN = /([a-z][\da-z-]*):(\w[\w-]*)/g;
   // Identifies FontAwesome prefixes that use <i> tag fallback when unregistered
   const FA_PREFIX_RE = /^fa[bklrs]?$/;
+  // Returns true for tokens already handled by FA_PATTERN (e.g. fa:fa-user, fab:fa-github)
+  const isFaPatternToken = (prefix: string, iconName: string) =>
+    FA_PREFIX_RE.test(prefix) && iconName.startsWith('fa-');
 
   const collectReplacement = (
     fullMatch: string,
@@ -305,7 +308,7 @@ export async function replaceIconSubstring(
 
   // Collect generic replacements, skipping tokens already covered by FA_PATTERN
   text.replace(GENERIC_ICON_PATTERN, (fullMatch, prefix, iconName) => {
-    if (FA_PREFIX_RE.test(prefix) && iconName.startsWith('fa-')) {
+    if (isFaPatternToken(prefix, iconName)) {
       return fullMatch; // Handled by FA_PATTERN above
     }
     return collectReplacement(fullMatch, prefix, iconName, false);
@@ -317,7 +320,7 @@ export async function replaceIconSubstring(
   let result = text;
   result = result.replace(FA_PATTERN, () => replacements.shift() ?? '');
   result = result.replace(GENERIC_ICON_PATTERN, (fullMatch, prefix, iconName) => {
-    if (FA_PREFIX_RE.test(prefix) && iconName.startsWith('fa-')) {
+    if (isFaPatternToken(prefix, iconName)) {
       return fullMatch; // Already replaced by FA_PATTERN pass above
     }
     return replacements.shift() ?? fullMatch;

--- a/packages/mermaid/src/rendering-util/createText.ts
+++ b/packages/mermaid/src/rendering-util/createText.ts
@@ -267,8 +267,6 @@ export async function replaceIconSubstring(
   // TODO: Make config mandatory
   config: MermaidConfig = {}
 ): Promise<string> {
-  const pendingReplacements: Promise<string>[] = [];
-
   // cspell: disable-next-line
   const FA_PATTERN = /(fa[bklrs]?):fa-([\w-]+)/g;
   // Generic Iconify-style: any lowercase prefix:name token not already matched by FA_PATTERN
@@ -279,13 +277,53 @@ export async function replaceIconSubstring(
   const isFaPatternToken = (prefix: string, iconName: string) =>
     FA_PREFIX_RE.test(prefix) && iconName.startsWith('fa-');
 
-  const collectReplacement = (
-    fullMatch: string,
-    prefix: string,
-    iconName: string,
-    faFallback: boolean
-  ) => {
-    pendingReplacements.push(
+  // Collect all token matches from the original text in left-to-right order.
+  // Operating exclusively on the original text prevents a second regex pass from
+  // matching SVG attributes (e.g. xmlns:xlink, xlink:href) that getIconSVG injects.
+  interface TokenMatch {
+    start: number;
+    end: number;
+    fullMatch: string;
+    prefix: string;
+    iconName: string;
+    faFallback: boolean;
+  }
+
+  const tokens: TokenMatch[] = [];
+
+  FA_PATTERN.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = FA_PATTERN.exec(text)) !== null) {
+    tokens.push({
+      start: m.index,
+      end: m.index + m[0].length,
+      fullMatch: m[0],
+      prefix: m[1],
+      iconName: m[2],
+      faFallback: true,
+    });
+  }
+
+  GENERIC_ICON_PATTERN.lastIndex = 0;
+  while ((m = GENERIC_ICON_PATTERN.exec(text)) !== null) {
+    if (isFaPatternToken(m[1], m[2])) {
+      continue; // FA_PATTERN already covers this token
+    }
+    // Skip positions already claimed by a FA match
+    const start = m.index;
+    const end = m.index + m[0].length;
+    if (tokens.some((t) => start < t.end && end > t.start)) {
+      continue;
+    }
+    tokens.push({ start, end, fullMatch: m[0], prefix: m[1], iconName: m[2], faFallback: false });
+  }
+
+  // Sort tokens by their position in the original text
+  tokens.sort((a, b) => a.start - b.start);
+
+  // Resolve all replacements concurrently
+  const replacements = await Promise.all(
+    tokens.map(({ fullMatch, prefix, iconName, faFallback }) =>
       (async () => {
         const registeredIconName = `${prefix}:${iconName}`;
         if (await isIconAvailable(registeredIconName)) {
@@ -297,34 +335,20 @@ export async function replaceIconSubstring(
           return fullMatch;
         }
       })()
-    );
-    return fullMatch;
-  };
-
-  // Collect FA replacements first (always use <i> fallback)
-  text.replace(FA_PATTERN, (fullMatch, prefix, iconName) =>
-    collectReplacement(fullMatch, prefix, iconName, true)
+    )
   );
 
-  // Collect generic replacements, skipping tokens already covered by FA_PATTERN
-  text.replace(GENERIC_ICON_PATTERN, (fullMatch, prefix, iconName) => {
-    if (isFaPatternToken(prefix, iconName)) {
-      return fullMatch; // Handled by FA_PATTERN above
-    }
-    return collectReplacement(fullMatch, prefix, iconName, false);
-  });
-
-  const replacements = await Promise.all(pendingReplacements);
-
-  // Apply replacements in the same order they were collected
-  let result = text;
-  result = result.replace(FA_PATTERN, () => replacements.shift() ?? '');
-  result = result.replace(GENERIC_ICON_PATTERN, (fullMatch, prefix, iconName) => {
-    if (isFaPatternToken(prefix, iconName)) {
-      return fullMatch; // Already replaced by FA_PATTERN pass above
-    }
-    return replacements.shift() ?? fullMatch;
-  });
+  // Build output from the original text in a single left-to-right pass.
+  // Replacements are spliced in at their original positions, so injected SVG
+  // is never scanned by either pattern.
+  let result = '';
+  let pos = 0;
+  for (const [i, token] of tokens.entries()) {
+    result += text.slice(pos, token.start);
+    result += replacements[i];
+    pos = token.end;
+  }
+  result += text.slice(pos);
 
   return result;
 }

--- a/packages/mermaid/src/rendering-util/createText.ts
+++ b/packages/mermaid/src/rendering-util/createText.ts
@@ -251,10 +251,16 @@ function updateTextContentAndStyles(
 }
 
 /**
- * Convert fontawesome labels into fontawesome icons by using a regex pattern
+ * Convert icon labels into icons by using regex patterns.
+ *
+ * FontAwesome tokens (`fa:`, `fab:`, etc.) always fall back to `<i>` tags when the
+ * icon is not registered. Any other Iconify-style `prefix:name` token is replaced
+ * only when the icon actually resolves via `isIconAvailable`; unresolvable tokens
+ * are left as literal text so unknown pack names are never silently discarded.
+ *
  * @param text - The raw string to convert
  * @param config - Mermaid config
- * @returns string with fontawesome icons as svg if the icon is registered otherwise as i tags
+ * @returns string with icons as SVG where registered, otherwise `<i>` tags (FA) or unchanged text (generic)
  */
 export async function replaceIconSubstring(
   text: string,
@@ -263,41 +269,58 @@ export async function replaceIconSubstring(
 ): Promise<string> {
   const pendingReplacements: Promise<string>[] = [];
 
-  // Define icon regex patterns
-  const iconPatterns = [
-    // cspell: disable-next-line
-    /(fa[bklrs]?):fa-([\w-]+)/g, // FontAwesome icons
-    /(logos|mdi|symbols):([\w-]+)/g, // Other icon types
-  ];
+  // cspell: disable-next-line
+  const FA_PATTERN = /(fa[bklrs]?):fa-([\w-]+)/g;
+  // Generic Iconify-style: any lowercase prefix:name token not already matched by FA_PATTERN
+  const GENERIC_ICON_PATTERN = /([a-z][\da-z-]*):(\w[\w-]*)/g;
+  // Identifies FontAwesome prefixes that use <i> tag fallback when unregistered
+  const FA_PREFIX_RE = /^fa[bklrs]?$/;
 
-  // Helper function to process icon replacements
-  const processIconMatch = (fullMatch: string, prefix: string, iconName: string) => {
+  const collectReplacement = (
+    fullMatch: string,
+    prefix: string,
+    iconName: string,
+    faFallback: boolean
+  ) => {
     pendingReplacements.push(
       (async () => {
         const registeredIconName = `${prefix}:${iconName}`;
         if (await isIconAvailable(registeredIconName)) {
           return await getIconSVG(registeredIconName, undefined, { class: 'label-icon' });
-        } else {
+        } else if (faFallback) {
           return `<i class='${sanitizeText(fullMatch, config).replace(':', ' ')}'></i>`;
+        } else {
+          // Leave the literal source token untouched
+          return fullMatch;
         }
       })()
     );
     return fullMatch;
   };
 
-  // Process each icon pattern
-  iconPatterns.forEach((pattern) => {
-    text.replace(pattern, (fullMatch, prefix, iconName) => {
-      return processIconMatch(fullMatch, prefix, iconName);
-    });
+  // Collect FA replacements first (always use <i> fallback)
+  text.replace(FA_PATTERN, (fullMatch, prefix, iconName) =>
+    collectReplacement(fullMatch, prefix, iconName, true)
+  );
+
+  // Collect generic replacements, skipping tokens already covered by FA_PATTERN
+  text.replace(GENERIC_ICON_PATTERN, (fullMatch, prefix, iconName) => {
+    if (FA_PREFIX_RE.test(prefix) && iconName.startsWith('fa-')) {
+      return fullMatch; // Handled by FA_PATTERN above
+    }
+    return collectReplacement(fullMatch, prefix, iconName, false);
   });
 
   const replacements = await Promise.all(pendingReplacements);
 
-  // Apply replacements using the same patterns
+  // Apply replacements in the same order they were collected
   let result = text;
-  iconPatterns.forEach((pattern) => {
-    result = result.replace(pattern, () => replacements.shift() ?? '');
+  result = result.replace(FA_PATTERN, () => replacements.shift() ?? '');
+  result = result.replace(GENERIC_ICON_PATTERN, (fullMatch, prefix, iconName) => {
+    if (FA_PREFIX_RE.test(prefix) && iconName.startsWith('fa-')) {
+      return fullMatch; // Already replaced by FA_PATTERN pass above
+    }
+    return replacements.shift() ?? fullMatch;
   });
 
   return result;

--- a/packages/mermaid/src/rendering-util/icons.ts
+++ b/packages/mermaid/src/rendering-util/icons.ts
@@ -26,6 +26,11 @@ export const unknownIcon: IconifyIcon = {
 const iconsStore = new Map<string, IconifyJSON>();
 const loaderStore = new Map<string, AsyncIconLoader['loader']>();
 
+export const clearIconPacks = () => {
+  iconsStore.clear();
+  loaderStore.clear();
+};
+
 export const registerIconPacks = (iconLoaders: IconLoader[]) => {
   for (const iconLoader of iconLoaders) {
     if (!iconLoader.name) {


### PR DESCRIPTION
## :bookmark_tabs: Summary

Flowchart: Render material icons in labels.

Resolves #7059

## :straight_ruler: Design Decisions

Add a material icon regexp to replaceIconSubstring

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated flowchart label icon rendering to support Material/other Iconify-style syntax (e.g. `mdi:user`, `logos:react`, `symbols:check`) by extending `replaceIconSubstring` to recognize generic `prefix:name` icon tokens in addition to existing Font Awesome syntax (`fa[bklrs]?:fa-...`). The function now collects token ranges from the original label text, resolves Font Awesome tokens to SVG when registered (otherwise injects a sanitized `<i>` fallback tag), and resolves generic `prefix:name` tokens to SVG only when `isIconAvailable` confirms the icon exists; otherwise the original literal token text is preserved. It also avoids double-handling Font Awesome-covered tokens via an `isFaPatternToken` helper and builds the final string in a single left-to-right pass by splicing replacements into their original positions.

Expanded unit coverage in `createText.spec.ts` with a new “generic Iconify icon tokens” suite, verifying that unregistered `logos:*`, `mdi:*`, and `symbols:*` tokens remain unchanged; registered generic tokens are replaced with rendered SVG; mixing Font Awesome with unregistered generic tokens converts only the Font Awesome icon; and unregistered hyphen/underscore icon names remain literal. The suite clears icon packs after each test for isolation.

Added `clearIconPacks` to `packages/mermaid/src/rendering-util/icons.ts` to clear internal icon pack caches (`iconsStore` and `loaderStore`).

Added a minor changeset for the `mermaid` package documenting: “Flowchart: Render material icons in labels.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->