### PR TITLE
fix(flowchart): warn when style targets a non-existent node

### DIFF
--- a/.changeset/fix-style-unknown-node-warning.md
+++ b/.changeset/fix-style-unknown-node-warning.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: warn when `style` statement targets a non-existent node in flowcharts

--- a/packages/mermaid/src/diagrams/flowchart/flowDb.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.ts
@@ -161,6 +161,11 @@ export class FlowDB implements DiagramDB {
 
     let vertex = this.vertices.get(id);
     if (vertex === undefined) {
+      if (textObj === undefined && type === undefined && style !== undefined && style !== null) {
+        log.warn(
+          `Style applied to unknown node "${id}". This may indicate a typo. The node will be created automatically.`
+        );
+      }
       vertex = {
         id,
         labelType: 'text',

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow-style.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow-style.spec.js
@@ -1,6 +1,8 @@
+import { vi } from 'vitest';
 import { FlowDB } from '../flowDb.js';
 import flow from './flowParser.ts';
 import { setConfig } from '../../../config.js';
+import { log } from '../../../logger.js';
 
 setConfig({
   securityLevel: 'strict',
@@ -350,6 +352,23 @@ describe('[Style] when parsing', () => {
     const edges = flow.parser.yy.getEdges();
 
     expect(edges[0].type).toBe('arrow_point');
+  });
+
+  it('should warn when style targets a non-existent node', function () {
+    const warnSpy = vi.spyOn(log, 'warn');
+    const res = flow.parser.parse('graph TD;\nAA-->BB;\nstyle A fill:#f00;');
+
+    const vert = flow.parser.yy.getVertices();
+
+    // Node A should still be created for backward compat, but a warning should be logged
+    expect(vert.get('A')).toBeDefined();
+    expect(vert.get('A').styles[0]).toBe('fill:#f00');
+    // AA and BB exist from the edge definition
+    expect(vert.get('AA')).toBeDefined();
+    expect(vert.get('BB')).toBeDefined();
+    // A warning should have been logged about the non-existent node
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('A'));
+    warnSpy.mockRestore();
   });
 
   it('should handle multiple vertices with style', function () {


### PR DESCRIPTION
## Summary

Resolves #7040

- When a `style` statement references a node that doesn't exist (e.g., `style A fill:#f00` when only `AA` is defined), a warning is now logged
- The node is still created for backward compatibility, but the warning helps users catch typos
- Previously this happened silently, making it hard to debug unexpected phantom nodes

## Test plan

- [x] New test: verifies warning is logged when `style` targets non-existent node
- [x] All 970 existing flowchart tests pass (no regressions)
- [x] ESLint clean (0 new errors)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)