### PR TITLE
fix(er): support left-side numeric entity identifier 1

### DIFF
--- a/packages/mermaid/src/diagrams/er/parser/erDiagram.jison
+++ b/packages/mermaid/src/diagrams/er/parser/erDiagram.jison
@@ -68,7 +68,8 @@ accDescr\s*"{"\s*                                { this.begin("acc_descr_multili
 "only one"                      return 'ONLY_ONE';
 [0-9]+\.[0-9]+                  return 'DECIMAL_NUM';
 "1"(?=\s+[A-Za-z_"'])           return 'ONLY_ONE';
-"1"(?=\s+[0-9])                 return 'ONLY_ONE';
+"1"(?=\s+to\b)                  return 'ONLY_ONE';
+"1"(?=\s+[0-9]+\s*:)       return 'ONLY_ONE';
 "1"(?=(\-\-|\.\.|\.\-|\-\.))    return 'ONLY_ONE';
 "1"                             return 'ENTITY_ONE';
 [0-9]+                          return 'NUM';
@@ -237,6 +238,7 @@ entityName
     | 'UNICODE_TEXT' { $$ = $1; }
     | 'NUM' { $$ = $1; }
     | 'DECIMAL_NUM' { $$ = $1; }
+    | 'ONLY_ONE' { $$ = $1; }
     | 'ENTITY_ONE' { $$ = $1; }
     ;
 

--- a/packages/mermaid/src/diagrams/er/parser/erDiagram.jison
+++ b/packages/mermaid/src/diagrams/er/parser/erDiagram.jison
@@ -67,9 +67,10 @@ accDescr\s*"{"\s*                                { this.begin("acc_descr_multili
 "one"                           return 'ONLY_ONE';
 "only one"                      return 'ONLY_ONE';
 [0-9]+\.[0-9]+                  return 'DECIMAL_NUM';
-"1"(?=\s+[A-Za-z_"'])           return 'ONLY_ONE';
+"1"(?=\s+(?:1|many|one|zero|only)\s+to\b) return 'ENTITY_ONE';
+"1"(?=\s+(?!(?:many|one|only|zero|optionally|to)\b)[A-Za-z_"'])           return 'ONLY_ONE';
 "1"(?=\s+to\b)                  return 'ONLY_ONE';
-"1"(?=\s+[0-9]+\s*:)       return 'ONLY_ONE';
+"1"(?=\s+[0-9]+\s*:)            return 'ONLY_ONE';
 "1"(?=(\-\-|\.\.|\.\-|\-\.))    return 'ONLY_ONE';
 "1"                             return 'ENTITY_ONE';
 [0-9]+                          return 'NUM';
@@ -238,7 +239,6 @@ entityName
     | 'UNICODE_TEXT' { $$ = $1; }
     | 'NUM' { $$ = $1; }
     | 'DECIMAL_NUM' { $$ = $1; }
-    | 'ONLY_ONE' { $$ = $1; }
     | 'ENTITY_ONE' { $$ = $1; }
     ;
 

--- a/packages/mermaid/src/diagrams/er/parser/erDiagram.spec.js
+++ b/packages/mermaid/src/diagrams/er/parser/erDiagram.spec.js
@@ -820,6 +820,43 @@ describe('when parsing ER diagram it...', function () {
     expect(rels[0].relSpec.relType).toBe(erDb.Identification.IDENTIFYING);
   });
 
+  it('should allow numeric entity identifier "1" on left side with cardinality 1', function () {
+    // This should parse without throwing - the fix for #7472 broke left-side numeric identifiers
+    erDiagram.parser.parse('erDiagram\n1 1 to many SomeEntity: label');
+    const entities = erDb.getEntities();
+    const rels = erDb.getRelationships();
+
+    // Verify both entities were created
+    expect(entities.size).toBe(2);
+    expect(entities.has('1')).toBe(true);
+    expect(entities.has('SomeEntity')).toBe(true);
+
+    // Verify one relationship was created
+    expect(rels.length).toBe(1);
+
+    // For "1 1 to many SomeEntity:": first "1" is entity name, second "1" is cardinality (ONLY_ONE)
+    // So cardB = 1 (ONLY_ONE), cardA = many (ZERO_OR_MORE)
+    expect(rels[0].relSpec.cardA).toBe(erDb.Cardinality.ZERO_OR_MORE); // "many"
+    expect(rels[0].relSpec.cardB).toBe(erDb.Cardinality.ONLY_ONE); // second "1"
+
+    // Verify relationship type: "to" means IDENTIFYING
+    expect(rels[0].relSpec.relType).toBe(erDb.Identification.IDENTIFYING);
+  });
+
+  it('should allow numeric entity identifier "1" on left side with many cardinality', function () {
+    erDiagram.parser.parse('erDiagram\n1 many to many SomeEntity: label');
+    const entities = erDb.getEntities();
+    const rels = erDb.getRelationships();
+
+    expect(entities.size).toBe(2);
+    expect(entities.has('1')).toBe(true);
+    expect(entities.has('SomeEntity')).toBe(true);
+    expect(rels.length).toBe(1);
+    expect(rels[0].relSpec.cardA).toBe(erDb.Cardinality.ZERO_OR_MORE);
+    expect(rels[0].relSpec.cardB).toBe(erDb.Cardinality.ZERO_OR_MORE);
+    expect(rels[0].relSpec.relType).toBe(erDb.Identification.IDENTIFYING);
+  });
+
   it('should represent identifying relationships properly', function () {
     erDiagram.parser.parse('erDiagram\nHOUSE ||--|{ ROOM : contains');
     const rels = erDb.getRelationships();


### PR DESCRIPTION
Disambiguate numeric token handling in ER parser so left-side entity name "1" works in relationship statements, while preserving right-side numeric entity cases from #7472.

- refine lexer lookahead for cardinality token 1
- allow ONLY_ONE token where an entity name is valid
- add regression tests for left-side forms: "1 1 to many" and "1 many to many"

Refs #7472

## :bookmark_tabs: Summary

This PR fixes an ER parser regression where the left-side entity name "1" could be interpreted as cardinality in relationship statements.

It disambiguates numeric token handling so left-side numeric entity names parse correctly, while preserving the right-side numeric entity behavior introduced in #7472.

Resolves #7472

## :straight_ruler: Design Decisions

- Refined lexer lookahead handling for token 1 to avoid over-greedy matching in ambiguous relationship contexts.
- Allowed ONLY_ONE in entity-name parsing context so numeric identifier "1" can be treated as an entity where valid.
- Added regression tests to cover both left-side forms:
  - 1 1 to many SomeEntity: label
  - 1 many to many SomeEntity: label

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit tests for the regression
- [x] :notebook: have added documentation. Not required for this bug fix because no new feature or syntax was introduced.
- [x] :butterfly: If this fix should be included in changelogs, generate a changeset with patch level and prefix fix:.
