### PR TITLE
fix(flowchart): apply ELK mergeEdges in subgraphs

### DIFF
--- a/.changeset/fix-elk-merge-edges-subgraphs.md
+++ b/.changeset/fix-elk-merge-edges-subgraphs.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: apply ELK mergeEdges option to subgraph layout

--- a/cypress/integration/rendering/flowchart/flowchart-elk.spec.js
+++ b/cypress/integration/rendering/flowchart/flowchart-elk.spec.js
@@ -56,6 +56,35 @@ describe('Flowchart ELK', () => {
     );
   });
 
+  it('4a-elk: should apply mergeEdges in subgraphs', () => {
+    imgSnapshotTest(
+      `---
+config:
+  layout: elk
+  elk:
+    mergeEdges: true
+---
+flowchart TD
+  A
+  B
+  C
+
+  subgraph S1
+    A & B --> C
+  end
+
+  subgraph S2
+    D
+    E
+    F
+  end
+
+  D & E --> F
+      `,
+      {}
+    );
+  });
+
   it('4-elk: Length of edges', () => {
     imgSnapshotTest(
       `flowchart-elk TD

--- a/packages/mermaid-layout-elk/src/render.ts
+++ b/packages/mermaid-layout-elk/src/render.ts
@@ -812,6 +812,7 @@ export const render = async (
       node.layoutOptions = {
         'spacing.baseValue': 30,
         'nodeLabels.placement': '[H_CENTER V_TOP, INSIDE]',
+        'elk.layered.mergeEdges': data4Layout.config.elk?.mergeEdges,
       };
       if (node.dir) {
         node.layoutOptions = {


### PR DESCRIPTION
## Summary

Fixes #7659.

This propagates the configured ELK `mergeEdges` option to subgraph layout options. Previously, Mermaid set `elk.layered.mergeEdges` on the root ELK graph, but subgraphs only received that option when they declared their own direction. As a result, `mergeEdges: true` worked for root-level flowchart edges but not for equivalent edges inside subgraphs.

## Why this approach

- Keeps the existing root graph options unchanged.
- Applies only the scoped `elk.layered.mergeEdges` option to all subgraphs.
- Leaves the existing explicit-direction branch and its `SEPARATE_CHILDREN` behavior intact to avoid changing unrelated hierarchy handling.
- Adds an ELK flowchart rendering regression test using the reported shape.

## Validation

- `pnpm exec prettier --check packages/mermaid-layout-elk/src/render.ts cypress/integration/rendering/flowchart/flowchart-elk.spec.js`
- `pnpm exec eslint --quiet packages/mermaid-layout-elk/src/render.ts cypress/integration/rendering/flowchart/flowchart-elk.spec.js`
- `pnpm --filter @mermaid-js/layout-elk exec tsc --noEmit`
- `pnpm run load:env -- start-server-and-test dev http://localhost:9000/ "cypress run --spec cypress/integration/rendering/flowchart/flowchart-elk.spec.js --browser electron"`
  - Result: 64 tests, 63 passing, 1 pending, 0 failing