### PR TITLE
Resolves #7312 by adding endianness to packets

### DIFF
--- a/demos/packet.html
+++ b/demos/packet.html
@@ -18,6 +18,35 @@
     <div class="diagrams">
       <pre class="mermaid">
       packet
+        title Big Endian
+        0-15: "Source Port"
+        16-31: "Destination Port"
+        32-63: "Sequence Number"
+        64-95: "Acknowledgment Number"
+        96-99: "Data Offset"
+        100-105: "Reserved"
+        106: "URG"
+        107: "ACK"
+        108: "PSH"
+        109: "RST"
+        110: "SYN"
+        111: "FIN"
+        112-127: "Window"
+        128-143: "Checksum"
+        144-159: "Urgent Pointer"
+        160-191: "(Options and Padding)"
+        192-223: "data"
+    </pre
+      >
+
+      <pre class="mermaid">
+      ---
+      config:
+        packet:
+          endianness: little
+      ---
+      packet
+        title Little Endian
         0-15: "Source Port"
         16-31: "Destination Port"
         32-63: "Sequence Number"
@@ -45,6 +74,36 @@
           showBits: false
       ---
       packet
+        title Big Endian - No bit labels
+        0-15: "Source Port"
+        16-31: "Destination Port"
+        32-63: "Sequence Number"
+        64-95: "Acknowledgment Number"
+        96-99: "Data Offset"
+        100-105: "Reserved"
+        106: "URG"
+        107: "ACK"
+        108: "PSH"
+        109: "RST"
+        110: "SYN"
+        111: "FIN"
+        112-127: "Window"
+        128-143: "Checksum"
+        144-159: "Urgent Pointer"
+        160-191: "(Options and Padding)"
+        192-223: "data"
+    </pre
+      >
+
+      <pre class="mermaid">
+      ---
+      config:
+        packet:
+          showBits: false
+          endianness: little
+      ---
+      packet
+        title Little endian - No bit labels
         0-15: "Source Port"
         16-31: "Destination Port"
         32-63: "Sequence Number"
@@ -71,7 +130,36 @@
         theme: forest
       ---
       packet
-        title Forest theme
+        title Big Endian - Forest theme
+        0-15: "Source Port"
+        16-31: "Destination Port"
+        32-63: "Sequence Number"
+        64-95: "Acknowledgment Number"
+        96-99: "Data Offset"
+        100-105: "Reserved"
+        106: "URG"
+        107: "ACK"
+        108: "PSH"
+        109: "RST"
+        110: "SYN"
+        111: "FIN"
+        112-127: "Window"
+        128-143: "Checksum"
+        144-159: "Urgent Pointer"
+        160-191: "(Options and Padding)"
+        192-223: "data"
+    </pre
+      >
+
+      <pre class="mermaid">
+      ---
+      config:
+        theme: forest
+        packet:
+          endianness: little
+      ---
+      packet
+        title Little Endian - Forest theme
         0-15: "Source Port"
         16-31: "Destination Port"
         32-63: "Sequence Number"
@@ -98,7 +186,36 @@
         theme: dark
       ---
       packet
-        title Dark theme
+        title Big Endian- Dark theme
+        0-15: "Source Port"
+        16-31: "Destination Port"
+        32-63: "Sequence Number"
+        64-95: "Acknowledgment Number"
+        96-99: "Data Offset"
+        100-105: "Reserved"
+        106: "URG"
+        107: "ACK"
+        108: "PSH"
+        109: "RST"
+        110: "SYN"
+        111: "FIN"
+        112-127: "Window"
+        128-143: "Checksum"
+        144-159: "Urgent Pointer"
+        160-191: "(Options and Padding)"
+        192-223: "data"
+    </pre
+      >
+
+      <pre class="mermaid" style="background-color: black">
+      ---
+      config:
+        theme: dark
+        packet:
+          endianness: little
+      ---
+      packet
+        title Little Endian - Dark theme
         0-15: "Source Port"
         16-31: "Destination Port"
         32-63: "Sequence Number"

