### PR TITLE
fix: support dashed CSS properties and functions in class diagram styles

### DIFF
--- a/.changeset/css-dash-in-styles.md
+++ b/.changeset/css-dash-in-styles.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: support dashed CSS properties, decimals, functions, and punctuation in class diagram style statements

--- a/demos/classchart.html
+++ b/demos/classchart.html
@@ -284,7 +284,7 @@
       Service --> Logger
       Service --> Cache
       Cache --> Config
-      style Controller fill:#f9f,font-family:Arial,font-size:14px
+      style Controller fill:#f9f,font-family:Comic Sans MS,font-size:18px
       style Service fill:rgb(200 230 255),font-weight:bold
       style Repository fill:#dfd,stroke:#393,stroke-width:2px
       style Logger fill:#ffd,stroke-dasharray:5,stroke:#aa0,stroke-width:1.5px

--- a/demos/classchart.html
+++ b/demos/classchart.html
@@ -255,6 +255,44 @@
     </pre>
     <hr />
 
+    <pre class="mermaid">
+    classDiagram
+      class Controller {
+        +handleRequest()
+      }
+      class Service {
+        -List~String~ items
+        +process()
+      }
+      class Repository {
+        +save()
+        +find()
+      }
+      class Logger {
+        +log(message)
+      }
+      class Cache {
+        +get(key)
+        +set(key)
+      }
+      class Config {
+        +String env
+        +load()
+      }
+      Controller --> Service
+      Service --> Repository
+      Service --> Logger
+      Service --> Cache
+      Cache --> Config
+      style Controller fill:#f9f,font-family:Arial,font-size:14px
+      style Service fill:rgb(200 230 255),font-weight:bold
+      style Repository fill:#dfd,stroke:#393,stroke-width:2px
+      style Logger fill:#ffd,stroke-dasharray:5,stroke:#aa0,stroke-width:1.5px
+      style Cache fill:#eef,stroke:#33a,stroke-width:3px,opacity:0.85
+      style Config fill:#fee,font-style:italic,stroke:#a33,stroke-width:2px
+    </pre>
+    <hr />
+
     <script type="module">
       import mermaid from './mermaid.esm.mjs';
       mermaid.initialize({

--- a/packages/examples/src/examples/class.ts
+++ b/packages/examples/src/examples/class.ts
@@ -30,5 +30,25 @@ export default {
       +run()
     }`,
     },
+    {
+      title: 'Class Styling',
+      code: `classDiagram
+    class Controller {
+      +handleRequest()
+    }
+    class Service {
+      -List~String~ items
+      +process()
+    }
+    class Repository {
+      +save()
+      +find()
+    }
+    Controller --> Service
+    Service --> Repository
+    style Controller fill:#f9f,font-family:Arial,font-size:14px
+    style Service fill:rgb(200 230 255),opacity:0.9,font-weight:bold
+    style Repository fill:#dfd,stroke:#393,stroke-width:2px`,
+    },
   ],
 } satisfies DiagramMetadata;

--- a/packages/mermaid/src/diagrams/class/classDiagram.spec.ts
+++ b/packages/mermaid/src/diagrams/class/classDiagram.spec.ts
@@ -1992,6 +1992,95 @@ class C13["With Città foreign language"]
   });
 });
 
