### PR TITLE
Add link in sidebar to Wardley map

### DIFF
--- a/.changeset/green-peas-search.md
+++ b/.changeset/green-peas-search.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+docs: add Wardley diagram link to sidebar

--- a/packages/mermaid/src/docs/.vitepress/config.ts
+++ b/packages/mermaid/src/docs/.vitepress/config.ts
@@ -191,6 +191,7 @@ function sidebarSyntax() {
         { text: 'Treemap 🔥', link: '/syntax/treemap' },
         { text: 'Venn 🔥', link: '/syntax/venn' },
         { text: 'Ishikawa 🔥', link: '/syntax/ishikawa' },
+        { text: 'Wardley 🔥', link: '/syntax/wardley' },
         { text: 'TreeView 🔥', link: '/syntax/treeView' },
         { text: 'Other Examples', link: '/syntax/examples' },
       ],


### PR DESCRIPTION
## :bookmark_tabs: Summary

As of 11.4, Wardley map beta has been released, including docs. It's available here https://mermaid.ai/open-source/syntax/wardley.html and was added with this  [PR](https://github.com/mermaid-js/mermaid/pull/7147)

There is no visible link to it on the sidebar, this PR adds the link 

<img width="800" alt="CleanShot 2026-04-06 at 16 55 26@2x" src="https://github.com/user-attachments/assets/93e194f3-8aad-461b-bba1-e99b0fad3d9e" />

## :straight_ruler: Design Decisions

N/A 

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
