### PR TITLE
fix(architecture): validate junction parent in addJunction

### DIFF
--- a/packages/mermaid/src/diagrams/architecture/architecture.spec.ts
+++ b/packages/mermaid/src/diagrams/architecture/architecture.spec.ts
@@ -58,4 +58,56 @@ describe('architecture diagrams', () => {
       expect(db.getAccDescription()).toBe('Accessibility Description');
     });
   });
+
+  describe('addJunction validation', () => {
+    it('should throw if junction id is already in use by a service', () => {
+      db.addGroup({ id: 'g1', title: 'Group' });
+      db.addService({ id: 'svc', type: 'service', icon: 'server', title: 'Svc', in: 'g1' });
+      expect(() => db.addJunction({ id: 'svc', type: 'junction' })).toThrow('already in use');
+    });
+
+    it('should throw if junction id is already in use by a group', () => {
+      db.addGroup({ id: 'g1', title: 'Group' });
+      expect(() => db.addJunction({ id: 'g1', type: 'junction' })).toThrow('already in use');
+    });
+
+    it('should throw if junction parent does not exist', () => {
+      expect(() => db.addJunction({ id: 'j1', type: 'junction', in: 'nonexistent' })).toThrow(
+        'parent does not exist'
+      );
+    });
+
+    it('should throw if junction parent is a node (service), not a group', () => {
+      db.addService({ id: 'app', type: 'service', icon: 'server', title: 'App' });
+      expect(() => db.addJunction({ id: 'j1', type: 'junction', in: 'app' })).toThrow(
+        'parent is not a group'
+      );
+    });
+
+    it('should throw if junction is placed within itself', () => {
+      expect(() => db.addJunction({ id: 'j1', type: 'junction', in: 'j1' })).toThrow(
+        'cannot be placed within itself'
+      );
+    });
+
+    it('should allow junction in a valid group', () => {
+      db.addGroup({ id: 'app_env', title: 'App Env' });
+      expect(() => db.addJunction({ id: 'mid', type: 'junction', in: 'app_env' })).not.toThrow();
+    });
+
+    it('should not crash with group name prefix matching a service name (issue #7408)', async () => {
+      const str = `architecture-beta
+  group app_env(cloud)[App Env]
+  service app(server)[Web App] in app_env
+  service db(database)[DB] in app_env
+  service api(server)[API] in app_env
+  junction mid in app_env
+  app:B -- T:mid
+  mid:R -- L:db
+  mid:B -- T:api`;
+      await expect(parser.parse(str)).resolves.not.toThrow();
+      expect(db.getJunctions()).toHaveLength(1);
+      expect(db.getJunctions()[0].in).toBe('app_env');
+    });
+  });
 });

--- a/packages/mermaid/src/diagrams/architecture/architectureDb.ts
+++ b/packages/mermaid/src/diagrams/architecture/architectureDb.ts
@@ -102,6 +102,25 @@ export class ArchitectureDB implements DiagramDB {
   }
 
   public addJunction({ id, in: parent }: Omit<ArchitectureJunction, 'edges'>): void {
+    if (this.registeredIds[id] !== undefined) {
+      throw new Error(
+        `The junction id [${id}] is already in use by another ${this.registeredIds[id]}`
+      );
+    }
+    if (parent !== undefined) {
+      if (id === parent) {
+        throw new Error(`The junction [${id}] cannot be placed within itself`);
+      }
+      if (this.registeredIds[parent] === undefined) {
+        throw new Error(
+          `The junction [${id}]'s parent does not exist. Please make sure the parent is created before this junction`
+        );
+      }
+      if (this.registeredIds[parent] === 'node') {
+        throw new Error(`The junction [${id}]'s parent is not a group`);
+      }
+    }
+
     this.registeredIds[id] = 'node';
 
     this.nodes[id] = {


### PR DESCRIPTION
## Summary
- `addJunction` lacked the validation checks that `addService` and `addGroup` already had, which could cause crashes when a junction was placed in an invalid parent
- Added the same 4 validation checks: duplicate ID, self-reference, parent existence, and parent-is-group
- Added unit tests covering all validation cases plus the exact reproduction from the issue

Resolves #7408

## Test plan
- [x] Added unit tests for all 4 validation checks (duplicate ID, self-reference, parent existence, parent type)
- [x] Added integration test with the exact diagram from the issue report
- [ ] Verify existing e2e architecture tests still pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)