### PR TITLE
fix: support nested generic types in class diagram definitions

### DIFF
--- a/.changeset/nested-generics-fix.md
+++ b/.changeset/nested-generics-fix.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: support nested generic types in class diagram definitions (e.g. `List~List~Person~~`)

--- a/packages/mermaid/src/diagrams/class/classDb.ts
+++ b/packages/mermaid/src/diagrams/class/classDb.ts
@@ -80,10 +80,11 @@ export class ClassDB implements DiagramDB {
     let genericType = '';
     let className = id;
 
-    if (id.indexOf('~') > 0) {
-      const split = id.split('~');
-      className = sanitizeText(split[0]);
-      genericType = sanitizeText(split[1]);
+    const firstTilde = id.indexOf('~');
+    if (firstTilde > 0) {
+      const lastTilde = id.lastIndexOf('~');
+      className = sanitizeText(id.substring(0, firstTilde));
+      genericType = sanitizeText(id.substring(firstTilde + 1, lastTilde));
     }
 
     return { className: className, type: genericType };

--- a/packages/mermaid/src/diagrams/class/classDiagram.spec.ts
+++ b/packages/mermaid/src/diagrams/class/classDiagram.spec.ts
@@ -1246,6 +1246,11 @@ describe('given a class diagram with generics, ', function () {
         'classDiagram\n' + 'class People~List~Person~~\n' + 'People -- Person : contains >';
 
       parser.parse(str);
+
+      const relations = classDb.getRelations();
+      expect(relations).toHaveLength(1);
+      expect(relations[0].id1).toBe('People');
+      expect(relations[0].id2).toBe('Person');
     });
 
     it('should handle nested generic class with brackets', function () {
@@ -1260,6 +1265,18 @@ describe('given a class diagram with generics, ', function () {
 
       const classNode = classDb.getClass('People');
       expect(classNode.type).toBe('List~Person~');
+    });
+
+    it('should handle empty generic class (no type parameter)', function () {
+      const str = 'classDiagram\n' + 'class Empty~~';
+
+      parser.parse(str);
+
+      // Empty generics (`~~`) produce no GENERICTYPE token, so the class
+      // is parsed without a type parameter — matching pre-existing behavior
+      const classNode = classDb.getClass('Empty');
+      expect(classNode).toBeDefined();
+      expect(classNode.type).toBe('');
     });
 
     it('should handle "namespace"', function () {

--- a/packages/mermaid/src/diagrams/class/classDiagram.spec.ts
+++ b/packages/mermaid/src/diagrams/class/classDiagram.spec.ts
@@ -1223,6 +1223,45 @@ describe('given a class diagram with generics, ', function () {
       parser.parse(str);
     });
 
+    it('should handle nested generic class', function () {
+      const str = 'classDiagram\n' + 'class People~List~Person~~';
+
+      parser.parse(str);
+
+      const classNode = classDb.getClass('People');
+      expect(classNode.type).toBe('List~Person~');
+    });
+
+    it('should handle deeply nested generic class', function () {
+      const str = 'classDiagram\n' + 'class Container~List~List~String~~~';
+
+      parser.parse(str);
+
+      const classNode = classDb.getClass('Container');
+      expect(classNode.type).toBe('List~List~String~~');
+    });
+
+    it('should handle nested generic class with relationships', function () {
+      const str =
+        'classDiagram\n' + 'class People~List~Person~~\n' + 'People -- Person : contains >';
+
+      parser.parse(str);
+    });
+
+    it('should handle nested generic class with brackets', function () {
+      const str =
+        'classDiagram\n' +
+        'class People~List~Person~~ {\n' +
+        'String name\n' +
+        'void add()\n' +
+        '}';
+
+      parser.parse(str);
+
+      const classNode = classDb.getClass('People');
+      expect(classNode.type).toBe('List~Person~');
+    });
+
     it('should handle "namespace"', function () {
       const str = `classDiagram
 namespace Namespace1 { class Class1 }

--- a/packages/mermaid/src/diagrams/class/parser/classDiagram.jison
+++ b/packages/mermaid/src/diagrams/class/parser/classDiagram.jison
@@ -102,6 +102,23 @@ line was introduced with 'click'.
 */
 <*>"href"                       return 'HREF';
 
+/*
+  Nested generic type support: track depth so `List~List~Person~~` is captured
+  as a single GENERICTYPE token with content `List~Person~`.
+
+  On each `~` inside the generic state, peek at the next character to decide:
+    - word char (\w) → opening a nested generic, increment depth
+    - anything else  → closing current level, decrement depth
+  When depth hits 0, pop state and emit the accumulated content.
+
+  This heuristic assumes generic type parameters contain identifier-like content.
+  Leading whitespace or punctuation inside generics (e.g. `Map~ Key~`) will close
+  the type prematurely — matching pre-existing behavior.
+
+  Empty generics (`~~`) intentionally skip emitting a GENERICTYPE token since the
+  grammar's className rule requires content between the tildes. An empty generic
+  simply produces no token and the class name is parsed without a type parameter.
+*/
 <generic>[^~]+                  %{ this._gContent += yytext; %}
 <generic>"~"                    %{
     var nextCh = this._input.length > 0 ? this._input.charAt(0) : '';

--- a/packages/mermaid/src/diagrams/class/parser/classDiagram.jison
+++ b/packages/mermaid/src/diagrams/class/parser/classDiagram.jison
@@ -102,9 +102,24 @@ line was introduced with 'click'.
 */
 <*>"href"                       return 'HREF';
 
-<generic>[~]                    this.popState();
-<generic>[^~]*                  return "GENERICTYPE";
-<*>"~"                          this.begin("generic");
+<generic>[^~]+                  %{ this._gContent += yytext; %}
+<generic>"~"                    %{
+    var nextCh = this._input.length > 0 ? this._input.charAt(0) : '';
+    if (/\w/.test(nextCh)) {
+        this._gDepth++;
+        this._gContent += '~';
+    } else {
+        this._gDepth--;
+        if (this._gDepth > 0) {
+            this._gContent += '~';
+        } else {
+            this.popState();
+            yytext = this._gContent;
+            if (this._gContent.length > 0) return "GENERICTYPE";
+        }
+    }
+%}
+<*>"~"                          %{ this.begin("generic"); this._gDepth = 1; this._gContent = ''; %}
 
 <bqstring>[`]                   this.popState();
 <bqstring>[^`]+                 return "BQUOTE_STR";


### PR DESCRIPTION
The jison lexer for class diagrams could not handle nested generic types like `List~List~Person~~` because each `~` inside the generic state immediately exited it. This adds depth tracking to the lexer so nested tildes are correctly captured as a single GENERICTYPE token, and fixes splitClassNameAndType to extract content between the first and last `~`.

Resolves #7480

## :bookmark_tabs: Summary

The class diagram parser failed on nested generic types (e.g. `class People~List~Person~~`) because the jison lexer's `<generic>` state exited at every `~` with no concept of nesting depth. This PR fixes the lexer to track depth and accumulate nested content, and updates `splitClassNameAndType` to correctly extract the full generic type string.

## :straight_ruler: Design Decisions

**Lexer (`classDiagram.jison`):** Replaced the three simple generic-state rules with depth-tracking logic. When a `~` is encountered inside the generic state, the lexer checks the next character — if it's a word character (`\w`), the tilde opens a nested generic (depth++); otherwise it closes one (depth--). Content accumulates in a buffer and `GENERICTYPE` is only returned when depth reaches 0.

**`splitClassNameAndType` (`classDb.ts`):** Changed from `id.split('~')[1]` (which broke on multiple tildes) to using `indexOf`/`lastIndexOf` to extract everything between the first and last `~`.

### :clipboard: Tasks

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

:robot: Co-authored by Claude Opus 4.6 (guided with care by @M-a-c)


<img width="1908" height="479" alt="Screenshot 2026-04-11 205447" src="https://github.com/user-attachments/assets/ceea8c24-f3bb-4d52-adab-0f13111d3345" />
