### PR TITLE
fix: Allow C4 Dynamic multiple interactions

### DIFF
--- a/.changeset/salty-wombats-sin.md
+++ b/.changeset/salty-wombats-sin.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: Allow multiple interactions between the same components in C4 Dynamic diagrams

--- a/packages/mermaid/src/diagrams/c4/c4Db.js
+++ b/packages/mermaid/src/diagrams/c4/c4Db.js
@@ -54,12 +54,7 @@ export const addRel = function (type, from, to, label, techn, descr, sprite, tag
   }
 
   let rel = {};
-  const old = rels.find((rel) => rel.from === from && rel.to === to);
-  if (old) {
-    rel = old;
-  } else {
-    rels.push(rel);
-  }
+  rels.push(rel);
 
   rel.type = type;
   rel.from = from;

--- a/packages/mermaid/src/diagrams/c4/parser/c4Dynamic.spec.js
+++ b/packages/mermaid/src/diagrams/c4/parser/c4Dynamic.spec.js
@@ -1,0 +1,30 @@
+import c4Db from '../c4Db.js';
+import c4 from './c4Diagram.jison';
+import { setConfig } from '../../../config.js';
+
+setConfig({
+  securityLevel: 'strict',
+});
+
+describe('parsing a C4 dynamic diagram', function () {
+  beforeEach(function () {
+    c4.parser.yy = c4Db;
+    c4.parser.yy.clear();
+  });
+
+  it('should allow multiple interactions between components', function () {
+    c4.parser.parse(`C4Dynamic
+System(a, "A")
+System(b, "B")
+Rel(a, b, "Interaction 1")
+Rel(a, b, "Interaction 2")`);
+
+    const yy = c4.parser.yy;
+
+    expect(yy.getC4Type()).toBe('C4Dynamic');
+    const rels = yy.getRels();
+    expect(rels.length).toBe(2);
+    expect(rels[0].label.text).toBe('Interaction 1');
+    expect(rels[1].label.text).toBe('Interaction 2');
+  });
+});


### PR DESCRIPTION
C4 Dynamic allows for multiple interactions
between the same components. Before, a second
interaction was merged with the previous
interaction, which was incorrect.

## :bookmark_tabs: Summary

Brief description about the content of your PR.

Resolves #7183

## :straight_ruler: Design Decisions

The parser cannot determine if relations are duplicate and should be merged easily because the `c4Type` is not parsed. Therefore do not merge relations in the database. If we want to keep merging relationships for other C4 diagram types, that could be solved in the renderer.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
