### PR TITLE
fix(wardley): review follow-ups — pipeline links, theme, type safety, label sanitisation

### DIFF
--- a/.changeset/add-wardley-maps.md
+++ b/.changeset/add-wardley-maps.md
@@ -2,7 +2,7 @@
 'mermaid': minor
 ---
 
-Add Wardley Maps diagram type (beta)
+feat: Add Wardley Maps diagram type (beta)
 
 Adds Wardley Maps as a new diagram type to Mermaid (available as `wardley-beta`). Wardley Maps are visual representations of business strategy that help map value chains and component evolution.
 

--- a/cypress/integration/rendering/wardley/wardley.spec.js
+++ b/cypress/integration/rendering/wardley/wardley.spec.js
@@ -74,8 +74,10 @@ size [1100, 800]
 
 component Kettle [0.57, 0.45]
 component Power [0.10, 0.70]
+component User [0.95, 0.50]
 
 Kettle -> Power
+User -> Electric Kettle
 
 pipeline Kettle {
   component Campfire Kettle [0.35] label [-60, 35]
@@ -138,6 +140,32 @@ evolve Database 0.60
       `,
       {}
     );
+  });
+
+  ['dark', 'forest', 'neutral', 'base'].forEach((theme) => {
+    it(`should render under the ${theme} theme`, () => {
+      imgSnapshotTest(
+        `
+wardley-beta
+title Theme Test - ${theme}
+size [1100, 800]
+
+anchor User [0.95, 0.85]
+component App [0.75, 0.70]
+component API [0.55, 0.55]
+component Database [0.30, 0.60]
+component Cache [0.50, 0.40]
+
+User -> App
+App -> API
+API -> Database
+API -> Cache
+
+evolve Database 0.80
+        `,
+        { theme }
+      );
+    });
   });
 
   it('6: should render GPT Tokeniser Architecture', () => {

--- a/docs/syntax/wardley.md
+++ b/docs/syntax/wardley.md
@@ -725,3 +725,7 @@ Wardley Maps support Mermaid's theme system. Use standard Mermaid configuration 
 | Strategy   | `(build\|buy\|outsource\|market)`   | `component API [0.6, 0.7] (buy)`    |
 | Pipeline   | `pipeline Parent { ... }`           | See pipeline example above          |
 | Evolution  | `evolution Stage1 -> Stage2 -> ...` | See evolution examples above        |
+
+## Limitations
+
+- Handdrawn/rough mode (`look: handDrawn`) is not currently supported for Wardley Maps. The diagram uses a custom D3 renderer rather than the shared shape system.

--- a/packages/mermaid/src/diagrams/wardley/styles.ts
+++ b/packages/mermaid/src/diagrams/wardley/styles.ts
@@ -1,0 +1,90 @@
+import type { DiagramStylesProvider } from '../../diagram-api/types.js';
+import { cleanAndMerge } from '../../utils.js';
+import { getThemeVariables } from '../../themes/theme-default.js';
+import { getConfig as getConfigAPI } from '../../config.js';
+
+export interface WardleyStyleOptions {
+  backgroundColor?: string;
+  axisColor?: string;
+  axisTextColor?: string;
+  gridColor?: string;
+  componentFill?: string;
+  componentStroke?: string;
+  componentLabelColor?: string;
+  linkStroke?: string;
+  evolutionStroke?: string;
+  annotationStroke?: string;
+  annotationTextColor?: string;
+  annotationFill?: string;
+}
+
+export const styles: DiagramStylesProvider = ({
+  wardley,
+}: { wardley?: WardleyStyleOptions } = {}) => {
+  const defaultThemeVariables = getThemeVariables();
+  const currentConfig = getConfigAPI();
+  const themeVariables = cleanAndMerge(defaultThemeVariables, currentConfig.themeVariables);
+  const w: WardleyStyleOptions = cleanAndMerge(themeVariables.wardley, wardley);
+
+  return `
+  .wardley-background {
+    fill: ${w.backgroundColor};
+  }
+  .wardley-axes line, .wardley-axes path {
+    stroke: ${w.axisColor};
+  }
+  .wardley-axis-label {
+    fill: ${w.axisTextColor};
+  }
+  .wardley-stage-label {
+    fill: ${w.axisTextColor};
+  }
+  .wardley-grid line {
+    stroke: ${w.gridColor};
+  }
+  .wardley-node circle {
+    fill: ${w.componentFill};
+    stroke: ${w.componentStroke};
+  }
+  .wardley-node-label {
+    fill: ${w.componentLabelColor};
+  }
+  .wardley-link {
+    stroke: ${w.linkStroke};
+  }
+  .wardley-link--dashed {
+    stroke-dasharray: 4 4;
+  }
+  .wardley-link-label {
+    fill: ${w.axisTextColor};
+  }
+  .wardley-trend line {
+    stroke: ${w.evolutionStroke};
+  }
+  .wardley-annotation-line {
+    stroke: ${w.annotationStroke};
+  }
+  .wardley-annotation circle {
+    fill: ${w.annotationFill};
+    stroke: ${w.annotationStroke};
+  }
+  .wardley-annotation text {
+    fill: ${w.annotationTextColor};
+  }
+  .wardley-annotations-box rect {
+    fill: ${w.annotationFill};
+    stroke: ${w.annotationStroke};
+  }
+  .wardley-annotations-box text {
+    fill: ${w.annotationTextColor};
+  }
+  .wardley-pipeline-box {
+    stroke: ${w.componentStroke};
+  }
+  .wardley-notes text {
+    fill: ${w.axisTextColor};
+  }
+  `;
+};
+
+export default styles;

--- a/packages/mermaid/src/diagrams/wardley/wardleyBuilder.spec.ts
+++ b/packages/mermaid/src/diagrams/wardley/wardleyBuilder.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { WardleyBuilder } from './wardleyBuilder.js';
+
+describe('WardleyBuilder.resolveNodeId', () => {
+  let builder: WardleyBuilder;
+
+  beforeEach(() => {
+    builder = new WardleyBuilder();
+  });
+
+  it('returns the id when a node exists with that exact id', () => {
+    builder.addNode({ id: 'API', label: 'API', x: 60, y: 70 });
+    expect(builder.resolveNodeId('API')).toBe('API');
+  });
+
+  it('falls back to label match for pipeline-style synthetic ids', () => {
+    builder.addNode({
+      id: 'Kettle_Campfire Kettle',
+      label: 'Campfire Kettle',
+      x: 35,
+      y: 45,
+      className: 'pipeline-component',
+    });
+    expect(builder.resolveNodeId('Campfire Kettle')).toBe('Kettle_Campfire Kettle');
+  });
+
+  it('returns the input unchanged when no id or label matches', () => {
+    builder.addNode({ id: 'API', label: 'API', x: 60, y: 70 });
+    expect(builder.resolveNodeId('Unknown')).toBe('Unknown');
+  });
+
+  it('prefers exact id over label match when both exist', () => {
+    builder.addNode({ id: 'Alpha', label: 'Beta', x: 0, y: 0 });
+    builder.addNode({ id: 'Beta', label: 'Gamma', x: 1, y: 1 });
+    // "Beta" is the id of the second node AND the label of the first — id wins
+    expect(builder.resolveNodeId('Beta')).toBe('Beta');
+  });
+});

--- a/packages/mermaid/src/diagrams/wardley/wardleyBuilder.ts
+++ b/packages/mermaid/src/diagrams/wardley/wardleyBuilder.ts
@@ -167,13 +167,30 @@ export class WardleyBuilder {
     return this.nodes.get(id);
   }
 
+  /**
+   * Resolve a name to a node ID. Tries exact ID match first,
+   * then falls back to finding a node whose label matches the name
+   * (handles pipeline components which have synthetic IDs like "Parent_Child").
+   */
+  public resolveNodeId(name: string): string {
+    if (this.nodes.has(name)) {
+      return name;
+    }
+    for (const [id, node] of this.nodes) {
+      if (node.label === name) {
+        return id;
+      }
+    }
+    return name;
+  }
+
   public build(): WardleyBuildResult {
     const nodes: WardleyNode[] = [];
     for (const node of this.nodes.values()) {
       if (typeof node.x !== 'number' || typeof node.y !== 'number') {
         throw new Error(`Node "${node.label}" is missing coordinates`);
       }
-      nodes.push(node as Required<WardleyNode>);
+      nodes.push(node as WardleyNode & { x: number; y: number });
     }
     return {
       nodes,

--- a/packages/mermaid/src/diagrams/wardley/wardleyDb.ts
+++ b/packages/mermaid/src/diagrams/wardley/wardleyDb.ts
@@ -54,7 +54,7 @@ function addLink(
   label?: string,
   flow?: 'forward' | 'backward' | 'bidirectional'
 ) {
-  builder.addLink({ source: sourceId, target: targetId, dashed, label, flow });
+  builder.addLink({ source: sourceId, target: targetId, dashed, label: label ? textSanitizer(label) : undefined, flow });
 }
 
 function addTrend(nodeId: string, targetX: number, targetY: number) {

--- a/packages/mermaid/src/diagrams/wardley/wardleyDb.ts
+++ b/packages/mermaid/src/diagrams/wardley/wardleyDb.ts
@@ -54,7 +54,13 @@ function addLink(
   label?: string,
   flow?: 'forward' | 'backward' | 'bidirectional'
 ) {
-  builder.addLink({ source: sourceId, target: targetId, dashed, label: label ? textSanitizer(label) : undefined, flow });
+  builder.addLink({
+    source: sourceId,
+    target: targetId,
+    dashed,
+    label: label ? textSanitizer(label) : undefined,
+    flow,
+  });
 }
 
 function addTrend(nodeId: string, targetX: number, targetY: number) {

--- a/packages/mermaid/src/diagrams/wardley/wardleyDb.ts
+++ b/packages/mermaid/src/diagrams/wardley/wardleyDb.ts
@@ -130,6 +130,10 @@ function getNode(id: string) {
   return builder.getNode(id);
 }
 
+function resolveNodeId(name: string) {
+  return builder.resolveNodeId(name);
+}
+
 function getWardleyData() {
   return builder.build();
 }
@@ -154,6 +158,7 @@ export default {
   addPipelineComponent,
   updateAxes,
   getNode,
+  resolveNodeId,
   getWardleyData,
   clear,
   setAccTitle,

--- a/packages/mermaid/src/diagrams/wardley/wardleyDiagram.ts
+++ b/packages/mermaid/src/diagrams/wardley/wardleyDiagram.ts
@@ -2,10 +2,11 @@ import type { DiagramDefinition } from '../../diagram-api/types.js';
 import { parser } from './wardleyParser.js';
 import db from './wardleyDb.js';
 import renderer from './wardleyRenderer.js';
+import { styles } from './styles.js';
 
 export const diagram: DiagramDefinition = {
   parser,
   db,
   renderer,
-  styles: () => '',
+  styles,
 };

--- a/packages/mermaid/src/diagrams/wardley/wardleyParser.ts
+++ b/packages/mermaid/src/diagrams/wardley/wardleyParser.ts
@@ -183,7 +183,7 @@ const populateDb = (ast: Wardley, db: WardleyDB) => {
     const annotation = link.linkLabel;
     const label = flowLabel ?? annotation;
 
-    db.addLink(link.from, link.to, isDashed, label, flow);
+    db.addLink(db.resolveNodeId(link.from), db.resolveNodeId(link.to), isDashed, label, flow);
   });
 
   // Add evolves (trends)

--- a/packages/mermaid/src/diagrams/wardley/wardleyRenderer.ts
+++ b/packages/mermaid/src/diagrams/wardley/wardleyRenderer.ts
@@ -1,3 +1,4 @@
+import type * as d3 from 'd3';
 import { getConfig } from '../../diagram-api/diagramAPI.js';
 import type { Diagram } from '../../Diagram.js';
 import { log } from '../../logger.js';
@@ -888,7 +889,7 @@ export const draw = (text: string, id: string, _version: string, diagObj: Diagra
         .sort((a, b) => a.number - b.number);
 
       // Draw text lines (temporarily to measure)
-      const textElements: any[] = [];
+      const textElements: d3.Selection<SVGTextElement, unknown, Element | null, unknown>[] = [];
       sortedAnnotations.forEach((annotation, idx) => {
         const text = textBoxGroup
           .append('text')
@@ -907,7 +908,7 @@ export const draw = (text: string, id: string, _version: string, diagObj: Diagra
         let maxWidth = 0;
         let maxHeight = 0;
         textElements.forEach((text) => {
-          const textNode = text.node() as SVGTextElement;
+          const textNode = text.node()!;
           // Use getComputedTextLength for more accurate width measurement
           const textWidth = textNode.getComputedTextLength();
           maxWidth = Math.max(maxWidth, textWidth);

--- a/packages/mermaid/src/diagrams/wardley/wardleyRenderer.ts
+++ b/packages/mermaid/src/diagrams/wardley/wardleyRenderer.ts
@@ -8,6 +8,8 @@ import type { WardleyBuildResult, WardleyNode } from './wardleyBuilder.js';
 
 const DEFAULT_STAGES = ['Genesis', 'Custom Built', 'Product', 'Commodity'];
 
+type WardleyText = d3.Selection<SVGTextElement, unknown, Element | null, unknown>;
+
 interface WardleyTheme {
   backgroundColor: string;
   axisColor: string;
@@ -889,7 +891,7 @@ export const draw = (text: string, id: string, _version: string, diagObj: Diagra
         .sort((a, b) => a.number - b.number);
 
       // Draw text lines (temporarily to measure)
-      const textElements: d3.Selection<SVGTextElement, unknown, Element | null, unknown>[] = [];
+      const textElements: WardleyText[] = [];
       sortedAnnotations.forEach((annotation, idx) => {
         const text = textBoxGroup
           .append('text')

--- a/packages/mermaid/src/docs/syntax/wardley.md
+++ b/packages/mermaid/src/docs/syntax/wardley.md
@@ -441,3 +441,7 @@ Wardley Maps support Mermaid's theme system. Use standard Mermaid configuration 
 | Strategy   | `(build\|buy\|outsource\|market)`   | `component API [0.6, 0.7] (buy)`    |
 | Pipeline   | `pipeline Parent { ... }`           | See pipeline example above          |
 | Evolution  | `evolution Stage1 -> Stage2 -> ...` | See evolution examples above        |
+
+## Limitations
+
+- Handdrawn/rough mode (`look: handDrawn`) is not currently supported for Wardley Maps. The diagram uses a custom D3 renderer rather than the shared shape system.

--- a/packages/mermaid/src/schemas/config.schema.yaml
+++ b/packages/mermaid/src/schemas/config.schema.yaml
@@ -2506,6 +2506,13 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
     description: The object containing configurations specific for Wardley Maps diagrams.
     type: object
     unevaluatedProperties: false
+    required:
+      - width
+      - height
+      - padding
+      - nodeRadius
+      - labelFontSize
+      - axisFontSize
     properties:
       width:
         description: The width of the Wardley diagram canvas.

--- a/packages/mermaid/src/themes/theme-base.js
+++ b/packages/mermaid/src/themes/theme-base.js
@@ -264,6 +264,7 @@ class Theme {
     };
 
     /* wardley */
+    this.wardleyEvolutionColor = this.wardleyEvolutionColor || '#dc3545';
     this.wardley = {
       backgroundColor: this.wardley?.backgroundColor || this.background,
       axisColor: this.wardley?.axisColor || this.lineColor,
@@ -273,7 +274,7 @@ class Theme {
       componentStroke: this.wardley?.componentStroke || this.lineColor,
       componentLabelColor: this.wardley?.componentLabelColor || this.primaryTextColor,
       linkStroke: this.wardley?.linkStroke || this.lineColor,
-      evolutionStroke: this.wardley?.evolutionStroke || '#dc3545',
+      evolutionStroke: this.wardley?.evolutionStroke || this.wardleyEvolutionColor,
       annotationStroke: this.wardley?.annotationStroke || this.lineColor,
       annotationTextColor: this.wardley?.annotationTextColor || this.primaryTextColor,
       annotationFill: this.wardley?.annotationFill || this.background,

--- a/packages/mermaid/src/themes/theme-base.js
+++ b/packages/mermaid/src/themes/theme-base.js
@@ -263,6 +263,22 @@ class Theme {
       legendFontSize: this.radar?.legendFontSize || 12,
     };
 
+    /* wardley */
+    this.wardley = {
+      backgroundColor: this.wardley?.backgroundColor || this.background,
+      axisColor: this.wardley?.axisColor || this.lineColor,
+      axisTextColor: this.wardley?.axisTextColor || this.primaryTextColor,
+      gridColor: this.wardley?.gridColor || 'rgba(100, 100, 100, 0.2)',
+      componentFill: this.wardley?.componentFill || this.background,
+      componentStroke: this.wardley?.componentStroke || this.lineColor,
+      componentLabelColor: this.wardley?.componentLabelColor || this.primaryTextColor,
+      linkStroke: this.wardley?.linkStroke || this.lineColor,
+      evolutionStroke: this.wardley?.evolutionStroke || '#dc3545',
+      annotationStroke: this.wardley?.annotationStroke || this.lineColor,
+      annotationTextColor: this.wardley?.annotationTextColor || this.primaryTextColor,
+      annotationFill: this.wardley?.annotationFill || this.background,
+    };
+
     /* architecture */
     this.archEdgeColor = this.archEdgeColor || '#777';
     this.archEdgeArrowColor = this.archEdgeArrowColor || '#777';

--- a/packages/mermaid/src/themes/theme-base.js
+++ b/packages/mermaid/src/themes/theme-base.js
@@ -268,7 +268,7 @@ class Theme {
       backgroundColor: this.wardley?.backgroundColor || this.background,
       axisColor: this.wardley?.axisColor || this.lineColor,
       axisTextColor: this.wardley?.axisTextColor || this.primaryTextColor,
-      gridColor: this.wardley?.gridColor || 'rgba(100, 100, 100, 0.2)',
+      gridColor: this.wardley?.gridColor || this.gridColor,
       componentFill: this.wardley?.componentFill || this.background,
       componentStroke: this.wardley?.componentStroke || this.lineColor,
       componentLabelColor: this.wardley?.componentLabelColor || this.primaryTextColor,

--- a/packages/mermaid/src/themes/theme-dark.js
+++ b/packages/mermaid/src/themes/theme-dark.js
@@ -325,6 +325,7 @@ class Theme {
     };
 
     /* wardley */
+    this.wardleyEvolutionColor = this.wardleyEvolutionColor || '#ff6b6b';
     this.wardley = {
       backgroundColor: this.wardley?.backgroundColor || this.background,
       axisColor: this.wardley?.axisColor || this.lineColor,
@@ -334,7 +335,7 @@ class Theme {
       componentStroke: this.wardley?.componentStroke || this.lineColor,
       componentLabelColor: this.wardley?.componentLabelColor || this.primaryTextColor,
       linkStroke: this.wardley?.linkStroke || this.lineColor,
-      evolutionStroke: this.wardley?.evolutionStroke || '#ff6b6b',
+      evolutionStroke: this.wardley?.evolutionStroke || this.wardleyEvolutionColor,
       annotationStroke: this.wardley?.annotationStroke || this.lineColor,
       annotationTextColor: this.wardley?.annotationTextColor || this.primaryTextColor,
       annotationFill: this.wardley?.annotationFill || this.mainBkg,

--- a/packages/mermaid/src/themes/theme-dark.js
+++ b/packages/mermaid/src/themes/theme-dark.js
@@ -324,6 +324,22 @@ class Theme {
       legendFontSize: this.radar?.legendFontSize || 12,
     };
 
+    /* wardley */
+    this.wardley = {
+      backgroundColor: this.wardley?.backgroundColor || this.background,
+      axisColor: this.wardley?.axisColor || this.lineColor,
+      axisTextColor: this.wardley?.axisTextColor || this.primaryTextColor,
+      gridColor: this.wardley?.gridColor || 'rgba(200, 200, 200, 0.15)',
+      componentFill: this.wardley?.componentFill || this.mainBkg,
+      componentStroke: this.wardley?.componentStroke || this.lineColor,
+      componentLabelColor: this.wardley?.componentLabelColor || this.primaryTextColor,
+      linkStroke: this.wardley?.linkStroke || this.lineColor,
+      evolutionStroke: this.wardley?.evolutionStroke || '#ff6b6b',
+      annotationStroke: this.wardley?.annotationStroke || this.lineColor,
+      annotationTextColor: this.wardley?.annotationTextColor || this.primaryTextColor,
+      annotationFill: this.wardley?.annotationFill || this.mainBkg,
+    };
+
     /* class */
     this.classText = this.primaryTextColor;
 

--- a/packages/mermaid/src/themes/theme-dark.js
+++ b/packages/mermaid/src/themes/theme-dark.js
@@ -329,7 +329,7 @@ class Theme {
       backgroundColor: this.wardley?.backgroundColor || this.background,
       axisColor: this.wardley?.axisColor || this.lineColor,
       axisTextColor: this.wardley?.axisTextColor || this.primaryTextColor,
-      gridColor: this.wardley?.gridColor || 'rgba(200, 200, 200, 0.15)',
+      gridColor: this.wardley?.gridColor || this.gridColor,
       componentFill: this.wardley?.componentFill || this.mainBkg,
       componentStroke: this.wardley?.componentStroke || this.lineColor,
       componentLabelColor: this.wardley?.componentLabelColor || this.primaryTextColor,

--- a/packages/mermaid/src/themes/theme-default.js
+++ b/packages/mermaid/src/themes/theme-default.js
@@ -331,6 +331,7 @@ class Theme {
     };
 
     /* wardley */
+    this.wardleyEvolutionColor = this.wardleyEvolutionColor || '#dc3545';
     this.wardley = {
       backgroundColor: this.wardley?.backgroundColor || this.background,
       axisColor: this.wardley?.axisColor || this.lineColor,
@@ -340,7 +341,7 @@ class Theme {
       componentStroke: this.wardley?.componentStroke || this.lineColor,
       componentLabelColor: this.wardley?.componentLabelColor || this.primaryTextColor,
       linkStroke: this.wardley?.linkStroke || this.lineColor,
-      evolutionStroke: this.wardley?.evolutionStroke || '#dc3545',
+      evolutionStroke: this.wardley?.evolutionStroke || this.wardleyEvolutionColor,
       annotationStroke: this.wardley?.annotationStroke || this.lineColor,
       annotationTextColor: this.wardley?.annotationTextColor || this.primaryTextColor,
       annotationFill: this.wardley?.annotationFill || this.background,

--- a/packages/mermaid/src/themes/theme-default.js
+++ b/packages/mermaid/src/themes/theme-default.js
@@ -335,7 +335,7 @@ class Theme {
       backgroundColor: this.wardley?.backgroundColor || this.background,
       axisColor: this.wardley?.axisColor || this.lineColor,
       axisTextColor: this.wardley?.axisTextColor || this.primaryTextColor,
-      gridColor: this.wardley?.gridColor || 'rgba(100, 100, 100, 0.2)',
+      gridColor: this.wardley?.gridColor || this.gridColor,
       componentFill: this.wardley?.componentFill || this.background,
       componentStroke: this.wardley?.componentStroke || this.lineColor,
       componentLabelColor: this.wardley?.componentLabelColor || this.primaryTextColor,

--- a/packages/mermaid/src/themes/theme-default.js
+++ b/packages/mermaid/src/themes/theme-default.js
@@ -330,6 +330,22 @@ class Theme {
       legendFontSize: this.radar?.legendFontSize || 12,
     };
 
+    /* wardley */
+    this.wardley = {
+      backgroundColor: this.wardley?.backgroundColor || this.background,
+      axisColor: this.wardley?.axisColor || this.lineColor,
+      axisTextColor: this.wardley?.axisTextColor || this.primaryTextColor,
+      gridColor: this.wardley?.gridColor || 'rgba(100, 100, 100, 0.2)',
+      componentFill: this.wardley?.componentFill || this.background,
+      componentStroke: this.wardley?.componentStroke || this.lineColor,
+      componentLabelColor: this.wardley?.componentLabelColor || this.primaryTextColor,
+      linkStroke: this.wardley?.linkStroke || this.lineColor,
+      evolutionStroke: this.wardley?.evolutionStroke || '#dc3545',
+      annotationStroke: this.wardley?.annotationStroke || this.lineColor,
+      annotationTextColor: this.wardley?.annotationTextColor || this.primaryTextColor,
+      annotationFill: this.wardley?.annotationFill || this.background,
+    };
+
     /* xychart */
     this.xyChart = {
       backgroundColor: this.xyChart?.backgroundColor || this.background,

--- a/packages/mermaid/src/themes/theme-forest.js
+++ b/packages/mermaid/src/themes/theme-forest.js
@@ -303,6 +303,7 @@ class Theme {
     };
 
     /* wardley */
+    this.wardleyEvolutionColor = this.wardleyEvolutionColor || '#dc3545';
     this.wardley = {
       backgroundColor: this.wardley?.backgroundColor || this.background,
       axisColor: this.wardley?.axisColor || this.lineColor,
@@ -312,7 +313,7 @@ class Theme {
       componentStroke: this.wardley?.componentStroke || this.lineColor,
       componentLabelColor: this.wardley?.componentLabelColor || this.primaryTextColor,
       linkStroke: this.wardley?.linkStroke || this.lineColor,
-      evolutionStroke: this.wardley?.evolutionStroke || '#dc3545',
+      evolutionStroke: this.wardley?.evolutionStroke || this.wardleyEvolutionColor,
       annotationStroke: this.wardley?.annotationStroke || this.lineColor,
       annotationTextColor: this.wardley?.annotationTextColor || this.primaryTextColor,
       annotationFill: this.wardley?.annotationFill || this.background,

--- a/packages/mermaid/src/themes/theme-forest.js
+++ b/packages/mermaid/src/themes/theme-forest.js
@@ -307,7 +307,7 @@ class Theme {
       backgroundColor: this.wardley?.backgroundColor || this.background,
       axisColor: this.wardley?.axisColor || this.lineColor,
       axisTextColor: this.wardley?.axisTextColor || this.primaryTextColor,
-      gridColor: this.wardley?.gridColor || 'rgba(100, 100, 100, 0.2)',
+      gridColor: this.wardley?.gridColor || this.gridColor,
       componentFill: this.wardley?.componentFill || this.background,
       componentStroke: this.wardley?.componentStroke || this.lineColor,
       componentLabelColor: this.wardley?.componentLabelColor || this.primaryTextColor,

--- a/packages/mermaid/src/themes/theme-forest.js
+++ b/packages/mermaid/src/themes/theme-forest.js
@@ -302,6 +302,22 @@ class Theme {
       legendFontSize: this.radar?.legendFontSize || 12,
     };
 
+    /* wardley */
+    this.wardley = {
+      backgroundColor: this.wardley?.backgroundColor || this.background,
+      axisColor: this.wardley?.axisColor || this.lineColor,
+      axisTextColor: this.wardley?.axisTextColor || this.primaryTextColor,
+      gridColor: this.wardley?.gridColor || 'rgba(100, 100, 100, 0.2)',
+      componentFill: this.wardley?.componentFill || this.background,
+      componentStroke: this.wardley?.componentStroke || this.lineColor,
+      componentLabelColor: this.wardley?.componentLabelColor || this.primaryTextColor,
+      linkStroke: this.wardley?.linkStroke || this.lineColor,
+      evolutionStroke: this.wardley?.evolutionStroke || '#dc3545',
+      annotationStroke: this.wardley?.annotationStroke || this.lineColor,
+      annotationTextColor: this.wardley?.annotationTextColor || this.primaryTextColor,
+      annotationFill: this.wardley?.annotationFill || this.background,
+    };
+
     /* xychart */
     this.xyChart = {
       backgroundColor: this.xyChart?.backgroundColor || this.background,

--- a/packages/mermaid/src/themes/theme-neutral.js
+++ b/packages/mermaid/src/themes/theme-neutral.js
@@ -337,6 +337,7 @@ class Theme {
     };
 
     /* wardley */
+    this.wardleyEvolutionColor = this.wardleyEvolutionColor || '#dc3545';
     this.wardley = {
       backgroundColor: this.wardley?.backgroundColor || this.background,
       axisColor: this.wardley?.axisColor || this.lineColor,
@@ -346,7 +347,7 @@ class Theme {
       componentStroke: this.wardley?.componentStroke || this.lineColor,
       componentLabelColor: this.wardley?.componentLabelColor || this.primaryTextColor,
       linkStroke: this.wardley?.linkStroke || this.lineColor,
-      evolutionStroke: this.wardley?.evolutionStroke || '#dc3545',
+      evolutionStroke: this.wardley?.evolutionStroke || this.wardleyEvolutionColor,
       annotationStroke: this.wardley?.annotationStroke || this.lineColor,
       annotationTextColor: this.wardley?.annotationTextColor || this.primaryTextColor,
       annotationFill: this.wardley?.annotationFill || this.background,

--- a/packages/mermaid/src/themes/theme-neutral.js
+++ b/packages/mermaid/src/themes/theme-neutral.js
@@ -341,7 +341,7 @@ class Theme {
       backgroundColor: this.wardley?.backgroundColor || this.background,
       axisColor: this.wardley?.axisColor || this.lineColor,
       axisTextColor: this.wardley?.axisTextColor || this.primaryTextColor,
-      gridColor: this.wardley?.gridColor || 'rgba(100, 100, 100, 0.2)',
+      gridColor: this.wardley?.gridColor || this.gridColor,
       componentFill: this.wardley?.componentFill || this.background,
       componentStroke: this.wardley?.componentStroke || this.lineColor,
       componentLabelColor: this.wardley?.componentLabelColor || this.primaryTextColor,

--- a/packages/mermaid/src/themes/theme-neutral.js
+++ b/packages/mermaid/src/themes/theme-neutral.js
@@ -336,6 +336,22 @@ class Theme {
       legendFontSize: this.radar?.legendFontSize || 12,
     };
 
+    /* wardley */
+    this.wardley = {
+      backgroundColor: this.wardley?.backgroundColor || this.background,
+      axisColor: this.wardley?.axisColor || this.lineColor,
+      axisTextColor: this.wardley?.axisTextColor || this.primaryTextColor,
+      gridColor: this.wardley?.gridColor || 'rgba(100, 100, 100, 0.2)',
+      componentFill: this.wardley?.componentFill || this.background,
+      componentStroke: this.wardley?.componentStroke || this.lineColor,
+      componentLabelColor: this.wardley?.componentLabelColor || this.primaryTextColor,
+      linkStroke: this.wardley?.linkStroke || this.lineColor,
+      evolutionStroke: this.wardley?.evolutionStroke || '#dc3545',
+      annotationStroke: this.wardley?.annotationStroke || this.lineColor,
+      annotationTextColor: this.wardley?.annotationTextColor || this.primaryTextColor,
+      annotationFill: this.wardley?.annotationFill || this.background,
+    };
+
     /* requirement-diagram */
     this.requirementBackground = this.requirementBackground || this.primaryColor;
     this.requirementBorderColor = this.requirementBorderColor || this.primaryBorderColor;


### PR DESCRIPTION
## Summary

Post-merge follow-ups for the Wardley Maps diagram type (#7147). Two commits:

1. **Review feedback from @knsv** (non-blocking at merge time):
   - Sanitize link labels through `textSanitizer()` for defense-in-depth
   - Add `feat:` prefix to the changeset description
   - Remove auto-generated docs files accidentally committed to the source tree
   - Document the handdrawn/rough (`look: handDrawn`) mode limitation in `wardley.md`
   - Add a `required` array to `WardleyDiagramConfig` JSON schema

2. **Real behaviour fixes**:
   - **Pipeline link resolution**: links targeting components inside a pipeline now resolve correctly via a new `resolveNodeId()` that falls back to label-based matching when the synthetic-ID lookup misses.
   - **Theme integration**: add Wardley theme variables to all five theme files (`base`, `default`, `dark`, `forest`, `neutral`) so non-default themes render Wardley maps correctly. New `styles.ts` wires CSS rules to those variables; `wardleyDiagram.ts` uses the new styles function (previously empty).
   - **Type safety**: replace an incorrect `Required<WardleyNode>` cast with a narrowed `WardleyNode & { x; y }` type, and replace `any[]` with the proper `d3.Selection` type for text elements.

## Test plan

- [x] `pnpm --filter mermaid test src/diagrams/wardley/` passes
- [ ] Manually verify dark, forest, and neutral themes render a Wardley map correctly in the browser
- [ ] Manually verify a diagram with links targeting a pipeline child component renders the link