### PR TITLE
fix: frontmatter indentation in sankey demo

### DIFF
--- a/demos/sankey.html
+++ b/demos/sankey.html
@@ -1,21 +1,23 @@
 <!doctype html>
 <html lang="en" xmlns="http://www.w3.org/1999/html">
-  <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>Sankey Mermaid Quick Test Page</title>
-    <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgo=" />
-  </head>
 
-  <body>
-    <h1>Sankey diagram demos</h1>
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <title>Sankey Mermaid Quick Test Page</title>
+  <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgo=" />
+</head>
 
-    <h2>Apple-style Financial Flow (New Features)</h2>
-    <p>
-      Demonstrates the new Apple-style rendering with outlined labels, smart label positioning, and
-      custom node colors (grey for income, red for expenses, green for profits).
-    </p>
-    <pre class="mermaid">
+<body>
+  <h1>Sankey diagram demos</h1>
+
+  <h2>Apple-style Financial Flow (New Features)</h2>
+  <p>
+    Demonstrates the new Apple-style rendering with outlined labels, smart label positioning, and
+    custom node colors (grey for income, red for expenses, green for profits).
+  </p>
+
+  <pre class="mermaid">
 ---
 config:
   sankey:
@@ -57,119 +59,123 @@ Op Profit,Tax,19
 Op Profit,Net Profit,100
     </pre>
 
-    <h2>FY20-21 Performance</h2>
-    <pre class="mermaid">
-      ---
-      config:
-        sankey:
-          showValues: true
-          prefix: $
-          suffix: B
-          width: 800
-          nodeAlignment: left
-      ---
-     sankey
-        a,b,8
-        b,c,8
-        c,d,8
-        d,e,8
+  <h2>FY20-21 Performance</h2>
 
-        x,c,4
-        c,y,4
+  <pre class="mermaid">
+---
+config:
+  sankey:
+    showValues: true
+    prefix: $
+    suffix: B
+    width: 800
+    nodeAlignment: left
+---
+sankey
+
+a,b,8
+b,c,8
+c,d,8
+d,e,8
+
+x,c,4
+c,y,4
     </pre>
 
-    <h2>Energy flow</h2>
-    <pre class="mermaid">
-      ---
-      config:
-        sankey:
-          useMaxWidth: true
-          showValues: false
-          width: 1200
-          height: 600
-          linkColor: gradient
-          nodeAlignment: justify
-      ---
-      sankey
+  <h2>Energy flow</h2>
 
