### PR TITLE
fix: Update the clusterDb assignment from plain objects to Map in v11.12.0

### DIFF
--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/mermaid-graphlib.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/mermaid-graphlib.js
@@ -240,7 +240,7 @@ export const adjustClustersAndEdges = (graph, depth) => {
     }
   });
 
-  for (let id of clusterDb.keys()) {
+  for (let id of Object.keys(clusterDb)) {
     const nonClusterChild = clusterDb.get(id).id;
     const parent = graph.parent(nonClusterChild);
 


### PR DESCRIPTION
Resolves #7006 

render() immediately fails with TypeError: id of clusterDb.keys is not a function
**Root Cause**: Major regression introduced in Mermaid v11.0.0 where clusterDb objects are created as plain objects instead of Map instances, causing .keys() method to be undefined

Change :
Change the clusterDb assignment from plain objects to Map in a for loop