--- a/docs/syntax/packet.md
+++ b/docs/syntax/packet.md
@@ -105,6 +105,36 @@ title UDP Packet
 64-95: "Data (variable length)"
 ```
 
+## Packet Endianness (v\<MERMAID_RELEASE_VERSION>+)
+
+Packets have an endianness associated with them, which defines the order in which the bytes get transmitted or accessed.
+
+```mermaid-example
+---
+config:
+  packet:
+    showBits: true
+    endianness: little
+---
+packet
+0-15: "Source Port"
+16-31: "Destination Port"
+32-63: "Sequence Number"
+```
+
+```mermaid
+---
+config:
+  packet:
+    showBits: true
+    endianness: little
+---
+packet
+0-15: "Source Port"
+16-31: "Destination Port"
+32-63: "Sequence Number"
+```
+
 ## Details of Syntax
 
 - **Ranges**: Each line after the title represents a different field in the packet. The range (e.g., `0-15`) indicates the bit positions in the packet.

--- a/packages/mermaid/src/config.type.ts
+++ b/packages/mermaid/src/config.type.ts
@@ -1654,6 +1654,10 @@ export interface PacketDiagramConfig extends BaseDiagramConfig {
    * The vertical padding between the rows.
    */
   paddingY?: number;
+  /**
+   * Endianness of the packet bit ordering when displaying bit numbers and labels.
+   */
+  endianness?: string;
 }
 /**
  * The object containing configurations specific for block diagrams.

--- a/packages/mermaid/src/diagrams/packet/renderer.ts
+++ b/packages/mermaid/src/diagrams/packet/renderer.ts
@@ -37,12 +37,23 @@ const drawWord = (
   svg: SVG,
   word: PacketWord,
   rowNumber: number,
-  { rowHeight, paddingX, paddingY, bitWidth, bitsPerRow, showBits }: Required<PacketDiagramConfig>
+  {
+    rowHeight,
+    paddingX,
+    paddingY,
+    bitWidth,
+    bitsPerRow,
+    showBits,
+    endianness,
+  }: Required<PacketDiagramConfig>
 ) => {
   const group: SVGGroup = svg.append('g');
   const wordY = rowNumber * (rowHeight + paddingY) + paddingY;
+  const isLittleEndian = endianness === 'little';
   for (const block of word) {
-    const blockX = (block.start % bitsPerRow) * bitWidth + 1;
+    const blockX = isLittleEndian
+      ? (bitsPerRow - (block.end % bitsPerRow) - 1) * bitWidth + 1
+      : (block.start % bitsPerRow) * bitWidth + 1;
     const width = (block.end - block.start + 1) * bitWidth - paddingX;
     // Block rectangle
     group
@@ -69,14 +80,21 @@ const drawWord = (
     // Start byte count
     const isSingleBlock = block.end === block.start;
     const bitNumberY = wordY - 2;
+
+    const leftText = isLittleEndian ? block.end : block.start;
+    const leftClass = isLittleEndian ? 'packetByte end' : 'packetByte start';
+
+    const rightText = isLittleEndian ? block.start : block.end;
+    const rightClass = isLittleEndian ? 'packetByte start' : 'packetByte end';
+
     group
       .append('text')
       .attr('x', blockX + (isSingleBlock ? width / 2 : 0))
       .attr('y', bitNumberY)
-      .attr('class', 'packetByte start')
+      .attr('class', leftClass)
       .attr('dominant-baseline', 'auto')
       .attr('text-anchor', isSingleBlock ? 'middle' : 'start')
-      .text(block.start);
+      .text(leftText);
 
     // Draw end byte count if it is not the same as start byte count
     if (!isSingleBlock) {
@@ -84,10 +102,10 @@ const drawWord = (
         .append('text')
         .attr('x', blockX + width)
         .attr('y', bitNumberY)
-        .attr('class', 'packetByte end')
+        .attr('class', rightClass)
         .attr('dominant-baseline', 'auto')
         .attr('text-anchor', 'end')
-        .text(block.end);
+        .text(rightText);
     }
   }
 };

--- a/packages/mermaid/src/diagrams/packet/styles.ts
+++ b/packages/mermaid/src/diagrams/packet/styles.ts
@@ -13,6 +13,7 @@ const defaultPacketStyleOptions: PacketStyleOptions = {
   blockStrokeColor: 'black',
   blockStrokeWidth: '1',
   blockFillColor: '#efefef',
+  endianness: 'big',
 };
 
 export const styles: DiagramStylesProvider = ({ packet }: { packet?: PacketStyleOptions } = {}) => {

--- a/packages/mermaid/src/diagrams/packet/types.ts
+++ b/packages/mermaid/src/diagrams/packet/types.ts
@@ -22,6 +22,7 @@ export interface PacketStyleOptions {
   blockFillColor?: string;
   titleColor?: string;
   titleFontSize?: string;
+  endianness?: string;
 }
 
 export interface PacketData {

--- a/packages/mermaid/src/docs/syntax/packet.md
+++ b/packages/mermaid/src/docs/syntax/packet.md
@@ -65,6 +65,23 @@ title UDP Packet
 64-95: "Data (variable length)"
 ```
 
+## Packet Endianness (v<MERMAID_RELEASE_VERSION>+)
+
+Packets have an endianness associated with them, which defines the order in which the bytes get transmitted or accessed.
+
+```mermaid-example
+---
+config:
+  packet:
+    showBits: true
+    endianness: little
+---
+packet
+0-15: "Source Port"
+16-31: "Destination Port"
+32-63: "Sequence Number"
+```
+
 ## Details of Syntax
 
 - **Ranges**: Each line after the title represents a different field in the packet. The range (e.g., `0-15`) indicates the bit positions in the packet.

--- a/packages/mermaid/src/schemas/config.schema.yaml
+++ b/packages/mermaid/src/schemas/config.schema.yaml
@@ -2351,6 +2351,10 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
         type: number
         minimum: 0
         default: 5
+      endianness:
+        description: Endianness of the packet bit ordering when displaying bit numbers and labels.
+        type: string
+        default: 'big'
 
   BlockDiagramConfig:
     title: Block Diagram Config


### PR DESCRIPTION
## :bookmark_tabs: Summary

Adds endianness to packets.

Resolves #7312 

## :straight_ruler: Design Decisions

The packet type is a great feature for documenting binary data payloads. However, the current implementation limits users to big endian formats. There are a number of applications that use little endian format, where the bytes display in the reverse order. These applications need a way to toggle the endianness of the packet class to display properly. 

I used two primary design constraints: 
1. minimize the impact to existing applications and
2. minimize the code changes.

I implemented 1 by having the default configuration item use big endian. This ensures that existing implementations are unaffected. I minimized code changes by isolating the functional change to just the renderer. 

** Note**: I have not added the E2E visual regression test as this is a little outside of my wheelhouse / skills at the moment. I am pushing this PR by recommendation in the ticket.

### :clipboard: Tasks

Make sure you

- [X] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [X] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
