### PR TITLE
fix: Fix C4 model diagrams description text fitting

### DIFF
--- a/.changeset/five-readers-flow.md
+++ b/.changeset/five-readers-flow.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: Fix C4 model diagram description text fitting

--- a/packages/mermaid/src/diagrams/c4/c4Renderer.js
+++ b/packages/mermaid/src/diagrams/c4/c4Renderer.js
@@ -288,7 +288,7 @@ export const drawC4ShapeArray = function (currentBounds, diagram, c4ShapeArray, 
       rectHeight = Y - c4Shape.descr.textLines * 5;
     }
 
-    rectWidth = rectWidth + conf.c4ShapePadding;
+    rectWidth = rectWidth + conf.c4ShapePadding * 2;
     // let rectHeight =
 
     c4Shape.width = Math.max(c4Shape.width || conf.width, rectWidth, conf.width);

--- a/packages/mermaid/src/diagrams/c4/svgDraw.js
+++ b/packages/mermaid/src/diagrams/c4/svgDraw.js
@@ -346,7 +346,7 @@ export const drawC4Shape = function (elem, c4Shape, conf) {
     c4Shape.y + c4Shape.label.Y,
     c4Shape.width,
     c4Shape.height,
-    { fill: fontColor },
+    { fill: fontColor, 'font-size': textFontConf.fontSize },
     textFontConf
   );
 
@@ -362,7 +362,7 @@ export const drawC4Shape = function (elem, c4Shape, conf) {
       c4Shape.y + c4Shape.techn.Y,
       c4Shape.width,
       c4Shape.height,
-      { fill: fontColor, 'font-style': 'italic' },
+      { fill: fontColor, 'font-size': textFontConf.fontSize, 'font-style': 'italic' },
       textFontConf
     );
   } else if (c4Shape.type && c4Shape.type.text !== '') {
@@ -373,14 +373,13 @@ export const drawC4Shape = function (elem, c4Shape, conf) {
       c4Shape.y + c4Shape.type.Y,
       c4Shape.width,
       c4Shape.height,
-      { fill: fontColor, 'font-style': 'italic' },
+      { fill: fontColor, 'font-size': textFontConf.fontSize, 'font-style': 'italic' },
       textFontConf
     );
   }
 
   // draw descr
   if (c4Shape.descr && c4Shape.descr.text !== '') {
-    textFontConf = conf.personFont();
     textFontConf.fontColor = fontColor;
     _drawTextCandidateFunc(conf)(
       c4Shape.descr.text,
@@ -389,7 +388,7 @@ export const drawC4Shape = function (elem, c4Shape, conf) {
       c4Shape.y + c4Shape.descr.Y,
       c4Shape.width,
       c4Shape.height,
-      { fill: fontColor },
+      { fill: fontColor, 'font-size': textFontConf.fontSize },
       textFontConf
     );
   }


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fix the overflow of description text in C4 models. See for example the abominable rendering in <https://mermaid.js.org/syntax/c4.html> or <https://docs.mermaidchart.com/mermaid-oss/syntax/c4.html#c4-diagrams> **in Firefox**. Note: In Edge and Chrome the rendering looks OK! 

Resolves #3990

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
