### PR TITLE
fix(sequence): prevent hang when "as" lacks trailing space

### DIFF
--- a/.changeset/fix-sequence-hang-missing-space-after-as.md
+++ b/.changeset/fix-sequence-hang-missing-space-after-as.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: prevent sequence diagram hang when "as" is used without a trailing space in participant declarations

--- a/packages/mermaid/src/diagrams/sequence/parser/sequenceDiagram.jison
+++ b/packages/mermaid/src/diagrams/sequence/parser/sequenceDiagram.jison
@@ -36,6 +36,7 @@
 <ID>[^<>:\n,;@\s]+(?=\s+as\s)                                   { yytext = yytext.trim(); this.begin('ALIAS'); return 'ACTOR'; }
 <ID>[^<>:\n,;@]+(?=\s*[\n;#]|$)                                 { yytext = yytext.trim(); this.popState(); return 'ACTOR'; }
 <ID>[^<>:\n,;@]*\<[^\n]*                                        { this.popState(); return 'INVALID'; }
+<ID>[^\n]+                                                      { yytext = yytext.trim(); this.popState(); return 'INVALID'; }
 "box"															{ this.begin('LINE'); return 'box'; }
 "participant"                                                   { this.begin('ID'); return 'participant'; }
 "actor"                                                   		{ this.begin('ID'); return 'participant_actor'; }

--- a/packages/mermaid/src/diagrams/sequence/sequenceDiagram.spec.js
+++ b/packages/mermaid/src/diagrams/sequence/sequenceDiagram.spec.js
@@ -2622,6 +2622,20 @@ Bob->>Alice:Got it!
       expect(error).toBe(true);
     });
 
+    it('should not hang when "as" is used without a space before the alias text', async () => {
+      let errorMessage = '';
+      try {
+        await Diagram.fromText(`
+          sequenceDiagram
+          participant X_AutoPublishable asAAAAAAAAAAAAA:AAAAAAAAAAAAA
+        `);
+      } catch (e) {
+        errorMessage = e instanceof Error ? e.message : String(e);
+      }
+      expect(errorMessage).not.toBe('');
+      expect(errorMessage).not.toContain('Lexical error');
+    }, 5000);
+
     it('should parse participant with stereotype and alias', async () => {
       const diagram = await Diagram.fromText(`
       sequenceDiagram


### PR DESCRIPTION
## Summary\n\nResolves #6399\n\n- Add catch-all `<ID>[^\\n]+` rule in the sequence diagram JISON lexer to handle unmatched input in the exclusive ID state\n- When `participant X_AutoPublishable asAAAAAAAAAAAAA:AAAAAAAAAAAAA` is parsed (missing space after \"as\"), the existing ID-state rules all fail to match because the colon terminates the character class before end-of-line. Without a catch-all, this left the lexer with no token to produce, causing browsers to hang.\n- The new rule produces an INVALID token, allowing the parser to emit a clean parse error instead of hanging\n\n## Classification\n\n- **Change type:** Parser (JISON grammar)\n- **Breaking change:** No — malformed input that previously hung now produces a parse error\n- **Shared code touched:** No\n\n## Verification\n\n- [x] TDD: test failed before fix (\"Lexical error\"), passes after (clean parse error)\n- [x] Lint: passed\n- [x] Unit tests: 142/142 passed\n- [ ] Visual spot-check: N/A — parser-only change\n- [ ] Full e2e: Not run — parser-only change\n- [x] Changeset: generated (patch)\n\n🤖 Generated with [Claude Code](https://claude.ai/code)