### PR TITLE
fix(flowchart): warn when click event binding fails due to securityLevel

### DIFF
--- a/packages/mermaid/src/diagrams/flowchart/flowDb.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.ts
@@ -489,6 +489,9 @@ You have to call mermaid.initialize.`
   private setClickFun(id: string, functionName: string, functionArgs: string) {
     // if (_id[0].match(/\d/)) id = MERMAID_DOM_ID_PREFIX + id;
     if (getConfig().securityLevel !== 'loose') {
+      log.warn(
+        `"click" event bindings are only supported when securityLevel is set to "loose". Current securityLevel: "${getConfig().securityLevel}". Not binding click event for node "${id}".`
+      );
       return;
     }
     if (functionName === undefined) {


### PR DESCRIPTION
## Summary

Fixes #6809

When `securityLevel` is not set to `"loose"`, the `click` directive in flowcharts silently fails without any feedback. Users see the "clickable" CSS class applied to nodes but the actual `click` callback never fires, making it very difficult to debug.

## Fix

Added a `log.warn()` message in `setClickFun()` (in `flowDb.ts`) that informs the user when a click event binding is skipped due to the security level restriction. The warning message includes:
- The current `securityLevel` value
- The node ID that was affected
- A clear explanation that `securityLevel: "loose"` is required

## Example Warning

```
"click" event bindings are only supported when securityLevel is set to "loose". Current securityLevel: "strict". Not binding click event for node "getOriginalTrack".
```

## Testing

The `log` module from `../../logger.js` is already imported and used elsewhere in `flowDb.ts`, so no new dependencies are introduced.