### PR TITLE
feature(er)/7319: allow nullable attribute types with ?

### DIFF
--- a/.changeset/sour-horses-pump.md
+++ b/.changeset/sour-horses-pump.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+feat: support nullable ER attribute types with ?

--- a/docs/syntax/entityRelationshipDiagram.md
+++ b/docs/syntax/entityRelationshipDiagram.md
@@ -245,7 +245,23 @@ erDiagram
     }
 ```
 
-The `type` values must begin with an alphabetic character and may contain digits, hyphens, underscores, parentheses and square brackets. The `name` values follow a similar format to `type`, but may start with an asterisk as another option to indicate an attribute is a primary key. Other than that, there are no restrictions, and there is no implicit set of valid data types.
+The `type` values must begin with an alphabetic character and may contain digits, hyphens, underscores, parentheses and square brackets. The `name` values follow a similar format to `type`, but may start with an asterisk as another option to indicate an attribute is a primary key. Other than that, there are no restrictions, and there is no implicit set of valid data types. To indicate a nullable type, append a `?` to the type.
+
+```mermaid-example
+erDiagram
+    FOO {
+        string id PK
+        string? alias
+    }
+```
+
+```mermaid
+erDiagram
+    FOO {
+        string id PK
+        string? alias
+    }
+```
 
 ### Entity Name Aliases
 

--- a/packages/mermaid/src/diagrams/er/parser/erDiagram.jison
+++ b/packages/mermaid/src/diagrams/er/parser/erDiagram.jison
@@ -34,7 +34,7 @@ accDescr\s*"{"\s*                                { this.begin("acc_descr_multili
 <block>\s+                      /* skip whitespace in block */
 <block>\b((?:PK)|(?:FK)|(?:UK))\b      return 'ATTRIBUTE_KEY'
 <block>([^\s]*)[~].*[~]([^\s]*)        return 'ATTRIBUTE_WORD';
-<block>([\*A-Za-z_\u00C0-\uFFFF][A-Za-z0-9\-\_\[\]\(\)\u00C0-\uFFFF\*]*)  return 'ATTRIBUTE_WORD';
+<block>([\*A-Za-z_\u00C0-\uFFFF][A-Za-z0-9\-\_\[\]\(\)\u00C0-\uFFFF\*]*\??)  return 'ATTRIBUTE_WORD';
 <block>\"[^"]*\"                return 'COMMENT';
 <block>[\n]+                    /* nothing */
 <block>"}"                      { this.popState(); return 'BLOCK_STOP'; }

--- a/packages/mermaid/src/diagrams/er/parser/erDiagram.spec.js
+++ b/packages/mermaid/src/diagrams/er/parser/erDiagram.spec.js
@@ -346,6 +346,19 @@ describe('when parsing ER diagram it...', function () {
     expect(entities.get(entity).attributes[1].type).toBe('varchar(5)');
   });
 
+  it('should allow an entity with a nullable attribute type', function () {
+    const entity = 'BOOK';
+    const attribute1 = 'string? alias';
+    const attribute2 = 'int? id PK';
+
+    erDiagram.parser.parse(`erDiagram\n${entity} {\n${attribute1}\n${attribute2}\n}`);
+    const entities = erDb.getEntities();
+    expect(entities.size).toBe(1);
+    expect(entities.get(entity).attributes.length).toBe(2);
+    expect(entities.get(entity).attributes[0].type).toBe('string?');
+    expect(entities.get(entity).attributes[1].type).toBe('int?');
+  });
+
   it('should allow an entity with multiple attributes to be defined', function () {
     const entity = 'BOOK';
     const attribute1 = 'string title';

--- a/packages/mermaid/src/docs/syntax/entityRelationshipDiagram.md
+++ b/packages/mermaid/src/docs/syntax/entityRelationshipDiagram.md
@@ -171,7 +171,15 @@ erDiagram
     }
 ```
 
-The `type` values must begin with an alphabetic character and may contain digits, hyphens, underscores, parentheses and square brackets. The `name` values follow a similar format to `type`, but may start with an asterisk as another option to indicate an attribute is a primary key. Other than that, there are no restrictions, and there is no implicit set of valid data types.
+The `type` values must begin with an alphabetic character and may contain digits, hyphens, underscores, parentheses and square brackets. The `name` values follow a similar format to `type`, but may start with an asterisk as another option to indicate an attribute is a primary key. Other than that, there are no restrictions, and there is no implicit set of valid data types. To indicate a nullable type, append a `?` to the type.
+
+```mermaid-example
+erDiagram
+    FOO {
+        string id PK
+        string? alias
+    }
+```
 
 ### Entity Name Aliases
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

Allows nullable types/cols in the ER diagram

Resolves #7319

## :straight_ruler: Design Decisions
Followed the decision from the Issue PR. Made minimal changes just to address this.
<img width="765" height="338" alt="Screenshot 2026-01-27 at 8 36 19 PM" src="https://github.com/user-attachments/assets/32eff0f5-9caf-40f6-98fd-e983cb5cd07e" />


### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
