### PR TITLE
7142:Add showCommitHashLabel option to hide auto-generated commit hash labels

### DIFF
--- a/.changeset/yellow-waves-type.md
+++ b/.changeset/yellow-waves-type.md
@@ -1,0 +1,5 @@
+---
+'mermaid': minor
+---
+
+feat: Add showCommitHashLabel config to hide auto-generated commit hash labels

--- a/cypress/integration/rendering/gitGraph.spec.js
+++ b/cypress/integration/rendering/gitGraph.spec.js
@@ -1569,4 +1569,93 @@ gitGraph TB:
       {}
     );
   });
+  it('77: should hide commit hash labels when showCommitHashLabel is false', () => {
+    imgSnapshotTest(
+      `%%{init: { 'gitGraph': { 'showCommitHashLabel': false } } }%%
+      gitGraph
+        commit id: "Alpha"
+        commit
+        commit
+        branch develop
+        commit id: "Beta"
+        commit
+        checkout main
+        commit id: "Gamma"
+        commit
+        merge develop id: "Delta"
+        commit
+      `,
+      {}
+    );
+  });
+  it('78: should show all commit labels when showCommitHashLabel is true', () => {
+    imgSnapshotTest(
+      `%%{init: { 'gitGraph': { 'showCommitHashLabel': true } } }%%
+      gitGraph
+        commit id: "Alpha"
+        commit
+        commit
+        branch develop
+        commit id: "Beta"
+        commit
+        checkout main
+        commit id: "Gamma"
+        commit
+        merge develop id: "Delta"
+        commit
+      `,
+      {}
+    );
+  });
+  it('79: should hide commit hash labels with mixed custom and auto-generated IDs', () => {
+    imgSnapshotTest(
+      `%%{init: { 'gitGraph': { 'showCommitHashLabel': false } } }%%
+      gitGraph
+        commit id: "1-abcdefg"
+        commit
+        branch feature
+        commit id: "Custom Feature"
+        commit
+        checkout main
+        commit id: "2-abcdefg"
+        merge feature id: "Merge Feature"
+        commit
+      `,
+      {}
+    );
+  });
+  it('80: should hide commit hash labels in vertical orientation (TB)', () => {
+    imgSnapshotTest(
+      `%%{init: { 'gitGraph': { 'showCommitHashLabel': false } } }%%
+      gitGraph TB:
+        commit id: "Alpha"
+        commit
+        branch develop
+        commit id: "Beta"
+        commit
+        checkout main
+        commit id: "Gamma"
+        merge develop
+        commit
+      `,
+      {}
+    );
+  });
+  it('81: should hide commit hash labels in bottom-to-top orientation (BT)', () => {
+    imgSnapshotTest(
+      `%%{init: { 'gitGraph': { 'showCommitHashLabel': false } } }%%
+      gitGraph BT:
+        commit id: "Alpha"
+        commit
+        branch develop
+        commit id: "Beta"
+        commit
+        checkout main
+        commit id: "Gamma"
+        merge develop
+        commit
+      `,
+      {}
+    );
+  });
 });

--- a/docs/syntax/gitgraph.md
+++ b/docs/syntax/gitgraph.md
@@ -651,6 +651,8 @@ gitGraph
 
 Sometimes you may want to hide the commit labels from the diagram. You can do this by using the `showCommitLabel` keyword. By default its value is `true`. You can set it to `false` using directives.
 
+### Hiding all commit labels
+
 Usage example:
 
 ```mermaid-example
@@ -758,6 +760,106 @@ config:
         checkout develop
         merge release
 ```