+describe('given a class diagram with inline styles, ', function () {
+  let classDb: ClassDB;
+
+  beforeEach(function () {
+    classDb = new ClassDB();
+    parser.yy = classDb;
+    classDb.clear();
+  });
+
+  it('should handle style with simple CSS properties', function () {
+    const str = `classDiagram
+class C1
+style C1 fill:#f9f`;
+
+    parser.parse(str);
+
+    const c1 = classDb.getClass('C1');
+    expect(c1.styles).toContain('fill:#f9f');
+  });
+
+  it('should handle style with dashed CSS property names', function () {
+    const str = `classDiagram
+class C1
+style C1 font-family:Arial`;
+
+    parser.parse(str);
+
+    const c1 = classDb.getClass('C1');
+    expect(c1.styles).toContain('font-family:Arial');
+  });
+
+  it('should handle style with multiple dashed CSS properties', function () {
+    const str = `classDiagram
+class C1
+style C1 font-family:Arial,font-size:14px,background-color:#fff`;
+
+    parser.parse(str);
+
+    const c1 = classDb.getClass('C1');
+    expect(c1.styles).toContain('font-family:Arial');
+    expect(c1.styles).toContain('font-size:14px');
+    expect(c1.styles).toContain('background-color:#fff');
+  });
+
+  it('should handle style with decimal values in CSS properties', function () {
+    const str = `classDiagram
+class C1
+style C1 opacity:0.5`;
+
+    parser.parse(str);
+
+    const c1 = classDb.getClass('C1');
+    expect(c1.styles).toContain('opacity:0.5');
+  });
+
+  it('should handle style with !important', function () {
+    const str = `classDiagram
+class C1
+style C1 fill:#f9f!important`;
+
+    parser.parse(str);
+
+    const c1 = classDb.getClass('C1');
+    expect(c1.styles).toContain('fill:#f9f!important');
+  });
+
+  it('should handle style with CSS functions like rgb()', function () {
+    const str = `classDiagram
+class C1
+style C1 fill:rgb(255 0 0)`;
+
+    parser.parse(str);
+
+    const c1 = classDb.getClass('C1');
+    expect(c1.styles).toContain('fill:rgb(255 0 0)');
+  });
+
+  it('should handle style with calc()', function () {
+    const str = `classDiagram
+class C1
+style C1 width:calc(100% - 20px)`;
+
+    parser.parse(str);
+
+    const c1 = classDb.getClass('C1');
+    expect(c1.styles).toContain('width:calc(100% - 20px)');
+  });
+});
+
 describe('class db class', () => {
   let classDb: ClassDB;
   beforeEach(() => {

--- a/packages/mermaid/src/diagrams/class/parser/classDiagram.jison
+++ b/packages/mermaid/src/diagrams/class/parser/classDiagram.jison
@@ -139,6 +139,8 @@ line was introduced with 'click'.
 <*>\w+                          return 'ALPHA';
 <*>"["                          return 'SQS';
 <*>"]"                          return 'SQE';
+<*>"("                          return 'LPAREN';
+<*>")"                          return 'RPAREN';
 <*>[!"#$%&'*+,-.`?\\/]          return 'PUNCTUATION';
 <*>[0-9]+                       return 'NUM';
 <*>[\u00AA\u00B5\u00BA\u00C0-\u00D6\u00D8-\u00F6]|
@@ -418,7 +420,7 @@ style
     | style styleComponent  {$$ = $style + $styleComponent;}
     ;
 
-styleComponent: ALPHA | NUM | COLON | UNIT | SPACE | BRKT | STYLE | PCT | LABEL;
+styleComponent: ALPHA | NUM | COLON | UNIT | SPACE | BRKT | STYLE | PCT | LABEL | MINUS | DOT | PLUS | PUNCTUATION | LPAREN | RPAREN;
 
 commentToken   : textToken | graphCodeTokens ;
 


### PR DESCRIPTION
The styleComponent grammar rule was missing tokens needed for common CSS syntax. Added MINUS (for dashed properties like font-family), DOT (for decimals like 0.5), PLUS (for calc expressions), PUNCTUATION (for !important), and LPAREN/RPAREN (for CSS functions like rgb() and calc()).

Also added a styling demo to classchart.html and a class styling example.

Resolves #7306

## :bookmark_tabs: Summary

Brief description about the content of your PR.

Resolves #<your issue id here>

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.


<img width="663" height="577" alt="Screenshot 2026-04-11 220651" src="https://github.com/user-attachments/assets/1c51c10c-d6ff-4743-8ad3-39dc94b1caa3" />
