### PR TITLE
fix(wardley): allow hyphens in unquoted component names

### DIFF
--- a/.changeset/fix-wardley-hyphenated-names.md
+++ b/.changeset/fix-wardley-hyphenated-names.md
@@ -1,0 +1,8 @@
+---
+'@mermaid-js/parser': patch
+'mermaid': patch
+---
+
+fix(wardley): allow hyphens in unquoted component names
+
+Multi-word names containing hyphens — e.g. `real-time processing`, `end-user`, `on-call engineer` — now parse without quoting, bringing the grammar in line with the OnlineWardleyMaps (OWM) convention. `A->B` (no-space arrow) still tokenises correctly.

--- a/docs/syntax/wardley.md
+++ b/docs/syntax/wardley.md
@@ -155,6 +155,28 @@ component Database [0.40, 0.85] label [-50, 10]
 component "Custom Service" [0.55, 0.35]
 ```
 
+Names may contain hyphens (`real-time processing`, `end-user`) without quoting. Quote a name only if it begins with a non-letter or contains a character the grammar does not otherwise accept.
+
+```mermaid-example
+wardley-beta
+title Hyphenated Names
+
+component real-time processing [0.55, 0.40]
+component end-user [0.90, 0.95]
+
+end-user -> real-time processing
+```
+
+```mermaid
+wardley-beta
+title Hyphenated Names
+
+component real-time processing [0.55, 0.40]
+component end-user [0.90, 0.95]
+
+end-user -> real-time processing
+```
+
 #### Anchors
 
 Anchors represent users or customers with bold labels:

--- a/packages/mermaid/src/diagrams/wardley/wardleyParser.spec.ts
+++ b/packages/mermaid/src/diagrams/wardley/wardleyParser.spec.ts
@@ -224,4 +224,96 @@ deaccelerator "Legacy Data" [0.40, 0.35]`
     expect(data.accelerators[0]).toMatchObject({ name: 'Cloud Native', x: 85, y: 20 });
     expect(data.deaccelerators[0]).toMatchObject({ name: 'Legacy Data', x: 35, y: 40 });
   });
+
+  it('accepts hyphens in unquoted component names', async () => {
+    await parser.parse(
+      `wardley-beta
+component real-time processing [0.5, 0.5]
+component end-user [0.8, 0.9]`
+    );
+
+    const data = db.getWardleyData();
+    const realtime = data.nodes.find((n) => n.label === 'real-time processing');
+    const enduser = data.nodes.find((n) => n.label === 'end-user');
+    expect(realtime?.x).toBeCloseTo(50);
+    expect(realtime?.y).toBeCloseTo(50);
+    expect(enduser?.x).toBeCloseTo(90);
+    expect(enduser?.y).toBeCloseTo(80);
+  });
+
+  it('accepts hyphens in link endpoints', async () => {
+    await parser.parse(
+      `wardley-beta
+component real-time processing [0.5, 0.5]
+component end-user [0.8, 0.9]
+real-time processing -> end-user`
+    );
+
+    const data = db.getWardleyData();
+    expect(data.links).toHaveLength(1);
+    expect(data.links[0].source).toBe('real-time processing');
+    expect(data.links[0].target).toBe('end-user');
+  });
+
+  it('accepts hyphens in anchor names', async () => {
+    await parser.parse(
+      `wardley-beta
+anchor on-call engineer [0.9, 0.95]`
+    );
+
+    const data = db.getWardleyData();
+    const anchor = data.nodes.find((n) => n.label === 'on-call engineer');
+    expect(anchor?.className).toBe('anchor');
+    expect(anchor?.x).toBeCloseTo(95);
+    expect(anchor?.y).toBeCloseTo(90);
+  });
+
+  it('still tokenises A->B as an arrow (no-space regression)', async () => {
+    await parser.parse(
+      `wardley-beta
+component A [0.1, 0.1]
+component B [0.2, 0.2]
+A->B`
+    );
+
+    const data = db.getWardleyData();
+    expect(data.links).toHaveLength(1);
+    expect(data.links[0].source).toBe('A');
+    expect(data.links[0].target).toBe('B');
+  });
+
+  it('parses foo-bar->baz as link from foo-bar to baz', async () => {
+    await parser.parse(
+      `wardley-beta
+component foo-bar [0.3, 0.3]
+component baz [0.6, 0.6]
+foo-bar->baz`
+    );
+
+    const data = db.getWardleyData();
+    expect(data.links).toHaveLength(1);
+    expect(data.links[0].source).toBe('foo-bar');
+    expect(data.links[0].target).toBe('baz');
+  });
+
+  it('accepts hyphens in pipeline component names with label overrides', async () => {
+    await parser.parse(
+      `wardley-beta
+component Data Store [0.5, 0.5]
+pipeline Data Store {
+  component real-time queue [0.3] label [-40, 20]
+  component batch-loader [0.7]
+}`
+    );
+
+    const data = db.getWardleyData();
+    const realtime = data.nodes.find((n) => n.label === 'real-time queue');
+    const batch = data.nodes.find((n) => n.label === 'batch-loader');
+    expect(realtime?.className).toBe('pipeline-component');
+    expect(realtime?.labelOffsetX).toBe(-40);
+    expect(realtime?.labelOffsetY).toBe(20);
+    expect(realtime?.x).toBeCloseTo(30);
+    expect(batch?.className).toBe('pipeline-component');
+    expect(batch?.x).toBeCloseTo(70);
+  });
 });

