### PR TITLE
fix: add rotateTagLabel option and adjust branch spacing

### DIFF
--- a/.changeset/afraid-flies-add.md
+++ b/.changeset/afraid-flies-add.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: add rotateTagLabel option and adjust branch spacing

--- a/cypress/integration/rendering/gitGraph.spec.js
+++ b/cypress/integration/rendering/gitGraph.spec.js
@@ -2078,5 +2078,59 @@ gitGraph TB:
         {}
       );
     });
+
+    it('97: should render tags without rotation in TB mode when rotateTagLabel is false', () => {
+      imgSnapshotTest(
+        `%%{init: { 'logLevel': 'debug', 'theme': 'base' , 'gitGraph': {
+          'rotateCommitLabel': false,
+          'rotateTagLabel': false
+        } } }%%
+        gitGraph TB:
+          commit id: "1" tag: "v1.0"
+          commit id: "2" tag: "v1.1"
+          branch release
+          checkout release
+          commit id: "3" tag: "v2.0"
+        `,
+        {}
+      );
+    });
+
+    it('98: should render with adequate branch spacing in TB mode when rotateCommitLabel is false', () => {
+      imgSnapshotTest(
+        `%%{init: { 'logLevel': 'debug', 'theme': 'base' , 'gitGraph': {
+          'rotateCommitLabel': false
+        } } }%%
+        gitGraph TB:
+          commit id: "A" tag: "v1.0"
+          commit id: "B" tag: "v1.1"
+          branch feature1
+          checkout feature1
+          commit id: "C" tag: "beta1"
+          checkout main
+          branch feature2
+          checkout feature2
+          commit id: "D" tag: "beta2"
+        `,
+        {}
+      );
+    });
+
+    it('99: should render tags without rotation in BT mode when rotateTagLabel is false', () => {
+      imgSnapshotTest(
+        `%%{init: { 'logLevel': 'debug', 'theme': 'base' , 'gitGraph': {
+          'rotateCommitLabel': false,
+          'rotateTagLabel': false
+        } } }%%
+        gitGraph BT:
+          commit id: "A" tag: "v1.0"
+          commit id: "B" tag: "v1.1"
+          branch feature
+          checkout feature
+          commit id: "C" tag: "beta"
+        `,
+        {}
+      );
+    });
   });
 });

--- a/cypress/integration/rendering/gitGraph.spec.js
+++ b/cypress/integration/rendering/gitGraph.spec.js
@@ -2096,27 +2096,7 @@ gitGraph TB:
       );
     });
 
