### PR TITLE
feat: add sandboxLinkBaseUrl for relative links in sandbox mode

### DIFF
--- a/.changeset/feat-sandbox-link-base-url.md
+++ b/.changeset/feat-sandbox-link-base-url.md
@@ -1,0 +1,5 @@
+---
+'mermaid': minor
+---
+
+feat: add `sandboxLinkBaseUrl` to resolve relative links in sandbox mode

--- a/docs/config/setup/mermaid/interfaces/MermaidConfig.md
+++ b/docs/config/setup/mermaid/interfaces/MermaidConfig.md
@@ -26,7 +26,7 @@ Defined in: [packages/mermaid/src/config.type.ts:159](https://github.com/mermaid
 
 > `optional` **architecture**: `ArchitectureDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:231](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L231)
+Defined in: [packages/mermaid/src/config.type.ts:240](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L240)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [packages/mermaid/src/config.type.ts:231](https://github.com/mermaid
 
 > `optional` **arrowMarkerAbsolute**: `boolean`
 
-Defined in: [packages/mermaid/src/config.type.ts:178](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L178)
+Defined in: [packages/mermaid/src/config.type.ts:187](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L187)
 
 Controls whether or arrow markers in html code are absolute paths or anchors.
 This matters if you are using base tag settings.
@@ -45,7 +45,7 @@ This matters if you are using base tag settings.
 
 > `optional` **block**: `BlockDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:239](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L239)
+Defined in: [packages/mermaid/src/config.type.ts:248](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L248)
 
 ---
 
@@ -53,7 +53,7 @@ Defined in: [packages/mermaid/src/config.type.ts:239](https://github.com/mermaid
 
 > `optional` **c4**: `C4DiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:236](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L236)
+Defined in: [packages/mermaid/src/config.type.ts:245](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L245)
 
 ---
 
@@ -61,7 +61,7 @@ Defined in: [packages/mermaid/src/config.type.ts:236](https://github.com/mermaid
 
 > `optional` **class**: `ClassDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:224](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L224)
+Defined in: [packages/mermaid/src/config.type.ts:233](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L233)
 
 ---
 
@@ -77,7 +77,7 @@ Defined in: [packages/mermaid/src/config.type.ts:143](https://github.com/mermaid
 
 > `optional` **deterministicIds**: `boolean`
 
-Defined in: [packages/mermaid/src/config.type.ts:211](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L211)
+Defined in: [packages/mermaid/src/config.type.ts:220](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L220)
 
 This option controls if the generated ids of nodes in the SVG are
 generated randomly or based on a seed.
@@ -93,7 +93,7 @@ should not change unless content is changed.
 
 > `optional` **deterministicIDSeed**: `string`
 
-Defined in: [packages/mermaid/src/config.type.ts:218](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L218)
+Defined in: [packages/mermaid/src/config.type.ts:227](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L227)
 
 This option is the optional seed for deterministic ids.
 If set to `undefined` but deterministicIds is `true`, a simple number iterator is used.
@@ -105,7 +105,7 @@ You can set this attribute to base the seed on a static string.
 
 > `optional` **dompurifyConfig**: `Config`
 
-Defined in: [packages/mermaid/src/config.type.ts:245](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L245)
+Defined in: [packages/mermaid/src/config.type.ts:254](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L254)
 
 ---
 
@@ -151,7 +151,7 @@ Elk specific option affecting how nodes are placed.
 
 > `optional` **er**: `ErDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:226](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L226)
+Defined in: [packages/mermaid/src/config.type.ts:235](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L235)
 
 ---
 
@@ -159,7 +159,7 @@ Defined in: [packages/mermaid/src/config.type.ts:226](https://github.com/mermaid
 
 > `optional` **eventmodeling**: `EventModelingDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:240](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L240)
+Defined in: [packages/mermaid/src/config.type.ts:249](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L249)
 
 ---
 