--- a/packages/mermaid/src/diagrams/wardley/wardleyParser.spec.ts
+++ b/packages/mermaid/src/diagrams/wardley/wardleyParser.spec.ts
@@ -316,4 +316,30 @@ pipeline Data Store {
     expect(batch?.className).toBe('pipeline-component');
     expect(batch?.x).toBeCloseTo(70);
   });
+
+  it('accepts consecutive hyphens inside a name', async () => {
+    await parser.parse(
+      `wardley-beta
+component foo--bar [0.3, 0.4]`
+    );
+
+    const data = db.getWardleyData();
+    const node = data.nodes.find((n) => n.label === 'foo--bar');
+    expect(node).toBeDefined();
+    expect(node?.x).toBeCloseTo(40);
+    expect(node?.y).toBeCloseTo(30);
+  });
+
+  it('accepts a trailing hyphen in a name', async () => {
+    await parser.parse(
+      `wardley-beta
+component foo- [0.2, 0.3]`
+    );
+
+    const data = db.getWardleyData();
+    const node = data.nodes.find((n) => n.label === 'foo-');
+    expect(node).toBeDefined();
+    expect(node?.x).toBeCloseTo(30);
+    expect(node?.y).toBeCloseTo(20);
+  });
 });

--- a/packages/mermaid/src/docs/syntax/wardley.md
+++ b/packages/mermaid/src/docs/syntax/wardley.md
@@ -96,6 +96,18 @@ component Database [0.40, 0.85] label [-50, 10]
 component "Custom Service" [0.55, 0.35]
 ```
 
+Names may contain hyphens (`real-time processing`, `end-user`) without quoting. Quote a name only if it begins with a non-letter or contains a character the grammar does not otherwise accept.
+
+```mermaid-example
+wardley-beta
+title Hyphenated Names
+
+component real-time processing [0.55, 0.40]
+component end-user [0.90, 0.95]
+
+end-user -> real-time processing
+```
+
 #### Anchors
 
 Anchors represent users or customers with bold labels:

--- a/packages/parser/src/language/wardley/wardley.langium
+++ b/packages/parser/src/language/wardley/wardley.langium
@@ -133,7 +133,11 @@ terminal KW_DEACCELERATOR: 'deaccelerator';
 // NAME_WITH_SPACES must be defined LAST to avoid shadowing other terminals
 // Uses negative lookahead to exclude matching content that starts with reserved keywords
 // Matches names like "Campfire Kettle" and "byte pair encoding (BPE)"
-// Pattern: letter, then any combo of letters/digits/_()&, then optionally (space/tab + letter OR open-paren, then more chars) repeating
+// Pattern: letter, then any combo of letters/digits/_()& or hyphen not followed by `>`,
+// then optionally (space/tab + letter OR open-paren, then more chars) repeating.
+// The `-(?!>)` negative lookahead lets names contain hyphens ("real-time processing")
+// while preserving `->` as the ARROW terminal: in `A->B` the `-` is followed by `>`,
+// the lookahead fails, the name stops at `A`, and `->` tokenises as ARROW.
 // After a space, must start with letter [A-Za-z] or open paren [(] to allow both "Campfire Kettle" and "(BPE)"
 // Uses [ \t]+ instead of \s+ to avoid matching newlines
 terminal NAME_WITH_SPACES: /(?!title\s|accTitle|accDescr)[A-Za-z](?:[A-Za-z0-9_()&]|-(?!>))*(?:[ \t]+[A-Za-z(](?:[A-Za-z0-9_()&]|-(?!>))*)*/;

--- a/packages/parser/src/language/wardley/wardley.langium
+++ b/packages/parser/src/language/wardley/wardley.langium
@@ -136,7 +136,7 @@ terminal KW_DEACCELERATOR: 'deaccelerator';
 // Pattern: letter, then any combo of letters/digits/_()&, then optionally (space/tab + letter OR open-paren, then more chars) repeating
 // After a space, must start with letter [A-Za-z] or open paren [(] to allow both "Campfire Kettle" and "(BPE)"
 // Uses [ \t]+ instead of \s+ to avoid matching newlines
-terminal NAME_WITH_SPACES: /(?!title\s|accTitle|accDescr)[A-Za-z][A-Za-z0-9_()&]*(?:[ \t]+[A-Za-z(][A-Za-z0-9_()&]*)*/;
+terminal NAME_WITH_SPACES: /(?!title\s|accTitle|accDescr)[A-Za-z](?:[A-Za-z0-9_()&]|-(?!>))*(?:[ \t]+[A-Za-z(](?:[A-Za-z0-9_()&]|-(?!>))*)*/;
 // Removed EVOLUTION_NAME and COMPONENT_NAME terminals - they were too greedy
 // and shadowed imported terminals from common.langium (like TITLE)
 // Now using ID for evolution names and STRING for component names


### PR DESCRIPTION
## Summary

Widen `NAME_WITH_SPACES` in `wardley.langium` so multi-word names containing hyphens — e.g. `real-time processing`, `end-user`, `on-call engineer` — parse without needing quotes. Brings the grammar in line with the OnlineWardleyMaps (OWM) convention.

## The change

Single regex edit in `packages/parser/src/language/wardley/wardley.langium`:

```diff
- /(?!title\s|accTitle|accDescr)[A-Za-z][A-Za-z0-9_()&]*(?:[ \t]+[A-Za-z(][A-Za-z0-9_()&]*)*/
+ /(?!title\s|accTitle|accDescr)[A-Za-z](?:[A-Za-z0-9_()&]|-(?!>))*(?:[ \t]+[A-Za-z(](?:[A-Za-z0-9_()&]|-(?!>))*)*/
```

The key addition is the `-(?!>)` alternation: a hyphen is accepted inside a name only when **not** immediately followed by `>`. This preserves `A->B` (no-space arrow) tokenisation — the hyphen gets rejected, the name stops at `A`, and `->` tokenises as `ARROW`.

## Test plan

- [x] Six new spec cases in `wardleyParser.spec.ts` — hyphenated component/anchor/pipeline names, hyphenated link endpoints, plus `A->B` and `foo-bar->baz` regression guards
- [x] Full wardley suite passes (18/18)
- [x] Parser regenerates without ambiguity warnings
- [ ] Manual browser check of the new `mermaid-example` block in `wardley.md`