### PR TITLE
fix: support classDef styling inside composite states

### DIFF
--- a/.changeset/gentle-states-shine.md
+++ b/.changeset/gentle-states-shine.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: Allow :::className syntax inside composite state blocks

--- a/packages/mermaid/src/diagrams/state/parser/state-style.spec.js
+++ b/packages/mermaid/src/diagrams/state/parser/state-style.spec.js
@@ -186,6 +186,38 @@ describe('ClassDefs and classes when parsing a State diagram', () => {
         });
       });
 
+      describe('::: syntax inside composite states', () => {
+        it('can be applied to a state inside a composite state', () => {
+          let diagram = '';
+          diagram += 'stateDiagram-v2\n\n';
+          diagram += 'classDef exampleStyleClass background:#bbb,border:1px solid red;\n';
+          diagram += 'state A {\n';
+          diagram += '  a:::exampleStyleClass --> b\n';
+          diagram += '}\n';
+
+          stateDiagram.parser.parse(diagram);
+
+          const stateA = stateDiagram.parser.yy.getStates().get('A');
+          const relation = stateA.doc[0];
+          expect(relation.state1.classes[0]).toEqual('exampleStyleClass');
+        });
+
+        it('can be applied to a [*] state inside a composite state', () => {
+          let diagram = '';
+          diagram += 'stateDiagram-v2\n\n';
+          diagram += 'classDef exampleStyleClass background:#bbb,border:1px solid red;\n';
+          diagram += 'state A {\n';
+          diagram += '  [*]:::exampleStyleClass --> a\n';
+          diagram += '}\n';
+
+          stateDiagram.parser.parse(diagram);
+
+          const stateA = stateDiagram.parser.yy.getStates().get('A');
+          const relation = stateA.doc[0];
+          expect(relation.state1.classes[0]).toEqual('exampleStyleClass');
+        });
+      });
+
       describe('comments parsing', () => {
         it('working inside states', function () {
           let diagram = '';

--- a/packages/mermaid/src/diagrams/state/parser/stateDiagram.jison
+++ b/packages/mermaid/src/diagrams/state/parser/stateDiagram.jison
@@ -144,7 +144,7 @@ accDescr\s*"{"\s*                                { this.begin("acc_descr_multili
 
 <INITIAL,struct>"-->"             return '-->';
 <struct>"--"                      return 'CONCURRENT';
-":::"                             return 'STYLE_SEPARATOR';
+<INITIAL,struct>":::"             return 'STYLE_SEPARATOR';
 <<EOF>>                           return 'NL';
 .                                 return 'INVALID';
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fixes #7290 - Allow `:::className` syntax inside composite state blocks (`state A { ... }`).

**Changes:**
- Add `<INITIAL,struct>` prefix to the `STYLE_SEPARATOR` (`:::`) lexer rule in stateDiagram.jison
- Add unit tests for `:::` syntax inside composite states

Resolves #7290

## :straight_ruler: Design Decisions

### 1. Lexer-only fix
The grammar rules (`idStatement`) already support `ID STYLE_SEPARATOR ID` and
  `EDGE_STATE STYLE_SEPARATOR ID`. These rules are shared across top-level and
  composite state contexts. Only the lexer rule for `:::` was missing the
  `<struct>` state prefix, preventing it from being tokenized inside composite
  state blocks.

```diff
-":::"                             return 'STYLE_SEPARATOR';
+<INITIAL,struct>":::"             return 'STYLE_SEPARATOR';
```

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.