### PR TITLE
Feature/3208 Add open arrow type

### DIFF
--- a/.changeset/add-invisible-arrow-head.md
+++ b/.changeset/add-invisible-arrow-head.md
@@ -1,0 +1,5 @@
+---
+'mermaid': minor
+---
+
+feat: Add invisible arrow head to support backward arrow (e.g. `A <--~ B` or `A o--~ B --> C`).

--- a/.changeset/fix-mixed-arrow-types.md
+++ b/.changeset/fix-mixed-arrow-types.md
@@ -1,0 +1,7 @@
+---
+'mermaid': patch
+---
+
+fix: support mixed arrow types in flowchart edges
+
+Fixes #1665 where multi-directional arrows with mixed types (e.g., `A o---> B` or `A x---o B`) did not render correctly.

--- a/packages/mermaid/src/dagre-wrapper/edgeMarker.ts
+++ b/packages/mermaid/src/dagre-wrapper/edgeMarker.ts
@@ -26,6 +26,7 @@ export const addEdgeMarkers = (
 };
 
 const arrowTypesMap = {
+  arrow_invisible: 'invisible',
   arrow_cross: 'cross',
   arrow_point: 'point',
   arrow_barb: 'barb',

--- a/packages/mermaid/src/diagrams/flowchart/flowDb.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.ts
@@ -858,28 +858,52 @@ You have to call mermaid.initialize.`
     let line = str.slice(0, -1);
     let type = 'arrow_open';
 
+    // Determine end arrow type
+    let endArrowType: string | null = null;
     switch (str.slice(-1)) {
       case 'x':
-        type = 'arrow_cross';
-        if (str.startsWith('x')) {
-          type = 'double_' + type;
-          line = line.slice(1);
-        }
+        endArrowType = 'arrow_cross';
         break;
       case '>':
-        type = 'arrow_point';
-        if (str.startsWith('<')) {
-          type = 'double_' + type;
-          line = line.slice(1);
-        }
+        endArrowType = 'arrow_point';
         break;
       case 'o':
-        type = 'arrow_circle';
-        if (str.startsWith('o')) {
-          type = 'double_' + type;
-          line = line.slice(1);
-        }
+        endArrowType = 'arrow_circle';
         break;
+    }
+
+    // Determine start arrow type
+    let startArrowType: string | null = null;
+    const firstChar = str[0];
+    switch (firstChar) {
+      case 'x':
+        startArrowType = 'arrow_cross';
+        line = line.slice(1);
+        break;
+      case '<':
+        startArrowType = 'arrow_point';
+        line = line.slice(1);
+        break;
+      case 'o':
+        startArrowType = 'arrow_circle';
+        line = line.slice(1);
+        break;
+    }
+
+    // Set the type based on start and end arrow types
+    if (endArrowType) {
+      if (startArrowType) {
+        if (startArrowType === endArrowType) {
+          // Same type on both ends: e.g., x----x, o----o
+          type = 'double_' + endArrowType;
+        } else {
+          // Mixed types: e.g., x----o, o---->
+          type = `${startArrowType}_${endArrowType}`;
+        }
+      } else {
+        // Only end type: e.g., ---->
+        type = endArrowType;
+      }
     }
 
     let stroke = 'normal';
@@ -917,12 +941,14 @@ You have to call mermaid.initialize.`
         // -- xyz -->  - take arrow type from ending
         startInfo.type = info.type;
       } else {
-        // x-- xyz -->  - not supported
         if (startInfo.type !== info.type) {
-          return { type: 'INVALID', stroke: 'INVALID' };
+          // Mixed arrow types: e.g., o-- xyz --> (circle to point)
+          // Create a combined type format: startType_endType
+          startInfo.type = `${startInfo.type}_${info.type}`;
+        } else {
+          // Same type on both ends: e.g., o-- xyz --o (circle to circle)
+          startInfo.type = 'double_' + startInfo.type;
         }
-
-        startInfo.type = 'double_' + startInfo.type;
       }
 
       if (startInfo.type === 'double_arrow') {
@@ -997,6 +1023,15 @@ You have to call mermaid.initialize.`
   private destructEdgeType(type: string | undefined) {
     let arrowTypeStart = 'none';
     let arrowTypeEnd = 'arrow_point';
+
+    // Check for mixed arrow types (e.g., arrow_circle_arrow_point)
+    const mixedTypeMatch = type?.match(/^(arrow_\w+)_(arrow_\w+)$/);
+    if (mixedTypeMatch) {
+      arrowTypeStart = mixedTypeMatch[1];
+      arrowTypeEnd = mixedTypeMatch[2];
+      return { arrowTypeStart, arrowTypeEnd };
+    }
+
     switch (type) {
       case 'arrow_point':
       case 'arrow_circle':

--- a/packages/mermaid/src/diagrams/flowchart/flowDb.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.ts
@@ -827,6 +827,10 @@ You have to call mermaid.initialize.`
         type = 'arrow_circle';
         str = str.slice(1);
         break;
+      case '~':
+        type = 'arrow_invisible';
+        str = str.slice(1);
+        break;
     }
 
     let stroke = 'normal';
