### PR TITLE
replace Arial with Arimo in font-family settings across styles and themes

### DIFF
--- a/packages/mermaid/src/diagrams/git/styles.js
+++ b/packages/mermaid/src/diagrams/git/styles.js
@@ -5,7 +5,7 @@ const getStyles = (options) =>
   .branch-label {
     fill: lightgrey;
     color: lightgrey;
-    font-family: 'trebuchet ms', verdana, arial, sans-serif;
+    font-family: 'trebuchet ms', verdana, Arimo, sans-serif;
     font-family: var(--mermaid-font-family);
   }
   ${[0, 1, 2, 3, 4, 5, 6, 7]

--- a/packages/mermaid/src/schemas/config.schema.yaml
+++ b/packages/mermaid/src/schemas/config.schema.yaml
@@ -165,7 +165,7 @@ properties:
       Can be any possible CSS `font-family`.
       See https://developer.mozilla.org/en-US/docs/Web/CSS/font-family
     type: string
-    default: '"trebuchet ms", verdana, arial, sans-serif;'
+    default: '"trebuchet ms", verdana, Arimo, sans-serif;'
   altFontFamily:
     # TODO: seems to be unused, except for in tests
     type: string
@@ -1665,7 +1665,7 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
       titleFontFamily:
         description: Font family to be used for the title text in Journey Diagrams
         type: string
-        default: '"trebuchet ms", verdana, arial, sans-serif'
+        default: '"trebuchet ms", verdana, Arimo, sans-serif'
       titleFontSize:
         description: Font size to be used for the title text in Journey Diagrams
         type: string
@@ -2042,7 +2042,7 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
       noteFontFamily:
         description: This sets the font family of actor-attached notes
         type: string
-        default: '"trebuchet ms", verdana, arial, sans-serif'
+        default: '"trebuchet ms", verdana, Arimo, sans-serif'
       noteFontWeight:
         description: This sets the font weight of actor-attached notes
         type: ['string', 'number']
@@ -2060,7 +2060,7 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
       messageFontFamily:
         description: This sets the font family of actor messages
         type: string
-        default: '"trebuchet ms", verdana, arial, sans-serif'
+        default: '"trebuchet ms", verdana, Arimo, sans-serif'
       messageFontWeight:
         description: This sets the font weight of actor messages
         type: ['string', 'number']

--- a/packages/mermaid/src/themes/theme-base.js
+++ b/packages/mermaid/src/themes/theme-base.js
@@ -23,7 +23,7 @@ class Theme {
 
     // dark
 
-    this.fontFamily = '"trebuchet ms", verdana, arial, sans-serif';
+    this.fontFamily = '"trebuchet ms", verdana, Arimo, sans-serif';
     this.fontSize = '16px';
   }
   updateColors() {

--- a/packages/mermaid/src/themes/theme-dark.js
+++ b/packages/mermaid/src/themes/theme-dark.js
@@ -24,7 +24,7 @@ class Theme {
     this.border1 = '#ccc';
     this.border2 = rgba(255, 255, 255, 0.25);
     this.arrowheadColor = 'calculated';
-    this.fontFamily = '"trebuchet ms", verdana, arial, sans-serif';
+    this.fontFamily = '"trebuchet ms", verdana, Arimo, sans-serif';
     this.fontSize = '16px';
     this.labelBackground = '#181818';
     this.textColor = '#ccc';

--- a/packages/mermaid/src/themes/theme-default.js
+++ b/packages/mermaid/src/themes/theme-default.js
@@ -32,7 +32,7 @@ class Theme {
     this.border1 = '#9370DB';
     this.border2 = '#aaaa33';
     this.arrowheadColor = '#333333';
-    this.fontFamily = '"trebuchet ms", verdana, arial, sans-serif';
+    this.fontFamily = '"trebuchet ms", verdana, Arimo, sans-serif';
     this.fontSize = '16px';
     this.labelBackground = 'rgba(232,232,232, 0.8)';
     this.textColor = '#333';

--- a/packages/mermaid/src/themes/theme-forest.js
+++ b/packages/mermaid/src/themes/theme-forest.js
@@ -18,7 +18,7 @@ class Theme {
     this.border1 = '#13540c';
     this.border2 = '#6eaa49';
     this.arrowheadColor = 'green';
-    this.fontFamily = '"trebuchet ms", verdana, arial, sans-serif';
+    this.fontFamily = '"trebuchet ms", verdana, Arimo, sans-serif';
     this.fontSize = '16px';
 
     this.tertiaryColor = lighten('#cde498', 10);

--- a/packages/mermaid/src/themes/theme-neutral.js
+++ b/packages/mermaid/src/themes/theme-neutral.js
@@ -39,7 +39,7 @@ class Theme {
     this.critical = '#d42';
     this.done = '#bbb';
     this.arrowheadColor = '#333333';
-    this.fontFamily = '"trebuchet ms", verdana, arial, sans-serif';
+    this.fontFamily = '"trebuchet ms", verdana, Arimo, sans-serif';
     this.fontSize = '16px';
     this.THEME_COLOR_LIMIT = 12;
 

--- a/packages/mermaid/src/utils.ts
+++ b/packages/mermaid/src/utils.ts
@@ -564,7 +564,7 @@ export const wrapLabel: (label: string, maxWidth: number, config: WrapLabelConfi
         return label;
       }
       config = Object.assign(
-        { fontSize: 12, fontWeight: 400, fontFamily: 'Arial', joinWith: '<br/>' },
+        { fontSize: 12, fontWeight: 400, fontFamily: 'Arimo', joinWith: '<br/>' },
         config
       );
       if (common.lineBreakRegex.test(label)) {
@@ -616,7 +616,7 @@ const breakString: (
     config: WrapLabelConfig
   ): BreakStringOutput => {
     config = Object.assign(
-      { fontSize: 12, fontWeight: 400, fontFamily: 'Arial', margin: 0 },
+      { fontSize: 12, fontWeight: 400, fontFamily: 'Arimo', margin: 0 },
       config
     );
     const characters = [...word];
@@ -688,7 +688,7 @@ export const calculateTextDimensions: (
   config: TextDimensionConfig
 ) => TextDimensions = memoize(
   (text: string, config: TextDimensionConfig): TextDimensions => {
-    const { fontSize = 12, fontFamily = 'Arial', fontWeight = 400 } = config;
+    const { fontSize = 12, fontFamily = 'Arimo', fontWeight = 400 } = config;
     if (!text) {
       return { width: 0, height: 0 };
     }


### PR DESCRIPTION
## :bookmark_tabs: Summary

Replacing Arial with Arimo resolves licensing issue and enables font embedding in exports.

### :clipboard: Tasks

Make sure you

- [ ] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
