### PR TITLE
feat(eventmodeling): enforce Event Modeling connection invariants via Langium validator

### DIFF
--- a/.changeset/cold-mails-fly.md
+++ b/.changeset/cold-mails-fly.md
@@ -1,0 +1,5 @@
+---
+'@mermaid-js/parser': major
+---
+
+enforce eventmodeling connection invariants via Langium validator

--- a/packages/parser/src/language/eventmodeling/event-modeling-validator.ts
+++ b/packages/parser/src/language/eventmodeling/event-modeling-validator.ts
@@ -1,0 +1,66 @@
+import type { ValidationAcceptor, ValidationChecks } from 'langium';
+import type { EmFrame, EmResetFrame, EmTimeFrame, MermaidAstType } from '../generated/ast.js';
+import type { EventModelingServices } from './module.js';
+
+const COMMAND_TYPES = new Set<string>(['cmd', 'command']);
+const EVENT_TYPES = new Set<string>(['evt', 'event']);
+const READMODEL_TYPES = new Set<string>(['rmo', 'readmodel']);
+const PROCESSOR_TYPES = new Set<string>(['pcr', 'processor']);
+const SCREEN_TYPES = new Set<string>(['scn', 'screen']);
+
+export function registerValidationChecks(services: EventModelingServices) {
+  const validator = services.validation.EventModelingValidator;
+  const registry = services.validation.ValidationRegistry;
+  if (registry) {
+    const checks: ValidationChecks<MermaidAstType> = {
+      EmTimeFrame: validator.checkSourceFrameTypes.bind(validator),
+      EmResetFrame: validator.checkSourceFrameTypes.bind(validator),
+    };
+    registry.register(checks, validator);
+  }
+}
+
+export class EventModelingValidator {
+  checkSourceFrameTypes(frame: EmTimeFrame | EmResetFrame, accept: ValidationAcceptor): void {
+    if (frame.sourceFrames.length === 0) {
+      return;
+    }
+
+    if (COMMAND_TYPES.has(frame.modelEntityType)) {
+      this.validateSources(
+        frame,
+        new Set([...SCREEN_TYPES, ...PROCESSOR_TYPES]),
+        'command',
+        'screen or processor',
+        accept
+      );
+    } else if (EVENT_TYPES.has(frame.modelEntityType)) {
+      this.validateSources(frame, COMMAND_TYPES, 'event', 'command', accept);
+    } else if (READMODEL_TYPES.has(frame.modelEntityType)) {
+      this.validateSources(frame, EVENT_TYPES, 'read model', 'event', accept);
+    } else if (PROCESSOR_TYPES.has(frame.modelEntityType)) {
+      this.validateSources(frame, READMODEL_TYPES, 'processor', 'read model', accept);
+    } else if (SCREEN_TYPES.has(frame.modelEntityType)) {
+      this.validateSources(frame, READMODEL_TYPES, 'screen', 'read model', accept);
+    }
+  }
+
+  private validateSources(
+    frame: EmTimeFrame | EmResetFrame,
+    allowedSourceTypes: Set<string>,
+    targetLabel: string,
+    expectedSourceLabel: string,
+    accept: ValidationAcceptor
+  ): void {
+    for (const sourceRef of frame.sourceFrames) {
+      const source: EmFrame | undefined = sourceRef.ref;
+      if (source !== undefined && !allowedSourceTypes.has(source.modelEntityType)) {
+        accept(
+          'error',
+          `A ${targetLabel} can only receive input from a ${expectedSourceLabel}, not from '${source.modelEntityType}'.`,
+          { node: frame, property: 'sourceFrames' }
+        );
+      }
+    }
+  }
+}

--- a/packages/parser/src/language/eventmodeling/module.ts
+++ b/packages/parser/src/language/eventmodeling/module.ts
@@ -14,11 +14,15 @@ import {
 import { CommonValueConverter } from '../common/valueConverter.js';
 import { MermaidGeneratedSharedModule, EventModelingGeneratedModule } from '../generated/module.js';
 import { EventModelingTokenBuilder } from './tokenBuilder.js';
+import { EventModelingValidator, registerValidationChecks } from './event-modeling-validator.js';
 
 interface EventModelingAddedServices {
   parser: {
     TokenBuilder: EventModelingTokenBuilder;
     ValueConverter: CommonValueConverter;
+  };
+  validation: {
+    EventModelingValidator: EventModelingValidator;
   };
 }
 
@@ -31,6 +35,9 @@ export const EventModelingModule: Module<
   parser: {
     TokenBuilder: () => new EventModelingTokenBuilder(),
     ValueConverter: () => new CommonValueConverter(),
+  },
+  validation: {
+    EventModelingValidator: () => new EventModelingValidator(),
   },
 };
 
