### PR TITLE
fix(quadrant-chart): add UNICODE_TEXT support for CJK and emoji

### DIFF
--- a/.changeset/quadrant-chart-unicode-support.md
+++ b/.changeset/quadrant-chart-unicode-support.md
@@ -1,0 +1,9 @@
+---
+'mermaid': patch
+---
+
+fix(quadrant-chart): allow CJK, emoji, Latin-1 accented characters, and other non-ASCII text in unquoted axis/quadrant/point labels.
+
+Previously the lexer only matched ASCII `[A-Za-z]+` for text tokens, even though the grammar referenced `UNICODE_TEXT`. Bare Chinese, Japanese, Korean, emoji, and accented Latin characters in labels caused a parse error. Added a `[^\x00-\x7F]+` lexer rule to emit `UNICODE_TEXT` and included it in the `alphaNumToken` grammar rule.
+
+Fixes #7120.

--- a/packages/mermaid/src/diagrams/quadrant-chart/parser/quadrant.jison
+++ b/packages/mermaid/src/diagrams/quadrant-chart/parser/quadrant.jison
@@ -57,7 +57,8 @@ accDescr\s*"{"\s*                        { this.begin("acc_descr_multiline");}
 " "*"quadrantChart"" "*		                   return 'QUADRANT';
 
 [A-Za-z]+                                return 'ALPHA';
-[\u0080-\uFFFF]+                         return 'UNICODE_TEXT';
+// BMP non-ASCII: CJK, emoji, accented Latin, Cyrillic, etc.
+[^\x00-\x7F]+                            return 'UNICODE_TEXT';
 ":"                                      return 'COLON';
 \+                                       return 'PLUS';
 ","                                      return 'COMMA';

--- a/packages/mermaid/src/diagrams/quadrant-chart/parser/quadrant.jison
+++ b/packages/mermaid/src/diagrams/quadrant-chart/parser/quadrant.jison
@@ -57,6 +57,7 @@ accDescr\s*"{"\s*                        { this.begin("acc_descr_multiline");}
 " "*"quadrantChart"" "*		                   return 'QUADRANT';
 
 [A-Za-z]+                                return 'ALPHA';
+[\u0080-\uFFFF]+                         return 'UNICODE_TEXT';
 ":"                                      return 'COLON';
 \+                                       return 'PLUS';
 ","                                      return 'COMMA';
@@ -180,7 +181,7 @@ alphaNum
     ;
 
 
-alphaNumToken  : PUNCTUATION | AMP | NUM| ALPHA | COMMA | PLUS | EQUALS | MULT | DOT | BRKT| UNDERSCORE ;
+alphaNumToken  : PUNCTUATION | AMP | NUM| ALPHA | COMMA | PLUS | EQUALS | MULT | DOT | BRKT| UNDERSCORE | UNICODE_TEXT;
 
 textNoTagsToken: alphaNumToken | SPACE | MINUS;
 

--- a/packages/mermaid/src/diagrams/quadrant-chart/parser/quadrant.jison.spec.ts
+++ b/packages/mermaid/src/diagrams/quadrant-chart/parser/quadrant.jison.spec.ts
@@ -573,5 +573,31 @@ quadrant-4 可以改进
         type: 'text',
       });
     });
+
+    it('should parse Latin-1 accented text (French/Spanish/German)', () => {
+      const str = 'quadrantChart\nx-axis Café --> Größe';
+      expect(parserFnConstructor(str)).not.toThrow();
+      expect(mockDB.setXAxisLeftText).toHaveBeenCalledWith({
+        text: 'Café',
+        type: 'text',
+      });
+      expect(mockDB.setXAxisRightText).toHaveBeenCalledWith({
+        text: 'Größe',
+        type: 'text',
+      });
+    });
+
+    it('should parse accented characters in quadrant labels', () => {
+      const str = 'quadrantChart\nquadrant-1 catégoría\nquadrant-2 naïve';
+      expect(parserFnConstructor(str)).not.toThrow();
+      expect(mockDB.setQuadrant1Text).toHaveBeenCalledWith({
+        text: 'catégoría',
+        type: 'text',
+      });
+      expect(mockDB.setQuadrant2Text).toHaveBeenCalledWith({
+        text: 'naïve',
+        type: 'text',
+      });
+    });
   });
 });

