### PR TITLE
fix(baseAxis): fix y-axis tick positioning (#7061)

### DIFF
--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/components/axis/bandAxis.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/components/axis/bandAxis.ts
@@ -17,6 +17,7 @@ export class BandAxis extends BaseAxis {
     textDimensionCalculator: TextDimensionCalculator
   ) {
     super(axisConfig, title, textDimensionCalculator, axisThemeConfig);
+    this.isBandAxis = true;
     this.categories = categories;
     this.scale = scaleBand().domain(this.categories).range(this.getRange());
   }

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/components/axis/baseAxis.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/components/axis/baseAxis.ts
@@ -46,6 +46,10 @@ export abstract class BaseAxis implements Axis {
   }
 
   getRange(): [number, number] {
+    if (this.axisPosition === 'left' || this.axisPosition === 'right') {
+      // do not apply outer padding to the bottom of the y-axis
+      return [this.range[0] + this.outerPadding, this.range[1]];
+    }
     return [this.range[0] + this.outerPadding, this.range[1] - this.outerPadding];
   }
 

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/components/axis/baseAxis.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/components/axis/baseAxis.ts
@@ -23,6 +23,7 @@ export abstract class BaseAxis implements Axis {
   protected outerPadding = 0;
   protected titleTextHeight = 0;
   protected labelTextHeight = 0;
+  protected isBandAxis = false;
 
   constructor(
     protected axisConfig: XYChartAxisConfig,
@@ -46,11 +47,16 @@ export abstract class BaseAxis implements Axis {
   }
 
   getRange(): [number, number] {
+    if (this.isBandAxis) {
+      return [this.range[0] + this.outerPadding, this.range[1] - this.outerPadding];
+    }
+    // This is a value axis
     if (this.axisPosition === 'left' || this.axisPosition === 'right') {
-      // do not apply outer padding to the bottom of the y-axis
+      // For vertical value axis, no padding at the bottom
       return [this.range[0] + this.outerPadding, this.range[1]];
     }
-    return [this.range[0] + this.outerPadding, this.range[1] - this.outerPadding];
+    // For horizontal value axis, padding only at the end
+    return [this.range[0], this.range[1] - this.outerPadding];
   }
 
   setAxisPosition(axisPosition: AxisPosition): void {

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/components/axis/baseAxis.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/components/axis/baseAxis.ts
@@ -23,7 +23,7 @@ export abstract class BaseAxis implements Axis {
   protected outerPadding = 0;
   protected titleTextHeight = 0;
   protected labelTextHeight = 0;
-  protected isBandAxis = false;
+  public isBandAxis = false;
 
   constructor(
     protected axisConfig: XYChartAxisConfig,

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/components/axis/index.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/components/axis/index.ts
@@ -19,6 +19,7 @@ export interface Axis extends ChartComponent {
   getTickDistance(): number;
   recalculateOuterPaddingToDrawBar(): void;
   setRange(range: [number, number]): void;
+  isBandAxis: boolean;
 }
 
 export function getAxis(

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/barPlot.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/barPlot.ts
@@ -19,11 +19,27 @@ export class BarPlot {
 
     const barPaddingPercent = 0.05;
 
-    const barWidth =
-      Math.min(this.xAxis.getAxisOuterPadding() * 2, this.xAxis.getTickDistance()) *
-      (1 - barPaddingPercent);
-    const barWidthHalf = barWidth / 2;
+    let barWidth: number;
+    let barWidthHalf: number;
 
+    // Axis at the bottom of the bar
+    let bandAxis: Axis;
+    if (this.yAxis.isBandAxis) {
+      bandAxis = this.yAxis;
+    } else {
+      bandAxis = this.xAxis;
+    }
+
+    if (bandAxis.isBandAxis) {
+      barWidth =
+        Math.min(bandAxis.getAxisOuterPadding() * 2, bandAxis.getTickDistance()) *
+        (1 - barPaddingPercent);
+      barWidthHalf = barWidth / 2;
+    } else {
+      // For value axis, keep bars aligned and adjust width for extra half bar
+      barWidth = Math.min(bandAxis.getAxisOuterPadding() * 2, bandAxis.getTickDistance()) * 0.5;
+      barWidthHalf = 0;
+    }
     if (this.orientation === 'horizontal') {
       return [
         {


### PR DESCRIPTION
## :bookmark_tabs: Summary

Add `isBandAxis` property to BaseAxis and refine axis padding logic to handle both vertical and horizontal charts:

* Distinguish axis types using `isBandAxis`
* Apply padding on both ends for band (categorical) axes
* Align start of linear axes with other axis and apply padding at the end
  
Resolves #7061

## :straight_ruler: Design Decisions

**Problem:** Previous `getRange()` logic only considered axis position, applied padding for both ends, causing misalignment in vertical and horizontal charts.

**Fix:**

* Introduce `isBandAxis` to identify band (categorical) axes
* Apply padding differently based on axis type and orientation:

  * Band axes: padding on both ends
  * Linear axes: align start with other axis, padding only on the end

**Effect:**

* Zero tick for vertical axes aligns at chart bottom
* Horizontal axes and existing behavior remain unaffected

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
