### PR TITLE
fix(xychart): prevent flipped point label from clipping x-axis

### DIFF
--- a/.changeset/add-xychart-point-labels.md
+++ b/.changeset/add-xychart-point-labels.md
@@ -1,0 +1,5 @@
+---
+'mermaid': minor
+---
+
+feat: add per-point text labels for xychart line plots

--- a/.changeset/fix-xychart-label-axis-clipping.md
+++ b/.changeset/fix-xychart-label-axis-clipping.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: prevent flipped xychart point label from clipping into x-axis area

--- a/.changeset/fix-xychart-label-line-collision.md
+++ b/.changeset/fix-xychart-label-line-collision.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: auto-flip xychart point labels to avoid collision with line on steep slopes

--- a/.cspell/misc-terms.txt
+++ b/.cspell/misc-terms.txt
@@ -3,6 +3,7 @@ Buzan
 circo
 handDrawn
 KOEPF
+MMLU
 neato
 newbranch
 validify

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ stats/
 
 .env
 
+demos/mermaid.esm.mjs
 demos/dev/**
 !/demos/dev/example.html
 !/demos/dev/reload.js

--- a/cypress/integration/rendering/xyChart.spec.js
+++ b/cypress/integration/rendering/xyChart.spec.js
@@ -879,4 +879,57 @@ describe('XY Chart', () => {
       });
     });
   });
+
+  it('should render a line chart with point labels', () => {
+    imgSnapshotTest(
+      `
+      xychart
+        title "Smallest AI models scoring above 60% on MMLU"
+        x-axis "Date" ["Apr 2022", "Feb 2023", "Jul 2023", "Sep 2023", "Apr 2024"]
+        y-axis "Parameters (B)" 0 --> 600
+        line [540 "PaLM", 65 "LLaMA-65B", 34 "Llama 2 34B", 7 "Mistral 7B", 3.8 "Phi-3-mini"]
+      `,
+      {}
+    );
+  });
+
+  it('should render a line chart with mixed labels (some points labeled, some not)', () => {
+    imgSnapshotTest(
+      `
+      xychart
+        title "Quarterly Performance"
+        x-axis [Q1, Q2, Q3, Q4]
+        y-axis "Revenue ($M)" 0 --> 100
+        line [25 "Launch", 45, 72, 90 "Target Hit"]
+      `,
+      {}
+    );
+  });
+
+  it('should render a horizontal line chart with point labels', () => {
+    imgSnapshotTest(
+      `
+      xychart horizontal
+        title "Model Sizes"
+        x-axis ["Model A", "Model B", "Model C"]
+        y-axis "Parameters" 0 --> 100
+        line [20 "Small", 50 "Medium", 90 "Large"]
+      `,
+      {}
+    );
+  });
+
+  it('should render multiple lines where only one has labels', () => {
+    imgSnapshotTest(
+      `
+      xychart
+        title "Comparison"
+        x-axis [Q1, Q2, Q3, Q4]
+        y-axis "Value" 0 --> 100
+        line [20, 40, 60, 80]
+        line [30 "Start", 50, 70, 95 "Peak"]
+      `,
+      {}
+    );
+  });
 });

--- a/cypress/integration/rendering/xyChart.spec.js
+++ b/cypress/integration/rendering/xyChart.spec.js
@@ -933,6 +933,19 @@ describe('XY Chart', () => {
     );
   });
 
+  it('should render reviewer example: label at 80 "target hit" does not collide with line', () => {
+    imgSnapshotTest(
+      `
+      xychart
+          title "Quarterly Performance"
+          x-axis [Q1, Q2, Q3, Q4]
+          y-axis "Revenue ($M)" 0 --> 100
+          line [25, 45, 80 "target hit", 90]
+      `,
+      {}
+    );
+  });
+
   describe('Point label collision avoidance', () => {
     it('should flip labels below line when steep descent causes collision', () => {
       imgSnapshotTest(

--- a/cypress/integration/rendering/xyChart.spec.js
+++ b/cypress/integration/rendering/xyChart.spec.js
@@ -932,4 +932,41 @@ describe('XY Chart', () => {
       {}
     );
   });
+
+  describe('Point label collision avoidance', () => {
+    it('should flip labels below line when steep descent causes collision', () => {
+      imgSnapshotTest(
+        `
+        xychart
+          title "Smallest AI models scoring above 60% on MMLU"
+          x-axis "Date" ["Apr 2022", "Feb 2023", "Jul 2023", "Sep 2023", "Apr 2024"]
+          y-axis "Parameters (B)" 0 --> 600
+          line [540 "PaLM", 65 "LLaMA-65B", 34 "Llama 2 34B", 7 "Mistral 7B", 3.8 "Phi-3-mini"]
+        `,
+        {}
+      );
+    });
+    it('should keep labels above line when no collision on gentle slope', () => {
+      imgSnapshotTest(
+        `
+        xychart
+          x-axis ["A", "B", "C"]
+          y-axis 0 --> 100
+          line [40 "Start", 50 "Mid", 45 "End"]
+        `,
+        {}
+      );
+    });
+    it('should handle mixed collision: some labels above, some below', () => {
+      imgSnapshotTest(
+        `
+        xychart
+          x-axis ["P1", "P2", "P3", "P4"]
+          y-axis 0 --> 500
+          line [400 "High", 50 "Low", 450 "Peak", 30 "Bottom"]
+        `,
+        {}
+      );
+    });
+  });
 });

--- a/demos/xychart.html
+++ b/demos/xychart.html
@@ -316,6 +316,26 @@ config:
     </pre>
     <hr />
 
+    <hr />
+    <h1>Line chart with point labels</h1>
+    <pre class="mermaid">
+    xychart
+      title "Smallest AI models scoring above 60% on MMLU"
+      x-axis "Date" ["Apr 2022", "Feb 2023", "Jul 2023", "Sep 2023", "Apr 2024"]
+      y-axis "Parameters (B)" 0 --> 600
+      line [540 "PaLM", 65 "LLaMA-65B", 34 "Llama 2 34B", 7 "Mistral 7B", 3.8 "Phi-3-mini"]
+    </pre>
+
+    <hr />
+    <h1>Line chart with mixed labels (some points labeled, some not)</h1>
+    <pre class="mermaid">
+    xychart
+      title "Quarterly Performance"
+      x-axis [Q1, Q2, Q3, Q4]
+      y-axis "Revenue ($M)" 0 --> 100
+      line [25 "Launch", 45, 72, 90 "Target Hit"]
+    </pre>
+
     <script type="module">
       import mermaid from './mermaid.esm.mjs';
       mermaid.initialize({

--- a/demos/xychart.html
+++ b/demos/xychart.html
@@ -365,6 +365,24 @@ config:
       line [400 "High", 50 "Low", 450 "Peak", 30 "Bottom"]
     </pre>
 
+    <hr />
+    <h1>Axis bounds: label near bottom should not clip x-axis</h1>
+    <pre class="mermaid">
+    xychart
+      x-axis [Q1, Q2, Q3, Q4]
+      y-axis "Revenue ($M)" 0 --> 100
+      line [95 "Top", 5 "Bottom", 92 "Near Top", 8 "Near Bottom"]
+    </pre>
+
+    <hr />
+    <h1>Axis bounds: horizontal — label near right should not clip y-axis</h1>
+    <pre class="mermaid">
+    xychart horizontal
+      x-axis [Q1, Q2, Q3, Q4]
+      y-axis "Revenue ($M)" 0 --> 100
+      line [5 "Start", 95 "End", 8 "Low", 92 "High"]
+    </pre>
+
     <script type="module">
       import mermaid from './mermaid.esm.mjs';
       mermaid.initialize({

--- a/demos/xychart.html
+++ b/demos/xychart.html
@@ -337,6 +337,16 @@ config:
     </pre>
 
     <hr />
+    <h1>Reviewer's failing example: label at 80 "target hit"</h1>
+    <pre class="mermaid">
+    xychart
+        title "Quarterly Performance"
+        x-axis [Q1, Q2, Q3, Q4]
+        y-axis "Revenue ($M)" 0 --> 100
+        line [25, 45, 80 "target hit", 90]
+    </pre>
+
+    <hr />
     <h1>Label collision avoidance: steep descent</h1>
     <pre class="mermaid">
     xychart

--- a/demos/xychart.html
+++ b/demos/xychart.html
@@ -336,6 +336,25 @@ config:
       line [25 "Launch", 45, 72, 90 "Target Hit"]
     </pre>
 
+    <hr />
+    <h1>Label collision avoidance: steep descent</h1>
+    <pre class="mermaid">
+    xychart
+      title "Smallest AI models scoring above 60% on MMLU"
+      x-axis "Date" ["Apr 2022", "Feb 2023", "Jul 2023", "Sep 2023", "Apr 2024"]
+      y-axis "Parameters (B)" 0 --> 600
+      line [540 "PaLM", 65 "LLaMA-65B", 34 "Llama 2 34B", 7 "Mistral 7B", 3.8 "Phi-3-mini"]
+    </pre>
+
+    <hr />
+    <h1>Label collision avoidance: zigzag pattern</h1>
+    <pre class="mermaid">
+    xychart
+      x-axis ["P1", "P2", "P3", "P4"]
+      y-axis 0 --> 500
+      line [400 "High", 50 "Low", 450 "Peak", 30 "Bottom"]
+    </pre>
+
     <script type="module">
       import mermaid from './mermaid.esm.mjs';
       mermaid.initialize({

--- a/docs/syntax/xyChart.md
+++ b/docs/syntax/xyChart.md
@@ -312,7 +312,7 @@ xychart
 Existing syntax without labels continues to work unchanged.
 
 > **Note**
-> Point labels use a fixed font size of 12px. In vertical charts, labels appear above each point. In horizontal charts, labels appear to the right.
+> Point labels use a fixed font size of 12px. In vertical charts, labels appear above each point. In horizontal charts, labels appear to the right. Labels are currently supported on `line` plots only; the syntax is accepted on `bar` plots but labels are ignored.
 
 ## Example on config and theme
 

--- a/docs/syntax/xyChart.md
+++ b/docs/syntax/xyChart.md
@@ -271,6 +271,49 @@ xychart
     bar [12,2,20,25,17,24]
 ```
 
+## Per-point text labels for line charts (v\<MERMAID_RELEASE_VERSION>+)
+
+Each data point in a `line` can optionally include a quoted string label after the numeric value. Labels render above points in vertical orientation, or to the right in horizontal orientation, using the line's stroke color.
+
+```mermaid-example
+xychart
+    title "Smallest AI models scoring above 60% on MMLU"
+    x-axis "Date" ["Apr 2022", "Feb 2023", "Jul 2023", "Sep 2023", "Apr 2024"]
+    y-axis "Parameters (B)" 0 --> 600
+    line [540 "PaLM", 65 "LLaMA-65B", 34 "Llama 2 34B", 7 "Mistral 7B", 3.8 "Phi-3-mini"]
+```
+
+```mermaid
+xychart
+    title "Smallest AI models scoring above 60% on MMLU"
+    x-axis "Date" ["Apr 2022", "Feb 2023", "Jul 2023", "Sep 2023", "Apr 2024"]
+    y-axis "Parameters (B)" 0 --> 600
+    line [540 "PaLM", 65 "LLaMA-65B", 34 "Llama 2 34B", 7 "Mistral 7B", 3.8 "Phi-3-mini"]
+```
+
+Labels are optional per point — you can mix labeled and unlabeled values:
+
+```mermaid-example
+xychart
+    title "Quarterly Performance"
+    x-axis [Q1, Q2, Q3, Q4]
+    y-axis "Revenue ($M)" 0 --> 100
+    line [25 "Launch", 45, 72, 90 "Target Hit"]
+```
+
+```mermaid
+xychart
+    title "Quarterly Performance"
+    x-axis [Q1, Q2, Q3, Q4]
+    y-axis "Revenue ($M)" 0 --> 100
+    line [25 "Launch", 45, 72, 90 "Target Hit"]
+```
+
+Existing syntax without labels continues to work unchanged.
+
+> **Note**
+> Point labels use a fixed font size of 12px. In vertical charts, labels appear above each point. In horizontal charts, labels appear to the right.
+
 ## Example on config and theme
 
 ```mermaid-example

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/components/axis/index.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/components/axis/index.ts
@@ -19,6 +19,7 @@ export interface Axis extends ChartComponent {
   getTickDistance(): number;
   recalculateOuterPaddingToDrawBar(): void;
   setRange(range: [number, number]): void;
+  getRange(): [number, number];
 }
 
 export function getAxis(

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/index.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/index.ts
@@ -7,8 +7,10 @@ import type {
   XYChartThemeConfig,
   XYChartConfig,
 } from '../../interfaces.js';
+import type { SVGGroup } from '../../../../../diagram-api/types.js';
 import type { Axis } from '../axis/index.js';
 import type { ChartComponent } from '../../interfaces.js';
+import { TextDimensionCalculatorWithFont } from '../../textDimensionCalculator.js';
 import { LinePlot } from './linePlot.js';
 import { BarPlot } from './barPlot.js';
 
@@ -20,11 +22,13 @@ export class BasePlot implements Plot {
   private boundingRect: BoundingRect;
   private xAxis?: Axis;
   private yAxis?: Axis;
+  private textDimensionCalculator: TextDimensionCalculatorWithFont;
 
   constructor(
     private chartConfig: XYChartConfig,
     private chartData: XYChartData,
-    private chartThemeConfig: XYChartThemeConfig
+    private chartThemeConfig: XYChartThemeConfig,
+    tmpSVGGroup: SVGGroup
   ) {
     this.boundingRect = {
       x: 0,
@@ -32,6 +36,7 @@ export class BasePlot implements Plot {
       width: 0,
       height: 0,
     };
+    this.textDimensionCalculator = new TextDimensionCalculatorWithFont(tmpSVGGroup);
   }
   setAxes(xAxis: Axis, yAxis: Axis) {
     this.xAxis = xAxis;
@@ -59,7 +64,14 @@ export class BasePlot implements Plot {
       switch (plot.type) {
         case 'line':
           {
-            const linePlot = new LinePlot(plot, this.xAxis, this.yAxis, this.chartConfig, i);
+            const linePlot = new LinePlot(
+              plot,
+              this.xAxis,
+              this.yAxis,
+              this.chartConfig,
+              i,
+              this.textDimensionCalculator
+            );
             drawableElem.push(...linePlot.getDrawableElement());
           }
           break;
@@ -85,7 +97,8 @@ export class BasePlot implements Plot {
 export function getPlotComponent(
   chartConfig: XYChartConfig,
   chartData: XYChartData,
-  chartThemeConfig: XYChartThemeConfig
+  chartThemeConfig: XYChartThemeConfig,
+  tmpSVGGroup: SVGGroup
 ): Plot {
-  return new BasePlot(chartConfig, chartData, chartThemeConfig);
+  return new BasePlot(chartConfig, chartData, chartThemeConfig, tmpSVGGroup);
 }

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/index.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/index.ts
@@ -63,7 +63,7 @@ export class BasePlot implements Plot {
               plot,
               this.xAxis,
               this.yAxis,
-              this.chartConfig.chartOrientation,
+              this.chartConfig,
               i
             );
             drawableElem.push(...linePlot.getDrawableElement());

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/index.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/index.ts
@@ -59,13 +59,7 @@ export class BasePlot implements Plot {
       switch (plot.type) {
         case 'line':
           {
-            const linePlot = new LinePlot(
-              plot,
-              this.xAxis,
-              this.yAxis,
-              this.chartConfig,
-              i
-            );
+            const linePlot = new LinePlot(plot, this.xAxis, this.yAxis, this.chartConfig, i);
             drawableElem.push(...linePlot.getDrawableElement());
           }
           break;

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/linePlot.spec.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/linePlot.spec.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect } from 'vitest';
+import { LinePlot } from './linePlot.js';
+import type { TextDimensionCalculator } from '../../textDimensionCalculator.js';
+import type { Dimension, LinePlotData, XYChartConfig } from '../../interfaces.js';
+import type { Axis } from '../axis/index.js';
+
+function makeCalc(width: number, height: number): TextDimensionCalculator {
+  return { getMaxDimension: (): Dimension => ({ width, height }) };
+}
+
+function makeAxis(scaleValues: number[], range: [number, number] = [0, 100]): Axis {
+  let idx = 0;
+  return {
+    getScaleValue: () => scaleValues[idx++],
+    getRange: () => range,
+  } as unknown as Axis;
+}
+
+function makeChartConfig(orientation: 'vertical' | 'horizontal' = 'vertical'): XYChartConfig {
+  return {
+    width: 500,
+    height: 400,
+    titleFontSize: 14,
+    titlePadding: 5,
+    showTitle: true,
+    showDataLabel: false,
+    showDataLabelOutsideBar: false,
+    chartOrientation: orientation,
+    plotReservedSpacePercent: 50,
+    xAxis: {
+      labelFontSize: 14,
+      labelPadding: 5,
+      showLabel: true,
+      showTitle: true,
+      titleFontSize: 14,
+      titlePadding: 5,
+    },
+    yAxis: {
+      labelFontSize: 14,
+      labelPadding: 5,
+      showLabel: true,
+      showTitle: true,
+      titleFontSize: 14,
+      titlePadding: 5,
+    },
+  } as unknown as XYChartConfig;
+}
+
+function makePlot(
+  pixelPoints: [number, number][],
+  labels: string[],
+  calc: TextDimensionCalculator,
+  orientation: 'vertical' | 'horizontal' = 'vertical',
+  axisRange: [number, number] = [0, 100]
+): LinePlot {
+  const plotData: LinePlotData = {
+    type: 'line',
+    strokeFill: '#000',
+    strokeWidth: 2,
+    data: pixelPoints.map(([x], i) => [String(i), x] as [string, number]),
+    pointLabels: labels,
+  };
+
+  const xScaleValues = pixelPoints.map(([x]) => x);
+  const yScaleValues = pixelPoints.map(([, y]) => y);
+
+  const xAxis = makeAxis(xScaleValues, axisRange);
+  const yAxis = makeAxis(yScaleValues, axisRange);
+
+  return new LinePlot(plotData, xAxis, yAxis, makeChartConfig(orientation), 0, calc);
+}
+
+describe('LinePlot label placement — vertical orientation', () => {
+  it('places label above when there are no adjacent segments', () => {
+    const plot = makePlot([[50, 50]], ['A'], makeCalc(20, 14));
+    const elems = plot.getDrawableElement();
+    const labels = elems.find((e) => e.type === 'text');
+    expect(labels).toBeDefined();
+    const textElem = (labels!.data as { y: number }[])[0];
+    expect(textElem.y).toBeLessThan(50);
+  });
+
+  it('narrow label stays above on steep diagonal line', () => {
+    // Line: [10,90] → [50,50] → [90,10] in pixel space (rising in SVG, y decreases = going up)
+    // Narrow label at index 1 — small bounding box doesn't overlap the steep segment
+    const plot = makePlot(
+      [
+        [10, 90],
+        [50, 50],
+        [90, 10],
+      ],
+      ['', 'i', ''],
+      makeCalc(10, 14)
+    );
+    const elems = plot.getDrawableElement();
+    const labels = elems.find((e) => e.type === 'text');
+    expect(labels).toBeDefined();
+    const textElem = (labels!.data as { y: number; text: string }[])[0];
+    expect(textElem.text).toBe('i');
+    expect(textElem.y).toBeLessThan(50);
+  });
+
+  it('wide label flips below on steep diagonal line', () => {
+    // Shallow inverted-V peaking at (50,50). A wide bounding box samples the line
+    // further from the apex, where y drops into the above-label region and forces
+    // a flip below. A narrow box at the same apex stays clear.
+    const plot = makePlot(
+      [
+        [0, 10],
+        [50, 50],
+        [100, 10],
+      ],
+      ['', 'MMMM', ''],
+      makeCalc(40, 14)
+    );
+    const elems = plot.getDrawableElement();
+    const labels = elems.find((e) => e.type === 'text');
+    expect(labels).toBeDefined();
+    const textElem = (labels!.data as { y: number; text: string }[])[0];
+    expect(textElem.text).toBe('MMMM');
+    expect(textElem.y).toBeGreaterThan(50);
+  });
+
+  it('same label string, different measured widths produce different flip decisions', () => {
+    const points: [number, number][] = [
+      [0, 10],
+      [50, 50],
+      [100, 10],
+    ];
+    const narrowPlot = makePlot([...points], ['', 'X', ''], makeCalc(4, 14));
+    const widePlot = makePlot([...points], ['', 'X', ''], makeCalc(40, 14));
+
+    const narrowLabels = narrowPlot.getDrawableElement().find((e) => e.type === 'text');
+    const wideLabels = widePlot.getDrawableElement().find((e) => e.type === 'text');
+
+    const narrowY = (narrowLabels!.data as { y: number }[])[0].y;
+    const wideY = (wideLabels!.data as { y: number }[])[0].y;
+
+    expect(narrowY).toBeLessThan(50);
+    expect(wideY).toBeGreaterThan(50);
+  });
+
+  it('label clipped above stays within plot bounds by flipping below', () => {
+    // Point near the top of the plot — label above would clip outside bounds [0,100]
+    const plot = makePlot([[50, 5]], ['A'], makeCalc(20, 14), 'vertical', [0, 100]);
+    const elems = plot.getDrawableElement();
+    const labels = elems.find((e) => e.type === 'text');
+    expect(labels).toBeDefined();
+    const textElem = (labels!.data as { y: number }[])[0];
+    expect(textElem.y).toBeGreaterThan(5);
+  });
+
+  it('skips entries with empty label strings', () => {
+    const plot = makePlot(
+      [
+        [10, 90],
+        [50, 50],
+        [90, 10],
+      ],
+      ['A', '', 'B'],
+      makeCalc(20, 14)
+    );
+    const elems = plot.getDrawableElement();
+    const labels = elems.find((e) => e.type === 'text');
+    expect((labels!.data as unknown[]).length).toBe(2);
+  });
+
+  it('returns no label group when all labels are empty', () => {
+    const plot = makePlot(
+      [
+        [10, 90],
+        [50, 50],
+      ],
+      ['', ''],
+      makeCalc(20, 14)
+    );
+    const elems = plot.getDrawableElement();
+    expect(elems.find((e) => e.type === 'text')).toBeUndefined();
+  });
+
+  it('returns no label group when pointLabels is absent', () => {
+    const plotData: LinePlotData = {
+      type: 'line',
+      strokeFill: '#000',
+      strokeWidth: 2,
+      data: [['0', 50] as [string, number]],
+    };
+    const xAxis = makeAxis([50]);
+    const yAxis = makeAxis([50]);
+    const plot = new LinePlot(plotData, xAxis, yAxis, makeChartConfig(), 0, makeCalc(20, 14));
+    const elems = plot.getDrawableElement();
+    expect(elems.find((e) => e.type === 'text')).toBeUndefined();
+  });
+});
+
+describe('LinePlot label placement — horizontal orientation', () => {
+  it('places label to the right when there are no adjacent segments', () => {
+    const plot = makePlot([[50, 50]], ['A'], makeCalc(20, 14), 'horizontal');
+    const elems = plot.getDrawableElement();
+    const labels = elems.find((e) => e.type === 'text');
+    const textElem = (labels!.data as { horizontalPos: string }[])[0];
+    expect(textElem.horizontalPos).toBe('left');
+  });
+
+  it('label clipped right stays within plot bounds by flipping left', () => {
+    // Point near the right edge — label to the right would exceed bounds
+    const plot = makePlot([[50, 95]], ['A'], makeCalc(20, 14), 'horizontal', [0, 100]);
+    const elems = plot.getDrawableElement();
+    const labels = elems.find((e) => e.type === 'text');
+    expect(labels).toBeDefined();
+    const textElem = (labels!.data as { horizontalPos: string }[])[0];
+    expect(textElem.horizontalPos).toBe('right');
+  });
+});
+
+describe('LinePlot — calculator integration', () => {
+  it('calls calculator once per non-empty label', () => {
+    let callCount = 0;
+    const trackingCalc: TextDimensionCalculator = {
+      getMaxDimension: (): Dimension => {
+        callCount++;
+        return { width: 20, height: 14 };
+      },
+    };
+    const plot = makePlot(
+      [
+        [10, 90],
+        [50, 50],
+        [90, 10],
+      ],
+      ['A', '', 'B'],
+      trackingCalc
+    );
+    plot.getDrawableElement();
+    expect(callCount).toBe(2);
+  });
+
+  it('passes label text and font size to calculator', () => {
+    const calls: { texts: string[]; fontSize: number }[] = [];
+    const trackingCalc: TextDimensionCalculator = {
+      getMaxDimension: (texts, fontSize): Dimension => {
+        calls.push({ texts, fontSize });
+        return { width: 20, height: 14 };
+      },
+    };
+    const plot = makePlot([[50, 50]], ['Hello'], trackingCalc);
+    plot.getDrawableElement();
+    expect(calls.length).toBe(1);
+    expect(calls[0].texts).toEqual(['Hello']);
+    expect(calls[0].fontSize).toBe(14);
+  });
+
+  it('respects calculator-reported width for bounding box (zero width)', () => {
+    const plot = makePlot(
+      [
+        [10, 90],
+        [50, 50],
+      ],
+      ['A', 'B'],
+      makeCalc(0, 14)
+    );
+    const elems = plot.getDrawableElement();
+    expect(elems.find((e) => e.type === 'text')).toBeDefined();
+  });
+});

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/linePlot.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/linePlot.ts
@@ -1,5 +1,5 @@
 import { line } from 'd3';
-import type { DrawableElem, LinePlotData, XYChartConfig } from '../../interfaces.js';
+import type { DrawableElem, LinePlotData, TextElem, XYChartConfig } from '../../interfaces.js';
 import type { Axis } from '../axis/index.js';
 
 export class LinePlot {
@@ -30,7 +30,8 @@ export class LinePlot {
     if (!path) {
       return [];
     }
-    return [
+
+    const elements: DrawableElem[] = [
       {
         groupTexts: ['plot', `line-plot-${this.plotIndex}`],
         type: 'path',
@@ -43,5 +44,52 @@ export class LinePlot {
         ],
       },
     ];
+
+    if (this.plotData.pointLabels && this.plotData.pointLabels.length > 0) {
+      const labelOffset = 10;
+      const fontSize = 12;
+      const textData: TextElem[] = [];
+
+      for (const [i, [px, py]] of finalData.entries()) {
+        const label = this.plotData.pointLabels[i];
+        if (!label) {
+          continue;
+        }
+
+        if (this.orientation === 'horizontal') {
+          textData.push({
+            x: py + labelOffset,
+            y: px,
+            text: label,
+            fill: this.plotData.strokeFill,
+            verticalPos: 'middle',
+            horizontalPos: 'left',
+            fontSize,
+            rotation: 0,
+          });
+        } else {
+          textData.push({
+            x: px,
+            y: py - labelOffset,
+            text: label,
+            fill: this.plotData.strokeFill,
+            verticalPos: 'middle',
+            horizontalPos: 'center',
+            fontSize,
+            rotation: 0,
+          });
+        }
+      }
+
+      if (textData.length > 0) {
+        elements.push({
+          groupTexts: ['plot', `line-plot-${this.plotIndex}`, 'labels'],
+          type: 'text',
+          data: textData,
+        });
+      }
+    }
+
+    return elements;
   }
 }

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/linePlot.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/linePlot.ts
@@ -111,13 +111,20 @@ interface LabelPlacement {
   offset: number;
 }
 
+interface PlotBounds {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+}
+
 /**
  * Compute the best placement for a label on a vertical chart.
  *
  * Tries placing the label above the point first. If the adjacent line segments
- * collide with that bounding box, tries below. If both positions collide, retries
- * with increasing offsets (up to 3x the base). Returns the first collision-free
- * placement, or below at max offset as the least-bad fallback.
+ * collide with that bounding box, or the label would clip outside the plot area,
+ * tries below. Retries with increasing offsets (up to 3x the base). Returns the
+ * first collision-free, non-clipping placement, or above at base offset as fallback.
  *
  * The bounding box is expanded by strokeWidth / 2 on all sides to account for the
  * visual width of the line itself.
@@ -128,7 +135,8 @@ function computeLabelPlacementVertical(
   labelText: string,
   fontSize: number,
   baseOffset: number,
-  strokeWidth: number
+  strokeWidth: number,
+  plotBounds: PlotBounds
 ): LabelPlacement {
   const [px, py] = finalData[index];
   const textWidth = fontSize * labelText.length * CHAR_WIDTH_FACTOR;
@@ -142,18 +150,24 @@ function computeLabelPlacementVertical(
   for (const offset of [baseOffset, baseOffset * 2, baseOffset * 3]) {
     const aboveTop = py - offset - halfHeight - strokePad;
     const aboveBottom = py - offset + halfHeight + strokePad;
-    if (!adjacentSegmentsIntersectBox(finalData, index, boxLeft, boxRight, aboveTop, aboveBottom)) {
+    if (
+      aboveTop >= plotBounds.top &&
+      !adjacentSegmentsIntersectBox(finalData, index, boxLeft, boxRight, aboveTop, aboveBottom)
+    ) {
       return { flip: false, offset };
     }
 
     const belowTop = py + offset - halfHeight - strokePad;
     const belowBottom = py + offset + halfHeight + strokePad;
-    if (!adjacentSegmentsIntersectBox(finalData, index, boxLeft, boxRight, belowTop, belowBottom)) {
+    if (
+      belowBottom <= plotBounds.bottom &&
+      !adjacentSegmentsIntersectBox(finalData, index, boxLeft, boxRight, belowTop, belowBottom)
+    ) {
       return { flip: true, offset };
     }
   }
 
-  return { flip: true, offset: baseOffset * 3 };
+  return { flip: false, offset: baseOffset };
 }
 
 /**
@@ -163,6 +177,8 @@ function computeLabelPlacementVertical(
  * swaps them: svgX = yAxisScale (d[1]), svgY = xAxisScale (d[0]). Collision checks
  * are performed in SVG space. The default position is to the right of the point;
  * the flipped position is to the left.
+ *
+ * Also guards against the label clipping outside the plot's left or right boundary.
  */
 function computeLabelPlacementHorizontal(
   finalData: [number, number][],
@@ -170,7 +186,8 @@ function computeLabelPlacementHorizontal(
   labelText: string,
   fontSize: number,
   baseOffset: number,
-  strokeWidth: number
+  strokeWidth: number,
+  plotBounds: PlotBounds
 ): LabelPlacement {
   const [px, py] = finalData[index];
   const textWidth = fontSize * labelText.length * CHAR_WIDTH_FACTOR;
@@ -185,18 +202,24 @@ function computeLabelPlacementHorizontal(
   for (const offset of [baseOffset, baseOffset * 2, baseOffset * 3]) {
     const rightLeft = py + offset - strokePad;
     const rightRight = py + offset + textWidth + strokePad;
-    if (!adjacentSegmentsIntersectBox(svgPoints, index, rightLeft, rightRight, boxTop, boxBottom)) {
+    if (
+      rightRight <= plotBounds.right &&
+      !adjacentSegmentsIntersectBox(svgPoints, index, rightLeft, rightRight, boxTop, boxBottom)
+    ) {
       return { flip: false, offset };
     }
 
     const leftLeft = py - offset - textWidth - strokePad;
     const leftRight = py - offset + strokePad;
-    if (!adjacentSegmentsIntersectBox(svgPoints, index, leftLeft, leftRight, boxTop, boxBottom)) {
+    if (
+      leftLeft >= plotBounds.left &&
+      !adjacentSegmentsIntersectBox(svgPoints, index, leftLeft, leftRight, boxTop, boxBottom)
+    ) {
       return { flip: true, offset };
     }
   }
 
-  return { flip: true, offset: baseOffset * 3 };
+  return { flip: false, offset: baseOffset };
 }
 
 export class LinePlot {
@@ -247,6 +270,25 @@ export class LinePlot {
       const labelOffset = fontSize + 2;
       const textData: TextElem[] = [];
 
+      const [yRangeA, yRangeB] = this.yAxis.getRange();
+      const [xRangeA, xRangeB] = this.xAxis.getRange();
+      let plotBounds: PlotBounds;
+      if (this.chartConfig.chartOrientation === 'horizontal') {
+        plotBounds = {
+          top: Math.min(xRangeA, xRangeB),
+          bottom: Math.max(xRangeA, xRangeB),
+          left: Math.min(yRangeA, yRangeB),
+          right: Math.max(yRangeA, yRangeB),
+        };
+      } else {
+        plotBounds = {
+          top: Math.min(yRangeA, yRangeB),
+          bottom: Math.max(yRangeA, yRangeB),
+          left: Math.min(xRangeA, xRangeB),
+          right: Math.max(xRangeA, xRangeB),
+        };
+      }
+
       for (const [i, [px, py]] of finalData.entries()) {
         const label = this.plotData.pointLabels[i];
         if (!label) {
@@ -260,7 +302,8 @@ export class LinePlot {
             label,
             fontSize,
             labelOffset,
-            this.plotData.strokeWidth
+            this.plotData.strokeWidth,
+            plotBounds
           );
           textData.push({
             x: flip ? py - offset : py + offset,
@@ -279,7 +322,8 @@ export class LinePlot {
             label,
             fontSize,
             labelOffset,
-            this.plotData.strokeWidth
+            this.plotData.strokeWidth,
+            plotBounds
           );
           textData.push({
             x: px,

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/linePlot.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/linePlot.ts
@@ -79,98 +79,124 @@ function doesSegmentIntersectBox(
 }
 
 /**
- * Determine if a label placed above (vertical) or to the right (horizontal)
- * of a data point would collide with an adjacent line segment.
+ * Check whether either adjacent segment (prev→current or current→next) intersects
+ * the given bounding box. Points are provided in the coordinate system already
+ * expected by doesSegmentIntersectBox.
  */
-function shouldFlipLabelVertical(
-  finalData: [number, number][],
+function adjacentSegmentsIntersectBox(
+  points: [number, number][],
   index: number,
-  labelText: string,
-  fontSize: number,
-  labelOffset: number
+  boxLeft: number,
+  boxRight: number,
+  boxTop: number,
+  boxBottom: number
 ): boolean {
-  const [px, py] = finalData[index];
-  const textWidth = fontSize * labelText.length * CHAR_WIDTH_FACTOR;
-  const halfWidth = textWidth / 2;
-  const halfHeight = fontSize / 2;
-
-  // Bounding box of label placed above the point
-  const boxLeft = px - halfWidth;
-  const boxRight = px + halfWidth;
-  const boxTop = py - labelOffset - halfHeight;
-  const boxBottom = py - labelOffset + halfHeight;
-
-  // Check previous segment
   if (
     index > 0 &&
-    doesSegmentIntersectBox(
-      finalData[index - 1],
-      finalData[index],
-      boxLeft,
-      boxRight,
-      boxTop,
-      boxBottom
-    )
+    doesSegmentIntersectBox(points[index - 1], points[index], boxLeft, boxRight, boxTop, boxBottom)
   ) {
     return true;
   }
-  // Check next segment
   if (
-    index < finalData.length - 1 &&
-    doesSegmentIntersectBox(
-      finalData[index],
-      finalData[index + 1],
-      boxLeft,
-      boxRight,
-      boxTop,
-      boxBottom
-    )
+    index < points.length - 1 &&
+    doesSegmentIntersectBox(points[index], points[index + 1], boxLeft, boxRight, boxTop, boxBottom)
   ) {
     return true;
   }
   return false;
 }
 
-function shouldFlipLabelHorizontal(
+interface LabelPlacement {
+  flip: boolean;
+  offset: number;
+}
+
+/**
+ * Compute the best placement for a label on a vertical chart.
+ *
+ * Tries placing the label above the point first. If the adjacent line segments
+ * collide with that bounding box, tries below. If both positions collide, retries
+ * with increasing offsets (up to 3x the base). Returns the first collision-free
+ * placement, or below at max offset as the least-bad fallback.
+ *
+ * The bounding box is expanded by strokeWidth / 2 on all sides to account for the
+ * visual width of the line itself.
+ */
+function computeLabelPlacementVertical(
   finalData: [number, number][],
   index: number,
   labelText: string,
   fontSize: number,
-  labelOffset: number
-): boolean {
-  // In horizontal orientation, finalData is still [xScaled, yScaled] but
-  // the path uses y(d[0]) and x(d[1]), so pixel positions are swapped.
-  // px = xAxis.getScaleValue (maps to SVG y), py = yAxis.getScaleValue (maps to SVG x)
-  // Label is placed at SVG (py + labelOffset, px) — to the right of the point.
-  // We check if that box collides with adjacent segments in SVG space.
+  baseOffset: number,
+  strokeWidth: number
+): LabelPlacement {
+  const [px, py] = finalData[index];
+  const textWidth = fontSize * labelText.length * CHAR_WIDTH_FACTOR;
+  const halfWidth = textWidth / 2;
+  const halfHeight = fontSize / 2;
+  const strokePad = strokeWidth / 2;
+
+  const boxLeft = px - halfWidth - strokePad;
+  const boxRight = px + halfWidth + strokePad;
+
+  for (const offset of [baseOffset, baseOffset * 2, baseOffset * 3]) {
+    const aboveTop = py - offset - halfHeight - strokePad;
+    const aboveBottom = py - offset + halfHeight + strokePad;
+    if (!adjacentSegmentsIntersectBox(finalData, index, boxLeft, boxRight, aboveTop, aboveBottom)) {
+      return { flip: false, offset };
+    }
+
+    const belowTop = py + offset - halfHeight - strokePad;
+    const belowBottom = py + offset + halfHeight + strokePad;
+    if (!adjacentSegmentsIntersectBox(finalData, index, boxLeft, boxRight, belowTop, belowBottom)) {
+      return { flip: true, offset };
+    }
+  }
+
+  return { flip: true, offset: baseOffset * 3 };
+}
+
+/**
+ * Compute the best placement for a label on a horizontal chart.
+ *
+ * In horizontal orientation finalData is [xAxisScale, yAxisScale] but the SVG path
+ * swaps them: svgX = yAxisScale (d[1]), svgY = xAxisScale (d[0]). Collision checks
+ * are performed in SVG space. The default position is to the right of the point;
+ * the flipped position is to the left.
+ */
+function computeLabelPlacementHorizontal(
+  finalData: [number, number][],
+  index: number,
+  labelText: string,
+  fontSize: number,
+  baseOffset: number,
+  strokeWidth: number
+): LabelPlacement {
   const [px, py] = finalData[index];
   const textWidth = fontSize * labelText.length * CHAR_WIDTH_FACTOR;
   const halfHeight = fontSize / 2;
+  const strokePad = strokeWidth / 2;
 
-  // In SVG space for horizontal: svgX = py, svgY = px
-  // Label "to the right": svgX = py + labelOffset, svgY = px
-  // Box in SVG coords:
-  const boxLeft = py + labelOffset;
-  const boxRight = py + labelOffset + textWidth;
-  const boxTop = px - halfHeight;
-  const boxBottom = px + halfHeight;
+  const svgPoints = finalData.map((d): [number, number] => [d[1], d[0]]);
 
-  // Segments in SVG space: point i has svgX=py_i, svgY=px_i
-  const toSvg = (idx: number): [number, number] => [finalData[idx][1], finalData[idx][0]];
+  const boxTop = px - halfHeight - strokePad;
+  const boxBottom = px + halfHeight + strokePad;
 
-  if (
-    index > 0 &&
-    doesSegmentIntersectBox(toSvg(index - 1), toSvg(index), boxLeft, boxRight, boxTop, boxBottom)
-  ) {
-    return true;
+  for (const offset of [baseOffset, baseOffset * 2, baseOffset * 3]) {
+    const rightLeft = py + offset - strokePad;
+    const rightRight = py + offset + textWidth + strokePad;
+    if (!adjacentSegmentsIntersectBox(svgPoints, index, rightLeft, rightRight, boxTop, boxBottom)) {
+      return { flip: false, offset };
+    }
+
+    const leftLeft = py - offset - textWidth - strokePad;
+    const leftRight = py - offset + strokePad;
+    if (!adjacentSegmentsIntersectBox(svgPoints, index, leftLeft, leftRight, boxTop, boxBottom)) {
+      return { flip: true, offset };
+    }
   }
-  if (
-    index < finalData.length - 1 &&
-    doesSegmentIntersectBox(toSvg(index), toSvg(index + 1), boxLeft, boxRight, boxTop, boxBottom)
-  ) {
-    return true;
-  }
-  return false;
+
+  return { flip: true, offset: baseOffset * 3 };
 }
 
 export class LinePlot {
@@ -217,7 +243,7 @@ export class LinePlot {
     ];
 
     if (this.plotData.pointLabels && this.plotData.pointLabels.length > 0) {
-      const labelOffset = 10;
+      const labelOffset = 14;
       const fontSize = 12;
       const textData: TextElem[] = [];
 
@@ -228,9 +254,16 @@ export class LinePlot {
         }
 
         if (this.orientation === 'horizontal') {
-          const flip = shouldFlipLabelHorizontal(finalData, i, label, fontSize, labelOffset);
+          const { flip, offset } = computeLabelPlacementHorizontal(
+            finalData,
+            i,
+            label,
+            fontSize,
+            labelOffset,
+            this.plotData.strokeWidth
+          );
           textData.push({
-            x: flip ? py - labelOffset : py + labelOffset,
+            x: flip ? py - offset : py + offset,
             y: px,
             text: label,
             fill: this.plotData.strokeFill,
@@ -240,10 +273,17 @@ export class LinePlot {
             rotation: 0,
           });
         } else {
-          const flip = shouldFlipLabelVertical(finalData, i, label, fontSize, labelOffset);
+          const { flip, offset } = computeLabelPlacementVertical(
+            finalData,
+            i,
+            label,
+            fontSize,
+            labelOffset,
+            this.plotData.strokeWidth
+          );
           textData.push({
             x: px,
-            y: flip ? py + labelOffset : py - labelOffset,
+            y: flip ? py + offset : py - offset,
             text: label,
             fill: this.plotData.strokeFill,
             verticalPos: 'middle',

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/linePlot.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/linePlot.ts
@@ -2,6 +2,177 @@ import { line } from 'd3';
 import type { DrawableElem, LinePlotData, TextElem, XYChartConfig } from '../../interfaces.js';
 import type { Axis } from '../axis/index.js';
 
+const CHAR_WIDTH_FACTOR = 0.7;
+
+/**
+ * Interpolate a line segment's y-value at a given x.
+ * Returns null if x is outside the segment's x-range.
+ */
+function lineYAtX(segStart: [number, number], segEnd: [number, number], x: number): number | null {
+  const [x0, y0] = segStart;
+  const [x1, y1] = segEnd;
+  const minX = Math.min(x0, x1);
+  const maxX = Math.max(x0, x1);
+  if (x < minX || x > maxX) {
+    return null;
+  }
+  if (x0 === x1) {
+    return null; // vertical segment — can't interpolate by x
+  }
+  const t = (x - x0) / (x1 - x0);
+  return y0 + t * (y1 - y0);
+}
+
+/**
+ * Check if a line segment passes through an axis-aligned bounding box.
+ *
+ * Computes the y-range of the segment within the box's x-range and checks
+ * if it overlaps with the box's y-range. This correctly detects the case
+ * where a steep line enters from above and exits below the box (or vice
+ * versa) even if neither endpoint nor any single sample point falls inside.
+ */
+function doesSegmentIntersectBox(
+  segStart: [number, number],
+  segEnd: [number, number],
+  boxLeft: number,
+  boxRight: number,
+  boxTop: number,
+  boxBottom: number
+): boolean {
+  // Check if either endpoint is inside the box
+  for (const [ex, ey] of [segStart, segEnd]) {
+    if (ex >= boxLeft && ex <= boxRight && ey >= boxTop && ey <= boxBottom) {
+      return true;
+    }
+  }
+
+  // Compute the y-values of the line at the box's left and right x-edges
+  const yAtLeft = lineYAtX(segStart, segEnd, boxLeft);
+  const yAtRight = lineYAtX(segStart, segEnd, boxRight);
+
+  // Collect valid y-values (where segment overlaps box's x-range)
+  const ys: number[] = [];
+  if (yAtLeft !== null) {
+    ys.push(yAtLeft);
+  }
+  if (yAtRight !== null) {
+    ys.push(yAtRight);
+  }
+
+  // Also include segment endpoints that fall within the box's x-range
+  for (const [ex, ey] of [segStart, segEnd]) {
+    if (ex >= boxLeft && ex <= boxRight) {
+      ys.push(ey);
+    }
+  }
+
+  if (ys.length === 0) {
+    return false;
+  }
+
+  // The segment's y-range within the box's x-range
+  const segMinY = Math.min(...ys);
+  const segMaxY = Math.max(...ys);
+
+  // Check if the segment's y-range overlaps with the box's y-range
+  return segMaxY >= boxTop && segMinY <= boxBottom;
+}
+
+/**
+ * Determine if a label placed above (vertical) or to the right (horizontal)
+ * of a data point would collide with an adjacent line segment.
+ */
+function shouldFlipLabelVertical(
+  finalData: [number, number][],
+  index: number,
+  labelText: string,
+  fontSize: number,
+  labelOffset: number
+): boolean {
+  const [px, py] = finalData[index];
+  const textWidth = fontSize * labelText.length * CHAR_WIDTH_FACTOR;
+  const halfWidth = textWidth / 2;
+  const halfHeight = fontSize / 2;
+
+  // Bounding box of label placed above the point
+  const boxLeft = px - halfWidth;
+  const boxRight = px + halfWidth;
+  const boxTop = py - labelOffset - halfHeight;
+  const boxBottom = py - labelOffset + halfHeight;
+
+  // Check previous segment
+  if (
+    index > 0 &&
+    doesSegmentIntersectBox(
+      finalData[index - 1],
+      finalData[index],
+      boxLeft,
+      boxRight,
+      boxTop,
+      boxBottom
+    )
+  ) {
+    return true;
+  }
+  // Check next segment
+  if (
+    index < finalData.length - 1 &&
+    doesSegmentIntersectBox(
+      finalData[index],
+      finalData[index + 1],
+      boxLeft,
+      boxRight,
+      boxTop,
+      boxBottom
+    )
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function shouldFlipLabelHorizontal(
+  finalData: [number, number][],
+  index: number,
+  labelText: string,
+  fontSize: number,
+  labelOffset: number
+): boolean {
+  // In horizontal orientation, finalData is still [xScaled, yScaled] but
+  // the path uses y(d[0]) and x(d[1]), so pixel positions are swapped.
+  // px = xAxis.getScaleValue (maps to SVG y), py = yAxis.getScaleValue (maps to SVG x)
+  // Label is placed at SVG (py + labelOffset, px) — to the right of the point.
+  // We check if that box collides with adjacent segments in SVG space.
+  const [px, py] = finalData[index];
+  const textWidth = fontSize * labelText.length * CHAR_WIDTH_FACTOR;
+  const halfHeight = fontSize / 2;
+
+  // In SVG space for horizontal: svgX = py, svgY = px
+  // Label "to the right": svgX = py + labelOffset, svgY = px
+  // Box in SVG coords:
+  const boxLeft = py + labelOffset;
+  const boxRight = py + labelOffset + textWidth;
+  const boxTop = px - halfHeight;
+  const boxBottom = px + halfHeight;
+
+  // Segments in SVG space: point i has svgX=py_i, svgY=px_i
+  const toSvg = (idx: number): [number, number] => [finalData[idx][1], finalData[idx][0]];
+
+  if (
+    index > 0 &&
+    doesSegmentIntersectBox(toSvg(index - 1), toSvg(index), boxLeft, boxRight, boxTop, boxBottom)
+  ) {
+    return true;
+  }
+  if (
+    index < finalData.length - 1 &&
+    doesSegmentIntersectBox(toSvg(index), toSvg(index + 1), boxLeft, boxRight, boxTop, boxBottom)
+  ) {
+    return true;
+  }
+  return false;
+}
+
 export class LinePlot {
   constructor(
     private plotData: LinePlotData,
@@ -57,20 +228,22 @@ export class LinePlot {
         }
 
         if (this.orientation === 'horizontal') {
+          const flip = shouldFlipLabelHorizontal(finalData, i, label, fontSize, labelOffset);
           textData.push({
-            x: py + labelOffset,
+            x: flip ? py - labelOffset : py + labelOffset,
             y: px,
             text: label,
             fill: this.plotData.strokeFill,
             verticalPos: 'middle',
-            horizontalPos: 'left',
+            horizontalPos: flip ? 'right' : 'left',
             fontSize,
             rotation: 0,
           });
         } else {
+          const flip = shouldFlipLabelVertical(finalData, i, label, fontSize, labelOffset);
           textData.push({
             x: px,
-            y: py - labelOffset,
+            y: flip ? py + labelOffset : py - labelOffset,
             text: label,
             fill: this.plotData.strokeFill,
             verticalPos: 'middle',

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/linePlot.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/linePlot.ts
@@ -204,7 +204,7 @@ export class LinePlot {
     private plotData: LinePlotData,
     private xAxis: Axis,
     private yAxis: Axis,
-    private orientation: XYChartConfig['chartOrientation'],
+    private chartConfig: XYChartConfig,
     private plotIndex: number
   ) {}
 
@@ -215,7 +215,7 @@ export class LinePlot {
     ]);
 
     let path: string | null;
-    if (this.orientation === 'horizontal') {
+    if (this.chartConfig.chartOrientation === 'horizontal') {
       path = line()
         .y((d) => d[0])
         .x((d) => d[1])(finalData);
@@ -243,8 +243,8 @@ export class LinePlot {
     ];
 
     if (this.plotData.pointLabels && this.plotData.pointLabels.length > 0) {
-      const labelOffset = 14;
-      const fontSize = 12;
+      const fontSize = this.chartConfig.xAxis.labelFontSize;
+      const labelOffset = fontSize + 2;
       const textData: TextElem[] = [];
 
       for (const [i, [px, py]] of finalData.entries()) {
@@ -253,7 +253,7 @@ export class LinePlot {
           continue;
         }
 
-        if (this.orientation === 'horizontal') {
+        if (this.chartConfig.chartOrientation === 'horizontal') {
           const { flip, offset } = computeLabelPlacementHorizontal(
             finalData,
             i,

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/linePlot.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/linePlot.ts
@@ -1,8 +1,13 @@
 import { line } from 'd3';
-import type { DrawableElem, LinePlotData, TextElem, XYChartConfig } from '../../interfaces.js';
+import type {
+  Dimension,
+  DrawableElem,
+  LinePlotData,
+  TextElem,
+  XYChartConfig,
+} from '../../interfaces.js';
+import type { TextDimensionCalculator } from '../../textDimensionCalculator.js';
 import type { Axis } from '../axis/index.js';
-
-const CHAR_WIDTH_FACTOR = 0.7;
 
 /**
  * Interpolate a line segment's y-value at a given x.
@@ -132,16 +137,14 @@ interface PlotBounds {
 function computeLabelPlacementVertical(
   finalData: [number, number][],
   index: number,
-  labelText: string,
-  fontSize: number,
+  textDim: Dimension,
   baseOffset: number,
   strokeWidth: number,
   plotBounds: PlotBounds
 ): LabelPlacement {
   const [px, py] = finalData[index];
-  const textWidth = fontSize * labelText.length * CHAR_WIDTH_FACTOR;
-  const halfWidth = textWidth / 2;
-  const halfHeight = fontSize / 2;
+  const halfWidth = textDim.width / 2;
+  const halfHeight = textDim.height / 2;
   const strokePad = strokeWidth / 2;
 
   const boxLeft = px - halfWidth - strokePad;
@@ -183,15 +186,13 @@ function computeLabelPlacementVertical(
 function computeLabelPlacementHorizontal(
   finalData: [number, number][],
   index: number,
-  labelText: string,
-  fontSize: number,
+  textDim: Dimension,
   baseOffset: number,
   strokeWidth: number,
   plotBounds: PlotBounds
 ): LabelPlacement {
   const [px, py] = finalData[index];
-  const textWidth = fontSize * labelText.length * CHAR_WIDTH_FACTOR;
-  const halfHeight = fontSize / 2;
+  const halfHeight = textDim.height / 2;
   const strokePad = strokeWidth / 2;
 
   const svgPoints = finalData.map((d): [number, number] => [d[1], d[0]]);
@@ -201,7 +202,7 @@ function computeLabelPlacementHorizontal(
 
   for (const offset of [baseOffset, baseOffset * 2, baseOffset * 3]) {
     const rightLeft = py + offset - strokePad;
-    const rightRight = py + offset + textWidth + strokePad;
+    const rightRight = py + offset + textDim.width + strokePad;
     if (
       rightRight <= plotBounds.right &&
       !adjacentSegmentsIntersectBox(svgPoints, index, rightLeft, rightRight, boxTop, boxBottom)
@@ -209,7 +210,7 @@ function computeLabelPlacementHorizontal(
       return { flip: false, offset };
     }
 
-    const leftLeft = py - offset - textWidth - strokePad;
+    const leftLeft = py - offset - textDim.width - strokePad;
     const leftRight = py - offset + strokePad;
     if (
       leftLeft >= plotBounds.left &&
@@ -228,7 +229,8 @@ export class LinePlot {
     private xAxis: Axis,
     private yAxis: Axis,
     private chartConfig: XYChartConfig,
-    private plotIndex: number
+    private plotIndex: number,
+    private textDimensionCalculator: TextDimensionCalculator
   ) {}
 
   getDrawableElement(): DrawableElem[] {
@@ -295,12 +297,13 @@ export class LinePlot {
           continue;
         }
 
+        const textDim = this.textDimensionCalculator.getMaxDimension([label], fontSize);
+
         if (this.chartConfig.chartOrientation === 'horizontal') {
           const { flip, offset } = computeLabelPlacementHorizontal(
             finalData,
             i,
-            label,
-            fontSize,
+            textDim,
             labelOffset,
             this.plotData.strokeWidth,
             plotBounds
@@ -319,8 +322,7 @@ export class LinePlot {
           const { flip, offset } = computeLabelPlacementVertical(
             finalData,
             i,
-            label,
-            fontSize,
+            textDim,
             labelOffset,
             this.plotData.strokeWidth,
             plotBounds

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/linePlot.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/linePlot.ts
@@ -111,13 +111,20 @@ interface LabelPlacement {
   offset: number;
 }
 
+interface PlotBounds {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+}
+
 /**
  * Compute the best placement for a label on a vertical chart.
  *
  * Tries placing the label above the point first. If the adjacent line segments
- * collide with that bounding box, tries below. If both positions collide, retries
- * with increasing offsets (up to 3x the base). Returns the first collision-free
- * placement, or below at max offset as the least-bad fallback.
+ * collide with that bounding box, or the label would clip outside the plot area,
+ * tries below. Retries with increasing offsets (up to 3x the base). Returns the
+ * first collision-free, non-clipping placement, or above at base offset as fallback.
  *
  * The bounding box is expanded by strokeWidth / 2 on all sides to account for the
  * visual width of the line itself.
@@ -128,7 +135,8 @@ function computeLabelPlacementVertical(
   labelText: string,
   fontSize: number,
   baseOffset: number,
-  strokeWidth: number
+  strokeWidth: number,
+  plotBounds: PlotBounds
 ): LabelPlacement {
   const [px, py] = finalData[index];
   const textWidth = fontSize * labelText.length * CHAR_WIDTH_FACTOR;
@@ -142,18 +150,24 @@ function computeLabelPlacementVertical(
   for (const offset of [baseOffset, baseOffset * 2, baseOffset * 3]) {
     const aboveTop = py - offset - halfHeight - strokePad;
     const aboveBottom = py - offset + halfHeight + strokePad;
-    if (!adjacentSegmentsIntersectBox(finalData, index, boxLeft, boxRight, aboveTop, aboveBottom)) {
+    if (
+      aboveTop >= plotBounds.top &&
+      !adjacentSegmentsIntersectBox(finalData, index, boxLeft, boxRight, aboveTop, aboveBottom)
+    ) {
       return { flip: false, offset };
     }
 
     const belowTop = py + offset - halfHeight - strokePad;
     const belowBottom = py + offset + halfHeight + strokePad;
-    if (!adjacentSegmentsIntersectBox(finalData, index, boxLeft, boxRight, belowTop, belowBottom)) {
+    if (
+      belowBottom <= plotBounds.bottom &&
+      !adjacentSegmentsIntersectBox(finalData, index, boxLeft, boxRight, belowTop, belowBottom)
+    ) {
       return { flip: true, offset };
     }
   }
 
-  return { flip: true, offset: baseOffset * 3 };
+  return { flip: false, offset: baseOffset };
 }
 
 /**
@@ -163,6 +177,8 @@ function computeLabelPlacementVertical(
  * swaps them: svgX = yAxisScale (d[1]), svgY = xAxisScale (d[0]). Collision checks
  * are performed in SVG space. The default position is to the right of the point;
  * the flipped position is to the left.
+ *
+ * Also guards against the label clipping outside the plot's left or right boundary.
  */
 function computeLabelPlacementHorizontal(
   finalData: [number, number][],
@@ -170,7 +186,8 @@ function computeLabelPlacementHorizontal(
   labelText: string,
   fontSize: number,
   baseOffset: number,
-  strokeWidth: number
+  strokeWidth: number,
+  plotBounds: PlotBounds
 ): LabelPlacement {
   const [px, py] = finalData[index];
   const textWidth = fontSize * labelText.length * CHAR_WIDTH_FACTOR;
@@ -185,18 +202,24 @@ function computeLabelPlacementHorizontal(
   for (const offset of [baseOffset, baseOffset * 2, baseOffset * 3]) {
     const rightLeft = py + offset - strokePad;
     const rightRight = py + offset + textWidth + strokePad;
-    if (!adjacentSegmentsIntersectBox(svgPoints, index, rightLeft, rightRight, boxTop, boxBottom)) {
+    if (
+      rightRight <= plotBounds.right &&
+      !adjacentSegmentsIntersectBox(svgPoints, index, rightLeft, rightRight, boxTop, boxBottom)
+    ) {
       return { flip: false, offset };
     }
 
     const leftLeft = py - offset - textWidth - strokePad;
     const leftRight = py - offset + strokePad;
-    if (!adjacentSegmentsIntersectBox(svgPoints, index, leftLeft, leftRight, boxTop, boxBottom)) {
+    if (
+      leftLeft >= plotBounds.left &&
+      !adjacentSegmentsIntersectBox(svgPoints, index, leftLeft, leftRight, boxTop, boxBottom)
+    ) {
       return { flip: true, offset };
     }
   }
 
-  return { flip: true, offset: baseOffset * 3 };
+  return { flip: false, offset: baseOffset };
 }
 
 export class LinePlot {
@@ -247,6 +270,25 @@ export class LinePlot {
       const fontSize = 12;
       const textData: TextElem[] = [];
 
+      const [yRangeA, yRangeB] = this.yAxis.getRange();
+      const [xRangeA, xRangeB] = this.xAxis.getRange();
+      let plotBounds: PlotBounds;
+      if (this.orientation === 'horizontal') {
+        plotBounds = {
+          top: Math.min(xRangeA, xRangeB),
+          bottom: Math.max(xRangeA, xRangeB),
+          left: Math.min(yRangeA, yRangeB),
+          right: Math.max(yRangeA, yRangeB),
+        };
+      } else {
+        plotBounds = {
+          top: Math.min(yRangeA, yRangeB),
+          bottom: Math.max(yRangeA, yRangeB),
+          left: Math.min(xRangeA, xRangeB),
+          right: Math.max(xRangeA, xRangeB),
+        };
+      }
+
       for (const [i, [px, py]] of finalData.entries()) {
         const label = this.plotData.pointLabels[i];
         if (!label) {
@@ -260,7 +302,8 @@ export class LinePlot {
             label,
             fontSize,
             labelOffset,
-            this.plotData.strokeWidth
+            this.plotData.strokeWidth,
+            plotBounds
           );
           textData.push({
             x: flip ? py - offset : py + offset,
@@ -279,7 +322,8 @@ export class LinePlot {
             label,
             fontSize,
             labelOffset,
-            this.plotData.strokeWidth
+            this.plotData.strokeWidth,
+            plotBounds
           );
           textData.push({
             x: px,

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/interfaces.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/interfaces.ts
@@ -33,6 +33,7 @@ export interface LinePlotData {
   strokeFill: string;
   strokeWidth: number;
   data: SimplePlotDataType;
+  pointLabels?: string[];
 }
 
 export interface BarPlotData {

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/orchestrator.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/orchestrator.ts
@@ -28,7 +28,7 @@ export class Orchestrator {
   ) {
     this.componentStore = {
       title: getChartTitleComponent(chartConfig, chartData, chartThemeConfig, tmpSVGGroup),
-      plot: getPlotComponent(chartConfig, chartData, chartThemeConfig),
+      plot: getPlotComponent(chartConfig, chartData, chartThemeConfig, tmpSVGGroup),
       xAxis: getAxis(
         chartData.xAxis,
         chartConfig.xAxis,

--- a/packages/mermaid/src/diagrams/xychart/parser/xychart.jison
+++ b/packages/mermaid/src/diagrams/xychart/parser/xychart.jison
@@ -111,12 +111,17 @@ statement
   ;
 
 plotData
-  : SQUARE_BRACES_START commaSeparatedNumbers SQUARE_BRACES_END   { $$ = $commaSeparatedNumbers }
+  : SQUARE_BRACES_START dataPoints SQUARE_BRACES_END   { $$ = $dataPoints }
   ;
 
-commaSeparatedNumbers
-  : NUMBER_WITH_DECIMAL COMMA commaSeparatedNumbers                { $$ = [Number($NUMBER_WITH_DECIMAL), ...$commaSeparatedNumbers] }
-  | NUMBER_WITH_DECIMAL                                           { $$ = [Number($NUMBER_WITH_DECIMAL)] }
+dataPoints
+  : dataPoint COMMA dataPoints                { $$ = [$dataPoint, ...$dataPoints] }
+  | dataPoint                                 { $$ = [$dataPoint] }
+  ;
+
+dataPoint
+  : NUMBER_WITH_DECIMAL STR                   { $$ = { value: Number($1), label: $2 } }
+  | NUMBER_WITH_DECIMAL                       { $$ = { value: Number($1), label: '' } }
   ;
 
 parseXAxis

--- a/packages/mermaid/src/diagrams/xychart/parser/xychart.jison.spec.ts
+++ b/packages/mermaid/src/diagrams/xychart/parser/xychart.jison.spec.ts
@@ -29,6 +29,11 @@ function clearMocks() {
   }
 }
 
+/** Helper to create the expected parsed data point format */
+function dp(value: number, label = '') {
+  return { value, label };
+}
+
 describe('Testing xychart jison file', () => {
   beforeEach(() => {
     parser.yy = mockDB;
@@ -274,10 +279,11 @@ describe('Testing xychart jison file', () => {
   it('parse line Data', () => {
     const str = 'xychart\nx-axis xAxisName\ny-axis yAxisName\n line lineTitle [23, 45, 56.6]';
     expect(parserFnConstructor(str)).not.toThrow();
-    expect(mockDB.setLineData).toHaveBeenCalledWith(
-      { text: 'lineTitle', type: 'text' },
-      [23, 45, 56.6]
-    );
+    expect(mockDB.setLineData).toHaveBeenCalledWith({ text: 'lineTitle', type: 'text' }, [
+      dp(23),
+      dp(45),
+      dp(56.6),
+    ]);
     expect(mockDB.setXAxisTitle).toHaveBeenCalledWith({ text: 'xAxisName', type: 'text' });
     expect(mockDB.setYAxisTitle).toHaveBeenCalledWith({ text: 'yAxisName', type: 'text' });
   });
@@ -289,7 +295,7 @@ describe('Testing xychart jison file', () => {
     expect(mockDB.setXAxisTitle).toHaveBeenCalledWith({ text: 'xAxisName', type: 'text' });
     expect(mockDB.setLineData).toHaveBeenCalledWith(
       { text: 'lineTitle with space', type: 'text' },
-      [23, -45, 56.6]
+      [dp(23), dp(-45), dp(56.6)]
     );
   });
   it('parse line Data without title', () => {
@@ -297,10 +303,12 @@ describe('Testing xychart jison file', () => {
     expect(parserFnConstructor(str)).not.toThrow();
     expect(mockDB.setYAxisTitle).toHaveBeenCalledWith({ text: 'yAxisName', type: 'text' });
     expect(mockDB.setXAxisTitle).toHaveBeenCalledWith({ text: 'xAxisName', type: 'text' });
-    expect(mockDB.setLineData).toHaveBeenCalledWith(
-      { text: '', type: 'text' },
-      [23, -45, 56.6, 0.33]
-    );
+    expect(mockDB.setLineData).toHaveBeenCalledWith({ text: '', type: 'text' }, [
+      dp(23),
+      dp(-45),
+      dp(56.6),
+      dp(0.33),
+    ]);
   });
   it('parse line Data throws error unbalanced brackets', () => {
     let str =
@@ -333,10 +341,12 @@ describe('Testing xychart jison file', () => {
     expect(parserFnConstructor(str)).not.toThrow();
     expect(mockDB.setYAxisTitle).toHaveBeenCalledWith({ text: 'yAxisName', type: 'text' });
     expect(mockDB.setXAxisTitle).toHaveBeenCalledWith({ text: 'xAxisName', type: 'text' });
-    expect(mockDB.setBarData).toHaveBeenCalledWith(
-      { text: 'barTitle', type: 'text' },
-      [23, 45, 56.6, 0.22]
-    );
+    expect(mockDB.setBarData).toHaveBeenCalledWith({ text: 'barTitle', type: 'text' }, [
+      dp(23),
+      dp(45),
+      dp(56.6),
+      dp(0.22),
+    ]);
   });
   it('parse bar Data spaces and +,- symbol', () => {
     const str =
@@ -344,17 +354,22 @@ describe('Testing xychart jison file', () => {
     expect(parserFnConstructor(str)).not.toThrow();
     expect(mockDB.setYAxisTitle).toHaveBeenCalledWith({ text: 'yAxisName', type: 'text' });
     expect(mockDB.setXAxisTitle).toHaveBeenCalledWith({ text: 'xAxisName', type: 'text' });
-    expect(mockDB.setBarData).toHaveBeenCalledWith(
-      { text: 'barTitle with space', type: 'text' },
-      [23, -45, 56.6]
-    );
+    expect(mockDB.setBarData).toHaveBeenCalledWith({ text: 'barTitle with space', type: 'text' }, [
+      dp(23),
+      dp(-45),
+      dp(56.6),
+    ]);
   });
   it('parse bar Data without plot title', () => {
     const str = 'xychart\nx-axis xAxisName\ny-axis yAxisName\n bar   [  +23 , -45  , 56.6 ]   ';
     expect(parserFnConstructor(str)).not.toThrow();
     expect(mockDB.setYAxisTitle).toHaveBeenCalledWith({ text: 'yAxisName', type: 'text' });
     expect(mockDB.setXAxisTitle).toHaveBeenCalledWith({ text: 'xAxisName', type: 'text' });
-    expect(mockDB.setBarData).toHaveBeenCalledWith({ text: '', type: 'text' }, [23, -45, 56.6]);
+    expect(mockDB.setBarData).toHaveBeenCalledWith({ text: '', type: 'text' }, [
+      dp(23),
+      dp(-45),
+      dp(56.6),
+    ]);
   });
   it('parse bar should throw for unbalanced brackets', () => {
     let str =
@@ -389,22 +404,27 @@ describe('Testing xychart jison file', () => {
     expect(parserFnConstructor(str)).not.toThrow();
     expect(mockDB.setYAxisTitle).toHaveBeenCalledWith({ text: 'yAxisName', type: 'text' });
     expect(mockDB.setXAxisTitle).toHaveBeenCalledWith({ text: 'xAxisName', type: 'text' });
-    expect(mockDB.setBarData).toHaveBeenCalledWith(
-      { text: 'barTitle1', type: 'text' },
-      [23, 45, 56.6]
-    );
-    expect(mockDB.setBarData).toHaveBeenCalledWith(
-      { text: 'barTitle2', type: 'text' },
-      [13, 42, 56.89]
-    );
-    expect(mockDB.setLineData).toHaveBeenCalledWith(
-      { text: 'lineTitle1', type: 'text' },
-      [11, 45.5, 67, 23]
-    );
-    expect(mockDB.setLineData).toHaveBeenCalledWith(
-      { text: 'lineTitle2', type: 'text' },
-      [45, 99, 12]
-    );
+    expect(mockDB.setBarData).toHaveBeenCalledWith({ text: 'barTitle1', type: 'text' }, [
+      dp(23),
+      dp(45),
+      dp(56.6),
+    ]);
+    expect(mockDB.setBarData).toHaveBeenCalledWith({ text: 'barTitle2', type: 'text' }, [
+      dp(13),
+      dp(42),
+      dp(56.89),
+    ]);
+    expect(mockDB.setLineData).toHaveBeenCalledWith({ text: 'lineTitle1', type: 'text' }, [
+      dp(11),
+      dp(45.5),
+      dp(67),
+      dp(23),
+    ]);
+    expect(mockDB.setLineData).toHaveBeenCalledWith({ text: 'lineTitle2', type: 'text' }, [
+      dp(45),
+      dp(99),
+      dp(12),
+    ]);
   });
   it('parse multiple bar and line variant 2', () => {
     const str = `
@@ -425,22 +445,90 @@ describe('Testing xychart jison file', () => {
       { text: 'category 2', type: 'text' },
       { text: 'category3', type: 'text' },
     ]);
-    expect(mockDB.setBarData).toHaveBeenCalledWith(
-      { text: 'barTitle1', type: 'text' },
-      [23, 45, 56.6]
-    );
-    expect(mockDB.setBarData).toHaveBeenCalledWith(
-      { text: 'barTitle2', type: 'text' },
-      [13, 42, 56.89]
-    );
-    expect(mockDB.setLineData).toHaveBeenCalledWith(
-      { text: 'lineTitle1', type: 'text' },
-      [11, 45.5, 67, 23]
-    );
-    expect(mockDB.setLineData).toHaveBeenCalledWith(
-      { text: 'lineTitle2', type: 'text' },
-      [45, 99, 12]
-    );
+    expect(mockDB.setBarData).toHaveBeenCalledWith({ text: 'barTitle1', type: 'text' }, [
+      dp(23),
+      dp(45),
+      dp(56.6),
+    ]);
+    expect(mockDB.setBarData).toHaveBeenCalledWith({ text: 'barTitle2', type: 'text' }, [
+      dp(13),
+      dp(42),
+      dp(56.89),
+    ]);
+    expect(mockDB.setLineData).toHaveBeenCalledWith({ text: 'lineTitle1', type: 'text' }, [
+      dp(11),
+      dp(45.5),
+      dp(67),
+      dp(23),
+    ]);
+    expect(mockDB.setLineData).toHaveBeenCalledWith({ text: 'lineTitle2', type: 'text' }, [
+      dp(45),
+      dp(99),
+      dp(12),
+    ]);
+  });
+
+  describe('point labels', () => {
+    it('parse line data with point labels', () => {
+      const str =
+        'xychart\nx-axis xAxisName\ny-axis yAxisName\n line [10 "First", 20 "Second", 30 "Third"]';
+      expect(parserFnConstructor(str)).not.toThrow();
+      expect(mockDB.setLineData).toHaveBeenCalledWith({ text: '', type: 'text' }, [
+        dp(10, 'First'),
+        dp(20, 'Second'),
+        dp(30, 'Third'),
+      ]);
+    });
+
+    it('parse line data with mixed labels and no labels', () => {
+      const str = 'xychart\nx-axis xAxisName\ny-axis yAxisName\n line [10 "Start", 20, 30 "End"]';
+      expect(parserFnConstructor(str)).not.toThrow();
+      expect(mockDB.setLineData).toHaveBeenCalledWith({ text: '', type: 'text' }, [
+        dp(10, 'Start'),
+        dp(20),
+        dp(30, 'End'),
+      ]);
+    });
+
+    it('parse line data with labels containing spaces', () => {
+      const str =
+        'xychart\nx-axis xAxisName\ny-axis yAxisName\n line [10 "Hello World", 20 "Another Label"]';
+      expect(parserFnConstructor(str)).not.toThrow();
+      expect(mockDB.setLineData).toHaveBeenCalledWith({ text: '', type: 'text' }, [
+        dp(10, 'Hello World'),
+        dp(20, 'Another Label'),
+      ]);
+    });
+
+    it('parse line data with title and point labels', () => {
+      const str = 'xychart\nx-axis xAxisName\ny-axis yAxisName\n line "My Line" [10 "A", 20 "B"]';
+      expect(parserFnConstructor(str)).not.toThrow();
+      expect(mockDB.setLineData).toHaveBeenCalledWith({ text: 'My Line', type: 'text' }, [
+        dp(10, 'A'),
+        dp(20, 'B'),
+      ]);
+    });
+
+    it('parse bar data with point labels', () => {
+      const str = 'xychart\nx-axis xAxisName\ny-axis yAxisName\n bar [10 "A", 20 "B", 30 "C"]';
+      expect(parserFnConstructor(str)).not.toThrow();
+      expect(mockDB.setBarData).toHaveBeenCalledWith({ text: '', type: 'text' }, [
+        dp(10, 'A'),
+        dp(20, 'B'),
+        dp(30, 'C'),
+      ]);
+    });
+
+    it('parse line data with decimal values and labels', () => {
+      const str =
+        'xychart\nx-axis xAxisName\ny-axis yAxisName\n line [3.8 "Phi-3", 7 "Mistral", 540 "PaLM"]';
+      expect(parserFnConstructor(str)).not.toThrow();
+      expect(mockDB.setLineData).toHaveBeenCalledWith({ text: '', type: 'text' }, [
+        dp(3.8, 'Phi-3'),
+        dp(7, 'Mistral'),
+        dp(540, 'PaLM'),
+      ]);
+    });
   });
 
   describe('accessibility', () => {

--- a/packages/mermaid/src/diagrams/xychart/xychartDb.ts
+++ b/packages/mermaid/src/diagrams/xychart/xychartDb.ts
@@ -165,7 +165,7 @@ interface ParsedDataPoint {
 
 function setLineData(title: NormalTextType, data: ParsedDataPoint[]) {
   const values = data.map((d) => d.value);
-  const labels = data.map((d) => d.label);
+  const labels = data.map((d) => (d.label ? textSanitizer(d.label) : ''));
   const plotData = transformDataWithoutCategory(values);
   const hasAnyLabel = labels.some((l) => l !== '');
   xyChartData.plots.push({

--- a/packages/mermaid/src/diagrams/xychart/xychartDb.ts
+++ b/packages/mermaid/src/diagrams/xychart/xychartDb.ts
@@ -158,19 +158,29 @@ function getPlotColorFromPalette(plotIndex: number): string {
   return plotColorPalette[plotIndex === 0 ? 0 : plotIndex % plotColorPalette.length];
 }
 
-function setLineData(title: NormalTextType, data: number[]) {
-  const plotData = transformDataWithoutCategory(data);
+interface ParsedDataPoint {
+  value: number;
+  label: string;
+}
+
+function setLineData(title: NormalTextType, data: ParsedDataPoint[]) {
+  const values = data.map((d) => d.value);
+  const labels = data.map((d) => d.label);
+  const plotData = transformDataWithoutCategory(values);
+  const hasAnyLabel = labels.some((l) => l !== '');
   xyChartData.plots.push({
     type: 'line',
     strokeFill: getPlotColorFromPalette(plotIndex),
     strokeWidth: 2,
     data: plotData,
+    ...(hasAnyLabel ? { pointLabels: labels } : {}),
   });
   plotIndex++;
 }
 
-function setBarData(title: NormalTextType, data: number[]) {
-  const plotData = transformDataWithoutCategory(data);
+function setBarData(title: NormalTextType, data: ParsedDataPoint[]) {
+  const values = data.map((d) => d.value);
+  const plotData = transformDataWithoutCategory(values);
   xyChartData.plots.push({
     type: 'bar',
     fill: getPlotColorFromPalette(plotIndex),

--- a/packages/mermaid/src/docs/syntax/xyChart.md
+++ b/packages/mermaid/src/docs/syntax/xyChart.md
@@ -236,7 +236,7 @@ xychart
 Existing syntax without labels continues to work unchanged.
 
 ```note
-Point labels use a fixed font size of 12px. In vertical charts, labels appear above each point. In horizontal charts, labels appear to the right.
+Point labels use a fixed font size of 12px. In vertical charts, labels appear above each point. In horizontal charts, labels appear to the right. Labels are currently supported on `line` plots only; the syntax is accepted on `bar` plots but labels are ignored.
 ```
 
 ## Example on config and theme

--- a/packages/mermaid/src/docs/syntax/xyChart.md
+++ b/packages/mermaid/src/docs/syntax/xyChart.md
@@ -211,6 +211,26 @@ xychart
     bar [12,2,20,25,17,24]
 ```
 
+## Per-point text labels for line charts (v<MERMAID_RELEASE_VERSION>+)
+
+Each data point in a `line` can optionally include a quoted string label after the numeric value. Labels render above points in vertical orientation, or to the right in horizontal orientation, using the line's stroke color.
+
+```mermaid-example
+xychart
+    title "Smallest AI models scoring above 60% on MMLU"
+    x-axis "Date" ["Apr 2022", "Feb 2023", "Jul 2023", "Sep 2023", "Apr 2024"]
+    y-axis "Parameters (B)" 0 --> 600
+    line [540 "PaLM", 65 "LLaMA-65B", 34 "Llama 2 34B", 7 "Mistral 7B", 3.8 "Phi-3-mini"]
+```
+
+Labels are optional per point — you can mix labeled and unlabeled values:
+
+```
+line [10 "Start", 20, 30 "End"]
+```
+
+Existing syntax without labels continues to work unchanged.
+
 ## Example on config and theme
 
 ```mermaid-example

--- a/packages/mermaid/src/docs/syntax/xyChart.md
+++ b/packages/mermaid/src/docs/syntax/xyChart.md
@@ -225,11 +225,19 @@ xychart
 
 Labels are optional per point — you can mix labeled and unlabeled values:
 
-```
-line [10 "Start", 20, 30 "End"]
+```mermaid-example
+xychart
+    title "Quarterly Performance"
+    x-axis [Q1, Q2, Q3, Q4]
+    y-axis "Revenue ($M)" 0 --> 100
+    line [25 "Launch", 45, 72, 90 "Target Hit"]
 ```
 
 Existing syntax without labels continues to work unchanged.
+
+```note
+Point labels use a fixed font size of 12px. In vertical charts, labels appear above each point. In horizontal charts, labels appear to the right.
+```
 
 ## Example on config and theme
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

When a label is auto-flipped to avoid line collision, it can clip into the axis area if the data point is near a plot boundary. This adds full bounds checking to both placement functions, covering all four plot boundaries for both chart orientations.

Stacked on #7550 and #7551. Please merge those first.

[existing] top placement (default):

<img width="2880" height="1920" alt="Screenshot From 2026-04-05 11-25-56" src="https://github.com/user-attachments/assets/66ef989e-a693-44b1-a5c4-8eccd84bfb37" />

[existing] bottom placement (avoid intersecting with the line graph at acute angles): 

<img width="2880" height="1920" alt="Screenshot From 2026-04-05 11-26-04" src="https://github.com/user-attachments/assets/a9591c12-bc92-4ced-8679-04bd27a5611f" />

[new] forces intersection with line instead of intersecting with the x axis:
<img width="2880" height="1920" alt="Screenshot From 2026-04-05 11-26-15" src="https://github.com/user-attachments/assets/35cedcdd-3c39-49e1-afd4-1f5482adc069" />


## :straight_ruler: Design Decisions

- **Exposes `getRange()` on the `Axis` interface** — was already implemented on `BaseAxis` but not part of the public interface. Provides the inner plot boundaries needed for bounds checks.
- **Bounds checking integrated into placement functions** — `computeLabelPlacementVertical` and `computeLabelPlacementHorizontal` now accept a `PlotBounds` parameter. A candidate position is rejected if it clips any axis boundary, not just the x-axis bottom.
- **Fallback: non-flipped at base offset** — if all 6 candidates (3 offsets × 2 directions) either collide with the line or clip a boundary, the label stays above/right at minimum offset. This prefers line overlap over axis clipping.

### Coverage

| Orientation | Boundary | Handled |
|---|---|---|
| Vertical | x-axis (bottom) | ✅ |
| Vertical | top of plot | ✅ |
| Horizontal | y-axis (right) | ✅ |
| Horizontal | left boundary | ✅ |

### Changes

| File | Change |
|------|--------|
| `axis/index.ts` | Add `getRange()` to `Axis` interface |
| `linePlot.ts` | Add `PlotBounds` interface; integrate bounds checks into `computeLabelPlacementVertical` and `computeLabelPlacementHorizontal` |
| `demos/xychart.html` | Add axis-bounds demo charts for both orientations |
| `.gitignore` | Ignore `demos/mermaid.esm.mjs` build artifact |

### :clipboard: Tasks

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.