-      Agricultural 'waste',Bio-conversion,124.729
-      Bio-conversion,Liquid,0.597
-      Bio-conversion,Losses,26.862
-      Bio-conversion,Solid,280.322
-      Bio-conversion,Gas,81.144
-      Biofuel imports,Liquid,35
-      Biomass imports,Solid,35
-      Coal imports,Coal,11.606
-      Coal reserves,Coal,63.965
-      Coal,Solid,75.571
-      District heating,Industry,10.639
-      District heating,Heating and cooling - commercial,22.505
-      District heating,Heating and cooling - homes,46.184
-      Electricity grid,Over generation / exports,104.453
-      Electricity grid,Heating and cooling - homes,113.726
-      Electricity grid,H2 conversion,27.14
-      Electricity grid,Industry,342.165
-      Electricity grid,Road transport,37.797
-      Electricity grid,Agriculture,4.412
-      Electricity grid,Heating and cooling - commercial,40.858
-      Electricity grid,Losses,56.691
-      Electricity grid,Rail transport,7.863
-      Electricity grid,Lighting & appliances - commercial,90.008
-      Electricity grid,Lighting & appliances - homes,93.494
-      Gas imports,Ngas,40.719
-      Gas reserves,Ngas,82.233
-      Gas,Heating and cooling - commercial,0.129
-      Gas,Losses,1.401
-      Gas,Thermal generation,151.891
-      Gas,Agriculture,2.096
-      Gas,Industry,48.58
-      Geothermal,Electricity grid,7.013
-      H2 conversion,H2,20.897
-      H2 conversion,Losses,6.242
-      H2,Road transport,20.897
-      Hydro,Electricity grid,6.995
-      Liquid,Industry,121.066
-      Liquid,International shipping,128.69
-      Liquid,Road transport,135.835
-      Liquid,Domestic aviation,14.458
-      Liquid,International aviation,206.267
-      Liquid,Agriculture,3.64
-      Liquid,National navigation,33.218
-      Liquid,Rail transport,4.413
-      Marine algae,Bio-conversion,4.375
-      Ngas,Gas,122.952
-      Nuclear,Thermal generation,839.978
-      Oil imports,Oil,504.287
-      Oil reserves,Oil,107.703
-      Oil,Liquid,611.99
-      Other waste,Solid,56.587
-      Other waste,Bio-conversion,77.81
-      Pumped heat,Heating and cooling - homes,193.026
-      Pumped heat,Heating and cooling - commercial,70.672
-      Solar PV,Electricity grid,59.901
-      Solar Thermal,Heating and cooling - homes,19.263
-      Solar,Solar Thermal,19.263
-      Solar,Solar PV,59.901
-      Solid,Agriculture,0.882
-      Solid,Thermal generation,400.12
-      Solid,Industry,46.477
-      Thermal generation,Electricity grid,525.531
-      Thermal generation,Losses,787.129
-      Thermal generation,District heating,79.329
-      Tidal,Electricity grid,9.452
-      UK land based bioenergy,Bio-conversion,182.01
-      Wave,Electricity grid,19.013
-      Wind,Electricity grid,289.366
+  <pre class="mermaid">
+---
+config:
+  sankey:
+    useMaxWidth: true
+    showValues: false
+    width: 1200
+    height: 600
+    linkColor: gradient
+    nodeAlignment: justify
+---
+sankey
+
+Agricultural 'waste',Bio-conversion,124.729
+Bio-conversion,Liquid,0.597
+Bio-conversion,Losses,26.862
+Bio-conversion,Solid,280.322
+Bio-conversion,Gas,81.144
+Biofuel imports,Liquid,35
+Biomass imports,Solid,35
+Coal imports,Coal,11.606
+Coal reserves,Coal,63.965
+Coal,Solid,75.571
+District heating,Industry,10.639
+District heating,Heating and cooling - commercial,22.505
+District heating,Heating and cooling - homes,46.184
+Electricity grid,Over generation / exports,104.453
+Electricity grid,Heating and cooling - homes,113.726
+Electricity grid,H2 conversion,27.14
+Electricity grid,Industry,342.165
+Electricity grid,Road transport,37.797
+Electricity grid,Agriculture,4.412
+Electricity grid,Heating and cooling - commercial,40.858
+Electricity grid,Losses,56.691
+Electricity grid,Rail transport,7.863
+Electricity grid,Lighting & appliances - commercial,90.008
+Electricity grid,Lighting & appliances - homes,93.494
+Gas imports,Ngas,40.719
+Gas reserves,Ngas,82.233
+Gas,Heating and cooling - commercial,0.129
+Gas,Losses,1.401
+Gas,Thermal generation,151.891
+Gas,Agriculture,2.096
+Gas,Industry,48.58
+Geothermal,Electricity grid,7.013
+H2 conversion,H2,20.897
+H2 conversion,Losses,6.242
+H2,Road transport,20.897
+Hydro,Electricity grid,6.995
+Liquid,Industry,121.066
+Liquid,International shipping,128.69
+Liquid,Road transport,135.835
+Liquid,Domestic aviation,14.458
+Liquid,International aviation,206.267
+Liquid,Agriculture,3.64
+Liquid,National navigation,33.218
+Liquid,Rail transport,4.413
+Marine algae,Bio-conversion,4.375
+Ngas,Gas,122.952
+Nuclear,Thermal generation,839.978
+Oil imports,Oil,504.287
+Oil reserves,Oil,107.703
+Oil,Liquid,611.99
+Other waste,Solid,56.587
+Other waste,Bio-conversion,77.81
+Pumped heat,Heating and cooling - homes,193.026
+Pumped heat,Heating and cooling - commercial,70.672
+Solar PV,Electricity grid,59.901
+Solar Thermal,Heating and cooling - homes,19.263
+Solar,Solar Thermal,19.263
+Solar,Solar PV,59.901
+Solid,Agriculture,0.882
+Solid,Thermal generation,400.12
+Solid,Industry,46.477
+Thermal generation,Electricity grid,525.531
+Thermal generation,Losses,787.129
+Thermal generation,District heating,79.329
+Tidal,Electricity grid,9.452
+UK land based bioenergy,Bio-conversion,182.01
+Wave,Electricity grid,19.013
+Wind,Electricity grid,289.366
     </pre>
 