@@ -167,7 +167,7 @@ Defined in: [packages/mermaid/src/config.type.ts:240](https://github.com/mermaid
 
 > `optional` **flowchart**: `FlowchartDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:219](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L219)
+Defined in: [packages/mermaid/src/config.type.ts:228](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L228)
 
 ---
 
@@ -187,7 +187,7 @@ See <https://developer.mozilla.org/en-US/docs/Web/CSS/font-family>
 
 > `optional` **fontSize**: `number`
 
-Defined in: [packages/mermaid/src/config.type.ts:247](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L247)
+Defined in: [packages/mermaid/src/config.type.ts:256](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L256)
 
 ---
 
@@ -195,7 +195,7 @@ Defined in: [packages/mermaid/src/config.type.ts:247](https://github.com/mermaid
 
 > `optional` **forceLegacyMathML**: `boolean`
 
-Defined in: [packages/mermaid/src/config.type.ts:200](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L200)
+Defined in: [packages/mermaid/src/config.type.ts:209](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L209)
 
 This option forces Mermaid to rely on KaTeX's own stylesheet for rendering MathML. Due to differences between OS
 fonts and browser's MathML implementation, this option is recommended if consistent rendering is important.
@@ -207,7 +207,7 @@ If set to true, ignores legacyMathML.
 
 > `optional` **gantt**: `GanttDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:221](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L221)
+Defined in: [packages/mermaid/src/config.type.ts:230](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L230)
 
 ---
 
@@ -215,7 +215,7 @@ Defined in: [packages/mermaid/src/config.type.ts:221](https://github.com/mermaid
 
 > `optional` **gitGraph**: `GitGraphDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:235](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L235)
+Defined in: [packages/mermaid/src/config.type.ts:244](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L244)
 
 ---
 
@@ -246,7 +246,7 @@ over any diagram-specific settings.
 
 > `optional` **ishikawa**: `IshikawaDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:233](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L233)
+Defined in: [packages/mermaid/src/config.type.ts:242](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L242)
 
 ---
 
@@ -254,7 +254,7 @@ Defined in: [packages/mermaid/src/config.type.ts:233](https://github.com/mermaid
 
 > `optional` **journey**: `JourneyDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:222](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L222)
+Defined in: [packages/mermaid/src/config.type.ts:231](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L231)
 
 ---
 
@@ -262,7 +262,7 @@ Defined in: [packages/mermaid/src/config.type.ts:222](https://github.com/mermaid
 
 > `optional` **kanban**: `KanbanDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:234](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L234)
+Defined in: [packages/mermaid/src/config.type.ts:243](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L243)
 
 ---
 
@@ -280,7 +280,7 @@ Defines which layout algorithm to use for rendering the diagram.
 
 > `optional` **legacyMathML**: `boolean`
 
-Defined in: [packages/mermaid/src/config.type.ts:193](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L193)
+Defined in: [packages/mermaid/src/config.type.ts:202](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L202)
 
 This option specifies if Mermaid can expect the dependent to include KaTeX stylesheets for browsers
 without their own MathML implementation. If this option is disabled and MathML is not supported, the math
@@ -313,7 +313,7 @@ Defines which main look to use for the diagram.
 
 > `optional` **markdownAutoWrap**: `boolean`
 
-Defined in: [packages/mermaid/src/config.type.ts:248](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L248)
+Defined in: [packages/mermaid/src/config.type.ts:257](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L257)
 
 ---
 
@@ -341,7 +341,7 @@ The maximum allowed size of the users text diagram
 
 > `optional` **mindmap**: `MindmapDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:232](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L232)
+Defined in: [packages/mermaid/src/config.type.ts:241](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L241)
 
 ---
 
@@ -349,7 +349,7 @@ Defined in: [packages/mermaid/src/config.type.ts:232](https://github.com/mermaid
 
 > `optional` **packet**: `PacketDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:238](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L238)
+Defined in: [packages/mermaid/src/config.type.ts:247](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L247)
 
 ---
 
@@ -357,7 +357,7 @@ Defined in: [packages/mermaid/src/config.type.ts:238](https://github.com/mermaid
 
 > `optional` **pie**: `PieDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:227](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L227)
+Defined in: [packages/mermaid/src/config.type.ts:236](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L236)
 
 ---
 
@@ -365,7 +365,7 @@ Defined in: [packages/mermaid/src/config.type.ts:227](https://github.com/mermaid
 
 > `optional` **quadrantChart**: `QuadrantChartConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:228](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L228)
+Defined in: [packages/mermaid/src/config.type.ts:237](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L237)
 
 ---
 