--- a/packages/mermaid/src/diagrams/quadrant-chart/parser/quadrant.jison.spec.ts
+++ b/packages/mermaid/src/diagrams/quadrant-chart/parser/quadrant.jison.spec.ts
@@ -433,4 +433,145 @@ describe('Testing quadrantChart jison file', () => {
     expect(parserFnConstructor(str)).not.toThrow();
     expect(mockDB.addClass).toHaveBeenCalledWith('constructor', ['fill:#ff0000']);
   });
+
+  describe('Unicode support (CJK + Emoji)', () => {
+    it('should be able to parse Chinese text in quadrant labels', () => {
+      let str = 'quadrantChart\nquadrant-1 需要扩展';
+      expect(parserFnConstructor(str)).not.toThrow();
+      expect(mockDB.setQuadrant1Text).toHaveBeenCalledWith({
+        text: '需要扩展',
+        type: 'text',
+      });
+
+      clearMocks();
+      str = 'quadrantChart\nquadrant-2 需要推广\nquadrant-3 重新评估\nquadrant-4 可以改进';
+      expect(parserFnConstructor(str)).not.toThrow();
+      expect(mockDB.setQuadrant2Text).toHaveBeenCalledWith({
+        text: '需要推广',
+        type: 'text',
+      });
+      expect(mockDB.setQuadrant3Text).toHaveBeenCalledWith({
+        text: '重新评估',
+        type: 'text',
+      });
+      expect(mockDB.setQuadrant4Text).toHaveBeenCalledWith({
+        text: '可以改进',
+        type: 'text',
+      });
+    });
+
+    it('should be able to parse Chinese text in x-axis', () => {
+      const str = 'quadrantChart\nx-axis 低覆盖率 --> 高覆盖率';
+      expect(parserFnConstructor(str)).not.toThrow();
+      expect(mockDB.setXAxisLeftText).toHaveBeenCalledWith({
+        text: '低覆盖率',
+        type: 'text',
+      });
+      expect(mockDB.setXAxisRightText).toHaveBeenCalledWith({
+        text: '高覆盖率',
+        type: 'text',
+      });
+    });
+
+    it('should be able to parse Chinese text in y-axis', () => {
+      const str = 'quadrantChart\ny-axis 低参与度 --> 高参与度';
+      expect(parserFnConstructor(str)).not.toThrow();
+      expect(mockDB.setYAxisBottomText).toHaveBeenCalledWith({
+        text: '低参与度',
+        type: 'text',
+      });
+      expect(mockDB.setYAxisTopText).toHaveBeenCalledWith({
+        text: '高参与度',
+        type: 'text',
+      });
+    });
+
+    it('should be able to parse Chinese point names', () => {
+      const str = 'quadrantChart\n产品A: [0.3, 0.6]';
+      expect(parserFnConstructor(str)).not.toThrow();
+      expect(mockDB.addPoint).toHaveBeenCalledWith(
+        { text: '产品A', type: 'text' },
+        '',
+        '0.3',
+        '0.6',
+        []
+      );
+    });
+
+    it('should be able to parse a full chart with Chinese', () => {
+      const str = `quadrantChart
+title 分析象限图
+x-axis 低覆盖率 --> 高覆盖率
+y-axis 低参与度 --> 高参与度
+quadrant-1 需要扩展
+quadrant-2 需要推广
+quadrant-3 重新评估
+quadrant-4 可以改进
+产品A: [0.3, 0.6]
+产品B: [0.45, 0.23]`;
+      expect(parserFnConstructor(str)).not.toThrow();
+      expect(mockDB.setDiagramTitle).toHaveBeenCalledWith('分析象限图');
+      expect(mockDB.setXAxisLeftText).toHaveBeenCalledWith({
+        text: '低覆盖率',
+        type: 'text',
+      });
+      expect(mockDB.setXAxisRightText).toHaveBeenCalledWith({
+        text: '高覆盖率',
+        type: 'text',
+      });
+      expect(mockDB.setYAxisBottomText).toHaveBeenCalledWith({
+        text: '低参与度',
+        type: 'text',
+      });
+      expect(mockDB.setYAxisTopText).toHaveBeenCalledWith({
+        text: '高参与度',
+        type: 'text',
+      });
+      expect(mockDB.setQuadrant1Text).toHaveBeenCalledWith({
+        text: '需要扩展',
+        type: 'text',
+      });
+      expect(mockDB.addPoint).toHaveBeenCalledWith(
+        { text: '产品A', type: 'text' },
+        '',
+        '0.3',
+        '0.6',
+        []
+      );
+      expect(mockDB.addPoint).toHaveBeenCalledWith(
+        { text: '产品B', type: 'text' },
+        '',
+        '0.45',
+        '0.23',
+        []
+      );
+    });
+
+    it('should be able to parse Japanese text', () => {
+      const str = 'quadrantChart\nquadrant-1 拡張が必要\nx-axis 低い --> 高い';
+      expect(parserFnConstructor(str)).not.toThrow();
+      expect(mockDB.setQuadrant1Text).toHaveBeenCalledWith({
+        text: '拡張が必要',
+        type: 'text',
+      });
+    });
+
+    it('should be able to parse Korean text', () => {
+      const str = 'quadrantChart\nx-axis 낮음 --> 높음';
+      expect(parserFnConstructor(str)).not.toThrow();
+      expect(mockDB.setXAxisLeftText).toHaveBeenCalledWith({
+        text: '낮음',
+        type: 'text',
+      });
+    });
+
+    it('should be able to parse emoji in text', () => {
+      const str = 'quadrantChart\nquadrant-2 🚀Growth';
+      expect(parserFnConstructor(str)).not.toThrow();
+      expect(mockDB.setQuadrant2Text).toHaveBeenCalledWith({
+        text: '🚀Growth',
+        type: 'text',
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #7120 — Quadrant Chart render fail with Chinese/Unicode text.

The quadrant chart Jison parser's `ALPHA` lexer token only matched ASCII `[A-Za-z]+`, and the `UNICODE_TEXT` token was referenced in the grammar but never emitted by the lexer. This caused bare (non-quoted) Chinese, Japanese, Korean, and other Unicode text to fail with a parse error in `x-axis`, `y-axis`, `quadrant-N` labels, and point names.

## Changes

### `quadrant.jison` — 2 lines changed

1. **Lexer**: Added `[\u0080-\uFFFF]+ return 'UNICODE_TEXT';` rule after the `ALPHA` rule to emit a `UNICODE_TEXT` token for all non-ASCII BMP characters.
2. **Grammar**: Added `UNICODE_TEXT` to the `alphaNumToken` rule so bare Unicode text can be parsed via the `text` production.

### `quadrant.jison.spec.ts` — 8 new test cases

Added `Unicode support (CJK + Emoji)` test suite covering:
- Chinese quadrant labels
- Chinese x-axis / y-axis
- Chinese point names
- Full Chinese chart
- Japanese text
- Korean text
- Emoji in text

## Test plan

All existing tests pass (no regression). New tests verify:

```mermaid
quadrantChart
    title 优先级矩阵
    x-axis 低紧迫度 --> 高紧迫度
    y-axis 低重要性 --> 高重要性
    quadrant-1 需要扩展
    quadrant-2 需要推广
    quadrant-3 重新评估
    quadrant-4 可以改进
    产品A: [0.3, 0.6]
    产品B: [0.45, 0.23]
```

previously failed with `Parse error`, now renders correctly.