### PR TITLE
fix(er): normalize crow-foot marker alignment

### DIFF
--- a/packages/mermaid/src/diagrams/er/erMarkers.js
+++ b/packages/mermaid/src/diagrams/er/erMarkers.js
@@ -12,22 +12,26 @@ const ERMarkers = {
 };
 
 /**
- * Put the markers into the svg DOM for later use with edge paths
+ * Insert ER diagram markers into SVG <defs>
+ * Marker geometry is normalized to ensure consistent alignment
+ * across browsers and zoom levels.
  *
- * @param elem
- * @param conf
+ * @param {any} elem
+ * @param {any} conf
  */
 const insertMarkers = function (elem, conf) {
-  let marker;
+  /* ===============================
+     Parent markers
+     =============================== */
 
   elem
     .append('defs')
     .append('marker')
     .attr('id', ERMarkers.MD_PARENT_START)
-    .attr('refX', 0)
+    .attr('refX', 9)
     .attr('refY', 7)
-    .attr('markerWidth', 190)
-    .attr('markerHeight', 240)
+    .attr('markerWidth', 18)
+    .attr('markerHeight', 14)
     .attr('orient', 'auto')
     .append('path')
     .attr('d', 'M 18,7 L9,13 L1,7 L9,1 Z');
@@ -36,19 +40,23 @@ const insertMarkers = function (elem, conf) {
     .append('defs')
     .append('marker')
     .attr('id', ERMarkers.MD_PARENT_END)
-    .attr('refX', 19)
+    .attr('refX', 9)
     .attr('refY', 7)
-    .attr('markerWidth', 20)
-    .attr('markerHeight', 28)
+    .attr('markerWidth', 18)
+    .attr('markerHeight', 14)
     .attr('orient', 'auto')
     .append('path')
     .attr('d', 'M 18,7 L9,13 L1,7 L9,1 Z');
+
+  /* ===============================
+     Only-one markers
+     =============================== */
 
   elem
     .append('defs')
     .append('marker')
     .attr('id', ERMarkers.ONLY_ONE_START)
-    .attr('refX', 0)
+    .attr('refX', 9)
     .attr('refY', 9)
     .attr('markerWidth', 18)
     .attr('markerHeight', 18)
@@ -56,13 +64,13 @@ const insertMarkers = function (elem, conf) {
     .append('path')
     .attr('stroke', conf.stroke)
     .attr('fill', 'none')
-    .attr('d', 'M9,0 L9,18 M15,0 L15,18');
+    .attr('d', 'M6,0 L6,18 M12,0 L12,18');
 
   elem
     .append('defs')
     .append('marker')
     .attr('id', ERMarkers.ONLY_ONE_END)
-    .attr('refX', 18)
+    .attr('refX', 9)
     .attr('refY', 9)
     .attr('markerWidth', 18)
     .attr('markerHeight', 18)
@@ -70,17 +78,22 @@ const insertMarkers = function (elem, conf) {
     .append('path')
     .attr('stroke', conf.stroke)
     .attr('fill', 'none')
-    .attr('d', 'M3,0 L3,18 M9,0 L9,18');
+    .attr('d', 'M6,0 L6,18 M12,0 L12,18');
 
-  marker = elem
+  /* ===============================
+     Zero-or-one markers
+     =============================== */
+
+  let marker = elem
     .append('defs')
     .append('marker')
     .attr('id', ERMarkers.ZERO_OR_ONE_START)
-    .attr('refX', 0)
+    .attr('refX', 15)
     .attr('refY', 9)
     .attr('markerWidth', 30)
     .attr('markerHeight', 18)
     .attr('orient', 'auto');
+
   marker
     .append('circle')
     .attr('stroke', conf.stroke)
@@ -88,17 +101,19 @@ const insertMarkers = function (elem, conf) {
     .attr('cx', 21)
     .attr('cy', 9)
     .attr('r', 6);
+
   marker.append('path').attr('stroke', conf.stroke).attr('fill', 'none').attr('d', 'M9,0 L9,18');
 
   marker = elem
     .append('defs')
     .append('marker')
     .attr('id', ERMarkers.ZERO_OR_ONE_END)
-    .attr('refX', 30)
+    .attr('refX', 15)
     .attr('refY', 9)
     .attr('markerWidth', 30)
     .attr('markerHeight', 18)
     .attr('orient', 'auto');
+
   marker
     .append('circle')
     .attr('stroke', conf.stroke)
@@ -106,52 +121,69 @@ const insertMarkers = function (elem, conf) {
     .attr('cx', 9)
     .attr('cy', 9)
     .attr('r', 6);
+
   marker.append('path').attr('stroke', conf.stroke).attr('fill', 'none').attr('d', 'M21,0 L21,18');
+
+  /* ===============================
+     ONE-OR-MORE (FIXED)
+     =============================== */
+
+  const ONE_OR_MORE_WIDTH = 36;
+  const ONE_OR_MORE_CENTER = ONE_OR_MORE_WIDTH / 2;
 
   elem
     .append('defs')
     .append('marker')
     .attr('id', ERMarkers.ONE_OR_MORE_START)
-    .attr('refX', 18)
+    .attr('refX', ONE_OR_MORE_CENTER)
     .attr('refY', 18)
-    .attr('markerWidth', 45)
+    .attr('markerWidth', ONE_OR_MORE_WIDTH)
     .attr('markerHeight', 36)
     .attr('orient', 'auto')
     .append('path')
     .attr('stroke', conf.stroke)
     .attr('fill', 'none')
-    .attr('d', 'M0,18 Q 18,0 36,18 Q 18,36 0,18 M42,9 L42,27');
+    .attr('d', 'M0,18 Q18,0 36,18 Q18,36 0,18 M36,9 L36,27');
 
   elem
     .append('defs')
     .append('marker')
     .attr('id', ERMarkers.ONE_OR_MORE_END)
-    .attr('refX', 27)
+    .attr('refX', ONE_OR_MORE_CENTER)
     .attr('refY', 18)
-    .attr('markerWidth', 45)
+    .attr('markerWidth', ONE_OR_MORE_WIDTH)
     .attr('markerHeight', 36)
     .attr('orient', 'auto')
     .append('path')
     .attr('stroke', conf.stroke)
     .attr('fill', 'none')
-    .attr('d', 'M3,9 L3,27 M9,18 Q27,0 45,18 Q27,36 9,18');
+    .attr('d', 'M0,9 L0,27 M0,18 Q18,0 36,18 Q18,36 0,18');
+
+  /* ===============================
+     ZERO-OR-MORE markers
+     =============================== */
+
+  const ZERO_OR_MORE_WIDTH = 42;
+  const ZERO_OR_MORE_CENTER = ZERO_OR_MORE_WIDTH / 2;
 
   marker = elem
     .append('defs')
     .append('marker')
     .attr('id', ERMarkers.ZERO_OR_MORE_START)
-    .attr('refX', 18)
+    .attr('refX', ZERO_OR_MORE_CENTER)
     .attr('refY', 18)
-    .attr('markerWidth', 57)
+    .attr('markerWidth', ZERO_OR_MORE_WIDTH)
     .attr('markerHeight', 36)
     .attr('orient', 'auto');
+
   marker
     .append('circle')
     .attr('stroke', conf.stroke)
     .attr('fill', 'white')
-    .attr('cx', 48)
+    .attr('cx', 36)
     .attr('cy', 18)
     .attr('r', 6);
+
   marker
     .append('path')
     .attr('stroke', conf.stroke)
@@ -162,25 +194,25 @@ const insertMarkers = function (elem, conf) {
     .append('defs')
     .append('marker')
     .attr('id', ERMarkers.ZERO_OR_MORE_END)
-    .attr('refX', 39)
+    .attr('refX', ZERO_OR_MORE_CENTER)
     .attr('refY', 18)
-    .attr('markerWidth', 57)
+    .attr('markerWidth', ZERO_OR_MORE_WIDTH)
     .attr('markerHeight', 36)
     .attr('orient', 'auto');
+
   marker
     .append('circle')
     .attr('stroke', conf.stroke)
     .attr('fill', 'white')
-    .attr('cx', 9)
+    .attr('cx', 6)
     .attr('cy', 18)
     .attr('r', 6);
+
   marker
     .append('path')
     .attr('stroke', conf.stroke)
     .attr('fill', 'none')
-    .attr('d', 'M21,18 Q39,0 57,18 Q39,36 21,18');
-
-  return;
+    .attr('d', 'M6,18 Q24,0 42,18 Q24,36 6,18');
 };
 
 export default {


### PR DESCRIPTION
### Problem
Crow-foot markers in ER diagrams could appear misaligned across browsers and themes due to inconsistent SVG marker reference points.

### Solution
Normalized marker geometry by centering `refX` relative to marker width, ensuring consistent attachment of crow-foot symbols to relationship edges.

### Impact
- Improved cross-browser rendering consistency
- No visual redesign or breaking changes
- Affects ER diagram markers only
