### PR TITLE
fix(deps): move type-fest from devDependencies to dependencies

### DIFF
--- a/.changeset/fix-missing-type-fest.md
+++ b/.changeset/fix-missing-type-fest.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: move type-fest from devDependencies to dependencies

--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -87,6 +87,7 @@
     "roughjs": "^4.6.6",
     "stylis": "^4.3.6",
     "ts-dedent": "^2.2.0",
+    "type-fest": "^4.41.0",
     "uuid": "^11.1.0"
   },
   "devDependencies": {
@@ -123,7 +124,6 @@
     "remark-gfm": "^4.0.1",
     "rimraf": "^6.0.1",
     "start-server-and-test": "^2.1.3",
-    "type-fest": "^4.41.0",
     "typedoc": "^0.28.15",
     "typedoc-plugin-markdown": "^4.8.1",
     "typescript": "~5.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,6 +289,9 @@ importers:
       ts-dedent:
         specifier: ^2.2.0
         version: 2.2.0
+      type-fest:
+        specifier: ^4.41.0
+        version: 4.41.0
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -392,9 +395,6 @@ importers:
       start-server-and-test:
         specifier: ^2.1.3
         version: 2.1.3
-      type-fest:
-        specifier: ^4.41.0
-        version: 4.41.0
       typedoc:
         specifier: ^0.28.15
         version: 0.28.15(typescript@5.7.3)


### PR DESCRIPTION
## Summary

Resolves #6629

- Moved `type-fest` from `devDependencies` to `dependencies` in `packages/mermaid/package.json`

`type-fest` types (`SetRequired`, `SetOptional`, `RequiredDeep`, `Entries`) are used in 5 source files whose declarations are published in the `dist/` `.d.ts` files. With `type-fest` only in `devDependencies`, consumers get `TS2307: Cannot find module 'type-fest'` errors when `type-fest` is not available transitively — which happens when packages like `globals` (v14+) drop their own `type-fest` dependency.

## Classification

- **Change type:** Dependency/packaging fix
- **Breaking change:** No
- **Shared code touched:** No (only `package.json` manifest)

## Verification

- [x] Lint: passed
- [x] Build: passed (`pnpm build:mermaid`)
- [x] Dependency check: `type-fest` in `dependencies`, not in `devDependencies`
- [x] Changeset: generated (patch)
- [ ] TDD: N/A — packaging fix, no code logic changed
- [ ] Visual spot-check: N/A — no rendering changes
- [ ] Full e2e: not run — no code changes

🤖 Generated with [Claude Code](https://claude.ai/code)