### PR TITLE
feat: add nested namespace support for class diagrams

### DIFF
--- a/.changeset/feat-nested-namespaces.md
+++ b/.changeset/feat-nested-namespaces.md
@@ -1,0 +1,5 @@
+---
+'mermaid': minor
+---
+
+feat: add nested namespace support for class diagrams via dot notation and syntactic nesting

--- a/cypress/integration/rendering/classDiagram-elk-v3.spec.js
+++ b/cypress/integration/rendering/classDiagram-elk-v3.spec.js
@@ -1107,4 +1107,30 @@ class Class10
       { logLevel: 1, htmlLabels: true, layout: 'elk' }
     );
   });
+
+  it('ELK: should render compact mode with hierarchicalNamespaces: false', () => {
+    imgSnapshotTest(
+      `
+      classDiagram
+      namespace Company.Engineering.Backend {
+        class Developer {
+          +writeCode()
+        }
+      }
+      namespace Company.Engineering.Frontend {
+        class Designer {
+          +createMockup()
+        }
+      }
+      namespace Company {
+        class CEO {
+          +makeDecisions()
+        }
+      }
+      CEO --> Developer : oversees
+      CEO --> Designer : oversees
+    `,
+      { class: { hierarchicalNamespaces: false } }
+    );
+  });
 });

--- a/cypress/integration/rendering/classDiagram-elk-v3.spec.js
+++ b/cypress/integration/rendering/classDiagram-elk-v3.spec.js
@@ -1034,4 +1034,77 @@ class Class10
       { logLevel: 1, htmlLabels: true, layout: 'elk' }
     );
   });
+
+  it('ELK: should render nested namespaces with dot notation', () => {
+    imgSnapshotTest(
+      `
+      classDiagram
+      namespace Company.Engineering.Backend {
+        class Developer {
+          +writeCode()
+        }
+      }
+      namespace Company.Engineering.Frontend {
+        class Designer {
+          +createMockup()
+        }
+      }
+      namespace Company.Engineering {
+        class TechLead {
+          +planSprint()
+        }
+      }
+      TechLead --> Developer : leads
+      TechLead --> Designer : leads
+    `,
+      { logLevel: 1, htmlLabels: true, layout: 'elk' }
+    );
+  });
+
+  it('ELK: should render syntactically nested namespaces', () => {
+    imgSnapshotTest(
+      `
+      classDiagram
+      namespace Platform {
+        namespace Auth {
+          class UserService {
+            +login()
+            +logout()
+          }
+        }
+        namespace Data {
+          class Repository {
+            +find()
+            +save()
+          }
+        }
+        class Gateway {
+          +route()
+        }
+      }
+      Gateway --> UserService : delegates
+      Gateway --> Repository : delegates
+    `,
+      { logLevel: 1, htmlLabels: true, layout: 'elk' }
+    );
+  });
+
+  it('ELK: should render a namespace with a custom label', () => {
+    imgSnapshotTest(
+      `
+      classDiagram
+      namespace Auth["Authentication Service"] {
+        class UserService {
+          +login()
+          +logout()
+        }
+        class TokenManager {
+          +generate()
+        }
+      }
+      UserService --> TokenManager : uses
+    `,
+      { logLevel: 1, htmlLabels: true, layout: 'elk' }
+    );
+  });
 });

--- a/cypress/integration/rendering/classDiagram-handDrawn-v3.spec.js
+++ b/cypress/integration/rendering/classDiagram-handDrawn-v3.spec.js
@@ -1038,4 +1038,77 @@ class C13["With Città foreign language"]
       { logLevel: 1, htmlLabels: true, look: 'handDrawn' }
     );
   });
+
+  it('HD: should render nested namespaces with dot notation', () => {
+    imgSnapshotTest(
+      `
+      classDiagram
+      namespace Company.Engineering.Backend {
+        class Developer {
+          +writeCode()
+        }
+      }
+      namespace Company.Engineering.Frontend {
+        class Designer {
+          +createMockup()
+        }
+      }
+      namespace Company.Engineering {
+        class TechLead {
+          +planSprint()
+        }
+      }
+      TechLead --> Developer : leads
+      TechLead --> Designer : leads
+    `,
+      { logLevel: 1, htmlLabels: true, look: 'handDrawn' }
+    );
+  });
+
+  it('HD: should render syntactically nested namespaces', () => {
+    imgSnapshotTest(
+      `
+      classDiagram
+      namespace Platform {
+        namespace Auth {
+          class UserService {
+            +login()
+            +logout()
+          }
+        }
+        namespace Data {
+          class Repository {
+            +find()
+            +save()
+          }
+        }
+        class Gateway {
+          +route()
+        }
+      }
+      Gateway --> UserService : delegates
+      Gateway --> Repository : delegates
+    `,
+      { logLevel: 1, htmlLabels: true, look: 'handDrawn' }
+    );
+  });
+
+  it('HD: should render a namespace with a custom label', () => {
+    imgSnapshotTest(
+      `
+      classDiagram
+      namespace Auth["Authentication Service"] {
+        class UserService {
+          +login()
+          +logout()
+        }
+        class TokenManager {
+          +generate()
+        }
+      }
+      UserService --> TokenManager : uses
+    `,
+      { logLevel: 1, htmlLabels: true, look: 'handDrawn' }
+    );
+  });
 });

--- a/cypress/integration/rendering/classDiagram-handDrawn-v3.spec.js
+++ b/cypress/integration/rendering/classDiagram-handDrawn-v3.spec.js
@@ -1111,4 +1111,30 @@ class C13["With Città foreign language"]
       { logLevel: 1, htmlLabels: true, look: 'handDrawn' }
     );
   });
+
+  it('HD: should render compact mode with hierarchicalNamespaces: false', () => {
+    imgSnapshotTest(
+      `
+      classDiagram
+      namespace Company.Engineering.Backend {
+        class Developer {
+          +writeCode()
+        }
+      }
+      namespace Company.Engineering.Frontend {
+        class Designer {
+          +createMockup()
+        }
+      }
+      namespace Company {
+        class CEO {
+          +makeDecisions()
+        }
+      }
+      CEO --> Developer : oversees
+      CEO --> Designer : oversees
+    `,
+      { class: { hierarchicalNamespaces: false } }
+    );
+  });
 });

--- a/cypress/integration/rendering/classDiagram-v2.spec.js
+++ b/cypress/integration/rendering/classDiagram-v2.spec.js
@@ -654,4 +654,68 @@ class C13["With Città foreign language"]
 
     imgSnapshotTest(diagramDefinition);
   });
+
+  it('renders nested namespaces with dot notation', () => {
+    imgSnapshotTest(`
+      classDiagram-v2
+      namespace Company.Engineering.Backend {
+        class Developer {
+          +writeCode()
+        }
+      }
+      namespace Company.Engineering.Frontend {
+        class Designer {
+          +createMockup()
+        }
+      }
+      namespace Company.Engineering {
+        class TechLead {
+          +planSprint()
+        }
+      }
+      TechLead --> Developer : leads
+      TechLead --> Designer : leads
+    `);
+  });
+
+  it('renders syntactically nested namespaces', () => {
+    imgSnapshotTest(`
+      classDiagram-v2
+      namespace Platform {
+        namespace Auth {
+          class UserService {
+            +login()
+            +logout()
+          }
+        }
+        namespace Data {
+          class Repository {
+            +find()
+            +save()
+          }
+        }
+        class Gateway {
+          +route()
+        }
+      }
+      Gateway --> UserService : delegates
+      Gateway --> Repository : delegates
+    `);
+  });
+
+  it('renders a namespace with a custom label', () => {
+    imgSnapshotTest(`
+      classDiagram-v2
+      namespace Auth["Authentication Service"] {
+        class UserService {
+          +login()
+          +logout()
+        }
+        class TokenManager {
+          +generate()
+        }
+      }
+      UserService --> TokenManager : uses
+    `);
+  });
 });