@@ -870,6 +874,9 @@ You have to call mermaid.initialize.`
       case 'o':
         endArrowType = 'arrow_circle';
         break;
+      case '~':
+        endArrowType = 'arrow_invisible';
+        break;
     }
 
     // Determine start arrow type
@@ -886,6 +893,10 @@ You have to call mermaid.initialize.`
         break;
       case 'o':
         startArrowType = 'arrow_circle';
+        line = line.slice(1);
+        break;
+      case '~':
+        startArrowType = 'arrow_invisible';
         line = line.slice(1);
         break;
     }
@@ -1021,7 +1032,7 @@ You have to call mermaid.initialize.`
     return nodes.find((node) => node.id === id);
   }
   private destructEdgeType(type: string | undefined) {
-    let arrowTypeStart = 'none';
+    let arrowTypeStart = 'arrow_open';
     let arrowTypeEnd = 'arrow_point';
 
     // Check for mixed arrow types (e.g., arrow_circle_arrow_point)
@@ -1033,12 +1044,14 @@ You have to call mermaid.initialize.`
     }
 
     switch (type) {
+      case 'arrow_invisible':
       case 'arrow_point':
       case 'arrow_circle':
       case 'arrow_cross':
         arrowTypeEnd = type;
         break;
 
+      case 'double_arrow_invisible':
       case 'double_arrow_point':
       case 'double_arrow_circle':
       case 'double_arrow_cross':

--- a/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.ts
@@ -41,7 +41,7 @@ export const draw = async function (text: string, id: string, _version: string, 
   data4Layout.direction = direction;
   data4Layout.nodeSpacing = conf?.nodeSpacing || 50;
   data4Layout.rankSpacing = conf?.rankSpacing || 50;
-  data4Layout.markers = ['point', 'circle', 'cross'];
+  data4Layout.markers = ['point', 'circle', 'cross', 'invisible'];
 
   data4Layout.diagramId = id;
   log.debug('REF1:', data4Layout);

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow-edges.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow-edges.spec.js
@@ -39,6 +39,28 @@ const doubleEndedEdges = [
   { edgeStart: '<==', edgeEnd: '==>', stroke: 'thick', type: 'double_arrow_point' },
   { edgeStart: '<-.', edgeEnd: '.->', stroke: 'dotted', type: 'double_arrow_point' },
 ];
+
+// Mixed arrow types: different arrow heads on each end (issue #1665)
+const mixedEndedEdges = [
+  // circle to point
+  { edgeStart: 'o--', edgeEnd: '-->', stroke: 'normal', type: 'arrow_circle_arrow_point' },
+  { edgeStart: 'o==', edgeEnd: '==>', stroke: 'thick', type: 'arrow_circle_arrow_point' },
+  { edgeStart: 'o-.', edgeEnd: '.->', stroke: 'dotted', type: 'arrow_circle_arrow_point' },
+  // cross to circle
+  { edgeStart: 'x--', edgeEnd: '--o', stroke: 'normal', type: 'arrow_cross_arrow_circle' },
+  { edgeStart: 'x==', edgeEnd: '==o', stroke: 'thick', type: 'arrow_cross_arrow_circle' },
+  { edgeStart: 'x-.', edgeEnd: '.-o', stroke: 'dotted', type: 'arrow_cross_arrow_circle' },
+  // point to cross
+  { edgeStart: '<--', edgeEnd: '--x', stroke: 'normal', type: 'arrow_point_arrow_cross' },
+  { edgeStart: '<==', edgeEnd: '==x', stroke: 'thick', type: 'arrow_point_arrow_cross' },
+  { edgeStart: '<-.', edgeEnd: '.-x', stroke: 'dotted', type: 'arrow_point_arrow_cross' },
+  // circle to cross
+  { edgeStart: 'o--', edgeEnd: '--x', stroke: 'normal', type: 'arrow_circle_arrow_cross' },
+  // cross to point
+  { edgeStart: 'x--', edgeEnd: '-->', stroke: 'normal', type: 'arrow_cross_arrow_point' },
+  // point to circle
+  { edgeStart: '<--', edgeEnd: '--o', stroke: 'normal', type: 'arrow_point_arrow_circle' },
+];
 const regularEdges = [
   { edgeStart: '--', edgeEnd: '--x', stroke: 'normal', type: 'arrow_cross' },
   { edgeStart: '==', edgeEnd: '==x', stroke: 'thick', type: 'arrow_cross' },
@@ -212,6 +234,45 @@ A@{ shape: 'rect' }
           expect(edges[0].stroke).toBe(`${edgeType.stroke}`);
         }
       );
+    });
+  });
+
+  // Tests for mixed arrow types (issue #1665)
+  describe('mixed arrow type edges', function () {
+    mixedEndedEdges.forEach((edgeType) => {
+      it(`should handle ${edgeType.stroke} ${edgeType.type} with no text`, function () {
+        const res = flow.parser.parse(`graph TD;\nA ${edgeType.edgeStart}${edgeType.edgeEnd} B;`);
+
+        const vert = flow.parser.yy.getVertices();
+        const edges = flow.parser.yy.getEdges();
+
+        expect(vert.get('A').id).toBe('A');
+        expect(vert.get('B').id).toBe('B');
+        expect(edges.length).toBe(1);
+        expect(edges[0].start).toBe('A');
+        expect(edges[0].end).toBe('B');
+        expect(edges[0].type).toBe(`${edgeType.type}`);
+        expect(edges[0].text).toBe('');
+        expect(edges[0].stroke).toBe(`${edgeType.stroke}`);
+      });
+
+      it(`should handle ${edgeType.stroke} ${edgeType.type} with text`, function () {
+        const res = flow.parser.parse(
+          `graph TD;\nA ${edgeType.edgeStart} text ${edgeType.edgeEnd} B;`
+        );
+
+        const vert = flow.parser.yy.getVertices();
+        const edges = flow.parser.yy.getEdges();
+
+        expect(vert.get('A').id).toBe('A');
+        expect(vert.get('B').id).toBe('B');
+        expect(edges.length).toBe(1);
+        expect(edges[0].start).toBe('A');
+        expect(edges[0].end).toBe('B');
+        expect(edges[0].type).toBe(`${edgeType.type}`);
+        expect(edges[0].text).toBe('text');
+        expect(edges[0].stroke).toBe(`${edgeType.stroke}`);
+      });
     });
   });
 

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow-edges.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow-edges.spec.js
@@ -38,6 +38,9 @@ const doubleEndedEdges = [
   { edgeStart: '<--', edgeEnd: '-->', stroke: 'normal', type: 'double_arrow_point' },
   { edgeStart: '<==', edgeEnd: '==>', stroke: 'thick', type: 'double_arrow_point' },
   { edgeStart: '<-.', edgeEnd: '.->', stroke: 'dotted', type: 'double_arrow_point' },
+  { edgeStart: '~--', edgeEnd: '--~', stroke: 'normal', type: 'double_arrow_invisible' },
+  { edgeStart: '~==', edgeEnd: '==~', stroke: 'thick', type: 'double_arrow_invisible' },
+  { edgeStart: '~-.', edgeEnd: '.-~', stroke: 'dotted', type: 'double_arrow_invisible' },
 ];
 
 // Mixed arrow types: different arrow heads on each end (issue #1665)
