### PR TITLE
fix: use `<<` instead of `«` for requirement edge labels

### DIFF
--- a/packages/mermaid/src/diagrams/requirement/requirementDb.ts
+++ b/packages/mermaid/src/diagrams/requirement/requirementDb.ts
@@ -321,7 +321,7 @@ export class RequirementDB implements DiagramDB {
         id: `${relation.src}-${relation.dst}-${counter}`,
         start: this.requirements.get(relation.src)?.name ?? this.elements.get(relation.src)?.name,
         end: this.requirements.get(relation.dst)?.name ?? this.elements.get(relation.dst)?.name,
-        label: `«${relation.type}»`,
+        label: `&lt;&lt;${relation.type}&gt;&gt;`,
         classes: 'relationshipLine',
         style: ['fill:none', isContains ? '' : 'stroke-dasharray: 10,7'],
         labelpos: 'c',


### PR DESCRIPTION
## :bookmark_tabs: Summary

Before aac86f7de, we used to use `<<` for requirement edge labels.

However, due to a bug in `createText` with `useHtmlLabels: false`, where `<` was being rendered as `&lt;`, we updated it to `«`.

Now that this bug has been fixed in 57b70b3ac (fix: prevent escaping `<` and `&` when `htmlLabels: false`, 2026-03-02), we can revert this change and go back to using `<<`.

## :straight_ruler: Design Decisions

We have to encode it as `&lt;&lt;` instead of `<<`, as otherwise `marked` treats it as HTML.

No changelog should be necessary, assuming this gets merged before the next release.

## Screenshots

The edge label `<<satisfies>>` vs `«satisfies»`:

### Current behaviour in v11.12.3 and after this PR

<img width="1488" height="1344" alt="image" src="https://github.com/user-attachments/assets/31728d6e-149d-41b2-8bcb-848a8e95725b" />

### Current behaviour in `develop`

<img width="1488" height="1344" alt="image" src="https://github.com/user-attachments/assets/a5fcb40c-a78f-4c63-984f-1410fdc3e77a" />

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
  - Covered by our existing Argos tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
  - Not needed for a small fix like this.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
  - Not needed, as long as this gets merged before the next release.