@@ -373,7 +373,7 @@ Defined in: [packages/mermaid/src/config.type.ts:228](https://github.com/mermaid
 
 > `optional` **radar**: `RadarDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:242](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L242)
+Defined in: [packages/mermaid/src/config.type.ts:251](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L251)
 
 ---
 
@@ -381,7 +381,21 @@ Defined in: [packages/mermaid/src/config.type.ts:242](https://github.com/mermaid
 
 > `optional` **requirement**: `RequirementDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:230](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L230)
+Defined in: [packages/mermaid/src/config.type.ts:239](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L239)
+
+---
+
+### sandboxLinkBaseUrl?
+
+> `optional` **sandboxLinkBaseUrl**: `string`
+
+Defined in: [packages/mermaid/src/config.type.ts:177](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L177)
+
+Base URL used to resolve relative links when `securityLevel` is `sandbox`.
+
+Sandbox rendering serializes the diagram into a `data:` URL iframe, which removes the
+document context needed for links such as `./page.html` and `#section`.
+Provide `sandboxLinkBaseUrl` to pre-resolve those links before the SVG is embedded.
 
 ---
 
@@ -389,7 +403,7 @@ Defined in: [packages/mermaid/src/config.type.ts:230](https://github.com/mermaid
 
 > `optional` **sankey**: `SankeyDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:237](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L237)
+Defined in: [packages/mermaid/src/config.type.ts:246](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L246)
 
 ---
 
@@ -397,7 +411,7 @@ Defined in: [packages/mermaid/src/config.type.ts:237](https://github.com/mermaid
 
 > `optional` **secure**: `string`\[]
 
-Defined in: [packages/mermaid/src/config.type.ts:185](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L185)
+Defined in: [packages/mermaid/src/config.type.ts:194](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L194)
 
 This option controls which `currentConfig` keys are considered secure and
 can only be changed via call to `mermaid.initialize`.
@@ -419,7 +433,7 @@ Level of trust for parsed diagram
 
 > `optional` **sequence**: `SequenceDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:220](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L220)
+Defined in: [packages/mermaid/src/config.type.ts:229](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L229)
 
 ---
 
@@ -427,7 +441,7 @@ Defined in: [packages/mermaid/src/config.type.ts:220](https://github.com/mermaid
 
 > `optional` **startOnLoad**: `boolean`
 
-Defined in: [packages/mermaid/src/config.type.ts:172](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L172)
+Defined in: [packages/mermaid/src/config.type.ts:181](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L181)
 
 Dictates whether mermaid starts on Page load
 
@@ -437,7 +451,7 @@ Dictates whether mermaid starts on Page load
 
 > `optional` **state**: `StateDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:225](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L225)
+Defined in: [packages/mermaid/src/config.type.ts:234](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L234)
 
 ---
 
@@ -445,7 +459,7 @@ Defined in: [packages/mermaid/src/config.type.ts:225](https://github.com/mermaid
 
 > `optional` **suppressErrorRendering**: `boolean`
 
-Defined in: [packages/mermaid/src/config.type.ts:254](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L254)
+Defined in: [packages/mermaid/src/config.type.ts:263](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L263)
 
 Suppresses inserting 'Syntax error' diagram in the DOM.
 This is useful when you want to control how to handle syntax errors in your application.
@@ -483,7 +497,7 @@ Defined in: [packages/mermaid/src/config.type.ts:85](https://github.com/mermaid-
 
 > `optional` **timeline**: `TimelineDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:223](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L223)
+Defined in: [packages/mermaid/src/config.type.ts:232](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L232)
 
 ---
 
@@ -491,7 +505,7 @@ Defined in: [packages/mermaid/src/config.type.ts:223](https://github.com/mermaid
 
 > `optional` **treeView**: `TreeViewDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:241](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L241)
+Defined in: [packages/mermaid/src/config.type.ts:250](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L250)
 
 ---
 
@@ -499,7 +513,7 @@ Defined in: [packages/mermaid/src/config.type.ts:241](https://github.com/mermaid
 
 > `optional` **venn**: `VennDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:243](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L243)
+Defined in: [packages/mermaid/src/config.type.ts:252](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L252)
 
 ---
 