-    <script type="module">
-      import mermaid from './mermaid.esm.mjs';
-      mermaid.initialize({
-        theme: 'default',
-        logLevel: 3,
-        securityLevel: 'loose',
-        startOnLoad: true,
-      });
-    </script>
-  </body>
+  <script type="module">
+    import mermaid from './mermaid.esm.mjs';
+    mermaid.initialize({
+      theme: 'default',
+      logLevel: 3,
+      securityLevel: 'loose',
+      startOnLoad: true,
+    });
+  </script>
+</body>
+
 </html>

--- a/demos/sankey.html
+++ b/demos/sankey.html
@@ -1,23 +1,22 @@
 <!doctype html>
 <html lang="en" xmlns="http://www.w3.org/1999/html">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>Sankey Mermaid Quick Test Page</title>
+    <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgo=" />
+  </head>
 
-<head>
-  <meta charset="utf-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-  <title>Sankey Mermaid Quick Test Page</title>
-  <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgo=" />
-</head>
+  <body>
+    <h1>Sankey diagram demos</h1>
 
-<body>
-  <h1>Sankey diagram demos</h1>
+    <h2>Apple-style Financial Flow (New Features)</h2>
+    <p>
+      Demonstrates the new Apple-style rendering with outlined labels, smart label positioning, and
+      custom node colors (grey for income, red for expenses, green for profits).
+    </p>
 
-  <h2>Apple-style Financial Flow (New Features)</h2>
-  <p>
-    Demonstrates the new Apple-style rendering with outlined labels, smart label positioning, and
-    custom node colors (grey for income, red for expenses, green for profits).
-  </p>
-
-  <pre class="mermaid">
+    <pre class="mermaid">
 ---
 config:
   sankey:
@@ -59,9 +58,9 @@ Op Profit,Tax,19
 Op Profit,Net Profit,100
     </pre>
 
-  <h2>FY20-21 Performance</h2>
+    <h2>FY20-21 Performance</h2>
 
-  <pre class="mermaid">
+    <pre class="mermaid">
 ---
 config:
   sankey:
@@ -82,9 +81,9 @@ x,c,4
 c,y,4
     </pre>
 
-  <h2>Energy flow</h2>
+    <h2>Energy flow</h2>
 
-  <pre class="mermaid">
+    <pre class="mermaid">
 ---
 config:
   sankey:
@@ -167,15 +166,14 @@ Wave,Electricity grid,19.013
 Wind,Electricity grid,289.366
     </pre>
 
-  <script type="module">
-    import mermaid from './mermaid.esm.mjs';
-    mermaid.initialize({
-      theme: 'default',
-      logLevel: 3,
-      securityLevel: 'loose',
-      startOnLoad: true,
-    });
-  </script>
-</body>
-
+    <script type="module">
+      import mermaid from './mermaid.esm.mjs';
+      mermaid.initialize({
+        theme: 'default',
+        logLevel: 3,
+        securityLevel: 'loose',
+        startOnLoad: true,
+      });
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fixes the frontmatter indentation in the Sankey demo file that caused a "Syntax error in text" message.
Refs #7613

📏 Design Decisions
The demo failure was caused by indented --- frontmatter markers in demos/sankey.html.
Updated the demo file to ensure frontmatter starts at column 0, which allows the diagram to render correctly. This PR focuses on fixing the broken demo.

Before: 
<img width="1815" height="966" alt="sankeyy" src="https://github.com/user-attachments/assets/a523c5d4-a9c7-4101-a253-8296fc059885" />

After:
<img width="1808" height="865" alt="sankeyyy" src="https://github.com/user-attachments/assets/6cd295fe-80f8-4ce9-8c3e-44d47401001b" />


### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.