-    it('98: should render with adequate branch spacing in TB mode when rotateCommitLabel is false', () => {
-      imgSnapshotTest(
-        `%%{init: { 'logLevel': 'debug', 'theme': 'base' , 'gitGraph': {
-          'rotateCommitLabel': false
-        } } }%%
-        gitGraph TB:
-          commit id: "A" tag: "v1.0"
-          commit id: "B" tag: "v1.1"
-          branch feature1
-          checkout feature1
-          commit id: "C" tag: "beta1"
-          checkout main
-          branch feature2
-          checkout feature2
-          commit id: "D" tag: "beta2"
-        `,
-        {}
-      );
-    });
-
-    it('99: should render tags without rotation in BT mode when rotateTagLabel is false', () => {
+    it('98: should render tags without rotation in BT mode when rotateTagLabel is false', () => {
       imgSnapshotTest(
         `%%{init: { 'logLevel': 'debug', 'theme': 'base' , 'gitGraph': {
           'rotateCommitLabel': false,
@@ -2133,7 +2113,7 @@ gitGraph TB:
       );
     });
 
-    it('100: should handle long commit IDs and tags without overlap in TB mode', () => {
+    it('99: should render long commit IDs and tags without overlap in TB mode', () => {
       imgSnapshotTest(
         `%%{init: { 'logLevel': 'debug', 'theme': 'base' , 'gitGraph': {
           'rotateCommitLabel': false,
@@ -2154,7 +2134,7 @@ gitGraph TB:
       );
     });
 
-    it('101: should handle long tags with short branch names in TB mode', () => {
+    it('100: should render long tags with short branch names in TB mode', () => {
       imgSnapshotTest(
         `%%{init: { 'logLevel': 'debug', 'theme': 'base' , 'gitGraph': {
           'rotateCommitLabel': false,
@@ -2174,7 +2154,7 @@ gitGraph TB:
       );
     });
 
-    it('102: should handle long branch names with long tags in TB mode', () => {
+    it('101: should render long branch names with long tags in TB mode', () => {
       imgSnapshotTest(
         `%%{init: { 'logLevel': 'debug', 'theme': 'base' , 'gitGraph': {
           'rotateCommitLabel': false,
@@ -2194,20 +2174,102 @@ gitGraph TB:
       );
     });
 
-    it('103: should handle long tags with short branch names in BT mode', () => {
+    it('102: should render extremely long branch names and tags in TB mode', () => {
       imgSnapshotTest(
         `%%{init: { 'logLevel': 'debug', 'theme': 'base' , 'gitGraph': {
           'rotateCommitLabel': false,
           'rotateTagLabel': false
         } } }%%
-        gitGraph BT:
+        gitGraph TB:
           commit id: "A" tag: "v1.0.0-release-candidate-final"
-          branch feature
-          checkout feature
+          branch feature-branch-with-extremely-long-descriptive-name
+          checkout feature-branch-with-extremely-long-descriptive-name
           commit id: "B" tag: "beta-test-version-2024-Q4"
+          checkout main
+          branch bugfix-branch-with-very-long-name-describing-issue
+          checkout bugfix-branch-with-very-long-name-describing-issue
+          commit id: "C" tag: "hotfix-production-v2.5.1"
+        `,
+        {}
+      );
+    });
+
+    it('103: should render with rotateCommitLabel false and rotateTagLabel true in TB mode', () => {
+      imgSnapshotTest(
+        `%%{init: { 'logLevel': 'debug', 'theme': 'base' , 'gitGraph': {
+          'rotateCommitLabel': false,
+          'rotateTagLabel': true
+        } } }%%
+        gitGraph TB:
+          commit id: "VERY-LONG-COMMIT-ID" tag: "v1.0.0-release"
+          branch feature-branch
+          checkout feature-branch
+          commit id: "ANOTHER-LONG-ID" tag: "beta-version"
           checkout main
           branch bugfix
           checkout bugfix
+          commit id: "SHORT" tag: "hotfix"
+        `,
+        {}
+      );
+    });
+
+    it('104: should render long tags when rotateTagLabel is false', () => {
+      imgSnapshotTest(
+        `%%{init: { 'logLevel': 'debug', 'theme': 'base' , 'gitGraph': {
+          'rotateCommitLabel': true,
+          'rotateTagLabel': false
+        } } }%%
+        gitGraph TB:
+          commit id: "A" tag: "v1.0.0-release-candidate-final-production"
+          branch feature
+          checkout feature
+          commit id: "B" tag: "beta-test-version-2024-Q4-candidate"
+          checkout main
+          branch bugfix
+          checkout bugfix
+          commit id: "C" tag: "hotfix-production-v2.5.1-emergency"
+        `,
+        {}
+      );
+    });
+  });
+
+  describe('rotated labels tests', () => {
+    it('105: should render extremely long branch names with rotated labels in TB mode', () => {
+      imgSnapshotTest(
+        `%%{init: { 'logLevel': 'debug', 'theme': 'base' , 'gitGraph': {
+          'rotateCommitLabel': true,
+          'rotateTagLabel': true
+        } } }%%
+        gitGraph TB:
+          commit id: "A" tag: "v1.0.0-release-candidate-final"
+          branch feature-branch-with-extremely-long-descriptive-name
+          checkout feature-branch-with-extremely-long-descriptive-name
+          commit id: "B" tag: "beta-test-version-2024-Q4"
+          checkout main
+          branch bugfix-branch-with-very-long-name-describing-issue
+          checkout bugfix-branch-with-very-long-name-describing-issue
+          commit id: "C" tag: "hotfix-production-v2.5.1"
+        `,
+        {}
+      );
+    });
+
+    it('106: should render extremely long names with rotated labels in BT mode', () => {
+      imgSnapshotTest(
+        `%%{init: { 'logLevel': 'debug', 'theme': 'base' , 'gitGraph': {
+          'rotateCommitLabel': true,
+          'rotateTagLabel': true
+        } } }%%
+        gitGraph BT:
+          commit id: "A" tag: "v1.0.0-release-candidate-final"
+          branch feature-branch-with-extremely-long-descriptive-name
+          checkout feature-branch-with-extremely-long-descriptive-name
+          commit id: "B" tag: "beta-test-version-2024-Q4"
+          checkout main
+          branch bugfix-branch-with-very-long-name
+          checkout bugfix-branch-with-very-long-name
           commit id: "C" tag: "hotfix-production-v2.5.1"
         `,
         {}

--- a/cypress/integration/rendering/gitGraph.spec.js
+++ b/cypress/integration/rendering/gitGraph.spec.js
@@ -2132,5 +2132,86 @@ gitGraph TB:
         {}
       );
     });
+
+    it('100: should handle long commit IDs and tags without overlap in TB mode', () => {
+      imgSnapshotTest(
+        `%%{init: { 'logLevel': 'debug', 'theme': 'base' , 'gitGraph': {
+          'rotateCommitLabel': false,
+          'rotateTagLabel': false
+        } } }%%
+        gitGraph TB:
+          commit id: "VERY-LONG-COMMIT-ID-1234567890"
+          commit id: "ANOTHER-LONG-ID-ABCDEFGH" tag: "v1.0.0-release-candidate"
+          branch feature-branch-with-long-name
+          checkout feature-branch-with-long-name
+          commit id: "FEATURE-COMMIT-XYZ" tag: "beta-version-2024"
+          checkout main
+          branch second-feature
+          checkout second-feature
+          commit id: "SHORT" tag: "v2"
+        `,
+        {}
+      );
+    });
+
+    it('101: should handle long tags with short branch names in TB mode', () => {
+      imgSnapshotTest(
+        `%%{init: { 'logLevel': 'debug', 'theme': 'base' , 'gitGraph': {
+          'rotateCommitLabel': false,
+          'rotateTagLabel': false
+        } } }%%
+        gitGraph TB:
+          commit id: "A" tag: "v1.0.0-release-candidate-final"
+          branch feature
+          checkout feature
+          commit id: "B" tag: "beta-test-version-2024-Q4"
+          checkout main
+          branch bugfix
+          checkout bugfix
+          commit id: "C" tag: "hotfix-production-v2.5.1"
+        `,
+        {}
+      );
+    });
+
+    it('102: should handle long branch names with long tags in TB mode', () => {
+      imgSnapshotTest(
+        `%%{init: { 'logLevel': 'debug', 'theme': 'base' , 'gitGraph': {
+          'rotateCommitLabel': false,
+          'rotateTagLabel': false
+        } } }%%
+        gitGraph TB:
+          commit id: "A" tag: "v1.0.0-release-candidate-final"
+          branch feature-branch-with-long-name
+          checkout feature-branch-with-long-name
+          commit id: "B" tag: "beta-test-version-2024-Q4"
+          checkout main
+          branch bugfix-branch-with-long-name
+          checkout bugfix-branch-with-long-name
+          commit id: "C" tag: "hotfix-production-v2.5.1"
+        `,
+        {}
+      );
+    });
+
+    it('103: should handle long tags with short branch names in BT mode', () => {
+      imgSnapshotTest(
+        `%%{init: { 'logLevel': 'debug', 'theme': 'base' , 'gitGraph': {
+          'rotateCommitLabel': false,
+          'rotateTagLabel': false
+        } } }%%
+        gitGraph BT:
+          commit id: "A" tag: "v1.0.0-release-candidate-final"
+          branch feature
+          checkout feature
+          commit id: "B" tag: "beta-test-version-2024-Q4"
+          checkout main
+          branch bugfix
+          checkout bugfix
+          commit id: "C" tag: "hotfix-production-v2.5.1"
+        `,
+        {}
+      );
+    });
   });
 });

--- a/packages/mermaid/src/config.type.ts
+++ b/packages/mermaid/src/config.type.ts
@@ -1119,6 +1119,7 @@ export interface GitGraphDiagramConfig extends BaseDiagramConfig {
   showCommitLabel?: boolean;
   showBranches?: boolean;
   rotateCommitLabel?: boolean;
+  rotateTagLabel?: boolean;
   parallelCommits?: boolean;
   /**
    * Controls whether or arrow markers in html code are absolute paths or anchors.

--- a/packages/mermaid/src/diagrams/git/gitGraph.spec.ts
+++ b/packages/mermaid/src/diagrams/git/gitGraph.spec.ts
@@ -1387,5 +1387,12 @@ describe('when parsing a gitGraph', function () {
       expect(config).toBeDefined();
       expect(config).toHaveProperty('parallelCommits');
     });
+
+    it('should return config with rotateTagLabel property', () => {
+      const config = db.getConfig();
+      expect(config).toBeDefined();
+      expect(config).toHaveProperty('rotateTagLabel');
+      expect(config.rotateTagLabel).toBe(true);
+    });
   });
 });

--- a/packages/mermaid/src/diagrams/git/gitGraphTypes.ts
+++ b/packages/mermaid/src/diagrams/git/gitGraphTypes.ts
@@ -129,6 +129,7 @@ export interface GitGraphDBRenderProvider extends Partial<GitGraphDB> {
   getDirection: () => DiagramOrientation;
   getHead: () => Commit | null;
   getDiagramTitle: () => string;
+  getConfig: () => Required<GitGraphDiagramConfig>;
 }
 
 export type DiagramOrientation = 'LR' | 'TB' | 'BT';

--- a/packages/mermaid/src/schemas/config.schema.yaml
+++ b/packages/mermaid/src/schemas/config.schema.yaml
@@ -894,6 +894,9 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
       rotateCommitLabel:
         type: boolean
         default: true
+      rotateTagLabel:
+        type: boolean
+        default: true
       parallelCommits:
         type: boolean
         default: false


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fixes #7327 - Add `rotateTagLabel` configuration option and improve branch spacing in gitGraph TB/BT modes.

**Changes:**
- Add `rotateTagLabel` config option (default: `true`) for controlling tag label rotation in vertical layouts
- Adjust branch spacing to 20px minimum when `rotateCommitLabel: false` in TB/BT modes

Resolves #7327

## :straight_ruler: Design Decisions

### 1. rotateTagLabel Configuration Option
Added `rotateTagLabel` boolean option following the same pattern as existing `rotateCommitLabel`. When set to `false`, tags remain horizontal in TB/BT modes instead of being rotated.

Before: 
<img width="290" height="256" alt="image" src="https://github.com/user-attachments/assets/89001683-dd7e-4f62-b8d5-4290b91055c8" />

After: 
<img width="289" height="267" alt="image" src="https://github.com/user-attachments/assets/496c2a13-60a6-4a1b-bf4f-15836c7786ba" />


### 2. Branch Spacing Adjustment
Implemented minimum 20px spacing between branches in TB/BT modes when `rotateCommitLabel: false` by adding `branchSpacingOffset` constant. This resolves the issue where branches were rendered too close together.

Before: 
<img width="260" height="263" alt="image" src="https://github.com/user-attachments/assets/03b35028-6cb1-4bde-b0b2-740c5f87bac7" />

After: 
<img width="299" height="271" alt="image" src="https://github.com/user-attachments/assets/7b76b156-8996-498b-8250-f0c4f12ee175" />

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
