### PR TITLE
ci: add lint action for renovate config

### DIFF
--- a/.github/workflows/renovatebot-config-lint.yml
+++ b/.github/workflows/renovatebot-config-lint.yml
@@ -1,0 +1,31 @@
+name: Renovatebot Config Lint
+
+on:
+  pull_request:
+    paths:
+      - 'renovate.json'
+      - '.github/workflows/renovatebot-config-lint.yml'
+  push:
+    branches-ignore:
+      # The Renovatebot App will warn us about issues on `develop`
+      # or `renovate/**` branches:
+      # See https://docs.renovatebot.com/config-validation/#validation-of-renovate-config-change-prs
+      - develop
+      - 'renovate/**'
+    paths:
+      - 'renovate.json'
+      - '.github/workflows/renovatebot-config-lint.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # no version specifier -> the latest version should be roughly equivalent
+      # to the Renovate app version (although maybe a few versions ahead)
+      - run: |
+          npx --yes --package renovate -- renovate-config-validator


### PR DESCRIPTION
## :bookmark_tabs: Summary

We've pushed a broken renovate.json config to the `develop` branch accidentally. This should hopefully avoid similar PRs getting merged.

The @renovatebot App automatically checks this for branches that start with `renovate/`, but it doesn't work for PRs from forks, but a GitHub Action would work.

See: #7484
See: #7451
See: https://docs.renovatebot.com/config-validation/#config-validation

## :straight_ruler: Design Decisions

I've picked an `ubuntu-slim` runner, since we don't need a full runner.

And the `npx --yes --package renovate -- renovate-config-validator` will download the latest version of `renovate`, which might cause some flakiness, so I've made sure to only run this lint action when the `renovate.json` or the `.github/workflows/renovatebot-config-lint.yml` file are changed. Unfortunately, I couldn't think of a better way to just install the version of the @renovatebot app, but I think the app only lags behind the official version by a bit.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
  - CI change only
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
  - Development/CI change only
