### PR TITLE
fix: add width buffer for CJK characters to prevent truncation in PNG…

### DIFF
--- a/docs/config/setup/mermaid/interfaces/DetailedError.md
+++ b/docs/config/setup/mermaid/interfaces/DetailedError.md
@@ -10,7 +10,7 @@
 
 # Interface: DetailedError
 
-Defined in: [packages/mermaid/src/utils.ts:783](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/utils.ts#L783)
+Defined in: [packages/mermaid/src/utils.ts:805](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/utils.ts#L805)
 
 ## Properties
 
@@ -18,7 +18,7 @@ Defined in: [packages/mermaid/src/utils.ts:783](https://github.com/mermaid-js/me
 
 > `optional` **error**: `any`
 
-Defined in: [packages/mermaid/src/utils.ts:788](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/utils.ts#L788)
+Defined in: [packages/mermaid/src/utils.ts:810](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/utils.ts#L810)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [packages/mermaid/src/utils.ts:788](https://github.com/mermaid-js/me
 
 > **hash**: `any`
 
-Defined in: [packages/mermaid/src/utils.ts:786](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/utils.ts#L786)
+Defined in: [packages/mermaid/src/utils.ts:808](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/utils.ts#L808)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [packages/mermaid/src/utils.ts:786](https://github.com/mermaid-js/me
 
 > `optional` **message**: `string`
 
-Defined in: [packages/mermaid/src/utils.ts:789](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/utils.ts#L789)
+Defined in: [packages/mermaid/src/utils.ts:811](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/utils.ts#L811)
 
 ---
 
@@ -42,4 +42,4 @@ Defined in: [packages/mermaid/src/utils.ts:789](https://github.com/mermaid-js/me
 
 > **str**: `string`
 
-Defined in: [packages/mermaid/src/utils.ts:784](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/utils.ts#L784)
+Defined in: [packages/mermaid/src/utils.ts:806](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/utils.ts#L806)

--- a/packages/mermaid/src/diagrams/architecture/svgDraw.spec.ts
+++ b/packages/mermaid/src/diagrams/architecture/svgDraw.spec.ts
@@ -10,10 +10,8 @@ const { id, detector, loader } = architectureDetector;
 addDetector(id, detector, loader); // Add architecture schemas to Mermaid
 
 describe('architecture diagram SVGs', () => {
-  jsdomIt(
-    'should add ids',
-    async () => {
-      const svgNode = await drawDiagram(`
+  jsdomIt('should add ids', async () => {
+    const svgNode = await drawDiagram(`
       architecture-beta
         group api(cloud)[API]
 
@@ -27,22 +25,20 @@ describe('architecture diagram SVGs', () => {
         disk2:T -- B:db
     `);
 
-      const nodesForGroup = svgNode.querySelectorAll(`#group-api`);
-      expect(nodesForGroup.length).toBe(1);
+    const nodesForGroup = svgNode.querySelectorAll(`#group-api`);
+    expect(nodesForGroup.length).toBe(1);
 
-      const serviceIds = [...svgNode.querySelectorAll(`[id^=service-]`)].map(({ id }) => id).sort();
-      expect(serviceIds).toStrictEqual([
-        'service-db',
-        'service-disk1',
-        'service-disk2',
-        'service-server',
-      ]);
+    const serviceIds = [...svgNode.querySelectorAll(`[id^=service-]`)].map(({ id }) => id).sort();
+    expect(serviceIds).toStrictEqual([
+      'service-db',
+      'service-disk1',
+      'service-disk2',
+      'service-server',
+    ]);
 
-      const edgeIds = [...svgNode.querySelectorAll(`.edge[id^=L_]`)].map(({ id }) => id).sort();
-      expect(edgeIds).toStrictEqual(['L_db_server_0', 'L_disk1_server_0', 'L_disk2_db_0']);
-    },
-    15000
-  );
+    const edgeIds = [...svgNode.querySelectorAll(`.edge[id^=L_]`)].map(({ id }) => id).sort();
+    expect(edgeIds).toStrictEqual(['L_db_server_0', 'L_disk1_server_0', 'L_disk2_db_0']);
+  });
 });
 
 async function drawDiagram(diagramText: string): Promise<Element> {

--- a/packages/mermaid/src/diagrams/architecture/svgDraw.spec.ts
+++ b/packages/mermaid/src/diagrams/architecture/svgDraw.spec.ts
@@ -10,8 +10,10 @@ const { id, detector, loader } = architectureDetector;
 addDetector(id, detector, loader); // Add architecture schemas to Mermaid
 
 describe('architecture diagram SVGs', () => {
-  jsdomIt('should add ids', async () => {
-    const svgNode = await drawDiagram(`
+  jsdomIt(
+    'should add ids',
+    async () => {
+      const svgNode = await drawDiagram(`
       architecture-beta
         group api(cloud)[API]
 
@@ -25,20 +27,22 @@ describe('architecture diagram SVGs', () => {
         disk2:T -- B:db
     `);
 
-    const nodesForGroup = svgNode.querySelectorAll(`#group-api`);
-    expect(nodesForGroup.length).toBe(1);
+      const nodesForGroup = svgNode.querySelectorAll(`#group-api`);
+      expect(nodesForGroup.length).toBe(1);
 
-    const serviceIds = [...svgNode.querySelectorAll(`[id^=service-]`)].map(({ id }) => id).sort();
-    expect(serviceIds).toStrictEqual([
-      'service-db',
-      'service-disk1',
-      'service-disk2',
-      'service-server',
-    ]);
+      const serviceIds = [...svgNode.querySelectorAll(`[id^=service-]`)].map(({ id }) => id).sort();
+      expect(serviceIds).toStrictEqual([
+        'service-db',
+        'service-disk1',
+        'service-disk2',
+        'service-server',
+      ]);
 
-    const edgeIds = [...svgNode.querySelectorAll(`.edge[id^=L_]`)].map(({ id }) => id).sort();
-    expect(edgeIds).toStrictEqual(['L_db_server_0', 'L_disk1_server_0', 'L_disk2_db_0']);
-  });
+      const edgeIds = [...svgNode.querySelectorAll(`.edge[id^=L_]`)].map(({ id }) => id).sort();
+      expect(edgeIds).toStrictEqual(['L_db_server_0', 'L_disk1_server_0', 'L_disk2_db_0']);
+    },
+    15000
+  );
 });
 
 async function drawDiagram(diagramText: string): Promise<Element> {

--- a/packages/mermaid/src/utils.ts
+++ b/packages/mermaid/src/utils.ts
@@ -683,6 +683,18 @@ export function calculateTextWidth(
  *   the resulting size
  * @returns The dimensions for the given text
  */
+
+/**
+ * Checks if the text contains CJK (Chinese, Japanese, Korean) characters.
+ * CJK characters often require extra width buffer due to rendering differences
+ * between SVG and Canvas (used in PNG export).
+ */
+const hasCJKCharacters = (text: string): boolean => {
+  // CJK Unified Ideographs, Hangul, Hiragana, Katakana, and other CJK ranges
+  const cjkRegex = /[\u3040-\u30FF\u31F0-\u31FF\u3400-\u4DBF\u4E00-\u9FFF\uAC00-\uD7AF]/;
+  return cjkRegex.test(text);
+};
+
 export const calculateTextDimensions: (
   text: string,
   config: TextDimensionConfig
@@ -747,7 +759,17 @@ export const calculateTextDimensions: (
         dims[0].lineHeight > dims[1].lineHeight)
         ? 0
         : 1;
-    return dims[index];
+
+    const result = dims[index];
+
+    // Apply width buffer for CJK characters to prevent truncation during PNG export.
+    // SVG getBBox() can underestimate CJK character widths, causing clipping when
+    // converting to canvas for PNG export.
+    if (hasCJKCharacters(text)) {
+      result.width = Math.ceil(result.width * 1.05);
+    }
+
+    return result;
   },
   (text, config) => `${text}${config.fontSize}${config.fontWeight}${config.fontFamily}`
 );


### PR DESCRIPTION
… export

When exporting diagrams with Korean, Chinese, or Japanese text to PNG, the last 1-2 characters were being clipped. This was caused by SVG getBBox() underestimating CJK character widths during the conversion to canvas for PNG export.

This fix adds a 5% width buffer when CJK characters are detected in the text, ensuring proper rendering in exported images.

Fixes text truncation for:
- Korean (Hangul): U+AC00-U+D7AF
- Japanese (Hiragana/Katakana): U+3040-U+30FF, U+31F0-U+31FF
- Chinese (CJK Unified): U+4E00-U+9FFF, U+3400-U+4DBF

## :bookmark_tabs: Summary

Brief description about the content of your PR.

Resolves #<your issue id here>

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [ ] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
