### PR TITLE
fix(common): replace .toString() with String() on DOMPurify.sanitize() calls

### DIFF
--- a/.changeset/fix-tostring-eslint.md
+++ b/.changeset/fix-tostring-eslint.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: replace `.toString()` with `String()` on `DOMPurify.sanitize()` calls to avoid `@typescript-eslint/no-base-to-string` lint errors

--- a/packages/mermaid/src/diagrams/common/common.ts
+++ b/packages/mermaid/src/diagrams/common/common.ts
@@ -84,11 +84,13 @@ export const sanitizeText = (text: string, config: MermaidConfig): string => {
     return text;
   }
   if (config.dompurifyConfig) {
-    text = DOMPurify.sanitize(sanitizeMore(text, config), config.dompurifyConfig).toString();
+    text = String(DOMPurify.sanitize(sanitizeMore(text, config), config.dompurifyConfig));
   } else {
-    text = DOMPurify.sanitize(sanitizeMore(text, config), {
-      FORBID_TAGS: ['style'],
-    }).toString();
+    text = String(
+      DOMPurify.sanitize(sanitizeMore(text, config), {
+        FORBID_TAGS: ['style'],
+      })
+    );
   }
   return text;
 };


### PR DESCRIPTION
## Summary

Resolves #6113

- Replace `.toString()` with `String()` wrapper on `DOMPurify.sanitize()` calls in `common.ts` to avoid `@typescript-eslint/no-base-to-string` lint errors
- `DOMPurify.sanitize()` can return `DocumentFragment` (when config includes `RETURN_DOM_FRAGMENT`), which lacks a meaningful `.toString()` — `String()` is the safe alternative

## Test plan

- [x] Existing unit tests pass (22/22 in `common.spec.ts`)
- [x] ESLint passes on `common.ts`
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)