### PR TITLE
fix(eventmodeling): avoid shipping pre-release screen terminology

### DIFF
--- a/.changeset/three-melons-argue.md
+++ b/.changeset/three-melons-argue.md
@@ -1,0 +1,6 @@
+---
+'mermaid': major
+'@mermaid-js/parser': major
+---
+
+fix: replace Event Modeling `screen` / `scn` terminology with `ui`

--- a/cypress/integration/rendering/eventmodeling.spec.ts
+++ b/cypress/integration/rendering/eventmodeling.spec.ts
@@ -18,7 +18,7 @@ describe('Event Modeling Diagram', () => {
     imgSnapshotTest(
       `eventmodeling
 
-tf 01 scn CartScreen
+tf 01 ui CartScreen
 tf 02 cmd AddItem
 tf 03 evt ItemAdded
     `,
@@ -32,7 +32,7 @@ tf 03 evt ItemAdded
     imgSnapshotTest(
       `eventmodeling
 
-tf 01 scn CartScreen
+tf 01 ui CartScreen
 tf 02 cmd AddItem
 tf 03 evt ItemAdded
 tf 04 cmd RemoveItem
@@ -48,7 +48,7 @@ tf 05 evt ItemRemoved
     imgSnapshotTest(
       `eventmodeling
 
-tf 01 scn CartScreen
+tf 01 ui CartScreen
 tf 02 cmd AddItem
 tf 03 evt ItemAdded
 tf 04 rmo CartItems ->> 03
@@ -64,7 +64,7 @@ tf 05 evt AccountingItemAdded
     imgSnapshotTest(
       `eventmodeling
 
-tf 01 scn CartScreen
+tf 01 ui CartScreen
 tf 02 cmd AddItem { productId: 7 }
 tf 03 evt ItemAdded [[ItemAddedData]]
 
@@ -84,7 +84,7 @@ data ItemAddedData
     imgSnapshotTest(
       `eventmodeling
 
-tf 01 scn CartScreen
+tf 01 ui CartScreen
 tf 02 cmd Inventory.AddItem
 tf 03 evt Inventory.ItemAdded
     `,
@@ -98,7 +98,7 @@ tf 03 evt Inventory.ItemAdded
     imgSnapshotTest(
       `eventmodeling
 
-tf 01 scn CartScreen
+tf 01 ui CartScreen
 tf 02 cmd AddItem
 tf 03 cmd RemoveItem
 tf 04 evt ItemChanged ->> 02 ->> 03

--- a/docs/syntax/eventmodeling.md
+++ b/docs/syntax/eventmodeling.md
@@ -14,7 +14,7 @@ You can read more at [Event Modeling web page](https://eventmodeling.org/).
 
 Event Modeling diagram is composed of a few main entities:
 
-- Trigger - Screen and Processor
+- Trigger - UI and Processor
 - Command
 - View / Read Model
 - Event
@@ -43,7 +43,7 @@ The timeline is the key part of the diagram and it is composed of **Time Frame**
 ```md
 eventmodeling
 
-tf 01 scn CartScreen
+tf 01 ui CartUI
 tf 02 cmd AddItem
 tf 03 evt ItemAdded
 ```
@@ -53,7 +53,7 @@ rendering to
 ```mermaid-example
 eventmodeling
 
-tf 01 scn CartScreen
+tf 01 ui CartUI
 tf 02 cmd AddItem
 tf 03 evt ItemAdded
 ```
@@ -61,21 +61,21 @@ tf 03 evt ItemAdded
 ```mermaid
 eventmodeling
 
-tf 01 scn CartScreen
+tf 01 ui CartUI
 tf 02 cmd AddItem
 tf 03 evt ItemAdded
 ```
 
 Each Time Frame is referenced by a **unique number** in order to distinguish one from another and also to be able to reference it when needed. Depending on the complexity of the diagram it should be enough to have just two digit number or more. Imagine you are typing a BASIC program on your ZX Spectrum always starting with a two digit number, but the order of the numbers does not matter, just the uniqueness in the whole timeline.
 
-The Time Frame also contains an **Entity Identifier**, e.g. in case of `01` Time Frame it is `CartScreen`. One Entity Identifier can be used multiple times in the timeline for example when you want to express invocations of the same event in different points in time.
+The Time Frame also contains an **Entity Identifier**, e.g. in case of `01` Time Frame it is `CartUI`. One Entity Identifier can be used multiple times in the timeline for example when you want to express invocations of the same event in different points in time.
 
 Relaxed notation would look like this:
 
 ```md
 eventmodeling
 
-timeframe 01 screen CartScreen
+timeframe 01 ui CartUI
 timeframe 02 command AddItem
 timeframe 03 event ItemAdded
 ```
@@ -89,7 +89,7 @@ Compact version:
 ```mermaid-example
 eventmodeling
 
-tf 01 scn CartScreen
+tf 01 ui CartUI
 tf 02 cmd AddItem { description: string }
 tf 03 evt ItemAdded { description: string }
 ```
@@ -97,7 +97,7 @@ tf 03 evt ItemAdded { description: string }
 ```mermaid
 eventmodeling
 
-tf 01 scn CartScreen
+tf 01 ui CartUI
 tf 02 cmd AddItem { description: string }
 tf 03 evt ItemAdded { description: string }
 ```
@@ -107,7 +107,7 @@ Relaxed version:
 ```mermaid-example
 eventmodeling
 
-timeframe 01 screen CartScreen
+timeframe 01 ui CartUI
 timeframe 02 command AddItem { description: string }
 timeframe 03 event ItemAdded { description: string }
 ```
@@ -115,7 +115,7 @@ timeframe 03 event ItemAdded { description: string }
 ```mermaid
 eventmodeling
 
-timeframe 01 screen CartScreen
+timeframe 01 ui CartUI
 timeframe 02 command AddItem { description: string }
 timeframe 03 event ItemAdded { description: string }
 ```
@@ -131,7 +131,7 @@ Compact version:
 ```mermaid-example
 eventmodeling
 
-tf 01 scn CartScreen
+tf 01 ui CartUI
 tf 02 cmd AddItem [[AddItem01]]
 tf 03 evt ItemAdded [[ItemAdded]]
 tf 04 cmd AddItem [[AddItem02]]
@@ -159,7 +159,7 @@ data ItemAdded {
 ```mermaid
 eventmodeling
 
-tf 01 scn CartScreen
+tf 01 ui CartUI
 tf 02 cmd AddItem [[AddItem01]]
 tf 03 evt ItemAdded [[ItemAdded]]
 tf 04 cmd AddItem [[AddItem02]]
@@ -189,7 +189,7 @@ Relaxed version:
 ```mermaid-example
 eventmodeling
 
-timeframe 01 screen CartScreen
+timeframe 01 ui CartUI
 timeframe 02 command AddItem [[AddItem01]]
 timeframe 03 event ItemAdded [[ItemAdded]]
 timeframe 04 command AddItem [[AddItem02]]
@@ -217,7 +217,7 @@ data ItemAdded {
 ```mermaid
 eventmodeling
 
-timeframe 01 screen CartScreen
+timeframe 01 ui CartUI
 timeframe 02 command AddItem [[AddItem01]]
 timeframe 03 event ItemAdded [[ItemAdded]]
 timeframe 04 command AddItem [[AddItem02]]
@@ -251,7 +251,7 @@ Compact version:
 ```mermaid-example
 eventmodeling
 
-tf 01 scn CartScreen
+tf 01 ui CartUI
 tf 02 cmd AddItem
 tf 03 evt ItemAdded
 
@@ -264,7 +264,7 @@ tf 07 evt Cart.InventoryChanged
 ```mermaid
 eventmodeling
 
-tf 01 scn CartScreen
+tf 01 ui CartUI
 tf 02 cmd AddItem
 tf 03 evt ItemAdded
 
@@ -279,7 +279,7 @@ Relaxed version:
 ```mermaid-example
 eventmodeling
 
-timeframe 01 screen CartScreen
+timeframe 01 ui CartUI
 timeframe 02 command AddItem
 timeframe 03 event ItemAdded
 
@@ -292,7 +292,7 @@ timeframe 07 event Cart.InventoryChanged
 ```mermaid
 eventmodeling
 
-timeframe 01 screen CartScreen
+timeframe 01 ui CartUI
 timeframe 02 command AddItem
 timeframe 03 event ItemAdded
 
@@ -313,7 +313,7 @@ rf 02 evt CartCreated
 rf 03 evt ItemAdded
 rf 04 evt ItemRemoved
 rf 05 evt CartCleared
-tf 01 rmo CartScreen ->> 02 ->> 03 ->> 04 ->> 05
+tf 01 rmo CartUI ->> 02 ->> 03 ->> 04 ->> 05
 ```
 
 ```mermaid
@@ -323,7 +323,7 @@ rf 02 evt CartCreated
 rf 03 evt ItemAdded
 rf 04 evt ItemRemoved
 rf 05 evt CartCleared
-tf 01 rmo CartScreen ->> 02 ->> 03 ->> 04 ->> 05
+tf 01 rmo CartUI ->> 02 ->> 03 ->> 04 ->> 05
 ```
 
 ## Event Modeling patterns
@@ -335,7 +335,7 @@ This chapter briefly summarizes each Event Modeling pattern.
 ```mermaid-example
 eventmodeling
 
-tf 01 scn CartScreen
+tf 01 ui CartUI
 tf 02 cmd AddItem
 tf 03 evt ItemAdded
 ```
@@ -343,7 +343,7 @@ tf 03 evt ItemAdded
 ```mermaid
 eventmodeling
 
-tf 01 scn CartScreen
+tf 01 ui CartUI
 tf 02 cmd AddItem
 tf 03 evt ItemAdded
 ```
@@ -355,7 +355,7 @@ eventmodeling
 
 tf 03 evt ItemAdded
 tf 02 rmo CartItems
-tf 04 scn CartScreen
+tf 04 ui CartUI
 ```
 
 ```mermaid
@@ -363,7 +363,7 @@ eventmodeling
 
 tf 03 evt ItemAdded
 tf 02 rmo CartItems
-tf 04 scn CartScreen
+tf 04 ui CartUI
 ```
 
 ### Translation
@@ -408,7 +408,7 @@ Entities are assigned to default swimlanes unless a **Namespace** is specified i
 
 There are the following types available:
 
-- `scn` / `screen`: Screen - belongs to UI/Automation swimlane
+- `ui`: UI - belongs to UI/Automation swimlane
 - `pcr` / `processor`: Processor - belongs to UI/Automation swimlane
 - `cmd` / `command`: Command - belongs to Command/Read Model swimlane
 - `rmo` / `readmodel`: Read Model - belongs to Command/Read Model swimlane

--- a/packages/examples/src/examples/eventmodeling.ts
+++ b/packages/examples/src/examples/eventmodeling.ts
@@ -11,7 +11,7 @@ export default {
       isDefault: true,
       code: `eventmodeling
 
-tf 01 scn CartScreen
+tf 01 ui CartUI
 tf 02 cmd AddItem
 tf 03 evt ItemAdded
 tf 04 rmo CartItems ->> 03

--- a/packages/mermaid/src/diagrams/eventmodeling/db.ts
+++ b/packages/mermaid/src/diagrams/eventmodeling/db.ts
@@ -228,8 +228,7 @@ function calculateSwimlaneProps(
   const sw = findSwimlaneByNamespace(swimlanes, namespace);
 
   switch (frame.modelEntityType) {
-    case 'scn':
-    case 'screen':
+    case 'ui':
     case 'pcr':
     case 'processor':
       if (sw) {
@@ -281,11 +280,10 @@ function calculateSwimlaneProps(
 function calculateEntityVisualProps(frame: EmFrame): VisualProps {
   const { themeVariables } = commonGetConfig();
   switch (frame.modelEntityType) {
-    case 'scn':
-    case 'screen':
+    case 'ui':
       return {
-        fill: themeVariables.emScreenFill ?? 'white',
-        stroke: themeVariables.emScreenStroke ?? '#dbdada',
+        fill: themeVariables.emUiFill ?? 'white',
+        stroke: themeVariables.emUiStroke ?? '#dbdada',
       };
     case 'pcr':
     case 'processor':

--- a/packages/mermaid/src/diagrams/eventmodeling/eventmodeling.spec.ts
+++ b/packages/mermaid/src/diagrams/eventmodeling/eventmodeling.spec.ts
@@ -12,7 +12,7 @@ describe('eventmodeling diagrams', () => {
 
   it('should handle a simple eventmodeling definition', async () => {
     const str = `eventmodeling
-    tf 01 scn Screen
+    tf 01 ui UI
     tf 02 cmd RunAction
     tf 03 evt ActionExecuted`;
     await expect(parser.parse(str)).resolves.not.toThrow();
@@ -39,7 +39,7 @@ data ItemAddedData
 
   it('should handle qualified names', async () => {
     const str = `eventmodeling
-    tf 01 scn CartScreen
+    tf 01 ui CartUI
     tf 02 cmd Inventory.AddItem
     tf 03 evt Inventory.ItemAdded`;
     await expect(parser.parse(str)).resolves.not.toThrow();
@@ -47,7 +47,7 @@ data ItemAddedData
 
   it('should handle multiple source frames', async () => {
     const str = `eventmodeling
-    tf 01 scn CartScreen
+    tf 01 ui CartUI
     tf 02 cmd AddItem
     tf 03 cmd RemoveItem
     tf 04 evt ItemChanged ->> 02 ->> 03`;
@@ -56,7 +56,7 @@ data ItemAddedData
 
   it('should handle reset frames', async () => {
     const str = `eventmodeling
-    rf 01 scn CartScreen
+    rf 01 ui CartUI
     rf 02 cmd AddItem
     rf 03 evt ItemAdded`;
     await expect(parser.parse(str)).resolves.not.toThrow();
@@ -64,8 +64,8 @@ data ItemAddedData
 
   it('should handle all entity types', async () => {
     const str = `eventmodeling
-    tf 01 scn Screen
-    tf 02 screen Screen2
+    tf 01 ui UI
+    tf 02 ui UI2
     tf 03 cmd Command
     tf 04 command Command2
     tf 05 evt Event

--- a/packages/mermaid/src/docs/syntax/eventmodeling.md
+++ b/packages/mermaid/src/docs/syntax/eventmodeling.md
@@ -8,7 +8,7 @@ You can read more at [Event Modeling web page](https://eventmodeling.org/).
 
 Event Modeling diagram is composed of a few main entities:
 
-- Trigger - Screen and Processor
+- Trigger - UI and Processor
 - Command
 - View / Read Model
 - Event
@@ -37,7 +37,7 @@ The timeline is the key part of the diagram and it is composed of **Time Frame**
 ```md
 eventmodeling
 
-tf 01 scn CartScreen
+tf 01 ui CartUI
 tf 02 cmd AddItem
 tf 03 evt ItemAdded
 ```
@@ -47,21 +47,21 @@ rendering to
 ```mermaid
 eventmodeling
 
-tf 01 scn CartScreen
+tf 01 ui CartUI
 tf 02 cmd AddItem
 tf 03 evt ItemAdded
 ```
 
 Each Time Frame is referenced by a **unique number** in order to distinguish one from another and also to be able to reference it when needed. Depending on the complexity of the diagram it should be enough to have just two digit number or more. Imagine you are typing a BASIC program on your ZX Spectrum always starting with a two digit number, but the order of the numbers does not matter, just the uniqueness in the whole timeline.
 
-The Time Frame also contains an **Entity Identifier**, e.g. in case of `01` Time Frame it is `CartScreen`. One Entity Identifier can be used multiple times in the timeline for example when you want to express invocations of the same event in different points in time.
+The Time Frame also contains an **Entity Identifier**, e.g. in case of `01` Time Frame it is `CartUI`. One Entity Identifier can be used multiple times in the timeline for example when you want to express invocations of the same event in different points in time.
 
 Relaxed notation would look like this:
 
 ```md
 eventmodeling
 
-timeframe 01 screen CartScreen
+timeframe 01 ui CartUI
 timeframe 02 command AddItem
 timeframe 03 event ItemAdded
 ```
@@ -75,7 +75,7 @@ Compact version:
 ```mermaid-example
 eventmodeling
 
-tf 01 scn CartScreen
+tf 01 ui CartUI
 tf 02 cmd AddItem { description: string }
 tf 03 evt ItemAdded { description: string }
 ```
@@ -85,7 +85,7 @@ Relaxed version:
 ```mermaid-example
 eventmodeling
 
-timeframe 01 screen CartScreen
+timeframe 01 ui CartUI
 timeframe 02 command AddItem { description: string }
 timeframe 03 event ItemAdded { description: string }
 ```
@@ -101,7 +101,7 @@ Compact version:
 ```mermaid-example
 eventmodeling
 
-tf 01 scn CartScreen
+tf 01 ui CartUI
 tf 02 cmd AddItem [[AddItem01]]
 tf 03 evt ItemAdded [[ItemAdded]]
 tf 04 cmd AddItem [[AddItem02]]
@@ -131,7 +131,7 @@ Relaxed version:
 ```mermaid-example
 eventmodeling
 
-timeframe 01 screen CartScreen
+timeframe 01 ui CartUI
 timeframe 02 command AddItem [[AddItem01]]
 timeframe 03 event ItemAdded [[ItemAdded]]
 timeframe 04 command AddItem [[AddItem02]]
@@ -165,7 +165,7 @@ Compact version:
 ```mermaid-example
 eventmodeling
 
-tf 01 scn CartScreen
+tf 01 ui CartUI
 tf 02 cmd AddItem
 tf 03 evt ItemAdded
 
@@ -180,7 +180,7 @@ Relaxed version:
 ```mermaid-example
 eventmodeling
 
-timeframe 01 screen CartScreen
+timeframe 01 ui CartUI
 timeframe 02 command AddItem
 timeframe 03 event ItemAdded
 
@@ -201,7 +201,7 @@ rf 02 evt CartCreated
 rf 03 evt ItemAdded
 rf 04 evt ItemRemoved
 rf 05 evt CartCleared
-tf 01 rmo CartScreen ->> 02 ->> 03 ->> 04 ->> 05
+tf 01 rmo CartUI ->> 02 ->> 03 ->> 04 ->> 05
 ```
 
 ## Event Modeling patterns
@@ -213,7 +213,7 @@ This chapter briefly summarizes each Event Modeling pattern.
 ```mermaid-example
 eventmodeling
 
-tf 01 scn CartScreen
+tf 01 ui CartUI
 tf 02 cmd AddItem
 tf 03 evt ItemAdded
 ```
@@ -225,7 +225,7 @@ eventmodeling
 
 tf 03 evt ItemAdded
 tf 02 rmo CartItems
-tf 04 scn CartScreen
+tf 04 ui CartUI
 ```
 
 ### Translation
@@ -261,7 +261,7 @@ Entities are assigned to default swimlanes unless a **Namespace** is specified i
 
 There are the following types available:
 
-- `scn` / `screen`: Screen - belongs to UI/Automation swimlane
+- `ui`: UI - belongs to UI/Automation swimlane
 - `pcr` / `processor`: Processor - belongs to UI/Automation swimlane
 - `cmd` / `command`: Command - belongs to Command/Read Model swimlane
 - `rmo` / `readmodel`: Read Model - belongs to Command/Read Model swimlane

--- a/packages/mermaid/src/themes/theme-base.js
+++ b/packages/mermaid/src/themes/theme-base.js
@@ -382,8 +382,8 @@ class Theme {
     /* -------------------------------------------------- */
     /* Event Modeling diagrams                             */
 
-    this.emScreenFill = this.emScreenFill || 'white';
-    this.emScreenStroke = this.emScreenStroke || '#dbdada';
+    this.emUiFill = this.emUiFill || 'white';
+    this.emUiStroke = this.emUiStroke || '#dbdada';
     this.emProcessorFill = this.emProcessorFill || '#edb3f6';
     this.emProcessorStroke = this.emProcessorStroke || '#b88cbf';
     this.emReadModelFill = this.emReadModelFill || '#d3f1a2';

--- a/packages/mermaid/src/themes/theme-dark.js
+++ b/packages/mermaid/src/themes/theme-dark.js
@@ -375,8 +375,8 @@ class Theme {
     /* -------------------------------------------------- */
     /* Event Modeling diagrams                             */
 
-    this.emScreenFill = this.emScreenFill || '#2d2d2d';
-    this.emScreenStroke = this.emScreenStroke || '#555';
+    this.emUiFill = this.emUiFill || '#2d2d2d';
+    this.emUiStroke = this.emUiStroke || '#555';
     this.emProcessorFill = this.emProcessorFill || lighten('#5a3d5c', 10);
     this.emProcessorStroke = this.emProcessorStroke || '#8a6d8c';
     this.emReadModelFill = this.emReadModelFill || lighten('#3d5a2d', 10);

--- a/packages/mermaid/src/themes/theme-default.js
+++ b/packages/mermaid/src/themes/theme-default.js
@@ -413,8 +413,8 @@ class Theme {
     /* -------------------------------------------------- */
     /* Event Modeling diagrams                             */
 
-    this.emScreenFill = this.emScreenFill || 'white';
-    this.emScreenStroke = this.emScreenStroke || '#dbdada';
+    this.emUiFill = this.emUiFill || 'white';
+    this.emUiStroke = this.emUiStroke || '#dbdada';
     this.emProcessorFill = this.emProcessorFill || '#edb3f6';
     this.emProcessorStroke = this.emProcessorStroke || '#b88cbf';
     this.emReadModelFill = this.emReadModelFill || '#d3f1a2';

--- a/packages/mermaid/src/themes/theme-forest.js
+++ b/packages/mermaid/src/themes/theme-forest.js
@@ -385,8 +385,8 @@ class Theme {
     /* -------------------------------------------------- */
     /* Event Modeling diagrams                             */
 
-    this.emScreenFill = this.emScreenFill || 'white';
-    this.emScreenStroke = this.emScreenStroke || '#dbdada';
+    this.emUiFill = this.emUiFill || 'white';
+    this.emUiStroke = this.emUiStroke || '#dbdada';
     this.emProcessorFill = this.emProcessorFill || '#edb3f6';
     this.emProcessorStroke = this.emProcessorStroke || '#b88cbf';
     this.emReadModelFill = this.emReadModelFill || '#d3f1a2';

--- a/packages/mermaid/src/themes/theme-neutral.js
+++ b/packages/mermaid/src/themes/theme-neutral.js
@@ -385,8 +385,8 @@ class Theme {
     /* -------------------------------------------------- */
     /* Event Modeling diagrams                             */
 
-    this.emScreenFill = this.emScreenFill || 'white';
-    this.emScreenStroke = this.emScreenStroke || '#dbdada';
+    this.emUiFill = this.emUiFill || 'white';
+    this.emUiStroke = this.emUiStroke || '#dbdada';
     this.emProcessorFill = this.emProcessorFill || '#edb3f6';
     this.emProcessorStroke = this.emProcessorStroke || '#b88cbf';
     this.emReadModelFill = this.emReadModelFill || '#d3f1a2';

--- a/packages/parser/src/language/eventmodeling/event-modeling-validator.ts
+++ b/packages/parser/src/language/eventmodeling/event-modeling-validator.ts
@@ -6,7 +6,7 @@ const COMMAND_TYPES = new Set<string>(['cmd', 'command']);
 const EVENT_TYPES = new Set<string>(['evt', 'event']);
 const READMODEL_TYPES = new Set<string>(['rmo', 'readmodel']);
 const PROCESSOR_TYPES = new Set<string>(['pcr', 'processor']);
-const SCREEN_TYPES = new Set<string>(['scn', 'screen']);
+const UI_TYPES = new Set<string>(['ui']);
 
 export function registerValidationChecks(services: EventModelingServices) {
   const validator = services.validation.EventModelingValidator;
@@ -29,9 +29,9 @@ export class EventModelingValidator {
     if (COMMAND_TYPES.has(frame.modelEntityType)) {
       this.validateSources(
         frame,
-        new Set([...SCREEN_TYPES, ...PROCESSOR_TYPES]),
+        new Set([...UI_TYPES, ...PROCESSOR_TYPES]),
         'command',
-        'screen or processor',
+        'ui or processor',
         accept
       );
     } else if (EVENT_TYPES.has(frame.modelEntityType)) {
@@ -40,8 +40,8 @@ export class EventModelingValidator {
       this.validateSources(frame, EVENT_TYPES, 'read model', 'event', accept);
     } else if (PROCESSOR_TYPES.has(frame.modelEntityType)) {
       this.validateSources(frame, READMODEL_TYPES, 'processor', 'read model', accept);
-    } else if (SCREEN_TYPES.has(frame.modelEntityType)) {
-      this.validateSources(frame, READMODEL_TYPES, 'screen', 'read model', accept);
+    } else if (UI_TYPES.has(frame.modelEntityType)) {
+      this.validateSources(frame, READMODEL_TYPES, 'ui', 'read model', accept);
     }
   }
 

--- a/packages/parser/src/language/eventmodeling/event-modeling.langium
+++ b/packages/parser/src/language/eventmodeling/event-modeling.langium
@@ -12,7 +12,7 @@ entry EventModel:
 
 
 EmModelEntityType returns string:
-    'rmo' | 'readmodel' | 'scn' | 'screen' | 'cmd' | 'command' | 'evt' | 'event' | 'pcr' | 'processor';
+    'rmo' | 'readmodel' | 'ui' | 'cmd' | 'command' | 'evt' | 'event' | 'pcr' | 'processor';
 
 EmDataType returns string:
     'json' | 'jsobj' | 'figma' | 'salt' | 'uri' | 'md' | 'html' | 'text';

--- a/packages/parser/tests/eventmodeling.test.ts
+++ b/packages/parser/tests/eventmodeling.test.ts
@@ -91,7 +91,7 @@ timeframe 01 event Start
   it('should parse qualified names in model', () => {
     const result = parse(`eventmodeling
 
-timeframe 02 screen Screen
+timeframe 02 ui UI
 tf 01 evt Product.PriceChanged
 tf 03 evt Cart.ItemAdded
 
@@ -111,7 +111,7 @@ tf 03 evt Cart.ItemAdded
   it('should parse both types of frames in model', () => {
     const result = parse(`eventmodeling
 
-tf 02 screen Screen
+tf 02 ui UI
 resetframe 01 evt Product.PriceChanged
 tf 03 evt Cart.ItemAdded
 
@@ -193,13 +193,13 @@ tf 03 evt Cart.ItemAdded
       expect(errors).toHaveLength(1);
     });
 
-    it('should allow cmd sourced from scn', () => {
-      const errors = collectErrors(makeFrame('cmd'), [makeFrame('scn')]);
+    it('should allow cmd sourced from ui', () => {
+      const errors = collectErrors(makeFrame('cmd'), [makeFrame('ui')]);
       expect(errors).toHaveLength(0);
     });
 
-    it('should allow command sourced from screen', () => {
-      const errors = collectErrors(makeFrame('command'), [makeFrame('screen')]);
+    it('should allow command sourced from ui', () => {
+      const errors = collectErrors(makeFrame('command'), [makeFrame('ui')]);
       expect(errors).toHaveLength(0);
     });
 
@@ -217,35 +217,35 @@ tf 03 evt Cart.ItemAdded
       const errors = collectErrors(makeFrame('cmd'), [makeFrame('cmd')]);
       expect(errors).toHaveLength(1);
       expect(errors[0]).toContain('command');
-      expect(errors[0]).toContain('screen or processor');
+      expect(errors[0]).toContain('ui or processor');
     });
 
     it('should reject cmd sourced from evt', () => {
       const errors = collectErrors(makeFrame('cmd'), [makeFrame('evt')]);
       expect(errors).toHaveLength(1);
       expect(errors[0]).toContain('command');
-      expect(errors[0]).toContain('screen or processor');
+      expect(errors[0]).toContain('ui or processor');
     });
 
-    it('should reject scn sourced from evt', () => {
-      const errors = collectErrors(makeFrame('scn'), [makeFrame('evt')]);
+    it('should reject ui sourced from evt', () => {
+      const errors = collectErrors(makeFrame('ui'), [makeFrame('evt')]);
       expect(errors).toHaveLength(1);
     });
 
-    it('should allow scn sourced from rmo', () => {
-      const errors = collectErrors(makeFrame('scn'), [makeFrame('rmo')]);
+    it('should allow ui sourced from rmo', () => {
+      const errors = collectErrors(makeFrame('ui'), [makeFrame('rmo')]);
       expect(errors).toHaveLength(0);
     });
 
-    it('should allow screen sourced from readmodel', () => {
-      const errors = collectErrors(makeFrame('screen'), [makeFrame('readmodel')]);
+    it('should allow ui sourced from readmodel', () => {
+      const errors = collectErrors(makeFrame('ui'), [makeFrame('readmodel')]);
       expect(errors).toHaveLength(0);
     });
 
-    it('should reject scn sourced from cmd', () => {
-      const errors = collectErrors(makeFrame('scn'), [makeFrame('cmd')]);
+    it('should reject ui sourced from cmd', () => {
+      const errors = collectErrors(makeFrame('ui'), [makeFrame('cmd')]);
       expect(errors).toHaveLength(1);
-      expect(errors[0]).toContain('screen');
+      expect(errors[0]).toContain('ui');
       expect(errors[0]).toContain('read model');
     });
 
@@ -253,7 +253,7 @@ tf 03 evt Cart.ItemAdded
       const errors = collectErrors(makeFrame('cmd'), [makeFrame('rmo')]);
       expect(errors).toHaveLength(1);
       expect(errors[0]).toContain('command');
-      expect(errors[0]).toContain('screen or processor');
+      expect(errors[0]).toContain('ui or processor');
     });
 
     it('should allow rmo sourced from evt', () => {
@@ -295,8 +295,8 @@ tf 03 evt Cart.ItemAdded
       expect(errors).toHaveLength(1);
     });
 
-    it('should reject rmo sourced from scn', () => {
-      const errors = collectErrors(makeFrame('rmo'), [makeFrame('scn')]);
+    it('should reject rmo sourced from ui', () => {
+      const errors = collectErrors(makeFrame('rmo'), [makeFrame('ui')]);
       expect(errors).toHaveLength(1);
     });
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

- Align Event Modeling terminology with the UI language we want users to learn publicly.
- Remove pre-release `screen` wording before it becomes part of the long-term DSL and styling surface.
- Keep the parser, runtime, docs, and theming surface consistent so users do not have to translate between old and new terms.

## :straight_ruler: Design Decisions

- Treat this as a breaking terminology correction before release so the DSL ships with one canonical term.
- Keep the public surface consistent across parsing, rendering, documentation, examples, and theming to avoid mixed vocabulary.

### :clipboard: Tasks

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
