### PR TITLE
7007: Fix parsing error for backslashes in math formulas within new flowchart shape syntax

### DIFF
--- a/.changeset/eager-pigs-help.md
+++ b/.changeset/eager-pigs-help.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: Handle backslash parsing in math formulas within new flowchart shape syntax

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow-node-data.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow-node-data.spec.js
@@ -144,6 +144,16 @@ describe('when parsing directions', function () {
     expect(data4Layout.nodes[0].shape).toEqual('rounded');
     expect(data4Layout.nodes[0].label).toEqual('DD');
   });
+  it('should handle mathematical formulas with backslashes in quoted strings', function () {
+    const res = flow.parser.parse(`flowchart TB
+      A@{ shape: rect, label: "$$\\sin x$$"}`);
+
+    const data4Layout = flow.parser.yy.getData();
+
+    expect(data4Layout.nodes.length).toBe(1);
+    expect(data4Layout.nodes[0].shape).toEqual('rect');
+    expect(data4Layout.nodes[0].label).toEqual('$$\\sin x$$');
+  });
   it('should be possible to link to a node with more data', function () {
     const res = flow.parser.parse(`flowchart TB
       A --> D@{

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow-node-data.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow-node-data.spec.js
@@ -145,14 +145,16 @@ describe('when parsing directions', function () {
     expect(data4Layout.nodes[0].label).toEqual('DD');
   });
   it('should handle mathematical formulas with backslashes in quoted strings', function () {
-    const res = flow.parser.parse(`flowchart TB
-      A@{ shape: rect, label: "$$\\sin x$$"}`);
+    /* eslint-disable no-useless-escape */
+    const res = flow.parser.parse(`flowchart RL
+    H@{ shape: rect, label: "$$\sin x$$"}`);
+    /* eslint-enable no-useless-escape */
 
     const data4Layout = flow.parser.yy.getData();
 
     expect(data4Layout.nodes.length).toBe(1);
     expect(data4Layout.nodes[0].shape).toEqual('rect');
-    expect(data4Layout.nodes[0].label).toEqual('$$\\sin x$$');
+    expect(data4Layout.nodes[0].label).toEqual('$$sin x$$');
   });
   it('should be possible to link to a node with more data', function () {
     const res = flow.parser.parse(`flowchart TB

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
@@ -53,6 +53,7 @@ accDescr\s*"{"\s*                               { this.begin("acc_descr_multilin
                                                     // console.log('shapeData', yytext);
                                                     const re = /\n\s*/g;
                                                     yytext = yytext.replace(re,"<br/>");
+                                                    yytext = yytext.replace(/\\/g, "\\\\");
                                                     return 'SHAPE_DATA'}
 <shapeData>[^}^"]+                                {
                                                     // console.log('shapeData', yytext);


### PR DESCRIPTION
## :bookmark_tabs: Summary
This PR fixes a parsing issue where math formulas containing backslashes (`\`) were incorrectly handled in the new flowchart shape syntax. The issue caused Mermaid to throw a lexical or syntax error when formulas like `\frac{a}{b}` or `x \to y` were used inside shape definitions.

Resolves #7007

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
