### PR TITLE
fix: allow special characters in architecture service titles

### DIFF
--- a/.changeset/nice-knives-buy.md
+++ b/.changeset/nice-knives-buy.md
@@ -1,0 +1,5 @@
+---
+'@mermaid-js/parser': patch
+---
+
+fix: allow special characters in architecture service titles

--- a/.cspell/misc-terms.txt
+++ b/.cspell/misc-terms.txt
@@ -3,7 +3,7 @@ Buzan
 circo
 handDrawn
 KOEPF
+mywebs
 neato
 newbranch
 validify
-mywebs

--- a/.cspell/misc-terms.txt
+++ b/.cspell/misc-terms.txt
@@ -6,3 +6,4 @@ KOEPF
 neato
 newbranch
 validify
+mywebs

--- a/docs/syntax/architecture.md
+++ b/docs/syntax/architecture.md
@@ -84,6 +84,12 @@ service database1(database)[My Database]
 
 creates the service identified as `database1`, using the icon `database`, with the label `My Database`.
 
+Service titles support special characters including dots, hyphens, underscores, colons, and slashes, allowing for realistic service names:
+
+service dns(internet)\[<http://www.mywebs>]
+service api(server)\[api-gateway_v2.0]
+service db(database)\[db:5432/primary]
+
 If the service belongs to a group, it can be placed inside it through the optional `in` keyword
 
 ```

--- a/packages/mermaid/src/docs/syntax/architecture.md
+++ b/packages/mermaid/src/docs/syntax/architecture.md
@@ -64,6 +64,13 @@ service database1(database)[My Database]
 
 creates the service identified as `database1`, using the icon `database`, with the label `My Database`.
 
+Service titles support special characters including dots, hyphens, underscores, colons, and slashes, allowing for realistic service names:
+
+service dns(internet)[http://www.mywebs]
+service api(server)[api-gateway_v2.0]
+service db(database)[db:5432/primary]
+
+
 If the service belongs to a group, it can be placed inside it through the optional `in` keyword
 
 ```

--- a/packages/mermaid/src/docs/syntax/architecture.md
+++ b/packages/mermaid/src/docs/syntax/architecture.md
@@ -70,7 +70,6 @@ service dns(internet)[http://www.mywebs]
 service api(server)[api-gateway_v2.0]
 service db(database)[db:5432/primary]
 
-
 If the service belongs to a group, it can be placed inside it through the optional `in` keyword
 
 ```

--- a/packages/parser/src/language/architecture/arch.langium
+++ b/packages/parser/src/language/architecture/arch.langium
@@ -1,2 +1,2 @@
 terminal ARCH_ICON: /\([\w-:]+\)/;
-terminal ARCH_TITLE: /\[[\w ]+\]/;
+terminal ARCH_TITLE: /\[[^\]]+\]/;

--- a/packages/parser/tests/architecture.test.ts
+++ b/packages/parser/tests/architecture.test.ts
@@ -87,33 +87,31 @@ describe('architecture', () => {
   });
 
   describe('should handle special characters in service titles', () => {
-  it('should handle service with dot in title', () => {
-    const context = `architecture-beta
+    it('should handle service with dot in title', () => {
+      const context = `architecture-beta
       service dns1(internet)[www.mywebs]
     `;
-    const result = parse(context);
-    expectNoErrorsOrAlternatives(result);
-    expect(result.value.services[0].title).toBe('www.mywebs');
-  });
+      const result = parse(context);
+      expectNoErrorsOrAlternatives(result);
+      expect(result.value.services[0].title).toBe('www.mywebs');
+    });
 
-  it('should handle service with multiple special characters', () => {
-    const context = `architecture-beta
+    it('should handle service with multiple special characters', () => {
+      const context = `architecture-beta
       service api(server)[api-gateway_v2.0]
     `;
-    const result = parse(context);
-    expectNoErrorsOrAlternatives(result);
-    expect(result.value.services[0].title).toBe('api-gateway_v2.0');
-  });
+      const result = parse(context);
+      expectNoErrorsOrAlternatives(result);
+      expect(result.value.services[0].title).toBe('api-gateway_v2.0');
+    });
 
-  it('should handle service with colons and slashes', () => {
-    const context = `architecture-beta
+    it('should handle service with colons and slashes', () => {
+      const context = `architecture-beta
       service db(database)[db:5432/primary]
     `;
-    const result = parse(context);
-    expectNoErrorsOrAlternatives(result);
-    expect(result.value.services[0].title).toBe('db:5432/primary');
+      const result = parse(context);
+      expectNoErrorsOrAlternatives(result);
+      expect(result.value.services[0].title).toBe('db:5432/primary');
+    });
   });
-});
-
-
 });

--- a/packages/parser/tests/architecture.test.ts
+++ b/packages/parser/tests/architecture.test.ts
@@ -85,4 +85,35 @@ describe('architecture', () => {
       expect(accDescr).toBe('sample accDescr');
     });
   });
+
+  describe('should handle special characters in service titles', () => {
+  it('should handle service with dot in title', () => {
+    const context = `architecture-beta
+      service dns1(internet)[www.mywebs]
+    `;
+    const result = parse(context);
+    expectNoErrorsOrAlternatives(result);
+    expect(result.value.services[0].title).toBe('www.mywebs');
+  });
+
+  it('should handle service with multiple special characters', () => {
+    const context = `architecture-beta
+      service api(server)[api-gateway_v2.0]
+    `;
+    const result = parse(context);
+    expectNoErrorsOrAlternatives(result);
+    expect(result.value.services[0].title).toBe('api-gateway_v2.0');
+  });
+
+  it('should handle service with colons and slashes', () => {
+    const context = `architecture-beta
+      service db(database)[db:5432/primary]
+    `;
+    const result = parse(context);
+    expectNoErrorsOrAlternatives(result);
+    expect(result.value.services[0].title).toBe('db:5432/primary');
+  });
+});
+
+
 });


### PR DESCRIPTION
## :bookmark_tabs: Summary

Allow special characters (dots, hyphens, underscores, colons, slashes) in architecture diagram service titles. This enables users to use realistic service names like domain names (www.mywebs), versioned names (api-gateway_v2.0), and connection strings (db:5432/primary).

Resolves #7232

## :straight_ruler: Design Decisions

Updated the `ARCH_TITLE` terminal regex in `arch.langium` from `/\[[\w ]+\]/` to `/\[[^\]]+\]/` to accept any character except the closing bracket. This is a minimal, non-breaking change that:
- Maintains backward compatibility with existing diagrams
- Allows maximum flexibility for service naming conventions
- Prevents only the closing bracket to avoid syntax conflicts

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
