### PR TITLE
Update sidebar syntax to link to the newly added Ishikawa diagram

### DIFF
--- a/.changeset/dirty-regions-start.md
+++ b/.changeset/dirty-regions-start.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+add link to ishikawa diagram on mermaid.js.org

--- a/packages/mermaid/src/docs/.vitepress/config.ts
+++ b/packages/mermaid/src/docs/.vitepress/config.ts
@@ -195,6 +195,7 @@ function sidebarSyntax() {
         { text: 'Radar 🔥', link: '/syntax/radar' },
         { text: 'Treemap 🔥', link: '/syntax/treemap' },
         { text: 'Venn 🔥', link: '/syntax/venn' },
+        { text: 'Ishikawa 🔥', link: '/syntax/ishikawa' },
         { text: 'Other Examples', link: '/syntax/examples' },
       ],
     },


### PR DESCRIPTION
## :bookmark_tabs: Summary

Update sidebar syntax to link to the newly added Ishikawa diagram

Before

<img width="600" alt="CleanShot 2026-03-08 at 05 47 52@2x" src="https://github.com/user-attachments/assets/9e1211b0-683c-4e46-9293-67fcc9add56c" />

After

<img width="600" alt="CleanShot 2026-03-08 at 05 57 23@2x" src="https://github.com/user-attachments/assets/040272cf-8626-479e-b54a-0bc72014b1cc" />

## :straight_ruler: Design Decisions

We have a new diagram checklist as part of sisyphus-bot eg https://github.com/mermaid-js/mermaid/pull/7396#pullrequestreview-3865874985 - it's easy to miss updating the file with the sidebar syntax, so perhaps this is something the bot could check for

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