@@ -50,5 +57,6 @@ export function createEventModelingServices(
     EventModelingModule
   );
   shared.ServiceRegistry.register(EventModel);
+  registerValidationChecks(EventModel);
   return { shared, EventModel };
 }

--- a/packages/parser/tests/eventmodeling.test.ts
+++ b/packages/parser/tests/eventmodeling.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, assert } from 'vitest';
 import { eventModelingParse as parse } from './test-util.js';
+import {
+  EventModelingValidator,
+  registerValidationChecks,
+} from '../src/language/eventmodeling/event-modeling-validator.js';
+import type { EventModelingServices } from '../src/language/eventmodeling/module.js';
+import type { EmModelEntityType, EmTimeFrame } from '../src/language/generated/ast.js';
 
 describe('Parse Event Model', () => {
   it('should parse complex model', () => {
@@ -122,6 +128,187 @@ tf 03 evt Cart.ItemAdded
     expect(frame.name).toBe('01');
     expect(frame.modelEntityType).toBe('evt');
     expect(frame.entityIdentifier).toBe('Product.PriceChanged');
+  });
+
+  describe('Validation', () => {
+    describe('registerValidationChecks', () => {
+      it('registers checks against the validation registry', () => {
+        const registered: unknown[] = [];
+        const mockServices = {
+          validation: {
+            EventModelingValidator: new EventModelingValidator(),
+            ValidationRegistry: { register: (...args: unknown[]) => registered.push(args) },
+          },
+        };
+        registerValidationChecks(mockServices as unknown as EventModelingServices);
+        expect(registered).toHaveLength(1);
+      });
+    });
+
+    const validator = new EventModelingValidator();
+
+    function makeFrame(modelEntityType: EmModelEntityType): EmTimeFrame {
+      return {
+        $type: 'EmTimeFrame',
+        $container: undefined as unknown as EmTimeFrame['$container'],
+        $containerProperty: undefined,
+        $containerIndex: undefined,
+        $cstNode: undefined,
+        name: '00',
+        entityIdentifier: 'Test',
+        modelEntityType,
+        sourceFrames: [],
+      };
+    }
+
+    function collectErrors(frame: EmTimeFrame, sources: EmTimeFrame[]): string[] {
+      const errors: string[] = [];
+      const frameWithSources: EmTimeFrame = {
+        ...frame,
+        sourceFrames: sources.map((s) => ({ $refText: s.name, ref: s, error: undefined })),
+      };
+      validator.checkSourceFrameTypes(frameWithSources, (_, message) => errors.push(message));
+      return errors;
+    }
+
+    it('should allow evt sourced from cmd', () => {
+      const errors = collectErrors(makeFrame('evt'), [makeFrame('cmd')]);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should allow event sourced from command', () => {
+      const errors = collectErrors(makeFrame('event'), [makeFrame('command')]);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should reject evt sourced from rmo', () => {
+      const errors = collectErrors(makeFrame('evt'), [makeFrame('rmo')]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('event');
+      expect(errors[0]).toContain('command');
+    });
+
+    it('should reject evt sourced from pcr', () => {
+      const errors = collectErrors(makeFrame('evt'), [makeFrame('pcr')]);
+      expect(errors).toHaveLength(1);
+    });
+
+    it('should allow cmd sourced from scn', () => {
+      const errors = collectErrors(makeFrame('cmd'), [makeFrame('scn')]);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should allow command sourced from screen', () => {
+      const errors = collectErrors(makeFrame('command'), [makeFrame('screen')]);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should allow cmd sourced from pcr', () => {
+      const errors = collectErrors(makeFrame('cmd'), [makeFrame('pcr')]);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should allow command sourced from processor', () => {
+      const errors = collectErrors(makeFrame('command'), [makeFrame('processor')]);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should reject cmd sourced from cmd', () => {
+      const errors = collectErrors(makeFrame('cmd'), [makeFrame('cmd')]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('command');
+      expect(errors[0]).toContain('screen or processor');
+    });
+
+    it('should reject cmd sourced from evt', () => {
+      const errors = collectErrors(makeFrame('cmd'), [makeFrame('evt')]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('command');
+      expect(errors[0]).toContain('screen or processor');
+    });
+
+    it('should reject scn sourced from evt', () => {
+      const errors = collectErrors(makeFrame('scn'), [makeFrame('evt')]);
+      expect(errors).toHaveLength(1);
+    });
+
+    it('should allow scn sourced from rmo', () => {
+      const errors = collectErrors(makeFrame('scn'), [makeFrame('rmo')]);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should allow screen sourced from readmodel', () => {
+      const errors = collectErrors(makeFrame('screen'), [makeFrame('readmodel')]);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should reject scn sourced from cmd', () => {
+      const errors = collectErrors(makeFrame('scn'), [makeFrame('cmd')]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('screen');
+      expect(errors[0]).toContain('read model');
+    });
+
+    it('should reject cmd sourced from rmo', () => {
+      const errors = collectErrors(makeFrame('cmd'), [makeFrame('rmo')]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('command');
+      expect(errors[0]).toContain('screen or processor');
+    });
+
+    it('should allow rmo sourced from evt', () => {
+      const errors = collectErrors(makeFrame('rmo'), [makeFrame('evt')]);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should allow readmodel sourced from event', () => {
+      const errors = collectErrors(makeFrame('readmodel'), [makeFrame('event')]);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should allow pcr sourced from rmo', () => {
+      const errors = collectErrors(makeFrame('pcr'), [makeFrame('rmo')]);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should allow processor sourced from readmodel', () => {
+      const errors = collectErrors(makeFrame('processor'), [makeFrame('readmodel')]);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should reject rmo sourced directly from pcr', () => {
+      const errors = collectErrors(makeFrame('rmo'), [makeFrame('pcr')]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('read model');
+      expect(errors[0]).toContain('event');
+    });
+
+    it('should reject pcr sourced directly from evt', () => {
+      const errors = collectErrors(makeFrame('pcr'), [makeFrame('evt')]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('processor');
+      expect(errors[0]).toContain('read model');
+    });
+
+    it('should reject pcr sourced from cmd', () => {
+      const errors = collectErrors(makeFrame('pcr'), [makeFrame('cmd')]);
+      expect(errors).toHaveLength(1);
+    });
+
+    it('should reject rmo sourced from scn', () => {
+      const errors = collectErrors(makeFrame('rmo'), [makeFrame('scn')]);
+      expect(errors).toHaveLength(1);
+    });
+
+    it('should report an error for each invalid source', () => {
+      const errors = collectErrors(makeFrame('pcr'), [makeFrame('evt'), makeFrame('cmd')]);
+      expect(errors).toHaveLength(2);
+    });
+
+    it('should not validate frames with no sources', () => {
+      const errors = collectErrors(makeFrame('rmo'), []);
+      expect(errors).toHaveLength(0);
+    });
   });
 
   it('should parse multiple source frames model', () => {


### PR DESCRIPTION
## :bookmark_tabs: Summary

Adds a Langium semantic validator to the Event Modeling diagram that enforces the directional connection invariants defined by the Event Modeling methodology.

## :straight_ruler: Design Decisions

Event Modeling defines a strict information flow between entity types:

```
screen/ui → command → event → read model → processor/screen
```

Without enforcement, the grammar silently accepted connections that violate these invariants. Most notably, an event flowing directly into a processor (bypassing a read model), which is not a valid pattern in Event Modeling.

The validator enforces the following rules via Langium's `ValidationRegistry`, reporting errors on invalid `->>` source references:

| Target type | Allowed sources |
|---|---|
| `event` | `command` only |
| `read model` | `event` only |
| `processor` | `read model` only |
| `screen` | `read model` only |
| anything else | cannot source from `event` or `read model` |

The check also covers the complementary direction, e.g. a `command`, frame cannot consume an `event` as its source. Ensuring events flow exclusively into read models, and read models flow exclusively into processors or screens.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.