### PR TITLE
7194 :  fix for markdown processing to KaTeX text to preserve newlines

### DIFF
--- a/.changeset/giant-comics-wear.md
+++ b/.changeset/giant-comics-wear.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: render newlines in flowchart nodes containing KaTeX equations

--- a/cypress/integration/rendering/katex.spec.js
+++ b/cypress/integration/rendering/katex.spec.js
@@ -33,4 +33,70 @@ describe('Katex', () => {
   //     { fontFamily: 'courier' }
   //   );
   // });
+
+  describe('Katex with newlines (issue #7194)', () => {
+    it('5: should render newlines in plain text nodes with math', () => {
+      imgSnapshotTest(
+        `graph TD
+        plainmath["line 0
+        line 1
+        $$x=42$$
+        line 2"]`,
+        { fontFamily: 'courier' }
+      );
+    });
+
+    it('6: should render newlines in markdown nodes with math', () => {
+      imgSnapshotTest(
+        `graph TD
+        markdownmath["\`line 0
+        line 1
+        $$x=42$$
+        line 2\`"]`,
+        { fontFamily: 'courier' }
+      );
+    });
+
+    it('7: should render multiple math equations with newlines between them', () => {
+      imgSnapshotTest(
+        `graph TD
+        multimath["$$a=1$$
+        text between
+        $$b=2$$"]`,
+        { fontFamily: 'courier' }
+      );
+    });
+
+    it('8: should render newlines before and after math in markdown', () => {
+      imgSnapshotTest(
+        `graph TD
+        beforeafter["\`line before
+        $$x=42$$
+        line after\`"]`,
+        { fontFamily: 'courier' }
+      );
+    });
+
+    it('9: should render complex example with multiple nodes containing math and newlines', () => {
+      imgSnapshotTest(
+        `graph TD
+        plain["line 0
+        line 1"]
+        markdown["\`line 0
+        line 1\`"]
+        plainmath["line 0
+        line 1
+        $$x=42$$
+        line 2"]
+        markdownmath["\`line 0
+        line 1
+        $$x=42$$
+        \`"]
+        plain --> markdown
+        markdown --> plainmath
+        plainmath --> markdownmath`,
+        { fontFamily: 'courier' }
+      );
+    });
+  });
 });

--- a/packages/mermaid/src/rendering-util/createText.ts
+++ b/packages/mermaid/src/rendering-util/createText.ts
@@ -248,7 +248,9 @@ export const createText = async (
     const decodedReplacedText = await replaceIconSubstring(decodeEntities(htmlText), config);
 
     //for Katex the text could contain escaped characters, \\relax that should be transformed to \relax
-    const inputForKatex = text.replace(/\\\\/g, '\\');
+    const inputForKatex = hasKatex(text)
+      ? markdownToHTML(text.replace(/\\\\/g, '\\'), config)
+      : text.replace(/\\\\/g, '\\');
 
     const node = {
       isNode,


### PR DESCRIPTION
## :bookmark_tabs: Summary

This PR fixes the issue where newlines were not being rendered in flowchart nodes containing KaTeX math equations. The fix ensures that markdown processing (which converts `\n` to `<br/>` tags) is applied to text with KaTeX, allowing newlines to work correctly in both plain text and markdown-formatted nodes with math equations.

Resolves #7194

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [ ] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