+
+### Hiding only auto-generated commit hash labels
+
+In many cases, you may want to show labels only for commits with custom IDs (like "Alpha", "v1.0", "Feature-X") while hiding the auto-generated hash labels (like "0-a1b2c3d", "1-x9y8z7w"). This is useful when you want to emphasize important commits while keeping the diagram clean.
+
+You can achieve this by using the `showCommitHashLabel` keyword. By default its value is `true`. When set to `false`, only commits with custom IDs will show their labels, while commits with auto-generated hash IDs will be hidden.
+
+**How it works:**
+
+- **Auto-generated IDs**: Commits without a custom `id` are automatically assigned IDs in the format `seq-hash` (e.g., `0-a1b2c3d`, `1-x9y8z7w`). These follow the pattern of a number, a dash, and a random hash.
+- **Custom IDs**: Commits with explicitly defined IDs using `commit id: "YourID"` are considered custom IDs.
+- When `showCommitHashLabel: false`, only custom IDs are displayed.
+
+Usage example - Hiding auto-generated hash labels:
+
+```mermaid-example
+---
+config:
+  gitGraph:
+    showCommitHashLabel: false
+---
+gitGraph
+  commit id: "Alpha"
+  commit
+  commit
+  branch develop
+  commit id: "Beta"
+  commit
+  checkout main
+  commit id: "Gamma"
+  commit
+  merge develop id: "Delta"
+  commit
+```
+
+```mermaid
+---
+config:
+  gitGraph:
+    showCommitHashLabel: false
+---
+gitGraph
+  commit id: "Alpha"
+  commit
+  commit
+  branch develop
+  commit id: "Beta"
+  commit
+  checkout main
+  commit id: "Gamma"
+  commit
+  merge develop id: "Delta"
+  commit
+```
+
+In this example, only the commits with custom IDs ("Alpha", "Beta", "Gamma", "Delta") will show their labels. The commits without custom IDs (created with just `commit`) will not display their auto-generated hash labels.
+
+Usage example - Showing all labels (default behavior):
+
+```mermaid-example
+---
+config:
+  gitGraph:
+    showCommitHashLabel: true
+---
+gitGraph
+  commit id: "Alpha"
+  commit
+  commit
+  branch develop
+  commit id: "Beta"
+  commit
+  checkout main
+  commit id: "Gamma"
+  commit
+  merge develop id: "Delta"
+  commit
+```
+
+```mermaid
+---
+config:
+  gitGraph:
+    showCommitHashLabel: true
+---
+gitGraph
+  commit id: "Alpha"
+  commit
+  commit
+  branch develop
+  commit id: "Beta"
+  commit
+  checkout main
+  commit id: "Gamma"
+  commit
+  merge develop id: "Delta"
+  commit
+```
+
+In this example, all commits will show their labels, including both custom IDs and auto-generated hash IDs.
 
 ## Customizing main branch name
 

