### PR TITLE
fix: resolve syntax errors in classchart demo

### DIFF
--- a/.changeset/modern-ads-arrive.md
+++ b/.changeset/modern-ads-arrive.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: resolve syntax errors in classchart demo

--- a/demos/classchart.html
+++ b/demos/classchart.html
@@ -154,9 +154,11 @@
         -privateProperty : string
         #ProtectedProperty : string
         ~InternalProperty : string
-        ~AnotherInternalProperty : List~List~string~~
+        ~AnotherInternalProperty : List~List~string~ ~
       }
-      class People List~List~Person~~
+      class People {
+        +List~List~Person~~ members
+      }
     </pre>
     <hr />
     <pre class="mermaid">
@@ -164,7 +166,7 @@
       namespace Company.Project.Module {
         class GenericClass~T~ {
           +addItem(item: T)
-          +getItem() T
+          +getItem() : T
         }
       }
     </pre>


### PR DESCRIPTION
:bookmark_tabs: Summary
This PR addresses the "Syntax error in text" occurring in classchart.html when defining classes with nested generic types. The issue was caused by the parser misinterpreting the nested generic closing tokens (~~) as Markdown strike-through syntax.

Resolves #7480

:straight_ruler: Design Decisions
The fix involves standardizing the class definitions by utilizing bracketed notation and introducing space-separated generic closing tokens (~ ~). This ensures the parser treats the generic definitions as distinct tokens rather than interpreting the trailing tildes as Markdown formatting instructions.

:clipboard: Tasks
[x] :book: I have read the contribution guidelines.

[ ] :computer: I have added necessary unit/e2e tests.

[ ] :notebook: I have added documentation.

[x] :butterfly: I have generated a changeset.