@@ -46,22 +49,53 @@ const mixedEndedEdges = [
   { edgeStart: 'o--', edgeEnd: '-->', stroke: 'normal', type: 'arrow_circle_arrow_point' },
   { edgeStart: 'o==', edgeEnd: '==>', stroke: 'thick', type: 'arrow_circle_arrow_point' },
   { edgeStart: 'o-.', edgeEnd: '.->', stroke: 'dotted', type: 'arrow_circle_arrow_point' },
+  // circle to cross
+  { edgeStart: 'o--', edgeEnd: '--x', stroke: 'normal', type: 'arrow_circle_arrow_cross' },
+  { edgeStart: 'o==', edgeEnd: '==x', stroke: 'thick', type: 'arrow_circle_arrow_cross' },
+  { edgeStart: 'o-.', edgeEnd: '.-x', stroke: 'dotted', type: 'arrow_circle_arrow_cross' },
+  // circle to invisible
+  { edgeStart: 'o--', edgeEnd: '--~', stroke: 'normal', type: 'arrow_circle_arrow_invisible' },
+  { edgeStart: 'o==', edgeEnd: '==~', stroke: 'thick', type: 'arrow_circle_arrow_invisible' },
+  { edgeStart: 'o-.', edgeEnd: '.-~', stroke: 'dotted', type: 'arrow_circle_arrow_invisible' },
   // cross to circle
   { edgeStart: 'x--', edgeEnd: '--o', stroke: 'normal', type: 'arrow_cross_arrow_circle' },
   { edgeStart: 'x==', edgeEnd: '==o', stroke: 'thick', type: 'arrow_cross_arrow_circle' },
   { edgeStart: 'x-.', edgeEnd: '.-o', stroke: 'dotted', type: 'arrow_cross_arrow_circle' },
+  // cross to point
+  { edgeStart: 'x--', edgeEnd: '-->', stroke: 'normal', type: 'arrow_cross_arrow_point' },
+  { edgeStart: 'x==', edgeEnd: '==>', stroke: 'thick', type: 'arrow_cross_arrow_point' },
+  { edgeStart: 'x-.', edgeEnd: '.->', stroke: 'dotted', type: 'arrow_cross_arrow_point' },
+  // cross to invisible
+  { edgeStart: 'x--', edgeEnd: '--~', stroke: 'normal', type: 'arrow_cross_arrow_invisible' },
+  { edgeStart: 'x==', edgeEnd: '==~', stroke: 'thick', type: 'arrow_cross_arrow_invisible' },
+  { edgeStart: 'x-.', edgeEnd: '.-~', stroke: 'dotted', type: 'arrow_cross_arrow_invisible' },
+  // point to circle
+  { edgeStart: '<--', edgeEnd: '--o', stroke: 'normal', type: 'arrow_point_arrow_circle' },
+  { edgeStart: '<==', edgeEnd: '==o', stroke: 'thick', type: 'arrow_point_arrow_circle' },
+  { edgeStart: '<-.', edgeEnd: '.-o', stroke: 'dotted', type: 'arrow_point_arrow_circle' },
   // point to cross
   { edgeStart: '<--', edgeEnd: '--x', stroke: 'normal', type: 'arrow_point_arrow_cross' },
   { edgeStart: '<==', edgeEnd: '==x', stroke: 'thick', type: 'arrow_point_arrow_cross' },
   { edgeStart: '<-.', edgeEnd: '.-x', stroke: 'dotted', type: 'arrow_point_arrow_cross' },
-  // circle to cross
-  { edgeStart: 'o--', edgeEnd: '--x', stroke: 'normal', type: 'arrow_circle_arrow_cross' },
-  // cross to point
-  { edgeStart: 'x--', edgeEnd: '-->', stroke: 'normal', type: 'arrow_cross_arrow_point' },
-  // point to circle
-  { edgeStart: '<--', edgeEnd: '--o', stroke: 'normal', type: 'arrow_point_arrow_circle' },
+  // point to invisible
+  { edgeStart: '<--', edgeEnd: '--~', stroke: 'normal', type: 'arrow_point_arrow_invisible' },
+  { edgeStart: '<==', edgeEnd: '==~', stroke: 'thick', type: 'arrow_point_arrow_invisible' },
+  { edgeStart: '<-.', edgeEnd: '.-~', stroke: 'dotted', type: 'arrow_point_arrow_invisible' },
+  // invisible to circle
+  { edgeStart: '~--', edgeEnd: '--o', stroke: 'normal', type: 'arrow_invisible_arrow_circle' },
+  { edgeStart: '~==', edgeEnd: '==o', stroke: 'thick', type: 'arrow_invisible_arrow_circle' },
+  { edgeStart: '~-.', edgeEnd: '.-o', stroke: 'dotted', type: 'arrow_invisible_arrow_circle' },
+  // invisible to cross
+  { edgeStart: '~--', edgeEnd: '--x', stroke: 'normal', type: 'arrow_invisible_arrow_cross' },
+  { edgeStart: '~==', edgeEnd: '==x', stroke: 'thick', type: 'arrow_invisible_arrow_cross' },
+  { edgeStart: '~-.', edgeEnd: '.-x', stroke: 'dotted', type: 'arrow_invisible_arrow_cross' },
+  // invisible to point
+  { edgeStart: '~--', edgeEnd: '-->', stroke: 'normal', type: 'arrow_invisible_arrow_point' },
+  { edgeStart: '~==', edgeEnd: '==>', stroke: 'thick', type: 'arrow_invisible_arrow_point' },
+  { edgeStart: '~-.', edgeEnd: '.->', stroke: 'dotted', type: 'arrow_invisible_arrow_point' },
 ];
 const regularEdges = [
+  { edgeStart: '--', edgeEnd: '--', stroke: 'normal', type: 'arrow_open' },
   { edgeStart: '--', edgeEnd: '--x', stroke: 'normal', type: 'arrow_cross' },
   { edgeStart: '==', edgeEnd: '==x', stroke: 'thick', type: 'arrow_cross' },
   { edgeStart: '-.', edgeEnd: '.-x', stroke: 'dotted', type: 'arrow_cross' },
@@ -71,6 +105,9 @@ const regularEdges = [
   { edgeStart: '--', edgeEnd: '-->', stroke: 'normal', type: 'arrow_point' },
   { edgeStart: '==', edgeEnd: '==>', stroke: 'thick', type: 'arrow_point' },
   { edgeStart: '-.', edgeEnd: '.->', stroke: 'dotted', type: 'arrow_point' },
+  { edgeStart: '--', edgeEnd: '--~', stroke: 'normal', type: 'arrow_invisible' },
+  { edgeStart: '==', edgeEnd: '==~', stroke: 'thick', type: 'arrow_invisible' },
+  { edgeStart: '-.', edgeEnd: '.-~', stroke: 'dotted', type: 'arrow_invisible' },
 
   { edgeStart: '--', edgeEnd: '----x', stroke: 'normal', type: 'arrow_cross' },
   { edgeStart: '==', edgeEnd: '====x', stroke: 'thick', type: 'arrow_cross' },
@@ -81,6 +118,9 @@ const regularEdges = [
   { edgeStart: '--', edgeEnd: '---->', stroke: 'normal', type: 'arrow_point' },
   { edgeStart: '==', edgeEnd: '====>', stroke: 'thick', type: 'arrow_point' },
   { edgeStart: '-.', edgeEnd: '...->', stroke: 'dotted', type: 'arrow_point' },
+  { edgeStart: '--', edgeEnd: '----~', stroke: 'normal', type: 'arrow_invisible' },
+  { edgeStart: '==', edgeEnd: '====~', stroke: 'thick', type: 'arrow_invisible' },
+  { edgeStart: '-.', edgeEnd: '...-~', stroke: 'dotted', type: 'arrow_invisible' },
 ];
 
 describe('[Edges] when parsing', () => {
@@ -103,11 +143,18 @@ describe('[Edges] when parsing', () => {
     expect(edges[0].type).toBe('arrow_cross');
   });
 
-  it('should handle open ended edges', function () {
+  it('should handle circle ended edges', function () {
     const res = flow.parser.parse('graph TD;A--oB;');
     const edges = flow.parser.yy.getEdges();
 
     expect(edges[0].type).toBe('arrow_circle');
+  });
+
+  it('should handle invisible ended edges', function () {
+    const res = flow.parser.parse('graph TD;A--~B;');
+    const edges = flow.parser.yy.getEdges();
+
+    expect(edges[0].type).toBe('arrow_invisible');
   });
 
   describe('edges with ids', function () {

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
@@ -152,16 +152,16 @@ that id.
 ","                          return 'COMMA';
 "*"                          return 'MULT';
 
-<INITIAL,edgeText>\s*[xo<]?\-\-+[-xo>]\s*          { this.popState(); return 'LINK'; }
-<INITIAL>\s*[xo<]?\-\-\s*                          { this.pushState("edgeText"); return 'START_LINK'; }
+<INITIAL,edgeText>\s*[xo<~]?\-\-+[-xo>~]\s*          { this.popState(); return 'LINK'; }
+<INITIAL>\s*[xo<~]?\-\-\s*                          { this.pushState("edgeText"); return 'START_LINK'; }
 <edgeText>[^-]|\-(?!\-)+                           return 'EDGE_TEXT';
 
-<INITIAL,thickEdgeText>\s*[xo<]?\=\=+[=xo>]\s*      { this.popState(); return 'LINK'; }
-<INITIAL>\s*[xo<]?\=\=\s*                           { this.pushState("thickEdgeText"); return 'START_LINK'; }
+<INITIAL,thickEdgeText>\s*[xo<~]?\=\=+[=xo>~]\s*      { this.popState(); return 'LINK'; }
+<INITIAL>\s*[xo<~]?\=\=\s*                           { this.pushState("thickEdgeText"); return 'START_LINK'; }
 <thickEdgeText>[^=]|\=(?!=)                         return 'EDGE_TEXT';
 
-<INITIAL,dottedEdgeText>\s*[xo<]?\-?\.+\-[xo>]?\s*   { this.popState(); return 'LINK'; }
-<INITIAL>\s*[xo<]?\-\.\s*                            { this.pushState("dottedEdgeText"); return 'START_LINK'; }
+<INITIAL,dottedEdgeText>\s*[xo<~]?\-?\.+\-[xo>~]?\s*   { this.popState(); return 'LINK'; }
+<INITIAL>\s*[xo<~]?\-\.\s*                            { this.pushState("dottedEdgeText"); return 'START_LINK'; }
 <dottedEdgeText>[^\.]|\.(?!-)                        return 'EDGE_TEXT';
 
 

--- a/packages/mermaid/src/rendering-util/rendering-elements/edgeMarker.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/edgeMarker.ts
@@ -37,6 +37,7 @@ export const addEdgeMarkers = (
 };
 
 const arrowTypesMap = {
+  arrow_invisible: { type: 'invisible', fill: false },
   arrow_cross: { type: 'cross', fill: false },
   arrow_point: { type: 'point', fill: true },
   arrow_barb: { type: 'barb', fill: true },

--- a/packages/mermaid/src/rendering-util/rendering-elements/markers.js
+++ b/packages/mermaid/src/rendering-util/rendering-elements/markers.js
@@ -311,6 +311,12 @@ const lollipop = (elem, type, id) => {
     .attr('r', 6)
     .attr('stroke-width', 2);
 };
+const invisible = (elem, type, id) => {
+  elem
+    .append('marker')
+    .attr('id', id + '_' + type)
+    .attr('class', 'marker ' + type);
+};
 const point = (elem, type, id) => {
   elem
     .append('marker')
@@ -955,6 +961,7 @@ const markers = {
   aggregation,
   dependency,
   lollipop,
+  invisible,
   point,
   circle,
   cross,


### PR DESCRIPTION
## :bookmark_tabs: Summary

This PR introduces a new arrow type to allow for an "open" or "no arrow head" connector in Mermaid diagrams.

This implementation allows for explicitly defining an open-ended link, which helps resolve ambiguity when chaining nodes with mixed arrow types or when specific layout constraints require backwards arrows without adding visual arrowheads.

- Resolves #3208
- Extends/Depends on #7311

## :straight_ruler: Design Decisions

The solution introduces `~` as the placeholder for an open/no-arrowhead connector.

Syntax: Implements `~` to represent open links.

By allowing explicit "open" connectors, we can now distinguish between directional and non-directional segments in node chains:

```
A <--~ Node ~--> B
A <--~ Node --> B
A <-- Text --> B
```

### :clipboard: Tasks

Make sure you

- [X] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [X] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
