### PR TITLE
fix: loosen `uuid` dependency range to allow v14

### DIFF
--- a/.changeset/hungry-carrots-chew.md
+++ b/.changeset/hungry-carrots-chew.md
@@ -1,0 +1,8 @@
+---
+'mermaid': patch
+---
+
+fix: loosen `uuid` dependency range to allow v14
+
+Mermaid does not use any of the vulnerable code in CVE-2026-41907,
+but this allows users to silence any `npm audit` alerts on it.

--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -104,7 +104,6 @@
     "@types/katex": "^0.16.7",
     "@types/micromatch": "^4.0.10",
     "@types/stylis": "^4.2.7",
-    "@types/uuid": "^10.0.0",
     "ajv": "^8.17.1",
     "canvas": "^3.2.0",
     "chokidar": "3.6.0",

--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -88,7 +88,7 @@
     "roughjs": "^4.6.6",
     "stylis": "^4.3.6",
     "ts-dedent": "^2.2.0",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
   },
   "devDependencies": {
     "@adobe/jsonschema2md": "^8.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,9 +335,6 @@ importers:
       '@types/stylis':
         specifier: ^4.2.7
         version: 4.2.7
-      '@types/uuid':
-        specifier: ^10.0.0
-        version: 10.0.0
       ajv:
         specifier: ^8.17.1
         version: 8.18.0
@@ -3487,9 +3484,6 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
-
-  '@types/uuid@10.0.0':
-    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
@@ -13643,8 +13637,6 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
-
-  '@types/uuid@10.0.0': {}
 
   '@types/web-bluetooth@0.0.21': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,8 +293,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
       uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
+        specifier: ^11.1.0 || ^12 || ^13 || ^14.0.0
+        version: 14.0.0
     devDependencies:
       '@adobe/jsonschema2md':
         specifier: ^8.0.8
@@ -9732,8 +9732,8 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   uuid@8.3.2:
@@ -21146,7 +21146,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@11.1.0: {}
+  uuid@14.0.0: {}
 
   uuid@8.3.2: {}
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

Mermaid does not use any of the vulnerable code in [CVE-2026-41907](https://github.com/uuidjs/uuid/security/advisories/GHSA-w5hq-g745-h8pq), which is fixed in uuid v14, but this allows users to silence any `npm audit` alerts on it.

See: [CVE-2026-41907](https://github.com/uuidjs/uuid/security/advisories/GHSA-w5hq-g745-h8pq)
See: https://github.com/mermaid-js/mermaid/commit/d3c0893937da312c7e9680b98bbeb43f95aa6e8f

## :straight_ruler: Design Decisions

Since the only breaking changes in v12-v14 are essentially Node.JS version support, I've broadened our range to allow all versions:

- [v12][]: remove CommonJS and Node.JS v16 support
- [v13][]: make browser exports the default
- [v14][]: remove Node.JS v18 support

I don't think there would be any Mermaid users that are still on Node.JS v18, since https://github.com/mermaid-js/mermaid/commit/d3c0893937da312c7e9680b98bbeb43f95aa6e8f bumped [marked to v16][marked@v16], which requires Node.JS v20.

I've also removed the unused `@types/uuid` package, since `uuid` v11 now includes TypeScript types.

[v12]: https://github.com/uuidjs/uuid/releases/tag/v12.0.0
[v13]: https://github.com/uuidjs/uuid/releases/tag/v13.0.0
[v14]: https://github.com/uuidjs/uuid/releases/tag/v14.0.0
[marked@v16]: https://github.com/markedjs/marked/releases/tag/v16.0.0

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
  - Dependency update only, the changeset is the only documentation we need.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
