### PR TITLE
feat(docs): customize header based on DOCS_HOSTNAME env var

### DIFF
--- a/packages/mermaid/src/docs/.vitepress/config.ts
+++ b/packages/mermaid/src/docs/.vitepress/config.ts
@@ -2,7 +2,7 @@ import type { MarkdownOptions } from 'vitepress';
 import { defineConfig } from 'vitepress';
 import packageJson from '../../../package.json' assert { type: 'json' };
 import { addCanonicalUrls } from './canonical-urls.js';
-import { getHeaderLogo, withConditionalHomeNav } from './headerDomainRules.js';
+import { getHeaderLogo, getHeaderLogoLink, withConditionalHomeNav } from './headerDomainRules.js';
 import MermaidExample from './mermaid-markdown-all.js';
 
 const allMarkdownTransformers: MarkdownOptions = {
@@ -56,6 +56,7 @@ export default defineConfig({
   ],
   themeConfig: {
     logo: getHeaderLogo(docsHostname()),
+    logoLink: getHeaderLogoLink(docsHostname()),
     nav: nav(),
     editLink: {
       pattern: ({ filePath, frontmatter }) => {

--- a/packages/mermaid/src/docs/.vitepress/headerDomainRules.spec.ts
+++ b/packages/mermaid/src/docs/.vitepress/headerDomainRules.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { getHeaderLogo, HOME_NAV_ITEM, withConditionalHomeNav } from './headerDomainRules.ts';
+import {
+  getHeaderLogo,
+  getHeaderLogoLink,
+  HOME_NAV_ITEM,
+  withConditionalHomeNav,
+} from './headerDomainRules.ts';
 
 describe('headerDomainRules', () => {
   describe('withConditionalHomeNav', () => {
@@ -31,6 +36,16 @@ describe('headerDomainRules', () => {
       expect(getHeaderLogo('mermaid.ai')).toBe(
         'https://static.mermaidchart.dev/assets/mermaid-icon.svg'
       );
+    });
+  });
+
+  describe('getHeaderLogoLink', () => {
+    it('returns / for mermaid.js.org', () => {
+      expect(getHeaderLogoLink('mermaid.js.org')).toBe('/');
+    });
+
+    it('returns https://mermaid.ai for other domains', () => {
+      expect(getHeaderLogoLink('mermaid.ai')).toBe('https://mermaid.ai');
     });
   });
 });

--- a/packages/mermaid/src/docs/.vitepress/headerDomainRules.ts
+++ b/packages/mermaid/src/docs/.vitepress/headerDomainRules.ts
@@ -23,6 +23,15 @@ export function getHeaderLogo(hostname: string): string {
   return isMermaidJsOrgHostname(hostname) ? MERMAID_JS_ORG_LOGO : MERMAID_CHART_LOGO;
 }
 
+/**
+ * Return the URL the header logo should link to.
+ * On mermaid.js.org: links to '/' (site root)
+ * On other domains: links to 'https://mermaid.ai'
+ */
+export function getHeaderLogoLink(hostname: string): string {
+  return isMermaidJsOrgHostname(hostname) ? '/' : 'https://mermaid.ai';
+}
+
 function isHomeNavItem(item: unknown): boolean {
   if (!item || typeof item !== 'object') {
     return false;


### PR DESCRIPTION
## :bookmark_tabs: Summary

## Add domain-based header customization for docs site

This PR allows the docs site header to be customized based on the deployment domain via the `DOCS_HOSTNAME` environment variable.

### Changes

When `DOCS_HOSTNAME` is set to something other than `mermaid.js.org`:

| Element | mermaid.js.org | Other domains (e.g., mermaid.ai) |
|---------|----------------|----------------------------------|
| **Logo image** | `/favicon.svg` | Mermaid Chart logo |
| **Logo link** | `/` | `https://mermaid.ai` |
| **Nav bar** | Standard nav | Adds "Home" link at start |

### Usage

```bash
# Default behavior (mermaid.js.org)
pnpm docs:build

# Custom domain deployment
DOCS_HOSTNAME=mermaid.ai pnpm docs:build
```

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