--- a/cypress/integration/rendering/classDiagram-v2.spec.js
+++ b/cypress/integration/rendering/classDiagram-v2.spec.js
@@ -718,4 +718,30 @@ class C13["With Città foreign language"]
       UserService --> TokenManager : uses
     `);
   });
+
+  it('renders compact mode with hierarchicalNamespaces: false', () => {
+    imgSnapshotTest(
+      `
+      classDiagram
+      namespace Company.Engineering.Backend {
+        class Developer {
+          +writeCode()
+        }
+      }
+      namespace Company.Engineering.Frontend {
+        class Designer {
+          +createMockup()
+        }
+      }
+      namespace Company {
+        class CEO {
+          +makeDecisions()
+        }
+      }
+      CEO --> Developer : oversees
+      CEO --> Designer : oversees
+    `,
+      { class: { hierarchicalNamespaces: false } }
+    );
+  });
 });

--- a/cypress/integration/rendering/classDiagram-v3.spec.js
+++ b/cypress/integration/rendering/classDiagram-v3.spec.js
@@ -1106,4 +1106,30 @@ class C13["With Città foreign language"]
       UserService --> TokenManager : uses
     `);
   });
+
+  it('should render compact mode with hierarchicalNamespaces: false', () => {
+    imgSnapshotTest(
+      `
+      classDiagram
+      namespace Company.Engineering.Backend {
+        class Developer {
+          +writeCode()
+        }
+      }
+      namespace Company.Engineering.Frontend {
+        class Designer {
+          +createMockup()
+        }
+      }
+      namespace Company {
+        class CEO {
+          +makeDecisions()
+        }
+      }
+      CEO --> Developer : oversees
+      CEO --> Designer : oversees
+    `,
+      { class: { hierarchicalNamespaces: false } }
+    );
+  });
 });

--- a/cypress/integration/rendering/classDiagram-v3.spec.js
+++ b/cypress/integration/rendering/classDiagram-v3.spec.js
@@ -1042,4 +1042,68 @@ class C13["With Città foreign language"]
       { logLevel: 1, htmlLabels: true }
     );
   });
+
+  it('should render nested namespaces with dot notation', () => {
+    imgSnapshotTest(`
+      classDiagram
+      namespace Company.Engineering.Backend {
+        class Developer {
+          +writeCode()
+        }
+      }
+      namespace Company.Engineering.Frontend {
+        class Designer {
+          +createMockup()
+        }
+      }
+      namespace Company.Engineering {
+        class TechLead {
+          +planSprint()
+        }
+      }
+      TechLead --> Developer : leads
+      TechLead --> Designer : leads
+    `);
+  });
+
+  it('should render syntactically nested namespaces', () => {
+    imgSnapshotTest(`
+      classDiagram
+      namespace Platform {
+        namespace Auth {
+          class UserService {
+            +login()
+            +logout()
+          }
+        }
+        namespace Data {
+          class Repository {
+            +find()
+            +save()
+          }
+        }
+        class Gateway {
+          +route()
+        }
+      }
+      Gateway --> UserService : delegates
+      Gateway --> Repository : delegates
+    `);
+  });
+
+  it('should render a namespace with a custom label', () => {
+    imgSnapshotTest(`
+      classDiagram
+      namespace Auth["Authentication Service"] {
+        class UserService {
+          +login()
+          +logout()
+        }
+        class TokenManager {
+          +generate()
+        }
+      }
+      UserService --> TokenManager : uses
+    `);
+  });
 });

--- a/demos/classchart.html
+++ b/demos/classchart.html
@@ -339,6 +339,70 @@
     </pre>
     <hr />
 
+    <h2>Compact mode (hierarchicalNamespaces: false)</h2>
+    <p>
+      Same source as the dot-notation demo above, rendered with
+      <code>hierarchicalNamespaces: false</code>. Only the three user-declared namespaces are
+      emitted as flat boxes using their full qualified name; intermediate ancestors (e.g.
+      <code>Company.Engineering</code> would only appear if declared) are skipped.
+    </p>
+    <pre class="mermaid">
+    ---
+    config:
+      class:
+        hierarchicalNamespaces: false
+    ---
+    classDiagram
+      namespace Company.Engineering.Backend {
+        class Developer {
+          +writeCode()
+          +reviewPR()
+        }
+      }
+      namespace Company.Engineering.Frontend {
+        class Designer {
+          +createMockup()
+          +buildUI()
+        }
+      }
+      namespace Company {
+        class CEO {
+          +makeDecisions()
+        }
+      }
+      CEO --> Developer : oversees
+      CEO --> Designer : oversees
+    </pre>
+    <hr />
+
+    <h2>Compact mode with syntactic nesting</h2>
+    <p>
+      Syntactic nesting in compact mode: nested <code>namespace</code> blocks still produce
+      fully-qualified names, but only the explicit leaf namespaces render as flat boxes.
+    </p>
+    <pre class="mermaid">
+    ---
+    config:
+      class:
+        hierarchicalNamespaces: false
+    ---
+    classDiagram
+      namespace Platform {
+        namespace Auth {
+          class UserService {
+            +login()
+          }
+        }
+        namespace Data {
+          class Repository {
+            +find()
+          }
+        }
+      }
+      UserService --> Repository : reads
+    </pre>
+    <hr />
+
     <h2>Namespace labels</h2>
     <pre class="mermaid">
     classDiagram

--- a/demos/classchart.html
+++ b/demos/classchart.html
@@ -255,6 +255,90 @@
     </pre>
     <hr />
 