@@ -507,7 +521,7 @@ Defined in: [packages/mermaid/src/config.type.ts:243](https://github.com/mermaid
 
 > `optional` **wardley-beta**: `WardleyDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:244](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L244)
+Defined in: [packages/mermaid/src/config.type.ts:253](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L253)
 
 ---
 
@@ -515,7 +529,7 @@ Defined in: [packages/mermaid/src/config.type.ts:244](https://github.com/mermaid
 
 > `optional` **wrap**: `boolean`
 
-Defined in: [packages/mermaid/src/config.type.ts:246](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L246)
+Defined in: [packages/mermaid/src/config.type.ts:255](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L255)
 
 ---
 
@@ -523,4 +537,4 @@ Defined in: [packages/mermaid/src/config.type.ts:246](https://github.com/mermaid
 
 > `optional` **xyChart**: `XYChartConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:229](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L229)
+Defined in: [packages/mermaid/src/config.type.ts:238](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L238)

--- a/docs/config/usage.md
+++ b/docs/config/usage.md
@@ -137,6 +137,24 @@ mermaid.initialize({
 });
 ```
 
+### `sandboxLinkBaseUrl` (v\<MERMAID_RELEASE_VERSION>+)
+
+When `securityLevel` is set to `sandbox`, Mermaid renders the diagram into a sandboxed `data:` iframe. Relative links such as `./details.html` and `#section` no longer have the page URL as their base in that environment.
+
+Use `sandboxLinkBaseUrl` to resolve clickable relative links before Mermaid embeds the SVG into the sandboxed iframe:
+
+- Only applies when `securityLevel: 'sandbox'` is used.
+- Relative links such as `./details.html`, `../docs/page.html`, and `#section` are resolved against the configured base URL.
+- Absolute URLs remain unchanged.
+- Only clickable links are rewritten; Mermaid does not rewrite internal SVG references such as markers or symbols.
+
+```javascript
+mermaid.initialize({
+  securityLevel: 'sandbox',
+  sandboxLinkBaseUrl: window.location.href,
+});
+```
+
 ### Labels out of bounds
 
 If you use dynamically loaded fonts that are loaded through CSS, such as fonts, mermaid should wait for the whole page to load (dom + assets, particularly the fonts file).

