### PR TITLE
Improve the accessibility of flowcharts

### DIFF
--- a/.build/jsonSchema.ts
+++ b/.build/jsonSchema.ts
@@ -28,6 +28,7 @@ const MERMAID_CONFIG_DIAGRAM_KEYS = [
   'packet',
   'architecture',
   'radar',
+  'accessibility', // Not a diagram type, but needs the same support for nested default values.
 ] as const;
 
 /**

--- a/.changeset/tired-pugs-pull.md
+++ b/.changeset/tired-pugs-pull.md
@@ -1,0 +1,5 @@
+---
+'mermaid': minor
+---
+
+Add minimal accessibility support for dagre flowcharts.

--- a/cypress/integration/other/xss.spec.js
+++ b/cypress/integration/other/xss.spec.js
@@ -120,14 +120,14 @@ describe('XSS', () => {
   it('should sanitize colons properly', () => {
     cy.visit('/xss20.html');
     cy.wait(1000);
-    cy.get('a').click('');
+    cy.get('.nodeLabel a').click('');
     cy.wait(1000);
     cy.get('#the-malware').should('not.exist');
   });
   it('should sanitize colons properly', () => {
     cy.visit('/xss21.html');
     cy.wait(1000);
-    cy.get('a').click('');
+    cy.get('.nodeLabel a').click('');
     cy.wait(1000);
     cy.get('#the-malware').should('not.exist');
   });

--- a/docs/config/accessibility.md
+++ b/docs/config/accessibility.md
@@ -434,3 +434,107 @@ Here is the HTML generated for the SVG element: _(Note that some of the SVG attr
         Sit down: 5: Me
 
 ```
+
+### Accessible Diagram Structure
+
+#### Flowcharts (v\<MERMAID_RELEASE_VERSION>+)
+
+Flowcharts provide a list of the edges touching each node,
+as links to the node at the other end of the edge.
+Outbound edges are shown by default,
+while inbound edges can be enabled with:
+
+```
+config:
+  accessibility:
+    listInboundEdges: true
+```
+
+Outbound edges have the same accessible name as their visible label,
+while inbound edges use their label, "from", and the name of the other node.
+If either sort of edge doesn't have a visible label, it uses the name of the other node.
+
+You can configure the names of the lists using:
+
+```
+config:
+  accessibility:
+    listInboundEdges: true
+    inboundEdgesLabel: "Incoming edges"
+    outboundEdgesLabel: "Outgoing edges"
+```
+
+The following diagram
+
+```mermaid-example
+graph LR
+  accTitle: Big Decisions
+  accDescr: Bob's Burgers process for making big decisions
+  A[Identify Big Decision] --> B{Make Big Decision}
+  B --> D[Be done]
+```
+
+```mermaid
+graph LR
+  accTitle: Big Decisions
+  accDescr: Bob's Burgers process for making big decisions
+  A[Identify Big Decision] --> B{Make Big Decision}
+  B --> D[Be done]
+```
+
+generates the following (simplified) SVG:
+
+```html
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  role="graphics-document document"
+  aria-roledescription="flowchart-v2"
+  aria-describedby="chart-desc-mermaid-164"
+  aria-labelledby="chart-title-mermaid-164"
+>
+  <title id="chart-title-mermaid-164">Big Decisions</title>
+  <desc id="chart-desc-mermaid-164">Bob's Burgers process for making big decisions</desc>
+  <g>
+    <g class="root">
+      <g class="clusters"></g>
+      <g class="edgePaths" aria-hidden="true"></g>
+      <g class="edgeLabels" aria-hidden="true"></g>
+      <g class="nodes" role="list">
+        <g id="flowchart-A-0" role="listitem">
+          <rect></rect>
+          <g class="label">
+            <text>Identify Big Decision</text>
+          </g>
+          <g role="list" aria-label="Outbound edges">
+            <g role="listitem">
+              <a xlink:href="#flowchart-B-1" aria-label="Make Big Decision"></a>
+            </g>
+          </g>
+        </g>
+        <g id="flowchart-B-1" role="listitem">
+          <polygon></polygon>
+          <g class="label">
+            <g>
+              <text>Make Big Decision</text>
+            </g>
+          </g>
+          <g role="list" aria-label="Outbound edges">
+            <g role="listitem">
+              <a xlink:href="#flowchart-D-3" aria-label="Be done"></a>
+            </g>
+          </g>
+        </g>
+        <g id="flowchart-D-3" role="listitem">
+          <rect></rect>
+          <g class="label">
+            <g>
+              <text>Be done</text>
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>
+```

--- a/docs/config/setup/mermaid/interfaces/MermaidConfig.md
+++ b/docs/config/setup/mermaid/interfaces/MermaidConfig.md
@@ -14,6 +14,14 @@ Defined in: [packages/mermaid/src/config.type.ts:58](https://github.com/mermaid-
 
 ## Properties
 
+### accessibility?
+
+> `optional` **accessibility**: `AccessibilityConfig`
+
+Defined in: [packages/mermaid/src/config.type.ts:199](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L199)
+
+---
+
 ### altFontFamily?
 
 > `optional` **altFontFamily**: `string`
@@ -26,7 +34,7 @@ Defined in: [packages/mermaid/src/config.type.ts:139](https://github.com/mermaid
 
 > `optional` **architecture**: `ArchitectureDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:211](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L211)
+Defined in: [packages/mermaid/src/config.type.ts:212](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L212)
 
 ---
 
@@ -45,7 +53,7 @@ This matters if you are using base tag settings.
 
 > `optional` **block**: `BlockDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:218](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L218)
+Defined in: [packages/mermaid/src/config.type.ts:219](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L219)
 
 ---
 
@@ -53,7 +61,7 @@ Defined in: [packages/mermaid/src/config.type.ts:218](https://github.com/mermaid
 
 > `optional` **c4**: `C4DiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:215](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L215)
+Defined in: [packages/mermaid/src/config.type.ts:216](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L216)
 
 ---
 
@@ -61,7 +69,7 @@ Defined in: [packages/mermaid/src/config.type.ts:215](https://github.com/mermaid
 
 > `optional` **class**: `ClassDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:204](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L204)
+Defined in: [packages/mermaid/src/config.type.ts:205](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L205)
 
 ---
 
@@ -105,7 +113,7 @@ You can set this attribute to base the seed on a static string.
 
 > `optional` **dompurifyConfig**: `Config`
 
-Defined in: [packages/mermaid/src/config.type.ts:220](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L220)
+Defined in: [packages/mermaid/src/config.type.ts:221](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L221)
 
 ---
 
@@ -151,7 +159,7 @@ Elk specific option affecting how nodes are placed.
 
 > `optional` **er**: `ErDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:206](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L206)
+Defined in: [packages/mermaid/src/config.type.ts:207](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L207)
 
 ---
 
@@ -159,7 +167,7 @@ Defined in: [packages/mermaid/src/config.type.ts:206](https://github.com/mermaid
 
 > `optional` **flowchart**: `FlowchartDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:199](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L199)
+Defined in: [packages/mermaid/src/config.type.ts:200](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L200)
 
 ---
 
@@ -179,7 +187,7 @@ See <https://developer.mozilla.org/en-US/docs/Web/CSS/font-family>
 
 > `optional` **fontSize**: `number`
 
-Defined in: [packages/mermaid/src/config.type.ts:222](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L222)
+Defined in: [packages/mermaid/src/config.type.ts:223](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L223)
 
 ---
 
@@ -199,7 +207,7 @@ If set to true, ignores legacyMathML.
 
 > `optional` **gantt**: `GanttDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:201](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L201)
+Defined in: [packages/mermaid/src/config.type.ts:202](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L202)
 
 ---
 
@@ -207,7 +215,7 @@ Defined in: [packages/mermaid/src/config.type.ts:201](https://github.com/mermaid
 
 > `optional` **gitGraph**: `GitGraphDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:214](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L214)
+Defined in: [packages/mermaid/src/config.type.ts:215](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L215)
 
 ---
 
@@ -238,7 +246,7 @@ over any diagram-specific settings.
 
 > `optional` **journey**: `JourneyDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:202](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L202)
+Defined in: [packages/mermaid/src/config.type.ts:203](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L203)
 
 ---
 
@@ -246,7 +254,7 @@ Defined in: [packages/mermaid/src/config.type.ts:202](https://github.com/mermaid
 
 > `optional` **kanban**: `KanbanDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:213](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L213)
+Defined in: [packages/mermaid/src/config.type.ts:214](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L214)
 
 ---
 
@@ -297,7 +305,7 @@ Defines which main look to use for the diagram.
 
 > `optional` **markdownAutoWrap**: `boolean`
 
-Defined in: [packages/mermaid/src/config.type.ts:223](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L223)
+Defined in: [packages/mermaid/src/config.type.ts:224](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L224)
 
 ---
 
@@ -325,7 +333,7 @@ The maximum allowed size of the users text diagram
 
 > `optional` **mindmap**: `MindmapDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:212](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L212)
+Defined in: [packages/mermaid/src/config.type.ts:213](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L213)
 
 ---
 
@@ -333,7 +341,7 @@ Defined in: [packages/mermaid/src/config.type.ts:212](https://github.com/mermaid
 
 > `optional` **packet**: `PacketDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:217](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L217)
+Defined in: [packages/mermaid/src/config.type.ts:218](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L218)
 
 ---
 
@@ -341,7 +349,7 @@ Defined in: [packages/mermaid/src/config.type.ts:217](https://github.com/mermaid
 
 > `optional` **pie**: `PieDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:207](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L207)
+Defined in: [packages/mermaid/src/config.type.ts:208](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L208)
 
 ---
 
@@ -349,7 +357,7 @@ Defined in: [packages/mermaid/src/config.type.ts:207](https://github.com/mermaid
 
 > `optional` **quadrantChart**: `QuadrantChartConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:208](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L208)
+Defined in: [packages/mermaid/src/config.type.ts:209](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L209)
 
 ---
 
@@ -357,7 +365,7 @@ Defined in: [packages/mermaid/src/config.type.ts:208](https://github.com/mermaid
 
 > `optional` **radar**: `RadarDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:219](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L219)
+Defined in: [packages/mermaid/src/config.type.ts:220](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L220)
 
 ---
 
@@ -365,7 +373,7 @@ Defined in: [packages/mermaid/src/config.type.ts:219](https://github.com/mermaid
 
 > `optional` **requirement**: `RequirementDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:210](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L210)
+Defined in: [packages/mermaid/src/config.type.ts:211](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L211)
 
 ---
 
@@ -373,7 +381,7 @@ Defined in: [packages/mermaid/src/config.type.ts:210](https://github.com/mermaid
 
 > `optional` **sankey**: `SankeyDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:216](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L216)
+Defined in: [packages/mermaid/src/config.type.ts:217](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L217)
 
 ---
 
@@ -403,7 +411,7 @@ Level of trust for parsed diagram
 
 > `optional` **sequence**: `SequenceDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:200](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L200)
+Defined in: [packages/mermaid/src/config.type.ts:201](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L201)
 
 ---
 
@@ -421,7 +429,7 @@ Dictates whether mermaid starts on Page load
 
 > `optional` **state**: `StateDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:205](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L205)
+Defined in: [packages/mermaid/src/config.type.ts:206](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L206)
 
 ---
 
@@ -429,7 +437,7 @@ Defined in: [packages/mermaid/src/config.type.ts:205](https://github.com/mermaid
 
 > `optional` **suppressErrorRendering**: `boolean`
 
-Defined in: [packages/mermaid/src/config.type.ts:229](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L229)
+Defined in: [packages/mermaid/src/config.type.ts:230](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L230)
 
 Suppresses inserting 'Syntax error' diagram in the DOM.
 This is useful when you want to control how to handle syntax errors in your application.
@@ -467,7 +475,7 @@ Defined in: [packages/mermaid/src/config.type.ts:65](https://github.com/mermaid-
 
 > `optional` **timeline**: `TimelineDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:203](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L203)
+Defined in: [packages/mermaid/src/config.type.ts:204](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L204)
 
 ---
 
@@ -475,7 +483,7 @@ Defined in: [packages/mermaid/src/config.type.ts:203](https://github.com/mermaid
 
 > `optional` **wrap**: `boolean`
 
-Defined in: [packages/mermaid/src/config.type.ts:221](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L221)
+Defined in: [packages/mermaid/src/config.type.ts:222](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L222)
 
 ---
 
@@ -483,4 +491,4 @@ Defined in: [packages/mermaid/src/config.type.ts:221](https://github.com/mermaid
 
 > `optional` **xyChart**: `XYChartConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:209](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L209)
+Defined in: [packages/mermaid/src/config.type.ts:210](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L210)

--- a/packages/mermaid/src/config.type.ts
+++ b/packages/mermaid/src/config.type.ts
@@ -196,6 +196,7 @@ export interface MermaidConfig {
    *
    */
   deterministicIDSeed?: string;