+    <h2>Nested Namespaces (dot notation)</h2>
+    <pre class="mermaid">
+    classDiagram
+      namespace Company.Engineering.Backend {
+        class Developer {
+          +writeCode()
+          +reviewPR()
+        }
+      }
+      namespace Company.Engineering.Frontend {
+        class Designer {
+          +createMockup()
+          +buildUI()
+        }
+      }
+      namespace Company.Engineering {
+        class TechLead {
+          +planSprint()
+        }
+      }
+      namespace Company {
+        class CEO {
+          +makeDecisions()
+        }
+      }
+      CEO --> TechLead : oversees
+      TechLead --> Developer : leads
+      TechLead --> Designer : leads
+    </pre>
+    <hr />
+
+    <h2>Nested Namespaces (syntactic nesting)</h2>
+    <pre class="mermaid">
+    classDiagram
+      namespace Platform {
+        namespace Auth {
+          class UserService {
+            +login()
+            +logout()
+          }
+          class TokenManager {
+            +generateToken()
+            +validateToken()
+          }
+        }
+        namespace Data {
+          class Repository {
+            +find()
+            +save()
+          }
+        }
+        class Gateway {
+          +route()
+        }
+      }
+      UserService --> TokenManager : uses
+      Gateway --> UserService : delegates
+      Gateway --> Repository : delegates
+    </pre>
+    <hr />
+
+    <h2>Mixed: dot notation + syntactic nesting</h2>
+    <pre class="mermaid">
+    classDiagram
+      namespace App.Services {
+        namespace Billing {
+          class Invoice {
+            +calculate()
+          }
+        }
+        class Logger {
+          +log()
+        }
+      }
+      namespace App.Models {
+        class User {
+          +String name
+        }
+      }
+      Invoice --> Logger : logs to
+      Invoice --> User : bills
+    </pre>
+    <hr />
+
     <script type="module">
       import mermaid from './mermaid.esm.mjs';
       mermaid.initialize({

--- a/demos/classchart.html
+++ b/demos/classchart.html
@@ -339,6 +339,29 @@
     </pre>
     <hr />
 
+    <h2>Namespace labels</h2>
+    <pre class="mermaid">
+    classDiagram
+      namespace Auth["Authentication Service"] {
+        class UserService {
+          +login()
+          +logout()
+        }
+        class TokenManager {
+          +generate()
+        }
+      }
+      namespace Store["Data Store"] {
+        class Repository {
+          +find()
+          +save()
+        }
+      }
+      UserService --> TokenManager : uses
+      UserService --> Repository : reads from
+    </pre>
+    <hr />
+
     <script type="module">
       import mermaid from './mermaid.esm.mjs';
       mermaid.initialize({

--- a/docs/syntax/classDiagram.md
+++ b/docs/syntax/classDiagram.md
@@ -498,6 +498,104 @@ namespace BaseShapes {
 }
 ```
 
+### Nested Namespaces (v\<MERMAID_RELEASE_VERSION>+)
+
+Namespaces can be nested to represent hierarchical groupings. There are two ways to define nested namespaces:
+
+**Dot notation** creates intermediate namespaces automatically:
+
+```mermaid-example
+classDiagram
+    namespace Company.Engineering.Backend {
+        class Developer {
+            +writeCode()
+        }
+    }
+    namespace Company.Engineering.Frontend {
+        class Designer {
+            +createMockup()
+        }
+    }
+    namespace Company.Engineering {
+        class TechLead {
+            +planSprint()
+        }
+    }
+    TechLead --> Developer : leads
+    TechLead --> Designer : leads
+```
+
+```mermaid
+classDiagram
+    namespace Company.Engineering.Backend {
+        class Developer {
+            +writeCode()
+        }
+    }
+    namespace Company.Engineering.Frontend {
+        class Designer {
+            +createMockup()
+        }
+    }
+    namespace Company.Engineering {
+        class TechLead {
+            +planSprint()
+        }
+    }
+    TechLead --> Developer : leads
+    TechLead --> Designer : leads
+```
+
+**Syntactic nesting** places namespace blocks inside other namespace blocks:
+
+```mermaid-example
+classDiagram
+    namespace Platform {
+        namespace Auth {
+            class UserService {
+                +login()
+                +logout()
+            }
+        }
+        namespace Data {
+            class Repository {
+                +find()
+                +save()
+            }
+        }
+        class Gateway {
+            +route()
+        }
+    }
+    Gateway --> UserService : delegates
+    Gateway --> Repository : delegates
+```
+
+```mermaid
+classDiagram
+    namespace Platform {
+        namespace Auth {
+            class UserService {
+                +login()
+                +logout()
+            }
+        }
+        namespace Data {
+            class Repository {
+                +find()
+                +save()
+            }
+        }
+        class Gateway {
+            +route()
+        }
+    }
+    Gateway --> UserService : delegates
+    Gateway --> Repository : delegates
+```
+
+Both approaches can be combined. Dot notation like `namespace A.B.C` will automatically create namespaces `A` and `A.B` as parents if they don't already exist.
+
 ## Cardinality / Multiplicity on relations
 
 Multiplicity or cardinality in class diagrams indicates the number of instances of one class that can be linked to an instance of the other class. For example, each company will have one or more employees (not zero), and each employee currently works for zero or one companies.

--- a/docs/syntax/classDiagram.md
+++ b/docs/syntax/classDiagram.md
@@ -498,6 +498,32 @@ namespace BaseShapes {
 }
 ```
 
+### Namespace Labels (v\<MERMAID_RELEASE_VERSION>+)
+
+A namespace can be given a display label using square bracket syntax, similar to class labels:
+
+```mermaid-example
+classDiagram
+    namespace Auth["Authentication Service"] {
+        class UserService {
+            +login()
+            +logout()
+        }
+    }
+```
+
+```mermaid
+classDiagram
+    namespace Auth["Authentication Service"] {
+        class UserService {
+            +login()
+            +logout()
+        }
+    }
+```
+
+The label replaces the namespace name in the rendered diagram, while the name is still used internally for relationships and nesting.
+
 ### Nested Namespaces (v\<MERMAID_RELEASE_VERSION>+)
 
 Namespaces can be nested to represent hierarchical groupings. There are two ways to define nested namespaces:

--- a/docs/syntax/classDiagram.md
+++ b/docs/syntax/classDiagram.md
@@ -622,6 +622,64 @@ classDiagram
 
 Both approaches can be combined. Dot notation like `namespace A.B.C` will automatically create namespaces `A` and `A.B` as parents if they don't already exist.
 
+#### Compact rendering (`hierarchicalNamespaces: false`)
+
+By default (`hierarchicalNamespaces: true`), each segment of a dotted or syntactically-nested namespace name renders as its own cluster, producing a nested layout.
+
+Setting `hierarchicalNamespaces: false` in the class diagram config switches to **compact mode**: only namespaces the user explicitly declares are drawn — each as a single flat box labelled with its fully-qualified name. Auto-created intermediate ancestors are skipped, and classes inside them are moved to their nearest declared namespace.
+
+```mermaid-example
+---
+config:
+  class:
+    hierarchicalNamespaces: false
+---
+classDiagram
+    namespace Company.Engineering.Backend {
+        class Developer {
+            +writeCode()
+        }
+    }
+    namespace Company.Engineering.Frontend {
+        class Designer {
+            +createMockup()
+        }
+    }
+    namespace Company {
+        class CEO {
+            +makeDecisions()
+        }
+    }
+    CEO --> Developer : oversees
+    CEO --> Designer : oversees
+```
+
+```mermaid
+---
+config:
+  class:
+    hierarchicalNamespaces: false
+---
+classDiagram
+    namespace Company.Engineering.Backend {
+        class Developer {
+            +writeCode()
+        }
+    }
+    namespace Company.Engineering.Frontend {
+        class Designer {
+            +createMockup()
+        }
+    }
+    namespace Company {
+        class CEO {
+            +makeDecisions()
+        }
+    }
+    CEO --> Developer : oversees
+    CEO --> Designer : oversees
+```
+
 ## Cardinality / Multiplicity on relations
 
 Multiplicity or cardinality in class diagrams indicates the number of instances of one class that can be linked to an instance of the other class. For example, each company will have one or more employees (not zero), and each employee currently works for zero or one companies.

--- a/packages/mermaid/src/config.type.ts
+++ b/packages/mermaid/src/config.type.ts
@@ -801,6 +801,15 @@ export interface ClassDiagramConfig extends BaseDiagramConfig {
   diagramPadding?: number;
   htmlLabels?: boolean;
   hideEmptyMembersBox?: boolean;
+  /**
+   * When true (default), nested namespaces render as hierarchical clusters,
+   * with each segment of a dotted name (e.g. `A.B.C`) becoming its own nested
+   * box. When false, namespaces render in compact mode: only explicitly
+   * declared namespaces are emitted and their full qualified name is used as
+   * a single flat label.
+   *
+   */
+  hierarchicalNamespaces?: boolean;
 }
 /**
  * The object containing configurations specific for entity relationship diagrams

--- a/packages/mermaid/src/diagrams/class/classDb.ts
+++ b/packages/mermaid/src/diagrams/class/classDb.ts
@@ -589,11 +589,14 @@ export class ClassDB implements DiagramDB {
     child.parent ??= parentId;
   }
 
-  public addNamespace(id: string): string {
+  public addNamespace(id: string, label?: string): string {
     const qualifiedId = ClassDB.resolveQualifiedId(id, this.namespaceStack);
     this.namespaceStack.push(qualifiedId);
 
     if (this.namespaces.has(qualifiedId)) {
+      if (label) {
+        this.namespaces.get(qualifiedId)!.label = label;
+      }
       return qualifiedId;
     }
 
@@ -602,9 +605,11 @@ export class ClassDB implements DiagramDB {
     for (let i = 0; i < ancestorIds.length; i++) {
       const currentId = ancestorIds[i];
       const parentId = i > 0 ? ancestorIds[i - 1] : undefined;
+      const isLeaf = i === ancestorIds.length - 1;
+      const nodeLabel = isLeaf && label ? label : parts[i];
 
       if (!this.namespaces.has(currentId)) {
-        this.namespaces.set(currentId, this.createNamespaceNode(currentId, parts[i], parentId));
+        this.namespaces.set(currentId, this.createNamespaceNode(currentId, nodeLabel, parentId));
       }
       if (parentId) {
         this.linkParentChild(parentId, currentId);

--- a/packages/mermaid/src/diagrams/class/classDb.ts
+++ b/packages/mermaid/src/diagrams/class/classDb.ts
@@ -565,7 +565,12 @@ export class ClassDB implements DiagramDB {
     return ids;
   }
 
-  private createNamespaceNode(id: string, label: string, parentId?: string): NamespaceNode {
+  private createNamespaceNode(
+    id: string,
+    label: string,
+    parentId?: string,
+    explicit = false
+  ): NamespaceNode {
     return {
       id,
       label,
@@ -574,6 +579,7 @@ export class ClassDB implements DiagramDB {
       children: new Map<string, NamespaceNode>(),
       domId: MERMAID_DOM_ID_PREFIX + id + '-' + this.namespaceCounter++,
       parent: parentId,
+      explicit,
     };
   }
 
@@ -595,8 +601,11 @@ export class ClassDB implements DiagramDB {
     this.namespaceStack.push(qualifiedId);
 
     if (this.namespaces.has(qualifiedId)) {
+      const existing = this.namespaces.get(qualifiedId)!;
+      // Re-declaration promotes an auto-created ancestor to explicit
+      existing.explicit = true;
       if (label) {
-        this.namespaces.get(qualifiedId)!.label = label;
+        existing.label = label;
       }
       return qualifiedId;
     }
@@ -610,7 +619,12 @@ export class ClassDB implements DiagramDB {
       const nodeLabel = isLeaf && label ? label : parts[i];
 
       if (!this.namespaces.has(currentId)) {
-        this.namespaces.set(currentId, this.createNamespaceNode(currentId, nodeLabel, parentId));
+        this.namespaces.set(
+          currentId,
+          this.createNamespaceNode(currentId, nodeLabel, parentId, isLeaf)
+        );
+      } else if (isLeaf) {
+        this.namespaces.get(currentId)!.explicit = true;
       }
       if (parentId) {
         this.linkParentChild(parentId, currentId);
@@ -701,38 +715,66 @@ export class ClassDB implements DiagramDB {
     return marker;
   }
 
+  /**
+   * Walks up the namespace tree from the given id and returns the nearest ancestor
+   * (or the id itself) that is marked as explicit. Used by compact rendering mode
+   * to reassign children to the nearest user-declared namespace.
+   */
+  private resolveExplicitAncestor(id: string | undefined): string | undefined {
+    let current = id;
+    while (current) {
+      const ns = this.namespaces.get(current);
+      if (!ns) {
+        return undefined;
+      }
+      if (ns.explicit) {
+        return current;
+      }
+      current = ns.parent;
+    }
+    return undefined;
+  }
+
   public getData() {
     const nodes: Node[] = [];
     const edges: Edge[] = [];
     const config = getConfig();
+    const hierarchical = config.class?.hierarchicalNamespaces ?? true;
 
     for (const namespace of this.namespaces.values()) {
+      if (!hierarchical && !namespace.explicit) {
+        continue;
+      }
       const node: Node = {
         id: namespace.id,
-        label: namespace.label,
+        label: hierarchical ? namespace.label : namespace.id,
         isGroup: true,
         padding: config.class!.padding ?? 16,
         // parent node must be one of [rect, roundedWithTitle, noteGroup, divider]
         shape: 'rect',
         cssStyles: [],
         look: config.look,
-        parentId: namespace.parent,
+        parentId: hierarchical ? namespace.parent : undefined,
       };
       nodes.push(node);
     }
 
     for (const classNode of this.classes.values()) {
+      const parentId = hierarchical
+        ? classNode.parent
+        : this.resolveExplicitAncestor(classNode.parent);
       const node: Node = {
         ...classNode,
         type: undefined,
         isGroup: false,
-        parentId: classNode.parent,
+        parentId,
         look: config.look,
       };
       nodes.push(node);
     }
 
     for (const note of this.notes.values()) {
+      const noteParentId = hierarchical ? note.parent : this.resolveExplicitAncestor(note.parent);
       const noteNode: Node = {
         id: note.id,
         label: note.text,
@@ -746,7 +788,7 @@ export class ClassDB implements DiagramDB {
           `stroke: ${config.themeVariables.noteBorderColor}`,
         ],
         look: config.look,
-        parentId: note.parent,
+        parentId: noteParentId,
         labelType: 'markdown',
       };
       nodes.push(noteNode);

--- a/packages/mermaid/src/diagrams/class/classDb.ts
+++ b/packages/mermaid/src/diagrams/class/classDb.ts
@@ -565,9 +565,10 @@ export class ClassDB implements DiagramDB {
     return ids;
   }
 
-  private createNamespaceNode(id: string, parentId?: string): NamespaceNode {
+  private createNamespaceNode(id: string, label: string, parentId?: string): NamespaceNode {
     return {
       id,
+      label,
       classes: new Map<string, ClassNode>(),
       notes: new Map<string, ClassNote>(),
       children: new Map<string, NamespaceNode>(),
@@ -596,13 +597,14 @@ export class ClassDB implements DiagramDB {
       return qualifiedId;
     }
 
+    const parts = qualifiedId.split('.');
     const ancestorIds = ClassDB.getAncestorIds(qualifiedId);
     for (let i = 0; i < ancestorIds.length; i++) {
       const currentId = ancestorIds[i];
       const parentId = i > 0 ? ancestorIds[i - 1] : undefined;
 
       if (!this.namespaces.has(currentId)) {
-        this.namespaces.set(currentId, this.createNamespaceNode(currentId, parentId));
+        this.namespaces.set(currentId, this.createNamespaceNode(currentId, parts[i], parentId));
       }
       if (parentId) {
         this.linkParentChild(parentId, currentId);
@@ -701,7 +703,7 @@ export class ClassDB implements DiagramDB {
     for (const namespace of this.namespaces.values()) {
       const node: Node = {
         id: namespace.id,
-        label: namespace.id,
+        label: namespace.label,
         isGroup: true,
         padding: config.class!.padding ?? 16,
         // parent node must be one of [rect, roundedWithTitle, noteGroup, divider]

--- a/packages/mermaid/src/diagrams/class/classDb.ts
+++ b/packages/mermaid/src/diagrams/class/classDb.ts
@@ -43,6 +43,7 @@ export class ClassDB implements DiagramDB {
   // private static classCounter = 0;
   private namespaces = new Map<string, NamespaceNode>();
   private namespaceCounter = 0;
+  private namespaceStack: string[] = [];
   private diagramId = '';
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
@@ -56,6 +57,7 @@ export class ClassDB implements DiagramDB {
     this.addRelation = this.addRelation.bind(this);
     this.addClassesToNamespace = this.addClassesToNamespace.bind(this);
     this.addNamespace = this.addNamespace.bind(this);
+    this.popNamespace = this.popNamespace.bind(this);
     this.setCssClass = this.setCssClass.bind(this);
     this.addMembers = this.addMembers.bind(this);
     this.addClass = this.addClass.bind(this);
@@ -177,6 +179,7 @@ export class ClassDB implements DiagramDB {
     this.functions.push(this.setupToolTips.bind(this));
     this.namespaces = new Map<string, NamespaceNode>();
     this.namespaceCounter = 0;
+    this.namespaceStack = [];
     this.diagramId = '';
     this.direction = 'TB';
     commonClear();
@@ -547,26 +550,70 @@ export class ClassDB implements DiagramDB {
     this.direction = dir;
   }
 
-  /**
-   * Function called by parser when a namespace definition has been found.
-   *
-   * @param id - ID of the namespace to add
-   * @public
-   */
-  public addNamespace(id: string) {
-    if (this.namespaces.has(id)) {
-      return;
-    }
+  private static resolveQualifiedId(id: string, stack: string[]): string {
+    const prefix = stack.at(-1);
+    return prefix ? `${prefix}.${id}` : id;
+  }
 
-    this.namespaces.set(id, {
-      id: id,
+  private static getAncestorIds(qualifiedId: string): string[] {
+    const parts = qualifiedId.split('.');
+    const ids: string[] = new Array(parts.length);
+    ids[0] = parts[0];
+    for (let i = 1; i < parts.length; i++) {
+      ids[i] = `${ids[i - 1]}.${parts[i]}`;
+    }
+    return ids;
+  }
+
+  private createNamespaceNode(id: string, parentId?: string): NamespaceNode {
+    return {
+      id,
       classes: new Map<string, ClassNode>(),
       notes: new Map<string, ClassNote>(),
       children: new Map<string, NamespaceNode>(),
-      domId: MERMAID_DOM_ID_PREFIX + id + '-' + this.namespaceCounter,
-    });
+      domId: MERMAID_DOM_ID_PREFIX + id + '-' + this.namespaceCounter++,
+      parent: parentId,
+    };
+  }
 
-    this.namespaceCounter++;
+  private linkParentChild(parentId: string, childId: string) {
+    const parent = this.namespaces.get(parentId);
+    const child = this.namespaces.get(childId);
+    if (!parent || !child) {
+      return;
+    }
+    if (!parent.children.has(childId)) {
+      parent.children.set(childId, child);
+    }
+    child.parent ??= parentId;
+  }
+
+  public addNamespace(id: string): string {
+    const qualifiedId = ClassDB.resolveQualifiedId(id, this.namespaceStack);
+    this.namespaceStack.push(qualifiedId);
+
+    if (this.namespaces.has(qualifiedId)) {
+      return qualifiedId;
+    }
+
+    const ancestorIds = ClassDB.getAncestorIds(qualifiedId);
+    for (let i = 0; i < ancestorIds.length; i++) {
+      const currentId = ancestorIds[i];
+      const parentId = i > 0 ? ancestorIds[i - 1] : undefined;
+
+      if (!this.namespaces.has(currentId)) {
+        this.namespaces.set(currentId, this.createNamespaceNode(currentId, parentId));
+      }
+      if (parentId) {
+        this.linkParentChild(parentId, currentId);
+      }
+    }
+
+    return qualifiedId;
+  }
+
+  public popNamespace() {
+    this.namespaceStack.pop();
   }
 
   public getNamespace(name: string): NamespaceNode {
@@ -661,6 +708,7 @@ export class ClassDB implements DiagramDB {
         shape: 'rect',
         cssStyles: [],
         look: config.look,
+        parentId: namespace.parent,
       };
       nodes.push(node);
     }

--- a/packages/mermaid/src/diagrams/class/classDb.ts
+++ b/packages/mermaid/src/diagrams/class/classDb.ts
@@ -591,6 +591,7 @@ export class ClassDB implements DiagramDB {
 
   public addNamespace(id: string, label?: string): string {
     const qualifiedId = ClassDB.resolveQualifiedId(id, this.namespaceStack);
+    // Push first — grammar guarantees a matching popNamespace in all cases, including re-declarations
     this.namespaceStack.push(qualifiedId);
 
     if (this.namespaces.has(qualifiedId)) {

--- a/packages/mermaid/src/diagrams/class/classDiagram.spec.ts
+++ b/packages/mermaid/src/diagrams/class/classDiagram.spec.ts
@@ -141,6 +141,25 @@ describe('given a basic class diagram, ', function () {
       expect(namespaces.get('Outer')!.children.has('Outer.Inner')).toBe(true);
     });
 
+    it('should support custom labels on namespaces', () => {
+      const str = `classDiagram
+        namespace Auth["Authentication Service"] {
+          class UserService {
+            +login()
+          }
+        }`;
+
+      parser.parse(str);
+
+      const namespaces = classDb.getNamespaces();
+      const auth = namespaces.get('Auth')!;
+      expect(auth.id).toBe('Auth');
+      expect(auth.label).toBe('Authentication Service');
+
+      const userService = classDb.getClass('UserService');
+      expect(userService.parent).toBe('Auth');
+    });
+
     it('should handle accTitle and accDescr', function () {
       const str = `classDiagram
             accTitle: My Title
@@ -556,7 +575,7 @@ class C13["With Città foreign language"]
         {
           "annotations": [],
           "cssClasses": "default",
-          "domId": "classId-Student-143",
+          "domId": "classId-Student-144",
           "id": "Student",
           "label": "Student",
           "members": [

--- a/packages/mermaid/src/diagrams/class/classDiagram.spec.ts
+++ b/packages/mermaid/src/diagrams/class/classDiagram.spec.ts
@@ -108,6 +108,12 @@ describe('given a basic class diagram, ', function () {
       expect(
         namespaces.get('Company.Project.Module')!.children.has('Company.Project.Module.SubModule')
       ).toBe(true);
+
+      // Only the user-declared leaves are marked explicit; intermediate ancestors are not.
+      expect(namespaces.get('Company.Project.Module.SubModule')!.explicit).toBe(true);
+      expect(namespaces.get('Company.Project.Module')!.explicit).toBe(true);
+      expect(namespaces.get('Company.Project')!.explicit).toBe(false);
+      expect(namespaces.get('Company')!.explicit).toBe(false);
     });
 
     it('should handle syntactically nested namespace blocks', () => {
@@ -139,6 +145,107 @@ describe('given a basic class diagram, ', function () {
       expect(namespaces.has('Outer.Inner')).toBe(true);
       expect(namespaces.get('Outer.Inner')!.parent).toBe('Outer');
       expect(namespaces.get('Outer')!.children.has('Outer.Inner')).toBe(true);
+
+      // Both are explicitly declared via syntactic nesting, so both are `explicit`.
+      expect(namespaces.get('Outer')!.explicit).toBe(true);
+      expect(namespaces.get('Outer.Inner')!.explicit).toBe(true);
+    });
+
+    it('emits only explicit namespaces from getData() in compact mode', async () => {
+      const { setConfig } = await import('../../diagram-api/diagramAPI.js');
+      const { reset } = await import('../../config.js');
+      // setConfig merges into the live config; reset restores defaults.
+      // We only touch `class.hierarchicalNamespaces` here.
+      setConfig({ class: { hierarchicalNamespaces: false } });
+      try {
+        const str = `classDiagram
+          namespace Company.Engineering.Backend {
+            class Developer {
+              +writeCode()
+            }
+          }
+          namespace Company {
+            class CEO {
+              +makeDecisions()
+            }
+          }`;
+
+        parser.parse(str);
+
+        const { nodes } = classDb.getData();
+        const groups = nodes.filter((n) => n.isGroup);
+        const groupIds = groups.map((n) => n.id).sort();
+
+        // Only the two user-declared namespaces survive — the implicit
+        // ancestors (Company.Engineering) are elided.
+        expect(groupIds).toEqual(['Company', 'Company.Engineering.Backend']);
+
+        // Labels are the full qualified id in compact mode.
+        const backend = groups.find((n) => n.id === 'Company.Engineering.Backend')!;
+        expect(backend.label).toBe('Company.Engineering.Backend');
+        // Compact mode flattens: namespaces have no parent.
+        expect(backend.parentId).toBeUndefined();
+
+        // Classes remain parented to their own declared namespace (which is explicit here).
+        const developer = nodes.find((n) => n.id === 'Developer')!;
+        expect(developer.parentId).toBe('Company.Engineering.Backend');
+        const ceo = nodes.find((n) => n.id === 'CEO')!;
+        expect(ceo.parentId).toBe('Company');
+      } finally {
+        reset();
+      }
+    });
+
+    it('moves classes inside implicit namespaces to the nearest explicit ancestor in compact mode', async () => {
+      const { setConfig } = await import('../../diagram-api/diagramAPI.js');
+      const { reset } = await import('../../config.js');
+      setConfig({ class: { hierarchicalNamespaces: false } });
+      try {
+        // `Company` is declared; `Company.Engineering` is auto-created by the
+        // dotted leaf declaration and has no explicit declaration of its own.
+        const str = `classDiagram
+          namespace Company.Engineering.Backend {
+            class Developer
+          }
+          namespace Company {
+            class CEO
+          }`;
+
+        parser.parse(str);
+        // Precondition: the implicit ancestor exists and is not explicit.
+        const namespaces = classDb.getNamespaces();
+        expect(namespaces.get('Company.Engineering')!.explicit).toBe(false);
+
+        const { nodes } = classDb.getData();
+        const groupIds = nodes
+          .filter((n) => n.isGroup)
+          .map((n) => n.id)
+          .sort();
+        expect(groupIds).toEqual(['Company', 'Company.Engineering.Backend']);
+      } finally {
+        reset();
+      }
+    });
+
+    it('defaults to hierarchical rendering when hierarchicalNamespaces is unset', () => {
+      const str = `classDiagram
+        namespace A.B {
+          class Foo
+        }`;
+
+      parser.parse(str);
+
+      const { nodes } = classDb.getData();
+      const groupIds = nodes
+        .filter((n) => n.isGroup)
+        .map((n) => n.id)
+        .sort();
+      // Both the implicit ancestor `A` and the declared leaf `A.B` render.
+      expect(groupIds).toEqual(['A', 'A.B']);
+      const leaf = nodes.find((n) => n.id === 'A.B')!;
+      // In hierarchical mode, the namespace label is just the short segment.
+      expect(leaf.label).toBe('B');
+      expect(leaf.parentId).toBe('A');
     });
 
     it('should support custom labels on namespaces', () => {
@@ -575,7 +682,7 @@ class C13["With Città foreign language"]
         {
           "annotations": [],
           "cssClasses": "default",
-          "domId": "classId-Student-144",
+          "domId": "classId-Student-149",
           "id": "Student",
           "label": "Student",
           "members": [

--- a/packages/mermaid/src/diagrams/class/classDiagram.spec.ts
+++ b/packages/mermaid/src/diagrams/class/classDiagram.spec.ts
@@ -86,6 +86,59 @@ describe('given a basic class diagram, ', function () {
       expect(relations[0].id1).toBe('Admin');
       expect(relations[0].id2).toBe('Report');
       expect(relations[0].title).toBe('generates');
+
+      // Verify intermediate namespaces were created with hierarchy
+      const namespaces = classDb.getNamespaces();
+      expect(namespaces.has('Company')).toBe(true);
+      expect(namespaces.has('Company.Project')).toBe(true);
+      expect(namespaces.has('Company.Project.Module')).toBe(true);
+      expect(namespaces.has('Company.Project.Module.SubModule')).toBe(true);
+
+      // Verify parent-child relationships
+      expect(namespaces.get('Company')!.parent).toBeUndefined();
+      expect(namespaces.get('Company.Project')!.parent).toBe('Company');
+      expect(namespaces.get('Company.Project.Module')!.parent).toBe('Company.Project');
+      expect(namespaces.get('Company.Project.Module.SubModule')!.parent).toBe(
+        'Company.Project.Module'
+      );
+
+      // Verify children maps
+      expect(namespaces.get('Company')!.children.has('Company.Project')).toBe(true);
+      expect(namespaces.get('Company.Project')!.children.has('Company.Project.Module')).toBe(true);
+      expect(
+        namespaces.get('Company.Project.Module')!.children.has('Company.Project.Module.SubModule')
+      ).toBe(true);
+    });
+
+    it('should handle syntactically nested namespace blocks', () => {
+      const str = `classDiagram
+        namespace Outer {
+          namespace Inner {
+            class Foo {
+              +bar()
+            }
+          }
+          class Baz {
+            +qux()
+          }
+        }`;
+
+      parser.parse(str);
+
+      const foo = classDb.getClass('Foo');
+      const baz = classDb.getClass('Baz');
+      const namespaces = classDb.getNamespaces();
+
+      // Foo should be in the qualified inner namespace
+      expect(foo.parent).toBe('Outer.Inner');
+      // Baz should be in the outer namespace
+      expect(baz.parent).toBe('Outer');
+
+      // Verify namespace hierarchy
+      expect(namespaces.has('Outer')).toBe(true);
+      expect(namespaces.has('Outer.Inner')).toBe(true);
+      expect(namespaces.get('Outer.Inner')!.parent).toBe('Outer');
+      expect(namespaces.get('Outer')!.children.has('Outer.Inner')).toBe(true);
     });
 
     it('should handle accTitle and accDescr', function () {
@@ -503,7 +556,7 @@ class C13["With Città foreign language"]
         {
           "annotations": [],
           "cssClasses": "default",
-          "domId": "classId-Student-141",
+          "domId": "classId-Student-143",
           "id": "Student",
           "label": "Student",
           "members": [

--- a/packages/mermaid/src/diagrams/class/classRenderer-v2.ts
+++ b/packages/mermaid/src/diagrams/class/classRenderer-v2.ts
@@ -48,8 +48,47 @@ export const addNamespaces = function (
   log.info('keys:', [...namespaces.keys()]);
   log.info(namespaces);
 
+  const hierarchical = getConfig().class?.hierarchicalNamespaces ?? true;
+  const classes: ClassMap = diagObj.db.getClasses();
+  const relations: ClassRelation[] = diagObj.db.getRelations();
+  const notes: ClassNoteMap = diagObj.db.getNotes();
+
+  // Walks up the namespace chain to the nearest ancestor (or self) flagged as
+  // user-declared. Used in compact mode to reassign descendants of implicit
+  // intermediate namespaces onto the nearest explicit box.
+  const resolveExplicitAncestor = (parentId?: string): string | undefined => {
+    let current = parentId;
+    while (current) {
+      const ns = namespaces.get(current);
+      if (!ns) {
+        return undefined;
+      }
+      if (ns.explicit) {
+        return current;
+      }
+      current = ns.parent;
+    }
+    return undefined;
+  };
+
+  // In compact mode, collapse each child's parent to its nearest explicit ancestor
+  // so addClasses/addNotes' filter-by-parent logic naturally groups them.
+  if (!hierarchical) {
+    classes.forEach((cls) => {
+      cls.parent = resolveExplicitAncestor(cls.parent);
+    });
+    notes.forEach((note) => {
+      note.parent = resolveExplicitAncestor(note.parent);
+    });
+  }
+
   // Iterate through each item in the vertex object (containing all the vertices found) in the graph definition
   namespaces.forEach(function (vertex) {
+    // Compact mode skips auto-created intermediate namespaces entirely
+    if (!hierarchical && !vertex.explicit) {
+      return;
+    }
+
     // parent node must be one of [rect, roundedWithTitle, noteGroup, divider]
     const shape = 'rect';
 
@@ -57,7 +96,7 @@ export const addNamespaces = function (
       shape: shape,
       id: vertex.id,
       domId: vertex.domId,
-      labelText: sanitizeText(vertex.label),
+      labelText: sanitizeText(hierarchical ? vertex.label : vertex.id),
       labelStyle: '',
       style: 'fill: none; stroke: black',
       // TODO V10: Flowchart ? Keeping flowchart for backwards compatibility. Remove in next major release
@@ -66,14 +105,19 @@ export const addNamespaces = function (
 
     g.setNode(vertex.id, node);
 
-    if (vertex.parent && g.hasNode(vertex.parent)) {
+    if (hierarchical && vertex.parent && g.hasNode(vertex.parent)) {
       g.setParent(vertex.id, vertex.parent);
     }
 
-    addClasses(vertex.classes, g, _id, diagObj, vertex.id);
-    const classes: ClassMap = diagObj.db.getClasses();
-    const relations: ClassRelation[] = diagObj.db.getRelations();
-    addNotes(vertex.notes, g, relations.length + 1, classes, vertex.id);
+    if (hierarchical) {
+      addClasses(vertex.classes, g, _id, diagObj, vertex.id);
+      addNotes(vertex.notes, g, relations.length + 1, classes, vertex.id);
+    } else {
+      // Classes/notes have already been reassigned above; use the global maps so
+      // descendants of implicit ancestors get picked up here.
+      addClasses(classes, g, _id, diagObj, vertex.id);
+      addNotes(notes, g, relations.length + 1, classes, vertex.id);
+    }
 
     log.info('setNode', node);
   });

--- a/packages/mermaid/src/diagrams/class/classRenderer-v2.ts
+++ b/packages/mermaid/src/diagrams/class/classRenderer-v2.ts
@@ -65,6 +65,11 @@ export const addNamespaces = function (
     };
 
     g.setNode(vertex.id, node);
+
+    if (vertex.parent && g.hasNode(vertex.parent)) {
+      g.setParent(vertex.id, vertex.parent);
+    }
+
     addClasses(vertex.classes, g, _id, diagObj, vertex.id);
     const classes: ClassMap = diagObj.db.getClasses();
     const relations: ClassRelation[] = diagObj.db.getRelations();

--- a/packages/mermaid/src/diagrams/class/classRenderer-v2.ts
+++ b/packages/mermaid/src/diagrams/class/classRenderer-v2.ts
@@ -57,7 +57,7 @@ export const addNamespaces = function (
       shape: shape,
       id: vertex.id,
       domId: vertex.domId,
-      labelText: sanitizeText(vertex.id),
+      labelText: sanitizeText(vertex.label),
       labelStyle: '',
       style: 'fill: none; stroke: black',
       // TODO V10: Flowchart ? Keeping flowchart for backwards compatibility. Remove in next major release

--- a/packages/mermaid/src/diagrams/class/classTypes.ts
+++ b/packages/mermaid/src/diagrams/class/classTypes.ts
@@ -183,6 +183,12 @@ export interface NamespaceNode {
   notes: ClassNoteMap;
   children: NamespaceMap;
   parent?: string;
+  /**
+   * True if this namespace was explicitly declared by the user (e.g. `namespace A.B { ... }`).
+   * False for intermediate ancestors auto-created when parsing a dotted name.
+   * Used by compact (non-hierarchical) rendering mode to only emit declared namespaces.
+   */
+  explicit: boolean;
 }
 
 export interface StyleClass {

--- a/packages/mermaid/src/diagrams/class/classTypes.ts
+++ b/packages/mermaid/src/diagrams/class/classTypes.ts
@@ -177,6 +177,7 @@ export interface Interface {
 
 export interface NamespaceNode {
   id: string;
+  label: string;
   domId: string;
   classes: ClassMap;
   notes: ClassNoteMap;

--- a/packages/mermaid/src/diagrams/class/classTypes.ts
+++ b/packages/mermaid/src/diagrams/class/classTypes.ts
@@ -181,6 +181,7 @@ export interface NamespaceNode {
   classes: ClassMap;
   notes: ClassNoteMap;
   children: NamespaceMap;
+  parent?: string;
 }
 
 export interface StyleClass {

--- a/packages/mermaid/src/diagrams/class/parser/classDiagram.jison
+++ b/packages/mermaid/src/diagrams/class/parser/classDiagram.jison
@@ -63,10 +63,11 @@ Function arguments are optional: 'call <callback_name>()' simply executes 'callb
 "style"                         return 'STYLE';
 "classDef"                      return 'CLASSDEF';
 
-<INITIAL,namespace>"namespace"  { this.begin('namespace'); return 'NAMESPACE'; }
+<INITIAL,namespace,namespace-body>"namespace"  { this.begin('namespace'); return 'NAMESPACE'; }
 <namespace>\s*(\r?\n)+          { this.popState(); return 'NEWLINE'; }
 <namespace>\s+                  /* skip whitespace */
 <namespace>[{]                  { this.begin("namespace-body"); return 'STRUCT_START';}
+<namespace>[}]                  { this.popState(); this.less(0); }
 <namespace-body>[}]             { this.popState(); return 'STRUCT_STOP'; }
 <namespace-body><<EOF>>         return "EOF_IN_STRUCT";
 <namespace-body>\s*(\r?\n)+     return 'NEWLINE';
@@ -275,12 +276,12 @@ statement
     ;
 
 namespaceStatement
-    : namespaceIdentifier STRUCT_START classStatements STRUCT_STOP          { yy.addClassesToNamespace($1, $3[0], $3[1]); }
-    | namespaceIdentifier STRUCT_START NEWLINE classStatements STRUCT_STOP  { yy.addClassesToNamespace($1, $4[0], $4[1]); }
+    : namespaceIdentifier STRUCT_START classStatements STRUCT_STOP          { yy.addClassesToNamespace($1, $3[0], $3[1]); yy.popNamespace(); }
+    | namespaceIdentifier STRUCT_START NEWLINE classStatements STRUCT_STOP  { yy.addClassesToNamespace($1, $4[0], $4[1]); yy.popNamespace(); }
     ;
 
 namespaceIdentifier
-    : NAMESPACE namespaceName { $$=$2; yy.addNamespace($2); }
+    : NAMESPACE namespaceName { $$=yy.addNamespace($2); }
     ;
 
 classStatements
@@ -290,6 +291,9 @@ classStatements
     | noteStatement                             {$$=[[], [$1]]}
     | noteStatement NEWLINE                     {$$=[[], [$1]]}
     | noteStatement NEWLINE classStatements     {$3[1].unshift($1); $$=$3}
+    | namespaceStatement                        {$$=[[], []]}
+    | namespaceStatement NEWLINE                {$$=[[], []]}
+    | namespaceStatement NEWLINE classStatements {$$=$3}
     ;
 
 classStatement

--- a/packages/mermaid/src/diagrams/class/parser/classDiagram.jison
+++ b/packages/mermaid/src/diagrams/class/parser/classDiagram.jison
@@ -282,6 +282,7 @@ namespaceStatement
 
 namespaceIdentifier
     : NAMESPACE namespaceName { $$=yy.addNamespace($2); }
+    | NAMESPACE namespaceName classLabel { $$=yy.addNamespace($2, $3); }
     ;
 
 classStatements

--- a/packages/mermaid/src/docs/syntax/classDiagram.md
+++ b/packages/mermaid/src/docs/syntax/classDiagram.md
@@ -320,6 +320,22 @@ namespace BaseShapes {
 }
 ```
 
+### Namespace Labels (v<MERMAID_RELEASE_VERSION>+)
+
+A namespace can be given a display label using square bracket syntax, similar to class labels:
+
+```mermaid-example
+classDiagram
+    namespace Auth["Authentication Service"] {
+        class UserService {
+            +login()
+            +logout()
+        }
+    }
+```
+
+The label replaces the namespace name in the rendered diagram, while the name is still used internally for relationships and nesting.
+
 ### Nested Namespaces (v<MERMAID_RELEASE_VERSION>+)
 
 Namespaces can be nested to represent hierarchical groupings. There are two ways to define nested namespaces:

--- a/packages/mermaid/src/docs/syntax/classDiagram.md
+++ b/packages/mermaid/src/docs/syntax/classDiagram.md
@@ -320,6 +320,60 @@ namespace BaseShapes {
 }
 ```
 
+### Nested Namespaces (v<MERMAID_RELEASE_VERSION>+)
+
+Namespaces can be nested to represent hierarchical groupings. There are two ways to define nested namespaces:
+
+**Dot notation** creates intermediate namespaces automatically:
+
+```mermaid-example
+classDiagram
+    namespace Company.Engineering.Backend {
+        class Developer {
+            +writeCode()
+        }
+    }
+    namespace Company.Engineering.Frontend {
+        class Designer {
+            +createMockup()
+        }
+    }
+    namespace Company.Engineering {
+        class TechLead {
+            +planSprint()
+        }
+    }
+    TechLead --> Developer : leads
+    TechLead --> Designer : leads
+```
+
+**Syntactic nesting** places namespace blocks inside other namespace blocks:
+
+```mermaid-example
+classDiagram
+    namespace Platform {
+        namespace Auth {
+            class UserService {
+                +login()
+                +logout()
+            }
+        }
+        namespace Data {
+            class Repository {
+                +find()
+                +save()
+            }
+        }
+        class Gateway {
+            +route()
+        }
+    }
+    Gateway --> UserService : delegates
+    Gateway --> Repository : delegates
+```
+
+Both approaches can be combined. Dot notation like `namespace A.B.C` will automatically create namespaces `A` and `A.B` as parents if they don't already exist.
+
 ## Cardinality / Multiplicity on relations
 
 Multiplicity or cardinality in class diagrams indicates the number of instances of one class that can be linked to an instance of the other class. For example, each company will have one or more employees (not zero), and each employee currently works for zero or one companies.

--- a/packages/mermaid/src/docs/syntax/classDiagram.md
+++ b/packages/mermaid/src/docs/syntax/classDiagram.md
@@ -390,6 +390,38 @@ classDiagram
 
 Both approaches can be combined. Dot notation like `namespace A.B.C` will automatically create namespaces `A` and `A.B` as parents if they don't already exist.
 
+#### Compact rendering (`hierarchicalNamespaces: false`)
+
+By default (`hierarchicalNamespaces: true`), each segment of a dotted or syntactically-nested namespace name renders as its own cluster, producing a nested layout.
+
+Setting `hierarchicalNamespaces: false` in the class diagram config switches to **compact mode**: only namespaces the user explicitly declares are drawn — each as a single flat box labelled with its fully-qualified name. Auto-created intermediate ancestors are skipped, and classes inside them are moved to their nearest declared namespace.
+
+```mermaid-example
+---
+config:
+  class:
+    hierarchicalNamespaces: false
+---
+classDiagram
+    namespace Company.Engineering.Backend {
+        class Developer {
+            +writeCode()
+        }
+    }
+    namespace Company.Engineering.Frontend {
+        class Designer {
+            +createMockup()
+        }
+    }
+    namespace Company {
+        class CEO {
+            +makeDecisions()
+        }
+    }
+    CEO --> Developer : oversees
+    CEO --> Designer : oversees
+```
+
 ## Cardinality / Multiplicity on relations
 
 Multiplicity or cardinality in class diagrams indicates the number of instances of one class that can be linked to an instance of the other class. For example, each company will have one or more employees (not zero), and each employee currently works for zero or one companies.

--- a/packages/mermaid/src/schemas/config.schema.yaml
+++ b/packages/mermaid/src/schemas/config.schema.yaml
@@ -1540,6 +1540,15 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
       hideEmptyMembersBox:
         type: boolean
         default: false
+      hierarchicalNamespaces:
+        type: boolean
+        default: true
+        description: |
+          When true (default), nested namespaces render as hierarchical clusters,
+          with each segment of a dotted name (e.g. `A.B.C`) becoming its own nested
+          box. When false, namespaces render in compact mode: only explicitly
+          declared namespaces are emitted and their full qualified name is used as
+          a single flat label.
 
   JourneyDiagramConfig:
     title: Journey Diagram Config


### PR DESCRIPTION
## :bookmark_tabs: Summary

Restores and properly implements nested namespace support for class diagrams, which regressed between 11.3.0 and 11.4.x. Both dot notation (`namespace A.B.C`) and syntactic nesting (`namespace A { namespace B {} }`) now create hierarchical namespace clusters in the rendered diagram.

Resolves #3384, #4618, #5487, #6085
Partial: #6018

## :straight_ruler: Design Decisions

- **Dot notation** (`namespace A.B.C {}`): `addNamespace` splits on `.` and creates intermediate namespace nodes (`A`, `A.B`, `A.B.C`) with parent-child relationships wired up automatically.
- **Syntactic nesting** (`namespace A { namespace B {} }`): A namespace stack in `classDb` tracks the current context. `addNamespace` prepends the stack prefix to resolve qualified names, and `popNamespace` is called when each namespace block closes.
- Both the v2 (dagre) renderer via `g.setParent` and v3 (unified) renderer via `parentId` on namespace nodes support the hierarchy.
- The core logic is decomposed into pure helpers: `resolveQualifiedId`, `getAncestorIds`, `createNamespaceNode`, `linkParentChild`.

### :clipboard: Tasks

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts.

Co-Authored-By: Claude Opus 4.6 (prompted with care by @M-a-c)

additonal:
kept the bot to O(n) solutions as much as possible, pure functions, and verified changes, 9 yoe in typescript these changes look good, your code base has a lack of tests for anything not on the higher level