### PR TITLE
  fix: set hierarchicalNamespaces default to true in defaultConfig

### DIFF
--- a/docs/config/setup/defaultConfig/variables/configKeys.md
+++ b/docs/config/setup/defaultConfig/variables/configKeys.md
@@ -12,4 +12,4 @@
 
 > `const` **configKeys**: `Set`<`string`>
 
-Defined in: [packages/mermaid/src/defaultConfig.ts:310](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/defaultConfig.ts#L310)
+Defined in: [packages/mermaid/src/defaultConfig.ts:311](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/defaultConfig.ts#L311)

--- a/packages/mermaid/src/defaultConfig.ts
+++ b/packages/mermaid/src/defaultConfig.ts
@@ -57,6 +57,7 @@ const config: RequiredDeep<MermaidConfig> = {
   },
   class: {
     hideEmptyMembersBox: false,
+    hierarchicalNamespaces: true,
   },
   gantt: {
     ...defaultConfigJson.gantt,


### PR DESCRIPTION
  ## Summary
  Follow-up to #7604. The `hierarchicalNamespaces` option was declared in the config schema under `class`, but was missing from `defaultConfig.ts`. This meant the runtime default didn't match the schema-declared
  default, so the feature required users to explicitly opt in via config even though the intent was for it to be on by default.

  Adds the missing entry:
  ```ts
  class: {
    hideEmptyMembersBox: false,
    hierarchicalNamespaces: true,
  }

  Test plan

  - Class diagrams with nested namespaces render with hierarchical (compact) layout out of the box, without needing explicit config
  - Existing class diagrams without nested namespaces are unaffected
  - pnpm test passes