### PR TITLE
docs: specify how to use css classes to override styling

### DIFF
--- a/docs/syntax/flowchart.md
+++ b/docs/syntax/flowchart.md
@@ -1936,35 +1936,24 @@ flowchart LR
 
 ### CSS classes
 
-It is also possible to predefine classes in CSS styles that can be applied from the graph definition as in the example
-below:
+> **Note:** Applying styles to Mermaid nodes via external CSS (e.g., `.cssClass > rect { fill: ... }`) does **not** work reliably. Mermaid's internal styles are injected with `!important` and scoped to the SVG element ID, giving them higher specificity than external CSS rules. External CSS will be silently overridden.
+>
+> The recommended approach is to use the `classDef` syntax shown in the [Classes](#classes) section above, which works correctly and is the intended styling mechanism.
+>
+> If external CSS is strictly required, every property must use `!important` to override Mermaid's styles — but this is not recommended.
 
-**Example style**
-
-```html
-<style>
-  .cssClass > rect {
-    fill: #ff0000;
-    stroke: #ffff00;
-    stroke-width: 4px;
-  }
-</style>
-```
-
-**Example definition**
+**Working approach — use `classDef` instead:**
 
 ```mermaid-example
 flowchart LR
-    A-->B[AAA<span>BBB</span>]
-    B-->D
-    class A cssClass
+    A:::myStyle --> B
+    classDef myStyle fill:#ff0000,stroke:#ffff00,stroke-width:4px
 ```
 
 ```mermaid
 flowchart LR
-    A-->B[AAA<span>BBB</span>]
-    B-->D
-    class A cssClass
+    A:::myStyle --> B
+    classDef myStyle fill:#ff0000,stroke:#ffff00,stroke-width:4px
 ```
 
 ### Default class

--- a/packages/mermaid/src/docs/syntax/flowchart.md
+++ b/packages/mermaid/src/docs/syntax/flowchart.md
@@ -1241,28 +1241,18 @@ flowchart LR
 
 ### CSS classes
 
-It is also possible to predefine classes in CSS styles that can be applied from the graph definition as in the example
-below:
+> **Note:** Applying styles to Mermaid nodes via external CSS (e.g., `.cssClass > rect { fill: ... }`) does **not** work reliably. Mermaid's internal styles are injected with `!important` and scoped to the SVG element ID, giving them higher specificity than external CSS rules. External CSS will be silently overridden.
+>
+> The recommended approach is to use the `classDef` syntax shown in the [Classes](#classes) section above, which works correctly and is the intended styling mechanism.
+>
+> If external CSS is strictly required, every property must use `!important` to override Mermaid's styles — but this is not recommended.
 
-**Example style**
-
-```html
-<style>
-  .cssClass > rect {
-    fill: #ff0000;
-    stroke: #ffff00;
-    stroke-width: 4px;
-  }
-</style>
-```
-
-**Example definition**
+**Working approach — use `classDef` instead:**
 
 ```mermaid-example
 flowchart LR
-    A-->B[AAA<span>BBB</span>]
-    B-->D
-    class A cssClass
+    A:::myStyle --> B
+    classDef myStyle fill:#ff0000,stroke:#ffff00,stroke-width:4px
 ```
 
 ### Default class


### PR DESCRIPTION
## :bookmark_tabs: Summary

Updates the documentation in flowchar.md to specify that:

- using external CSS to change styling doesn't work due to Mermaid internal styles having higher specificty
- using classDef syntax is the recommended approach to overriding styles

An example of this is also provided.

Resolves #6419 

## :straight_ruler: Design Decisions

N/A - This PR just updates the docs.

### :clipboard: Tasks

Make sure you

-  [X] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [X] :computer: have added necessary unit/e2e tests.
- [X] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [X] :butterfly: If your PR makes a change that should be noted in one or mre packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
