### PR TITLE
fix: Fix C4 model font size on Firefox

### DIFF
--- a/.changeset/weak-terms-sit.md
+++ b/.changeset/weak-terms-sit.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: Fix C4 model font size in Firefox

--- a/packages/mermaid/src/diagrams/c4/svgDraw.js
+++ b/packages/mermaid/src/diagrams/c4/svgDraw.js
@@ -1,6 +1,7 @@
 import common from '../common/common.js';
 import * as svgDrawCommon from '../common/svgDrawCommon.js';
 import { sanitizeUrl } from '@braintree/sanitize-url';
+import { parseFontSize } from '../../utils.js';
 
 export const drawRect = function (elem, rectData) {
   return svgDrawCommon.drawRect(elem, rectData);
@@ -595,6 +596,8 @@ const _drawTextCandidateFunc = (function () {
   function byTspan(content, g, x, y, width, height, textAttrs, conf) {
     const { fontSize, fontFamily, fontWeight } = conf;
 
+    const [_textFontSize, _textFontSizePx] = parseFontSize(fontSize);
+
     const lines = content.split(common.lineBreakRegex);
     for (let i = 0; i < lines.length; i++) {
       const dy = i * fontSize - (fontSize * (lines.length - 1)) / 2;
@@ -604,7 +607,7 @@ const _drawTextCandidateFunc = (function () {
         .attr('y', y)
         .style('text-anchor', 'middle')
         .attr('dominant-baseline', 'middle')
-        .style('font-size', fontSize)
+        .style('font-size', _textFontSizePx)
         .style('font-weight', fontWeight)
         .style('font-family', fontFamily);
       text


### PR DESCRIPTION
Fix that font size was not applied in Firefox, resulting in badly rendered C4 model descriptions.

## :bookmark_tabs: Summary

Fix that numeric font size was not applied in Firefox. See how <https://mermaid.js.org/syntax/c4.html> is rendered in Firefox.

Fixes #7182.

## :straight_ruler: Design Decisions

Add "px" if font size is numeric.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
