### PR TITLE
docs/7420: replace CONTRIBUTING symlink with clear markdown link (#7420)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,3 @@
-./packages/mermaid/src/docs/community/contributing.md
+# Contributing to Mermaid
+
+Please see our comprehensive [Contributing Guidelines](./packages/mermaid/src/docs/community/contributing.md) for details on how to get started, install requirements, and submit pull requests.


### PR DESCRIPTION
Resolves #7420

The root `CONTRIBUTING.md` file was implemented as a symbolic link to
`./packages/mermaid/src/docs/community/contributing.md`.

GitHub does not render symlinked Markdown files as actual content,
which makes it harder for contributors to access the guidelines
from the standard repository root location.

This PR replaces the symlink with a small Markdown file that links to the
canonical contributing documentation.

This preserves a single source of truth while improving discoverability.