### PR TITLE
fix: switch zenuml renderer to native svg

### DIFF
--- a/.changeset/fix-zenuml-svg-renderer.md
+++ b/.changeset/fix-zenuml-svg-renderer.md
@@ -1,0 +1,10 @@
+---
+'mermaid': patch
+'@mermaid-js/mermaid-zenuml': patch
+---
+
+fix: update @zenuml/core to v3.46.11 with native SVG renderer
+
+- Fix vertical lifelines disappearing when printing (#6004)
+- Fix SVG dimensions exceeding container boundaries (#7266)
+- Fix invalid ZenUML syntax freezing the editor (#7154)

--- a/packages/mermaid-zenuml/package.json
+++ b/packages/mermaid-zenuml/package.json
@@ -33,7 +33,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@zenuml/core": "^3.41.6"
+    "@zenuml/core": "^3.46.11"
   },
   "devDependencies": {
     "mermaid": "workspace:^"

--- a/packages/mermaid-zenuml/src/types/zenuml-core.d.ts
+++ b/packages/mermaid-zenuml/src/types/zenuml-core.d.ts
@@ -1,0 +1,18 @@
+// Override @zenuml/core types for nodenext module resolution.
+// The package lacks "type": "module" so TS treats it as CJS,
+// rejecting named imports. This declaration fixes that.
+declare module '@zenuml/core' {
+  export interface RenderOptions {
+    theme?: 'theme-default' | 'theme-mermaid';
+  }
+
+  export interface RenderResult {
+    svg: string;
+    innerSvg: string;
+    width: number;
+    height: number;
+    viewBox: string;
+  }
+
+  export function renderToSvg(code: string, options?: RenderOptions): RenderResult;
+}

--- a/packages/mermaid-zenuml/src/zenumlRenderer.spec.ts
+++ b/packages/mermaid-zenuml/src/zenumlRenderer.spec.ts
@@ -1,0 +1,98 @@
+import { vi } from 'vitest';
+import { calculateSvgSizeAttrs } from './zenumlRenderer.js';
+
+vi.mock('@zenuml/core', () => ({
+  renderToSvg: vi.fn((code: string) => ({
+    innerSvg: `<text>${code.trim()}</text>`,
+    width: 400,
+    height: 300,
+    viewBox: '0 0 400 300',
+  })),
+}));
+
+vi.mock('./mermaidUtils.js', () => ({
+  log: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+  getConfig: vi.fn(() => ({
+    securityLevel: 'loose',
+    sequence: { useMaxWidth: true },
+  })),
+}));
+
+describe('calculateSvgSizeAttrs', function () {
+  it('should return responsive width when useMaxWidth is true', function () {
+    const attrs = calculateSvgSizeAttrs(133, 392, true);
+
+    expect(attrs.get('width')).toEqual('100%');
+    expect(attrs.get('style')).toEqual('max-width: 133px;');
+    expect(attrs.has('height')).toBe(false);
+  });
+
+  it('should return absolute dimensions when useMaxWidth is false', function () {
+    const attrs = calculateSvgSizeAttrs(133, 392, false);
+
+    expect(attrs.get('width')).toEqual('133');
+    expect(attrs.get('height')).toEqual('392');
+    expect(attrs.has('style')).toBe(false);
+  });
+});
+
+describe('draw', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('should render SVG content into the target element', async () => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.id = 'test-id';
+    document.body.appendChild(svg);
+
+    const { draw } = await import('./zenumlRenderer.js');
+    await draw('zenuml\n    Alice->Bob: hello', 'test-id');
+
+    expect(svg.innerHTML).toContain('Alice-');
+    expect(svg.getAttribute('viewBox')).toBe('0 0 400 300');
+    expect(svg.getAttribute('width')).toBe('100%');
+    expect(svg.getAttribute('style')).toBe('max-width: 400px;');
+  });
+
+  it('should set absolute dimensions when useMaxWidth is false', async () => {
+    const { getConfig } = await import('./mermaidUtils.js');
+    vi.mocked(getConfig).mockReturnValue({
+      securityLevel: 'loose',
+      sequence: { useMaxWidth: false },
+    });
+
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.id = 'test-abs';
+    document.body.appendChild(svg);
+
+    const { draw } = await import('./zenumlRenderer.js');
+    await draw('zenuml\n    A->B: msg', 'test-abs');
+
+    expect(svg.getAttribute('width')).toBe('400');
+    expect(svg.getAttribute('height')).toBe('300');
+  });
+
+  it('should handle missing SVG element gracefully', async () => {
+    const { draw } = await import('./zenumlRenderer.js');
+    const { log } = await import('./mermaidUtils.js');
+
+    await draw('zenuml\n    A->B: msg', 'nonexistent');
+
+    expect(log.error).toHaveBeenCalledWith('Cannot find svg element');
+  });
+
+  it('should strip the zenuml prefix before rendering', async () => {
+    const { renderToSvg } = await import('@zenuml/core');
+
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.id = 'test-strip';
+    document.body.appendChild(svg);
+
+    const { draw } = await import('./zenumlRenderer.js');
+    await draw('zenuml\n    Alice->Bob: hello', 'test-strip');
+
+    expect(renderToSvg).toHaveBeenCalledWith('\n    Alice->Bob: hello');
+  });
+});

--- a/packages/mermaid-zenuml/src/zenumlRenderer.ts
+++ b/packages/mermaid-zenuml/src/zenumlRenderer.ts
@@ -1,65 +1,86 @@
+import { renderToSvg } from '@zenuml/core';
 import { getConfig, log } from './mermaidUtils.js';
-import ZenUml from '@zenuml/core';
 
 const regexp = /^\s*zenuml/;
 
-// Create a Zen UML container outside the svg first for rendering, otherwise the Zen UML diagram cannot be rendered properly
-function createTemporaryZenumlContainer(id: string) {
-  const container = document.createElement('div');
-  container.id = `container-${id}`;
-  container.style.display = 'flex';
-  container.innerHTML = `<div id="zenUMLApp-${id}"></div>`;
-  const app = container.querySelector(`#zenUMLApp-${id}`)!;
-  return { container, app };
-}
+export const calculateSvgSizeAttrs = (
+  width: number,
+  height: number,
+  useMaxWidth: boolean
+): Map<string, string> => {
+  const attrs = new Map<string, string>();
 
-// Create a foreignObject to wrap the Zen UML container in the svg
-function createForeignObject(id: string) {
-  const foreignObject = document.createElementNS('http://www.w3.org/2000/svg', 'foreignObject');
-  foreignObject.setAttribute('x', '0');
-  foreignObject.setAttribute('y', '0');
-  foreignObject.setAttribute('width', '100%');
-  foreignObject.setAttribute('height', '100%');
-  const { container, app } = createTemporaryZenumlContainer(id);
-  foreignObject.appendChild(container);
-  return { foreignObject, container, app };
-}
+  if (useMaxWidth) {
+    attrs.set('width', '100%');
+    attrs.set('style', `max-width: ${width}px;`);
+  } else {
+    attrs.set('width', String(width));
+    attrs.set('height', String(height));
+  }
+
+  return attrs;
+};
 
 /**
- * Draws a Zen UML in the tag with id: id based on the graph definition in text.
+ * Resolves the root document and SVG element, handling sandbox mode.
+ * Follows the same pattern as mermaid's selectSvgElement utility.
+ */
+const selectSvgElement = (id: string): SVGSVGElement | null => {
+  const { securityLevel } = getConfig();
+  let root: Document = document;
+
+  if (securityLevel === 'sandbox') {
+    const sandboxElement = document.querySelector<HTMLIFrameElement>(`#i${id}`);
+    root = sandboxElement?.contentDocument ?? document;
+  }
+
+  return root.querySelector<SVGSVGElement>(`#${id}`);
+};
+
+const configureSvgSize = (
+  svgEl: SVGSVGElement,
+  width: number,
+  height: number,
+  useMaxWidth: boolean
+) => {
+  const attrs = calculateSvgSizeAttrs(width, height, useMaxWidth);
+
+  svgEl.removeAttribute('height');
+  svgEl.style.removeProperty('max-width');
+
+  for (const [attr, value] of attrs) {
+    svgEl.setAttribute(attr, value);
+  }
+};
+
+/**
+ * Draws a ZenUML diagram in the SVG element with id: id based on the
+ * graph definition in text, using native SVG rendering.
  *
  * @param text - The text of the diagram
- * @param id - The id of the diagram which will be used as a DOM element id¨
+ * @param id - The id of the diagram which will be used as a DOM element id
  */
-export const draw = async function (text: string, id: string) {
-  log.info('draw with Zen UML renderer', ZenUml);
+export const draw = function (text: string, id: string): Promise<void> {
+  log.info('draw with ZenUML native SVG renderer');
 
-  text = text.replace(regexp, '');
-  const { securityLevel } = getConfig();
-  // Handle root and Document for when rendering in sandbox mode
-  let sandboxElement: HTMLIFrameElement | null = null;
-  if (securityLevel === 'sandbox') {
-    sandboxElement = document.getElementById('i' + id) as HTMLIFrameElement;
+  const code = text.replace(regexp, '');
+  const config = getConfig();
+  const useMaxWidth = config.sequence?.useMaxWidth ?? true;
+
+  const svgEl = selectSvgElement(id);
+
+  if (!svgEl) {
+    log.error('Cannot find svg element');
+    return Promise.resolve();
   }
 
-  const root = securityLevel === 'sandbox' ? sandboxElement?.contentWindow?.document : document;
+  const result = renderToSvg(code);
 
-  const svgContainer = root?.querySelector(`svg#${id}`);
+  configureSvgSize(svgEl, result.width, result.height, useMaxWidth);
+  svgEl.setAttribute('viewBox', result.viewBox);
+  svgEl.innerHTML = result.innerSvg;
 
-  if (!root || !svgContainer) {
-    log.error('Cannot find root or svgContainer');
-    return;
-  }
-
-  const { foreignObject, container, app } = createForeignObject(id);
-  svgContainer.appendChild(foreignObject);
-  const zenuml = new ZenUml(app);
-  // default is a theme name. More themes to be added and will be configurable in the future
-  await zenuml.render(text, { theme: 'default', mode: 'static' });
-
-  const { width, height } = window.getComputedStyle(container);
-  log.debug('zenuml diagram size', width, height);
-  svgContainer.setAttribute('style', `width: ${width}; height: ${height};`);
+  return Promise.resolve();
 };
 
 export default {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -477,8 +477,8 @@ importers:
   packages/mermaid-zenuml:
     dependencies:
       '@zenuml/core':
-        specifier: ^3.41.6
-        version: 3.41.6(@babel/core@7.29.0)(@babel/template@7.28.6)
+        specifier: ^3.46.11
+        version: 3.46.11(@babel/core@7.29.0)(@babel/template@7.28.6)
     devDependencies:
       mermaid:
         specifier: workspace:^
@@ -3873,8 +3873,8 @@ packages:
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
-  '@zenuml/core@3.41.6':
-    resolution: {integrity: sha512-j+yHQb7W9I8ytyvbx+Wht66lsBqcWdbaBpyhOwVsny8m3ohVKNQhayJ7rANHKo6DAtdPnCexzOuttKciySnztA==}
+  '@zenuml/core@3.46.11':
+    resolution: {integrity: sha512-TeEeJnTKEBciOIc3uV+Sukl1scKzu5U2Ir4Adoz3bTK5jJPt792o/gYLltG8mTVF1au1gl/+0PPu3hdBbEwUGg==}
     engines: {node: '>=20'}
 
   JSONSelect@0.4.0:
@@ -14086,30 +14086,28 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
-  '@zenuml/core@3.41.6(@babel/core@7.29.0)(@babel/template@7.28.6)':
+  '@zenuml/core@3.46.11(@babel/core@7.29.0)(@babel/template@7.28.6)':
     dependencies:
-      '@floating-ui/react': 0.27.16(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@headlessui/react': 2.2.8(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@headlessui/tailwindcss': 0.2.2(tailwindcss@3.4.17)
+      '@floating-ui/react': 0.27.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@headlessui/react': 2.2.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@headlessui/tailwindcss': 0.2.2(tailwindcss@3.4.19)
       antlr4: 4.11.0
       class-variance-authority: 0.7.1
       clsx: 2.1.1
-      color-string: 2.1.2
+      color-string: 2.1.4
       dompurify: 3.3.3
       highlight.js: 10.7.3
       html-to-image: 1.11.13
-      immer: 10.1.3
-      jotai: 2.14.0(@babel/core@7.29.0)(@babel/template@7.28.6)(react@19.1.1)
+      immer: 10.2.0
+      jotai: 2.19.0(@babel/core@7.29.0)(@babel/template@7.28.6)(react@19.2.4)
       lodash: 4.17.21
       marked: 4.3.0
       pako: 2.1.0
       pino: 8.21.0
-      radash: 12.1.1
-      ramda: 0.28.0
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-      tailwind-merge: 3.3.1
-      tailwindcss: 3.4.17
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tailwind-merge: 3.5.0
+      tailwindcss: 3.4.19
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'


### PR DESCRIPTION
## Summary
- switch the Mermaid ZenUML renderer to native SVG output
- preserve Mermaid sizing behavior for responsive and fixed-width rendering
- add focused renderer tests and a local type override for `@zenuml/core`

## Details
The previous integration rendered ZenUML through HTML inside `foreignObject`. This change moves rendering to native SVG returned by `@zenuml/core`, which keeps the output inside the SVG tree and improves sizing behavior.

## Validation
- `pnpm exec vitest run packages/mermaid-zenuml/src/zenumlRenderer.spec.ts`
- `pnpm exec tsc -p packages/mermaid-zenuml/tsconfig.json --noEmit`