--- a/packages/mermaid/src/config.spec.ts
+++ b/packages/mermaid/src/config.spec.ts
@@ -19,6 +19,7 @@ describe('when working with site config', () => {
     const config_0: MermaidConfig = {
       fontFamily: 'foo-font',
       securityLevel: 'strict', // can't be changed
+      sandboxLinkBaseUrl: 'https://example.com/docs/',
       fontSize: 12345, // can't be changed
       secure: [...configApi.defaultConfig.secure!, 'fontSize'],
     };
@@ -28,11 +29,16 @@ describe('when working with site config', () => {
       // fontSize and securityLevel shouldn't be changed
       fontSize: 54321,
       securityLevel: 'loose',
+      sandboxLinkBaseUrl: 'https://malicious.example/override/',
     };
     const cfg: MermaidConfig = configApi.updateCurrentConfig(config_0, [directive]);
     expect(cfg.fontFamily).toEqual(directive.fontFamily);
     expect(cfg.fontSize).toBe(config_0.fontSize);
     expect(cfg.securityLevel).toBe(config_0.securityLevel);
+    expect(cfg.sandboxLinkBaseUrl).toBe(config_0.sandboxLinkBaseUrl);
+  });
+  it('should keep sandboxLinkBaseUrl in the default secure keys', () => {
+    expect(configApi.defaultConfig.secure).toContain('sandboxLinkBaseUrl');
   });
   it('should allow setting partial options', () => {
     const defaultConfig = configApi.getConfig();

--- a/packages/mermaid/src/config.type.ts
+++ b/packages/mermaid/src/config.type.ts
@@ -167,6 +167,15 @@ export interface MermaidConfig {
    */
   securityLevel?: 'strict' | 'loose' | 'antiscript' | 'sandbox';
   /**
+   * Base URL used to resolve relative links when `securityLevel` is `sandbox`.
+   *
+   * Sandbox rendering serializes the diagram into a `data:` URL iframe, which removes the
+   * document context needed for links such as `./page.html` and `#section`.
+   * Provide `sandboxLinkBaseUrl` to pre-resolve those links before the SVG is embedded.
+   *
+   */
+  sandboxLinkBaseUrl?: string;
+  /**
    * Dictates whether mermaid starts on Page load
    */
   startOnLoad?: boolean;

--- a/packages/mermaid/src/docs/config/usage.md
+++ b/packages/mermaid/src/docs/config/usage.md
@@ -132,6 +132,24 @@ mermaid.initialize({
 });
 ```
 
+### `sandboxLinkBaseUrl` (v<MERMAID_RELEASE_VERSION>+)
+
+When `securityLevel` is set to `sandbox`, Mermaid renders the diagram into a sandboxed `data:` iframe. Relative links such as `./details.html` and `#section` no longer have the page URL as their base in that environment.
+
+Use `sandboxLinkBaseUrl` to resolve clickable relative links before Mermaid embeds the SVG into the sandboxed iframe:
+
+- Only applies when `securityLevel: 'sandbox'` is used.
+- Relative links such as `./details.html`, `../docs/page.html`, and `#section` are resolved against the configured base URL.
+- Absolute URLs remain unchanged.
+- Only clickable links are rewritten; Mermaid does not rewrite internal SVG references such as markers or symbols.
+
+```javascript
+mermaid.initialize({
+  securityLevel: 'sandbox',
+  sandboxLinkBaseUrl: window.location.href,
+});
+```
+
 ### Labels out of bounds
 
 If you use dynamically loaded fonts that are loaded through CSS, such as fonts, mermaid should wait for the whole page to load (dom + assets, particularly the fonts file).

--- a/packages/mermaid/src/mermaidAPI.spec.ts
+++ b/packages/mermaid/src/mermaidAPI.spec.ts
@@ -8,6 +8,7 @@ import mermaidAPI, {
   cleanUpSvgCode,
   createCssStyles,
   createUserStyles,
+  isElementNode,
   putIntoIFrame,
   removeExistingElements,
 } from './mermaidAPI.js';
@@ -189,6 +190,22 @@ describe('mermaidAPI', () => {
 
       const result = putIntoIFrame(inputSvgCode, faux_svgElement);
       expect(result).toMatch(/style="(.*)height:42px;/);
+    });
+  });
+
+  describe('isElementNode', () => {
+    it('accepts elements created in another window realm', () => {
+      const otherDom = new JSDOM('<body><svg xmlns="http://www.w3.org/2000/svg"></svg></body>');
+      const otherSvg = otherDom.window.document.querySelector('svg');
+
+      expect(otherSvg).not.toBeNull();
+      expect(otherSvg instanceof Element).toBe(false);
+      expect(isElementNode(otherSvg)).toBe(true);
+    });
+
+    it('rejects non-element values', () => {
+      expect(isElementNode(null)).toBe(false);
+      expect(isElementNode({ nodeType: 1 })).toBe(false);
     });
   });
 

--- a/packages/mermaid/src/mermaidAPI.ts
+++ b/packages/mermaid/src/mermaidAPI.ts
@@ -25,6 +25,7 @@ import theme from './themes/index.js';
 import type { D3Element, ParseOptions, ParseResult, RenderResult } from './types.js';
 import { decodeEntities } from './utils.js';
 import { toBase64 } from './utils/base64.js';
+import { resolveRelativeLinksInElement } from './utils/sandboxLinks.js';
 
 const MAX_TEXTLENGTH = 50_000;
 const MAX_TEXTLENGTH_EXCEEDED_MSG =
@@ -222,6 +223,16 @@ export const putIntoIFrame = (svgCode = '', svgElement?: D3Element): string => {
   return `<iframe style="width:${IFRAME_WIDTH};height:${height};${IFRAME_STYLES}" src="data:text/html;charset=UTF-8;base64,${base64encodedSrc}" sandbox="${IFRAME_SANDBOX_OPTS}">
   ${IFRAME_NOT_SUPPORTED_MSG}
 </iframe>`;
+};
+
+export const isElementNode = (value: unknown): value is Element => {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'nodeType' in value &&
+    value.nodeType === 1 &&
+    'querySelectorAll' in value
+  );
 };
 
 /**
@@ -444,6 +455,11 @@ const render = async function (
   // -------------------------------------------------------------------------------
   // Clean up SVG code
   root.select(`[id="${id}"]`).selectAll('foreignobject > *').attr('xmlns', XMLNS_XHTML_STD);
+  const svgElement = svgNode.node();
+
+  if (isSandboxed && config.sandboxLinkBaseUrl && isElementNode(svgElement)) {
+    resolveRelativeLinksInElement(svgElement, config.sandboxLinkBaseUrl);
+  }
 
   // Fix for when the base tag is used
   let svgCode: string = root.select(enclosingDivID_selector).node().innerHTML;
@@ -452,8 +468,7 @@ const render = async function (
   svgCode = cleanUpSvgCode(svgCode, isSandboxed, evaluate(config.arrowMarkerAbsolute));
 
   if (isSandboxed) {
-    const svgEl = root.select(enclosingDivID_selector + ' svg').node();
-    svgCode = putIntoIFrame(svgCode, svgEl);
+    svgCode = putIntoIFrame(svgCode, svgElement);
   } else if (!isLooseSecurityLevel) {
     // Sanitize the svgCode using DOMPurify
     svgCode = DOMPurify.sanitize(svgCode, {

--- a/packages/mermaid/src/schemas/config.schema.yaml
+++ b/packages/mermaid/src/schemas/config.schema.yaml
@@ -222,6 +222,14 @@ properties:
         This prevent any JavaScript from running in the context.
         This may hinder interactive functionality of the diagram, like scripts, popups in the sequence diagram, or links to other tabs or targets, etc.
     default: strict
+  sandboxLinkBaseUrl:
+    description: |
+      Base URL used to resolve relative links when `securityLevel` is `sandbox`.
+
+      Sandbox rendering serializes the diagram into a `data:` URL iframe, which removes the
+      document context needed for links such as `./page.html` and `#section`.
+      Provide `sandboxLinkBaseUrl` to pre-resolve those links before the SVG is embedded.
+    type: string
   startOnLoad:
     description: Dictates whether mermaid starts on Page load
     type: boolean
@@ -246,6 +254,7 @@ properties:
         'maxTextSize',
         'suppressErrorRendering',
         'maxEdges',
+        'sandboxLinkBaseUrl',
       ]
     type: array
     items:

--- a/packages/mermaid/src/utils/sandboxLinks.spec.ts
+++ b/packages/mermaid/src/utils/sandboxLinks.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveRelativeLinksInElement } from './sandboxLinks.js';
+
+describe('resolveRelativeLinksInElement', () => {
+  const baseUrl = 'https://example.com/docs/index.html';
+
+  const createSvgElement = (svg: string): Element => {
+    const parser = new DOMParser();
+    return parser.parseFromString(svg, 'image/svg+xml').documentElement;
+  };
+
+  it('resolves relative href links on anchors', () => {
+    const svg = createSvgElement('<svg><a href="./page.html">Link</a></svg>');
+
+    resolveRelativeLinksInElement(svg, baseUrl);
+
+    expect(svg.querySelector('a')?.getAttribute('href')).toBe('https://example.com/docs/page.html');
+  });
+
+  it('resolves relative xlink:href links on anchors', () => {
+    const svg = createSvgElement(
+      '<svg xmlns:xlink="http://www.w3.org/1999/xlink"><a xlink:href="../page.html">Link</a></svg>'
+    );
+
+    resolveRelativeLinksInElement(svg, baseUrl);
+
+    expect(svg.querySelector('a')?.getAttributeNS('http://www.w3.org/1999/xlink', 'href')).toBe(
+      'https://example.com/page.html'
+    );
+  });
+
+  it('resolves hash links against the configured base URL', () => {
+    const svg = createSvgElement('<svg><a href="#section">Link</a></svg>');
+
+    resolveRelativeLinksInElement(svg, baseUrl);
+
+    expect(svg.querySelector('a')?.getAttribute('href')).toBe(
+      'https://example.com/docs/index.html#section'
+    );
+  });
+
+  it('leaves absolute and protocol-relative URLs unchanged', () => {
+    const svg = createSvgElement(`<svg xmlns:xlink="http://www.w3.org/1999/xlink">
+      <a href="https://mermaid.js.org/">Absolute</a>
+      <a xlink:href="//cdn.example.com/file.svg">Protocol relative</a>
+    </svg>`);
+
+    resolveRelativeLinksInElement(svg, baseUrl);
+
+    const anchors = svg.querySelectorAll('a');
+    expect(anchors[0].getAttribute('href')).toBe('https://mermaid.js.org/');
+    expect(anchors[1].getAttributeNS('http://www.w3.org/1999/xlink', 'href')).toBe(
+      '//cdn.example.com/file.svg'
+    );
+  });
+
+  it('does not rewrite non-anchor xlink references', () => {
+    const svg = createSvgElement(
+      '<svg xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="#icon" /></svg>'
+    );
+
+    resolveRelativeLinksInElement(svg, baseUrl);
+
+    expect(svg.querySelector('use')?.getAttributeNS('http://www.w3.org/1999/xlink', 'href')).toBe(
+      '#icon'
+    );
+  });
+
+  it('leaves links unchanged when the base URL is invalid', () => {
+    const svg = createSvgElement('<svg><a href="./page.html">Link</a></svg>');
+
+    resolveRelativeLinksInElement(svg, 'not-a-valid-url');
+
+    expect(svg.querySelector('a')?.getAttribute('href')).toBe('./page.html');
+  });
+});

--- a/packages/mermaid/src/utils/sandboxLinks.ts
+++ b/packages/mermaid/src/utils/sandboxLinks.ts
@@ -1,0 +1,35 @@
+const XLINK_NS = 'http://www.w3.org/1999/xlink';
+const ABSOLUTE_URL_PATTERN = /^[A-Za-z][\d+.A-Za-z-]*:/;
+
+const resolveRelativeUrl = (url: string, baseUrl: string): string | undefined => {
+  if (!url || ABSOLUTE_URL_PATTERN.test(url) || url.startsWith('//')) {
+    return;
+  }
+
+  try {
+    return new URL(url, baseUrl).href;
+  } catch {
+    return;
+  }
+};
+
+/**
+ * Resolve relative anchor links before serializing sandboxed SVG content into a data: iframe.
+ */
+export const resolveRelativeLinksInElement = (element: Element, baseUrl: string): void => {
+  for (const anchor of element.querySelectorAll('a')) {
+    const href = anchor.getAttribute('href');
+    const resolvedHref = href ? resolveRelativeUrl(href, baseUrl) : undefined;
+
+    if (resolvedHref) {
+      anchor.setAttribute('href', resolvedHref);
+    }
+
+    const xlinkHref = anchor.getAttributeNS(XLINK_NS, 'href') ?? anchor.getAttribute('xlink:href');
+    const resolvedXlinkHref = xlinkHref ? resolveRelativeUrl(xlinkHref, baseUrl) : undefined;
+
+    if (resolvedXlinkHref) {
+      anchor.setAttributeNS(XLINK_NS, 'xlink:href', resolvedXlinkHref);
+    }
+  }
+};


### PR DESCRIPTION
## :bookmark_tabs: Summary

Add `sandboxLinkBaseUrl` to resolve relative links when `securityLevel: 'sandbox'` renders diagrams inside a sandboxed `data:` iframe.

Relative links such as `./page.html` and `#section` lose their base URL context in that environment. This PR adds an opt-in configuration option so Mermaid can resolve those links before embedding the SVG.

```javascript
mermaid.initialize({
  securityLevel: 'sandbox',
  sandboxLinkBaseUrl: window.location.href,
});
```

## :straight_ruler: Design Decisions

- Keep the behavior opt-in through `sandboxLinkBaseUrl`; existing sandbox behavior stays unchanged unless the option is set.
- Rewrite only clickable anchor links (`href` and `xlink:href` on `<a>`) so Mermaid does not touch internal SVG references such as markers or symbols.
- Resolve links on the live SVG DOM before sandbox serialization rather than rewriting the serialized SVG string.
- Use a cross-realm-safe element guard so the link rewrite still runs for SVG elements created through the temporary iframe path used by sandbox rendering.

## Verification

- Added unit tests for config handling, relative-link resolution, and the cross-realm element guard.
- Added user documentation with `v<MERMAID_RELEASE_VERSION>+`.
- Added a changeset (`minor`).
- Verified in Chromium that sandboxed `./details.html` and `#results` links resolve correctly when `sandboxLinkBaseUrl` is set.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
