### PR TITLE
7125: Support merging master/main into other branches in GitGraph

### DIFF
--- a/.changeset/big-tools-do.md
+++ b/.changeset/big-tools-do.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: Handle master/main merges correctly in GitGraph diagrams

--- a/cypress/integration/rendering/gitGraph.spec.js
+++ b/cypress/integration/rendering/gitGraph.spec.js
@@ -1569,4 +1569,14 @@ gitGraph TB:
       {}
     );
   });
+  it('77: should render a gitGraph merging main into a newly created branch', () => {
+    imgSnapshotTest(
+      `gitGraph
+    commit
+    branch stable
+    checkout stable
+    merge main`,
+      {}
+    );
+  });
 });

--- a/packages/mermaid/src/diagrams/git/gitGraphAst.ts
+++ b/packages/mermaid/src/diagrams/git/gitGraphAst.ts
@@ -167,9 +167,6 @@ export const merge = (mergeDB: MergeDB): void => {
   const otherCommit: Commit | undefined = otherBranchCheck
     ? state.records.commits.get(otherBranchCheck)
     : undefined;
-  if (currentCommit && otherCommit && currentCommit.branch === otherBranch) {
-    throw new Error(`Cannot merge branch '${otherBranch}' into itself.`);
-  }
   if (state.records.currBranch === otherBranch) {
     const error: any = new Error('Incorrect usage of "merge". Cannot merge a branch to itself');
     error.hash = {
@@ -209,15 +206,6 @@ export const merge = (mergeDB: MergeDB): void => {
       text: `merge ${otherBranch}`,
       token: `merge ${otherBranch}`,
       expected: ['"commit"'],
-    };
-    throw error;
-  }
-  if (currentCommit === otherCommit) {
-    const error: any = new Error('Incorrect usage of "merge". Both branches have same head');
-    error.hash = {
-      text: `merge ${otherBranch}`,
-      token: `merge ${otherBranch}`,
-      expected: ['branch abc'],
     };
     throw error;
   }


### PR DESCRIPTION
## :bookmark_tabs: Summary

This PR fixes an issue where GitGraph diagrams did not correctly handle merges from master/main into other branches, preventing proper merge history visualization.
Resolves #7125

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
