### PR TITLE
docs: Remove trailing comma from radar diagram example

### DIFF
--- a/docs/syntax/radar.md
+++ b/docs/syntax/radar.md
@@ -62,7 +62,7 @@ radar-beta
 radar-beta
   title Restaurant Comparison
   axis food["Food Quality"], service["Service"], price["Price"]
-  axis ambiance["Ambiance"],
+  axis ambiance["Ambiance"]
 
   curve a["Restaurant A"]{4, 3, 2, 4}
   curve b["Restaurant B"]{3, 4, 3, 3}
@@ -78,7 +78,7 @@ radar-beta
 radar-beta
   title Restaurant Comparison
   axis food["Food Quality"], service["Service"], price["Price"]
-  axis ambiance["Ambiance"],
+  axis ambiance["Ambiance"]
 
   curve a["Restaurant A"]{4, 3, 2, 4}
   curve b["Restaurant B"]{3, 4, 3, 3}

--- a/packages/mermaid/src/docs/syntax/radar.md
+++ b/packages/mermaid/src/docs/syntax/radar.md
@@ -42,7 +42,7 @@ radar-beta
 radar-beta
   title Restaurant Comparison
   axis food["Food Quality"], service["Service"], price["Price"]
-  axis ambiance["Ambiance"],
+  axis ambiance["Ambiance"]
 
   curve a["Restaurant A"]{4, 3, 2, 4}
   curve b["Restaurant B"]{3, 4, 3, 3}


### PR DESCRIPTION
## :bookmark_tabs: Summary

I fixed the trailing comma in the radar diagram documentation example that causes a parse error.

Resolves https://github.com/mermaid-js/mermaid/issues/7187

## :straight_ruler: Design Decisions

There are no changes to Mermaid itself.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
