### PR TITLE
fix(common): preserve spaces around math formulas

### DIFF
--- a/.changeset/fix-math-formula-whitespace.md
+++ b/.changeset/fix-math-formula-whitespace.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: preserve spaces around math formulas by using `white-space: pre` instead of `nowrap`

--- a/packages/mermaid/src/diagrams/common/common.spec.ts
+++ b/packages/mermaid/src/diagrams/common/common.spec.ts
@@ -1,4 +1,10 @@
-import { sanitizeText, removeScript, parseGenericTypes, countOccurrence } from './common.js';
+import {
+  sanitizeText,
+  removeScript,
+  parseGenericTypes,
+  countOccurrence,
+  renderKatexSanitized,
+} from './common.js';
 
 describe('when securityLevel is antiscript, all script must be removed', () => {
   /**
@@ -124,3 +130,22 @@ it.each([
     expect(countOccurrence(str, substring)).toEqual(count);
   }
 );
+
+describe('renderKatexSanitized', () => {
+  beforeAll(() => {
+    // @ts-ignore -- injected is a build-time global
+    globalThis.injected = { version: '1.0.0', includeLargeFeatures: true };
+    // @ts-ignore -- stub MathMLElement so isMathMLSupported() returns true
+    window.MathMLElement = class {};
+  });
+
+  it('should use white-space: pre to preserve spaces around math formulas', async () => {
+    const text = 'hello $$x^2$$ world';
+    const result = await renderKatexSanitized(text, {
+      securityLevel: 'strict',
+      flowchart: { htmlLabels: true },
+    });
+    expect(result).toContain('white-space: pre');
+    expect(result).not.toContain('white-space: nowrap');
+  });
+});

--- a/packages/mermaid/src/diagrams/common/common.ts
+++ b/packages/mermaid/src/diagrams/common/common.ts
@@ -337,7 +337,7 @@ const renderKatexUnsanitized = async (text: string, config: MermaidConfig): Prom
       .split(lineBreakRegex)
       .map((line) =>
         hasKatex(line)
-          ? `<div style="display: flex; align-items: center; justify-content: center; white-space: nowrap;">${line}</div>`
+          ? `<div style="display: flex; align-items: center; justify-content: center; white-space: pre;">${line}</div>`
           : `<div>${line}</div>`
       )
       .join('')


### PR DESCRIPTION
## Summary

Resolves #6690

- Change `white-space: nowrap` to `white-space: pre` on the div wrapping KaTeX math formula lines
- `nowrap` collapsed spaces between `$$...$$` math expressions and surrounding text; `pre` preserves them
- Added unit test verifying the rendered output uses `white-space: pre`

## Test plan

- [x] New unit test: verifies `white-space: pre` is used (not `nowrap`) in KaTeX rendering output
- [x] All 23 existing tests pass in `common.spec.ts`
- [x] ESLint clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)