### PR TITLE
7279: Prevent browser hang with multiline accDescr in XY charts

### DIFF
--- a/.changeset/fair-swans-allow.md
+++ b/.changeset/fair-swans-allow.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: Prevent browser hang when using multiline accDescr in XY charts

--- a/packages/mermaid/src/diagrams/xychart/parser/xychart.jison
+++ b/packages/mermaid/src/diagrams/xychart/parser/xychart.jison
@@ -26,7 +26,7 @@
 "accDescr"\s*":"\s*                         { this.pushState("acc_descr");return 'acc_descr'; }
 <acc_descr>(?!\n|;|#)*[^\n]*              { this.popState(); return "acc_descr_value"; }
 "accDescr"\s*"{"\s*                         { this.pushState("acc_descr_multiline");}
-<acc_descr_multiline>"{"                 { this.popState(); }
+<acc_descr_multiline>"}"                 { this.popState(); }
 <acc_descr_multiline>[^\}]*               { return "acc_descr_multiline_value"; }
 
 "xychart-beta"                            {return 'XYCHART';}

--- a/packages/mermaid/src/diagrams/xychart/parser/xychart.jison.spec.ts
+++ b/packages/mermaid/src/diagrams/xychart/parser/xychart.jison.spec.ts
@@ -19,6 +19,8 @@ const mockDB: Record<string, Mock<any>> = {
   setYAxisRangeData: vi.fn(),
   setLineData: vi.fn(),
   setBarData: vi.fn(),
+  setAccTitle: vi.fn(),
+  setAccDescription: vi.fn(),
 };
 
 function clearMocks() {
@@ -439,5 +441,44 @@ describe('Testing xychart jison file', () => {
       { text: 'lineTitle2', type: 'text' },
       [45, 99, 12]
     );
+  });
+
+  describe('accessibility', () => {
+    it('should handle accTitle', () => {
+      const str = 'xychart\naccTitle: Accessible Title\nx-axis [Q1, Q2]\nline [1, 2]';
+      expect(parserFnConstructor(str)).not.toThrow();
+      expect(mockDB.setAccTitle).toHaveBeenCalledWith('Accessible Title');
+    });
+
+    it('should handle single-line accDescr', () => {
+      const str = 'xychart\naccDescr: This is a description\nx-axis [Q1, Q2]\nline [1, 2]';
+      expect(parserFnConstructor(str)).not.toThrow();
+      expect(mockDB.setAccDescription).toHaveBeenCalledWith('This is a description');
+    });
+
+    it('should handle multiline accDescr', () => {
+      const str = `xychart
+accDescr {
+  This is a multiline
+  description
+}
+x-axis [Q1, Q2]
+line [1, 2]`;
+      expect(parserFnConstructor(str)).not.toThrow();
+      expect(mockDB.setAccDescription).toHaveBeenCalledWith('This is a multiline\n  description');
+    });
+
+    it('should handle both accTitle and accDescr', () => {
+      const str = `xychart
+accTitle: Sales Overview
+accDescr: Revenue report for Q1-Q4
+title "Revenue Report"
+x-axis [Q1, Q2, Q3, Q4]
+line [45, 67, 89, 55]`;
+      expect(parserFnConstructor(str)).not.toThrow();
+      expect(mockDB.setAccTitle).toHaveBeenCalledWith('Sales Overview');
+      expect(mockDB.setAccDescription).toHaveBeenCalledWith('Revenue report for Q1-Q4');
+      expect(mockDB.setDiagramTitle).toHaveBeenCalledWith('Revenue Report');
+    });
   });
 });


### PR DESCRIPTION
## :bookmark_tabs: Summary

This PR fixes a browser hang (CODE_HUNG) that occurs when adding a multiline `accDescr` element to an XY chart.

Resolves #7279 

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