--- a/packages/mermaid/src/config.type.ts
+++ b/packages/mermaid/src/config.type.ts
@@ -1108,6 +1108,7 @@ export interface GitGraphDiagramConfig extends BaseDiagramConfig {
   showBranches?: boolean;
   rotateCommitLabel?: boolean;
   parallelCommits?: boolean;
+  showCommitHashLabel?: boolean;
   /**
    * Controls whether or arrow markers in html code are absolute paths or anchors.
    * This matters if you are using base tag settings.

--- a/packages/mermaid/src/diagrams/git/gitGraphRenderer.ts
+++ b/packages/mermaid/src/diagrams/git/gitGraphRenderer.ts
@@ -289,11 +289,15 @@ const drawCommitLabel = (
   commitPosition: CommitPositionOffset,
   pos: number
 ) => {
-  if (
+  const hasCustomId = commit.customId || !/^\d+-[\dA-Za-z]+$/.exec(commit.id);
+
+  const shouldShowLabel =
     commit.type !== commitType.CHERRY_PICK &&
     ((commit.customId && commit.type === commitType.MERGE) || commit.type !== commitType.MERGE) &&
-    DEFAULT_GITGRAPH_CONFIG?.showCommitLabel
-  ) {
+    DEFAULT_GITGRAPH_CONFIG?.showCommitLabel &&
+    (DEFAULT_GITGRAPH_CONFIG?.showCommitHashLabel || hasCustomId);
+
+  if (shouldShowLabel) {
     const wrapper = gLabels.append('g');
     const labelBkg = wrapper.insert('rect').attr('class', 'commit-label-bkg');
     const text = wrapper

--- a/packages/mermaid/src/docs/syntax/gitgraph.md
+++ b/packages/mermaid/src/docs/syntax/gitgraph.md
@@ -407,6 +407,8 @@ gitGraph
 
 Sometimes you may want to hide the commit labels from the diagram. You can do this by using the `showCommitLabel` keyword. By default its value is `true`. You can set it to `false` using directives.
 
+### Hiding all commit labels
+
 Usage example:
 
 ```mermaid-example
@@ -461,6 +463,66 @@ config:
         checkout develop
         merge release
 ```
+
+### Hiding only auto-generated commit hash labels
+
+In many cases, you may want to show labels only for commits with custom IDs (like "Alpha", "v1.0", "Feature-X") while hiding the auto-generated hash labels (like "0-a1b2c3d", "1-x9y8z7w"). This is useful when you want to emphasize important commits while keeping the diagram clean.
+
+You can achieve this by using the `showCommitHashLabel` keyword. By default its value is `true`. When set to `false`, only commits with custom IDs will show their labels, while commits with auto-generated hash IDs will be hidden.
+
+**How it works:**
+
+- **Auto-generated IDs**: Commits without a custom `id` are automatically assigned IDs in the format `seq-hash` (e.g., `0-a1b2c3d`, `1-x9y8z7w`). These follow the pattern of a number, a dash, and a random hash.
+- **Custom IDs**: Commits with explicitly defined IDs using `commit id: "YourID"` are considered custom IDs.
+- When `showCommitHashLabel: false`, only custom IDs are displayed.
+
+Usage example - Hiding auto-generated hash labels:
+
+```mermaid-example
+---
+config:
+  gitGraph:
+    showCommitHashLabel: false
+---
+gitGraph
+  commit id: "Alpha"
+  commit
+  commit
+  branch develop
+  commit id: "Beta"
+  commit
+  checkout main
+  commit id: "Gamma"
+  commit
+  merge develop id: "Delta"
+  commit
+```
+
+In this example, only the commits with custom IDs ("Alpha", "Beta", "Gamma", "Delta") will show their labels. The commits without custom IDs (created with just `commit`) will not display their auto-generated hash labels.
+
+Usage example - Showing all labels (default behavior):
+
+```mermaid-example
+---
+config:
+  gitGraph:
+    showCommitHashLabel: true
+---
+gitGraph
+  commit id: "Alpha"
+  commit
+  commit
+  branch develop
+  commit id: "Beta"
+  commit
+  checkout main
+  commit id: "Gamma"
+  commit
+  merge develop id: "Delta"
+  commit
+```
+
+In this example, all commits will show their labels, including both custom IDs and auto-generated hash IDs.
 
 ## Customizing main branch name
 

--- a/packages/mermaid/src/schemas/config.schema.yaml
+++ b/packages/mermaid/src/schemas/config.schema.yaml
@@ -892,6 +892,9 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
       parallelCommits:
         type: boolean
         default: false
+      showCommitHashLabel:
+        type: boolean
+        default: true
       # YAML anchor reference, don't use $ref since ajv doesn't load defaults
       arrowMarkerAbsolute: *arrowMarkerAbsolute
 


### PR DESCRIPTION
This PR adds a new configuration option `showCommitHashLabel` (default: true) that allows users to hide commit labels for commits with auto-generated hash IDs (e.g., "0-a1b2c3d") while still displaying labels for commits with custom IDs.

This feature addresses the use case where users want to emphasize important commits with custom IDs while keeping the diagram clean by hiding the less meaningful auto-generated hash labels.

- Add showCommitHashLabel to GitGraphDiagramConfig
- Update gitGraphRenderer to conditionally show/hide hash labels
- Add comprehensive tests for all orientations (LR, TB, BT)
- Update documentation with usage examples

Resolves #7142 

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
