### PR TITLE
fix(stateDiagram): prevent end note detection inside text

### DIFF
--- a/.changeset/cold-snakes-attend.md
+++ b/.changeset/cold-snakes-attend.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: updated the parser to require a new line boundary before the "end note" keyword to ensure it is only matched when used as an actual note terminator.

--- a/packages/mermaid/src/diagrams/state/parser/state-parser.spec.js
+++ b/packages/mermaid/src/diagrams/state/parser/state-parser.spec.js
@@ -170,4 +170,20 @@ ${prop} --> [*]`);
       expect(states.get(prop)).not.toBeUndefined();
     });
   });
+
+  describe('note parsing (issue #7089)', () => {
+    it('should not terminate a note when "end note" appears as part of a longer text', () => {
+      const diagramText = `stateDiagram-v2
+      State1
+      note right of State1
+        this sentence contains send note and end note inside the text
+      end note
+      State1 --> State2`;
+      stateDiagram.parser.parse(diagramText);
+      const relations = stateDiagram.parser.yy.getRelations();
+      expect(relations).toHaveLength(1);
+      expect(relations[0].id1).toEqual('State1');
+      expect(relations[0].id2).toEqual('State2');
+    });
+  });
 });

--- a/packages/mermaid/src/diagrams/state/parser/state-parser.spec.js
+++ b/packages/mermaid/src/diagrams/state/parser/state-parser.spec.js
@@ -172,18 +172,42 @@ ${prop} --> [*]`);
   });
 
   describe('note parsing (issue #7089)', () => {
-    it('should not terminate a note when "end note" appears as part of a longer text', () => {
+    it('should not terminate a note when "send note" appears within the note text', () => {
       const diagramText = `stateDiagram-v2
       State1
       note right of State1
-        this sentence contains send note and end note inside the text
+        this sentence contains send note inside the note text
       end note
       State1 --> State2`;
       stateDiagram.parser.parse(diagramText);
+
       const relations = stateDiagram.parser.yy.getRelations();
       expect(relations).toHaveLength(1);
       expect(relations[0].id1).toEqual('State1');
       expect(relations[0].id2).toEqual('State2');
+
+      const states = stateDiagram.parser.yy.getStates();
+      const noteState = states.get('State1');
+      expect(noteState?.note?.text).toContain('send note inside the note text');
+    });
+
+    it('should not treat "end note" as a closing keyword when it is part of the note text', () => {
+      const diagramText = `stateDiagram-v2
+      State1
+      note right of State1
+        this sentence contains end note as part of the note text
+      end note
+      State1 --> State2`;
+      stateDiagram.parser.parse(diagramText);
+
+      const relations = stateDiagram.parser.yy.getRelations();
+      expect(relations).toHaveLength(1);
+      expect(relations[0].id1).toEqual('State1');
+      expect(relations[0].id2).toEqual('State2');
+
+      const states = stateDiagram.parser.yy.getStates();
+      const noteState = states.get('State1');
+      expect(noteState?.note?.text).toContain('end note as part of the note text');
     });
   });
 });

--- a/packages/mermaid/src/diagrams/state/parser/stateDiagram.jison
+++ b/packages/mermaid/src/diagrams/state/parser/stateDiagram.jison
@@ -130,7 +130,7 @@ accDescr\s*"{"\s*                                { this.begin("acc_descr_multili
 <FLOATING_NOTE_ID>[^\n]*            { this.popState(); /* console.log('Floating note ID', yytext);*/ return "ID"; }
 <NOTE_ID>\s*[^:\n\s\-]+             { this.popState(); this.pushState('NOTE_TEXT'); /*console.log('Got ID for note', yytext);*/ return 'ID'; }
 <NOTE_TEXT>\s*":"[^:\n;]+           { this.popState(); /* console.log('Got NOTE_TEXT for note',yytext);*/yytext = yytext.substr(2).trim(); return 'NOTE_TEXT'; }
-<NOTE_TEXT>[\s\S]*?"end note"       { this.popState(); /* console.log('Got NOTE_TEXT for note',yytext);*/yytext = yytext.slice(0,-8).trim(); return 'NOTE_TEXT'; }
+<NOTE_TEXT>[\s\S]*?\n\s*"end note"  { this.popState(); /* console.log('Got NOTE_TEXT for note',yytext);*/yytext = yytext.slice(0,-8).trim(); return 'NOTE_TEXT'; }
 
 "stateDiagram"\s+                   { /* console.log('Got state diagram', yytext,'#'); */ return 'SD'; }
 "stateDiagram-v2"\s+                { /* console.log('Got state diagram', yytext,'#'); */ return 'SD'; }


### PR DESCRIPTION
## :bookmark_tabs: Summary

The `end note` keyword was being incorrectly detected within regular text (e.g., "send note").  This pull request addresses this issue by updating the detection logic to ensure `end note` is matched only when used as an actual note terminator.

Resolves #7089

## :straight_ruler: Design Decisions

The parser now requires a new line boundary before `end note` to clearly distinguish it from occurrences in regular text. A regression test was added to verify the fix, and all tests still pass. 

### Before: "send note" incorrectly closed the note
<img width="600" height="370" alt="IMG_6038" src="https://github.com/user-attachments/assets/cb1f5940-248c-400b-a66b-7d089b9408b0" />

### Now: notes only end with "end note" on a new line
<img width="600" height="370" alt="IMG_6039" src="https://github.com/user-attachments/assets/771a66c9-8870-4c43-a0e3-76880e9519bb" />

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