+  accessibility?: AccessibilityConfig;
   flowchart?: FlowchartDiagramConfig;
   sequence?: SequenceDiagramConfig;
   gantt?: GanttDiagramConfig;
@@ -227,6 +228,36 @@ export interface MermaidConfig {
    *
    */
   suppressErrorRendering?: boolean;
+}
+/**
+ * Defines how accessibility information should be included in diagrams.
+ *
+ * This interface was referenced by `MermaidConfig`'s JSON-Schema
+ * via the `definition` "AccessibilityConfig".
+ */
+export interface AccessibilityConfig {
+  /**
+   * When this flag is `true`, the accessibility tree for a node will
+   * include a list of links that follow the node's inbound edges.
+   *
+   */
+  listInboundEdges?: boolean;
+  /**
+   * When this flag is `true`, the accessibility tree for a node will
+   * include a list of links that follow the node's outbound edges.
+   *
+   */
+  listOutboundEdges?: boolean;
+  /**
+   * Label for the inbound edges list
+   *
+   */
+  inboundEdgesLabel?: string;
+  /**
+   * Label for the outbound edges list
+   *
+   */
+  outboundEdgesLabel?: string;
 }
 /**
  * The object containing configurations specific for flowcharts

--- a/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.spec.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.spec.ts
@@ -1,0 +1,90 @@
+import { select } from 'd3';
+import { setConfig } from '../../config.js';
+import { addDetector } from '../../diagram-api/detectType.js';
+import { Diagram } from '../../Diagram.js';
+import { ensureNodeFromSelector, jsdomIt } from '../../tests/util.js';
+import flowDetector from './flowDetector-v2.js';
+import { draw } from './flowRenderer-v3-unified.js';
+const { id, detector, loader } = flowDetector;
+
+addDetector(id, detector, loader); // Add architecture schemas to Mermaid
+
+describe('Accessibility', function () {
+  jsdomIt('should hide edges', async () => {
+    const svgNode = await drawDiagram(`
+      flowchart
+        A[First node] --> B[Second node]
+    `);
+    const edgePaths = svgNode.querySelectorAll('.edgePaths');
+    expect(edgePaths).toHaveLength(1);
+    expect(edgePaths[0].getAttribute('aria-hidden')).toBe('true');
+    const edgeLabels = svgNode.querySelectorAll('.edgeLabels');
+    expect(edgeLabels).toHaveLength(1);
+    expect(edgeLabels[0].getAttribute('aria-hidden')).toBe('true');
+  });
+
+  jsdomIt('should be an aria list of nodes, in declaration order', async () => {
+    const svgNode = await drawDiagram(`
+      flowchart
+        A[First node] --> B[Second node]
+    `);
+    const list = svgNode.querySelectorAll('g.nodes[role=list]');
+    expect(list).toHaveLength(1);
+    const nodes = [...list[0].querySelectorAll('g.node[role=listitem]')];
+    expect(nodes.map((node) => node.textContent)).toEqual(['First node', 'Second node']);
+  });
+
+  jsdomIt('should link to subsequent node', async () => {
+    const svgNode = await drawDiagram(`
+      flowchart
+        A[First node] --> B[Second node]
+    `);
+    const nodeA = svgNode.querySelector('#flowchart-A-0');
+    expect(nodeA).toBeTruthy();
+    const outboundList = nodeA!.querySelector('[role=list]');
+    expect(outboundList?.getAttribute('aria-label')).toBe('Outbound edges');
+    const outboundListItems = [...outboundList!.querySelectorAll('[role=listitem] a')];
+    expect(outboundListItems.map((item) => item.getAttribute('aria-label'))).toEqual([
+      'Second node',
+    ]);
+    expect(
+      outboundListItems.map((item) => item.getAttributeNS('http://www.w3.org/1999/xlink', 'href'))
+    ).toEqual(['#flowchart-B-1']);
+  });
+
+  jsdomIt('should also link to previous node when configured', async () => {
+    setConfig({ accessibility: { listInboundEdges: true } });
+    const svgNode = await drawDiagram(`
+      flowchart
+        A[First node] --> B[Second node]
+      `);
+    const nodeA = svgNode.querySelector('#flowchart-A-0');
+    expect(nodeA, 'Missing first node').toBeTruthy();
+    const outboundList = nodeA!.querySelector('[role=list]');
+    expect(outboundList?.getAttribute('aria-label')).toBe('Outbound edges');
+    const outboundListItems = [...outboundList!.querySelectorAll('[role=listitem] a')];
+    expect(outboundListItems.map((item) => item.getAttribute('aria-label'))).toEqual([
+      'Second node',
+    ]);
+    expect(
+      outboundListItems.map((item) => item.getAttributeNS('http://www.w3.org/1999/xlink', 'href'))
+    ).toEqual(['#flowchart-B-1']);
+
+    const nodeB = svgNode.querySelector('#flowchart-B-1');
+    expect(nodeB, 'Missing second node').toBeTruthy();
+    const inboundList = nodeB!.querySelector('[role=list]');
+    expect(inboundList?.getAttribute('aria-label')).toBe('Inbound edges');
+    const inboundListItems = [...inboundList!.querySelectorAll('[role=listitem] a')];
+    expect(inboundListItems.map((item) => item.getAttribute('aria-label'))).toEqual(['First node']);
+    expect(
+      inboundListItems.map((item) => item.getAttributeNS('http://www.w3.org/1999/xlink', 'href'))
+    ).toEqual(['#flowchart-A-0']);
+  });
+});
+
+async function drawDiagram(diagramText: string): Promise<Element> {
+  select('#svg').append('g'); // This renderer assumes there's a <g> inside the <svg>.
+  const diagram = await Diagram.fromText(diagramText);
+  await draw('NOT_USED', 'svg', '1.0.0', diagram);
+  return ensureNodeFromSelector('#svg');
+}

--- a/packages/mermaid/src/docs/config/accessibility.md
+++ b/packages/mermaid/src/docs/config/accessibility.md
@@ -287,3 +287,99 @@ Here is the HTML generated for the SVG element: _(Note that some of the SVG attr
         Sit down: 5: Me
 
 ```
+
+### Accessible Diagram Structure
+
+#### Flowcharts (v<MERMAID_RELEASE_VERSION>+)
+
+Flowcharts provide a list of the edges touching each node,
+as links to the node at the other end of the edge.
+Outbound edges are shown by default,
+while inbound edges can be enabled with:
+
+```
+config:
+  accessibility:
+    listInboundEdges: true
+```
+
+Outbound edges have the same accessible name as their visible label,
+while inbound edges use their label, "from", and the name of the other node.
+If either sort of edge doesn't have a visible label, it uses the name of the other node.
+
+You can configure the names of the lists using:
+
+```
+config:
+  accessibility:
+    listInboundEdges: true
+    inboundEdgesLabel: "Incoming edges"
+    outboundEdgesLabel: "Outgoing edges"
+```
+
+The following diagram
+
+```mermaid-example
+graph LR
+  accTitle: Big Decisions
+  accDescr: Bob's Burgers process for making big decisions
+  A[Identify Big Decision] --> B{Make Big Decision}
+  B --> D[Be done]
+```
+
+generates the following (simplified) SVG:
+
+```html
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  role="graphics-document document"
+  aria-roledescription="flowchart-v2"
+  aria-describedby="chart-desc-mermaid-164"
+  aria-labelledby="chart-title-mermaid-164"
+>
+  <title id="chart-title-mermaid-164">Big Decisions</title>
+  <desc id="chart-desc-mermaid-164">Bob's Burgers process for making big decisions</desc>
+  <g>
+    <g class="root">
+      <g class="clusters"></g>
+      <g class="edgePaths" aria-hidden="true"></g>
+      <g class="edgeLabels" aria-hidden="true"></g>
+      <g class="nodes" role="list">
+        <g id="flowchart-A-0" role="listitem">
+          <rect></rect>
+          <g class="label">
+            <text>Identify Big Decision</text>
+          </g>
+          <g role="list" aria-label="Outbound edges">
+            <g role="listitem">
+              <a xlink:href="#flowchart-B-1" aria-label="Make Big Decision"></a>
+            </g>
+          </g>
+        </g>
+        <g id="flowchart-B-1" role="listitem">
+          <polygon></polygon>
+          <g class="label">
+            <g>
+              <text>Make Big Decision</text>
+            </g>
+          </g>
+          <g role="list" aria-label="Outbound edges">
+            <g role="listitem">
+              <a xlink:href="#flowchart-D-3" aria-label="Be done"></a>
+            </g>
+          </g>
+        </g>
+        <g id="flowchart-D-3" role="listitem">
+          <rect></rect>
+          <g class="label">
+            <g>
+              <text>Be done</text>
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>
+```

--- a/packages/mermaid/src/rendering-util/types.ts
+++ b/packages/mermaid/src/rendering-util/types.ts
@@ -190,11 +190,21 @@ export type LayoutMethod =
   | 'osage'
   | 'grid';
 
+/** Provides enough information about an adjacent node to create an accessible link to it. */
+export interface AdjacentNode {
+  edgeLabel?: string;
+  nodeDomId: string;
+  nodeLabel: string;
+}
+
 export interface ShapeRenderOptions {
   config: MermaidConfig;
   /** Some shapes render differently if a diagram has a direction `LR` */
   dir?: Node['dir'];
   padding?: number;
+  /** Allows the node to include links to adjacent nodes, for accessibility. */
+  inboundEdges?: AdjacentNode[];
+  outboundEdges?: AdjacentNode[];
 }
 
 export type KanbanNode = Node & {

--- a/packages/mermaid/src/schemas/config.schema.yaml
+++ b/packages/mermaid/src/schemas/config.schema.yaml
@@ -35,6 +35,7 @@ required:
   - securityLevel
   - startOnLoad
   - arrowMarkerAbsolute
+  - accessibility
   - flowchart
   - sequence
   - gantt
@@ -273,6 +274,8 @@ properties:
       If set to `undefined` but deterministicIds is `true`, a simple number iterator is used.
       You can set this attribute to base the seed on a static string.
     type: string
+  accessibility:
+    $ref: '#/$defs/AccessibilityConfig'
   flowchart:
     $ref: '#/$defs/FlowchartDiagramConfig'
   sequence:
@@ -336,6 +339,34 @@ properties:
       This is useful when you want to control how to handle syntax errors in your application.
 
 $defs: # JSON Schema definition (maybe we should move these to a separate file)
+  AccessibilityConfig:
+    title: Accessibility Config
+    description: Defines how accessibility information should be included in diagrams.
+    type: object
+    unevaluatedProperties: false
+    properties:
+      listInboundEdges:
+        description: |
+          When this flag is `true`, the accessibility tree for a node will
+          include a list of links that follow the node's inbound edges.
+        type: boolean
+        default: false
+      listOutboundEdges:
+        description: |
+          When this flag is `true`, the accessibility tree for a node will
+          include a list of links that follow the node's outbound edges.
+        type: boolean
+        default: true
+      inboundEdgesLabel:
+        type: string
+        default: 'Inbound edges'
+        description: |
+          Label for the inbound edges list
+      outboundEdgesLabel:
+        type: string
+        default: 'Outbound edges'
+        description: |
+          Label for the outbound edges list
   BaseDiagramConfig:
     # TODO: More config needs to be moved here
     title: Base Diagram Config


### PR DESCRIPTION
## :bookmark_tabs: Summary

This takes the first step toward representing flowcharts' content in the Accessibility Tree, by representing a graph as a list of nodes, which represent their adjacent edges as a list of links.

Improves #2395 and a bit of #5632, but does not fully resolve them.

## :straight_ruler: Design Decisions

The basic strategy here is to present the overall chart as a list of nodes, where each node contains a list of its outbound edges, as links to their target nodes. Optionally, nodes can also contain a list of inbound edges, again as links. The heading of each list is configurable globally. All of these lists use aria-label instead of text content so that they don't affect the visual presentation.

`insertNode()`, which needs to create the links, didn't know which edges touched the node, so I also added that as an input.

This isn't complete, but hopefully is enough to merge as a start:

* The Elk renderer isn't updated.
* Clusters aren't handled. They should probably aria-owns their nodes, or all nodes should be physically inside the clusters.
* Nodes with callbacks and links currently have the interactive element surround the list of links to connected nodes. Nesting interactive nodes is forbidden, but fixing this probably requires moving the top-level <g> creation from `labelHelper()` across all the shapes, to `insertNode()`. For a future PR.
* There's no accessible indication of the shape of the node or the style of the edges. This will require some design, and possibly a change to the diagram language.
   * The easiest of these cases might be to exclude [~~~ edges](https://mermaid.js.org/syntax/flowchart.html#an-invisible-link), but I haven't done that.
* There's no way to customize the accessible name independently of the visible name. This will also need a change to the diagram language.

Thanks to https://www.ashleysheridan.co.uk/blog/Creating+Accessible+Flowcharts and https://tink.uk/accessible-svg-flowcharts/ for explaining how to make flowcharts accessible. Any remaining mistakes in this PR are entirely my fault.

@medeaoblongata, I didn't use `aria-flowto` here, because the links seem like they might be enough, but it would be easy to add if it improves the experience anywhere.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

### Example cases

I don't use a screen reader, so I'm not sure how you'll actually experience these. I'd greatly appreciate advice on how to improve them. Github embeds them as `<img>` tags, so you'll probably have to click through to test them.

@weedySeaDragon's example in https://github.com/mermaid-js/mermaid/issues/2395#issuecomment-1280079886 becomes:
![simple flowchart, as an <img> of an SVG. Follow the link to try out the full SVG with the attempted accessibility support.](https://github.com/user-attachments/assets/97078207-015e-4676-8e99-7a886d652c1c)

@aardrian's large example in https://github.com/mermaid-js/mermaid/issues/2395#issuecomment-1051278754 becomes:
![complex flowchart, as an <img> of an SVG. Follow the link to try out the full SVG with the attempted accessibility support.](https://github.com/user-attachments/assets/71041b4c-c5e2-4877-be26-80193dc8ade4)
