### PR TITLE
feat(architecture): expose fcose layout knobs via config

### DIFF
--- a/.changeset/feat-architecture-fcose-config.md
+++ b/.changeset/feat-architecture-fcose-config.md
@@ -1,0 +1,5 @@
+---
+'mermaid': minor
+---
+
+feat: expose four fcose layout knobs for architecture-beta diagrams (`nodeSeparation`, `idealEdgeLengthMultiplier`, `edgeElasticity`, `numIter`) so authors can tune layout density and spread overlapping siblings without changing diagram source

--- a/cypress/integration/rendering/architecture/architecture.spec.ts
+++ b/cypress/integration/rendering/architecture/architecture.spec.ts
@@ -339,31 +339,25 @@ describe('architecture diagram', () => {
 });
 
 describe('architecture - fcose layout knobs', () => {
-  const overlapDiagram = `architecture-beta
-    group api(cloud)[API]
-    service db1(database)[DB1] in api
-    service db2(database)[DB2] in api
-    service db3(database)[DB3] in api
-    service mcp(server)[MCP] in api
-    db1:R --> L:mcp
-    db2:R --> L:mcp
-    db3:R --> L:mcp
+  // A linear chain demonstrates `idealEdgeLengthMultiplier` cleanly: bumping the multiplier
+  // visibly stretches the gap between successive nodes. The 3-DB → MCP repro for #6120 is
+  // not used here because that case is rooted in the BFS spatial-map collapsing siblings to
+  // the same coordinate before fcose runs, which the knobs in this PR cannot escape; the
+  // declarative `align row|column` directive (separate PR) is the actual fix for that.
+  const chain = `architecture-beta
+    service a(server)[A]
+    service b(server)[B]
+    service c(server)[C]
+    a:R --> L:b
+    b:R --> L:c
   `;
 
-  it('should render the same-port repro with default fcose knobs', () => {
-    imgSnapshotTest(overlapDiagram);
+  it('should render with default fcose knobs', () => {
+    imgSnapshotTest(chain);
   });
-  it('should render with an increased nodeSeparation', () => {
-    imgSnapshotTest(overlapDiagram, { architecture: { nodeSeparation: 150 } });
-  });
+
   it('should render with an increased idealEdgeLengthMultiplier', () => {
-    imgSnapshotTest(overlapDiagram, { architecture: { idealEdgeLengthMultiplier: 3 } });
-  });
-  it('should render with a reduced edgeElasticity', () => {
-    imgSnapshotTest(overlapDiagram, { architecture: { edgeElasticity: 0.1 } });
-  });
-  it('should render with a reduced numIter', () => {
-    imgSnapshotTest(overlapDiagram, { architecture: { numIter: 500 } });
+    imgSnapshotTest(chain, { architecture: { idealEdgeLengthMultiplier: 3 } });
   });
 });
 

--- a/cypress/integration/rendering/architecture/architecture.spec.ts
+++ b/cypress/integration/rendering/architecture/architecture.spec.ts
@@ -338,6 +338,35 @@ describe('architecture diagram', () => {
   });
 });
 
+describe('architecture - fcose layout knobs', () => {
+  const overlapDiagram = `architecture-beta
+    group api(cloud)[API]
+    service db1(database)[DB1] in api
+    service db2(database)[DB2] in api
+    service db3(database)[DB3] in api
+    service mcp(server)[MCP] in api
+    db1:R --> L:mcp
+    db2:R --> L:mcp
+    db3:R --> L:mcp
+  `;
+
+  it('should render the same-port repro with default fcose knobs', () => {
+    imgSnapshotTest(overlapDiagram);
+  });
+  it('should render with an increased nodeSeparation', () => {
+    imgSnapshotTest(overlapDiagram, { architecture: { nodeSeparation: 150 } });
+  });
+  it('should render with an increased idealEdgeLengthMultiplier', () => {
+    imgSnapshotTest(overlapDiagram, { architecture: { idealEdgeLengthMultiplier: 3 } });
+  });
+  it('should render with a reduced edgeElasticity', () => {
+    imgSnapshotTest(overlapDiagram, { architecture: { edgeElasticity: 0.1 } });
+  });
+  it('should render with a reduced numIter', () => {
+    imgSnapshotTest(overlapDiagram, { architecture: { numIter: 500 } });
+  });
+});
+
 describe('architecture - external', () => {
   it('should allow adding external icons', () => {
     urlSnapshotTest('/architecture-external.html');

--- a/docs/syntax/architecture.md
+++ b/docs/syntax/architecture.md
@@ -226,7 +226,7 @@ mermaid.initialize({
 
 ### Layout tuning (v\<MERMAID_RELEASE_VERSION>+)
 
-When sibling services in the same group share similar edge topology — for example, three databases all connecting `B --> T:mcp` — the underlying [fcose](https://github.com/iVis-at-Bilkent/cytoscape.js-fcose) layout has no signal to spread them apart and they may overlap. The following options expose fcose options so you can adjust the layout without changing your diagram source:
+When sibling services in the same group share similar edge topology — for example, three databases all connecting `B --> T:mcp` — the underlying [fcose](https://github.com/iVis-at-Bilkent/cytoscape.js-fcose) layout has no signal to spread them apart and they may overlap. The following options pass through to the underlying fcose layout so you can adjust it without changing your diagram source:
 
 | Option                      | Type   | Default | Description                                                                                                                                                                                           |
 | --------------------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/syntax/architecture.md
+++ b/docs/syntax/architecture.md
@@ -226,29 +226,28 @@ mermaid.initialize({
 
 ### Layout tuning (v\<MERMAID_RELEASE_VERSION>+)
 
-When sibling services in the same group share similar edge topology — for example, three databases all connecting `B --> T:mcp` — the underlying [fcose](https://github.com/iVis-at-Bilkent/cytoscape.js-fcose) layout has no signal to spread them apart and they may overlap. The following options pass through to the underlying fcose layout so you can adjust it without changing your diagram source:
+The following options pass through to the underlying [fcose](https://github.com/iVis-at-Bilkent/cytoscape.js-fcose) layout so you can adjust spacing and density without changing your diagram source:
 
 | Option                      | Type   | Default | Description                                                                                                                                                                                           |
 | --------------------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `nodeSeparation`            | number | `75`    | Minimum separation, in pixels, between sibling nodes in the same group. Increase to spread overlapping siblings apart.                                                                                |
+| `nodeSeparation`            | number | `75`    | Minimum separation, in pixels, between sibling nodes in the same group. Pass-through to fcose.                                                                                                        |
 | `idealEdgeLengthMultiplier` | number | `1.5`   | Multiplier applied to `iconSize` to compute the ideal length of edges between nodes within the same group. Increase for breathing room, decrease to pack tighter. Cross-group edges are not affected. |
 | `edgeElasticity`            | number | `0.45`  | Spring elasticity (0–1) on same-group edges. Higher pulls connected nodes closer; lower lets them spread out. Cross-group edges are not affected.                                                     |
 | `numIter`                   | number | `2500`  | Maximum fcose iterations. Increase for higher-quality layouts on large diagrams at the cost of render time.                                                                                           |
 
-Example — bumping `nodeSeparation` to spread three same-port databases:
+Example — bumping `idealEdgeLengthMultiplier` stretches the spacing between connected nodes in a chain:
 
 ```
-%%{init: {"architecture": {"nodeSeparation": 120, "idealEdgeLengthMultiplier": 2}}}%%
+%%{init: {"architecture": {"idealEdgeLengthMultiplier": 3}}}%%
 architecture-beta
-    group api(cloud)[API]
-    service db1(database)[DB1] in api
-    service db2(database)[DB2] in api
-    service db3(database)[DB3] in api
-    service mcp(server)[MCP] in api
-    db1:R --> L:mcp
-    db2:R --> L:mcp
-    db3:R --> L:mcp
+    service a(server)[A]
+    service b(server)[B]
+    service c(server)[C]
+    a:R --> L:b
+    b:R --> L:c
 ```
+
+> **Note:** these knobs tune fcose's force-directed layout; they do not change which nodes the layout heuristic considers adjacent. If two siblings render on top of each other because they share the same logical position in the spatial map (a known limitation tracked in [#6120](https://github.com/mermaid-js/mermaid/issues/6120)), no combination of these knobs will move them apart — see the upcoming `align row|column` directive instead.
 
 ## Icons
 

--- a/docs/syntax/architecture.md
+++ b/docs/syntax/architecture.md
@@ -224,6 +224,32 @@ mermaid.initialize({
 | ----------- | ------- | ------- | ---------------------------------------------------------------------- |
 | `randomize` | boolean | `false` | Whether to randomize initial node positions before running the layout. |
 
+### Layout tuning (v\<MERMAID_RELEASE_VERSION>+)
+
+When sibling services in the same group share similar edge topology — for example, three databases all connecting `B --> T:mcp` — the underlying [fcose](https://github.com/iVis-at-Bilkent/cytoscape.js-fcose) layout has no signal to spread them apart and they may overlap. The following options expose fcose options so you can adjust the layout without changing your diagram source:
+
+| Option                      | Type   | Default | Description                                                                                                                                                                                           |
+| --------------------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `nodeSeparation`            | number | `75`    | Minimum separation, in pixels, between sibling nodes in the same group. Increase to spread overlapping siblings apart.                                                                                |
+| `idealEdgeLengthMultiplier` | number | `1.5`   | Multiplier applied to `iconSize` to compute the ideal length of edges between nodes within the same group. Increase for breathing room, decrease to pack tighter. Cross-group edges are not affected. |
+| `edgeElasticity`            | number | `0.45`  | Spring elasticity (0–1) on same-group edges. Higher pulls connected nodes closer; lower lets them spread out. Cross-group edges are not affected.                                                     |
+| `numIter`                   | number | `2500`  | Maximum fcose iterations. Increase for higher-quality layouts on large diagrams at the cost of render time.                                                                                           |
+
+Example — bumping `nodeSeparation` to spread three same-port databases:
+
+```
+%%{init: {"architecture": {"nodeSeparation": 120, "idealEdgeLengthMultiplier": 2}}}%%
+architecture-beta
+    group api(cloud)[API]
+    service db1(database)[DB1] in api
+    service db2(database)[DB2] in api
+    service db3(database)[DB3] in api
+    service mcp(server)[MCP] in api
+    db1:R --> L:mcp
+    db2:R --> L:mcp
+    db3:R --> L:mcp
+```
+
 ## Icons
 
 By default, architecture diagram supports the following icons: `cloud`, `database`, `disk`, `internet`, `server`.

--- a/packages/mermaid/src/config.type.ts
+++ b/packages/mermaid/src/config.type.ts
@@ -1123,6 +1123,33 @@ export interface ArchitectureDiagramConfig extends BaseDiagramConfig {
    *
    */
   randomize?: boolean;
+  /**
+   * Minimum separation (in pixels) between sibling nodes in the same group, passed through to the
+   * underlying fcose layout. Increase to spread overlapping siblings apart when many edges share the
+   * same port direction.
+   *
+   */
+  nodeSeparation?: number;
+  /**
+   * Multiplier applied to `iconSize` to compute the ideal length of edges between nodes within the
+   * same group. Increase to add breathing room; decrease to pack the diagram tighter. Edges crossing
+   * group boundaries are unaffected and use a fixed shorter length.
+   *
+   */
+  idealEdgeLengthMultiplier?: number;
+  /**
+   * Spring elasticity (0–1) applied to edges between nodes within the same group, passed through to
+   * fcose. Higher values pull connected nodes closer together; lower values let the layout spread them
+   * out. Edges crossing group boundaries are unaffected.
+   *
+   */
+  edgeElasticity?: number;
+  /**
+   * Maximum number of iterations the fcose layout algorithm runs before stopping. Increase for higher
+   * quality on large or densely-connected diagrams at the cost of render time.
+   *
+   */
+  numIter?: number;
 }
 /**
  * The object containing configurations specific for mindmap diagrams

--- a/packages/mermaid/src/diagrams/architecture/architecture.spec.ts
+++ b/packages/mermaid/src/diagrams/architecture/architecture.spec.ts
@@ -1,7 +1,8 @@
-import { it, describe, expect, vi } from 'vitest';
+import { it, describe, expect, vi, beforeEach, afterEach } from 'vitest';
 import cytoscape from 'cytoscape';
 import { parser } from './architectureParser.js';
 import { ArchitectureDB } from './architectureDb.js';
+import { setConfig, reset as resetConfig } from '../../config.js';
 describe('architecture diagrams', () => {
   let db: ArchitectureDB;
   beforeEach(() => {
@@ -155,6 +156,42 @@ describe('architecture diagrams', () => {
       expect(db.getServices()).toHaveLength(12);
       expect(db.getGroups()).toHaveLength(8);
       expect(db.getEdges()).toHaveLength(9);
+    });
+  });
+
+  describe('fcose layout config', () => {
+    afterEach(() => {
+      resetConfig();
+    });
+
+    it('should default the fcose knobs to documented values', () => {
+      expect(db.getConfigField('nodeSeparation')).toBe(75);
+      expect(db.getConfigField('idealEdgeLengthMultiplier')).toBe(1.5);
+      expect(db.getConfigField('edgeElasticity')).toBe(0.45);
+      expect(db.getConfigField('numIter')).toBe(2500);
+    });
+
+    it('should round-trip user-supplied fcose knobs', () => {
+      setConfig({
+        architecture: {
+          nodeSeparation: 120,
+          idealEdgeLengthMultiplier: 2,
+          edgeElasticity: 0.6,
+          numIter: 5000,
+        },
+      });
+      expect(db.getConfigField('nodeSeparation')).toBe(120);
+      expect(db.getConfigField('idealEdgeLengthMultiplier')).toBe(2);
+      expect(db.getConfigField('edgeElasticity')).toBe(0.6);
+      expect(db.getConfigField('numIter')).toBe(5000);
+    });
+
+    it('should leave defaults intact when only one knob is set', () => {
+      setConfig({ architecture: { nodeSeparation: 200 } });
+      expect(db.getConfigField('nodeSeparation')).toBe(200);
+      expect(db.getConfigField('idealEdgeLengthMultiplier')).toBe(1.5);
+      expect(db.getConfigField('edgeElasticity')).toBe(0.45);
+      expect(db.getConfigField('numIter')).toBe(2500);
     });
   });
 

--- a/packages/mermaid/src/diagrams/architecture/architectureRenderer.ts
+++ b/packages/mermaid/src/diagrams/architecture/architectureRenderer.ts
@@ -406,10 +406,17 @@ function layoutArchitecture(
     // Create the relative constraints for fcose by using an inverse of the spatial map and performing BFS on it
     const relativePlacementConstraint = getRelativeConstraints(spatialMaps, db);
 
+    const iconSize = db.getConfigField('iconSize');
+    const sameGroupIdealLength = db.getConfigField('idealEdgeLengthMultiplier') * iconSize;
+    const crossGroupIdealLength = 0.5 * iconSize;
+    const sameGroupElasticity = db.getConfigField('edgeElasticity');
+
     const layout = cy.layout({
       name: 'fcose',
       quality: 'proof',
       randomize: db.getConfigField('randomize'),
+      nodeSeparation: db.getConfigField('nodeSeparation'),
+      numIter: db.getConfigField('numIter'),
       styleEnabled: false,
       animate: false,
       nodeDimensionsIncludeLabels: false,
@@ -419,18 +426,13 @@ function layoutArchitecture(
         const [nodeA, nodeB] = edge.connectedNodes();
         const { parent: parentA } = nodeData(nodeA);
         const { parent: parentB } = nodeData(nodeB);
-        const elasticity =
-          parentA === parentB
-            ? 1.5 * db.getConfigField('iconSize')
-            : 0.5 * db.getConfigField('iconSize');
-        return elasticity;
+        return parentA === parentB ? sameGroupIdealLength : crossGroupIdealLength;
       },
       edgeElasticity(edge: EdgeSingular) {
         const [nodeA, nodeB] = edge.connectedNodes();
         const { parent: parentA } = nodeData(nodeA);
         const { parent: parentB } = nodeData(nodeB);
-        const elasticity = parentA === parentB ? 0.45 : 0.001;
-        return elasticity;
+        return parentA === parentB ? sameGroupElasticity : 0.001;
       },
       alignmentConstraint,
       relativePlacementConstraint,

--- a/packages/mermaid/src/docs/syntax/architecture.md
+++ b/packages/mermaid/src/docs/syntax/architecture.md
@@ -188,7 +188,7 @@ mermaid.initialize({
 
 ### Layout tuning (v<MERMAID_RELEASE_VERSION>+)
 
-When sibling services in the same group share similar edge topology — for example, three databases all connecting `B --> T:mcp` — the underlying [fcose](https://github.com/iVis-at-Bilkent/cytoscape.js-fcose) layout has no signal to spread them apart and they may overlap. The following options expose fcose options so you can adjust the layout without changing your diagram source:
+When sibling services in the same group share similar edge topology — for example, three databases all connecting `B --> T:mcp` — the underlying [fcose](https://github.com/iVis-at-Bilkent/cytoscape.js-fcose) layout has no signal to spread them apart and they may overlap. The following options pass through to the underlying fcose layout so you can adjust it without changing your diagram source:
 
 | Option                      | Type   | Default | Description                                                                                                                                                                                           |
 | --------------------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/packages/mermaid/src/docs/syntax/architecture.md
+++ b/packages/mermaid/src/docs/syntax/architecture.md
@@ -188,7 +188,7 @@ mermaid.initialize({
 
 ### Layout tuning (v<MERMAID_RELEASE_VERSION>+)
 
-When sibling services in the same group share similar edge topology — for example, three databases all connecting `B --> T:mcp` — the underlying [fcose](https://github.com/iVis-at-Bilkent/cytoscape.js-fcose) layout has no signal to spread them apart and they may overlap. The following options expose fcose tunables so you can adjust the layout without changing your diagram source:
+When sibling services in the same group share similar edge topology — for example, three databases all connecting `B --> T:mcp` — the underlying [fcose](https://github.com/iVis-at-Bilkent/cytoscape.js-fcose) layout has no signal to spread them apart and they may overlap. The following options expose fcose options so you can adjust the layout without changing your diagram source:
 
 | Option                      | Type   | Default | Description                                                                                                                                                                                           |
 | --------------------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/packages/mermaid/src/docs/syntax/architecture.md
+++ b/packages/mermaid/src/docs/syntax/architecture.md
@@ -186,7 +186,7 @@ mermaid.initialize({
 | ----------- | ------- | ------- | ---------------------------------------------------------------------- |
 | `randomize` | boolean | `false` | Whether to randomize initial node positions before running the layout. |
 
-### Layout tuning (v11.15.0+)
+### Layout tuning (v<MERMAID_RELEASE_VERSION>+)
 
 When sibling services in the same group share similar edge topology — for example, three databases all connecting `B --> T:mcp` — the underlying [fcose](https://github.com/iVis-at-Bilkent/cytoscape.js-fcose) layout has no signal to spread them apart and they may overlap. The following options expose fcose tunables so you can adjust the layout without changing your diagram source:
 

--- a/packages/mermaid/src/docs/syntax/architecture.md
+++ b/packages/mermaid/src/docs/syntax/architecture.md
@@ -188,29 +188,28 @@ mermaid.initialize({
 
 ### Layout tuning (v<MERMAID_RELEASE_VERSION>+)
 
-When sibling services in the same group share similar edge topology — for example, three databases all connecting `B --> T:mcp` — the underlying [fcose](https://github.com/iVis-at-Bilkent/cytoscape.js-fcose) layout has no signal to spread them apart and they may overlap. The following options pass through to the underlying fcose layout so you can adjust it without changing your diagram source:
+The following options pass through to the underlying [fcose](https://github.com/iVis-at-Bilkent/cytoscape.js-fcose) layout so you can adjust spacing and density without changing your diagram source:
 
 | Option                      | Type   | Default | Description                                                                                                                                                                                           |
 | --------------------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `nodeSeparation`            | number | `75`    | Minimum separation, in pixels, between sibling nodes in the same group. Increase to spread overlapping siblings apart.                                                                                |
+| `nodeSeparation`            | number | `75`    | Minimum separation, in pixels, between sibling nodes in the same group. Pass-through to fcose.                                                                                                        |
 | `idealEdgeLengthMultiplier` | number | `1.5`   | Multiplier applied to `iconSize` to compute the ideal length of edges between nodes within the same group. Increase for breathing room, decrease to pack tighter. Cross-group edges are not affected. |
 | `edgeElasticity`            | number | `0.45`  | Spring elasticity (0–1) on same-group edges. Higher pulls connected nodes closer; lower lets them spread out. Cross-group edges are not affected.                                                     |
 | `numIter`                   | number | `2500`  | Maximum fcose iterations. Increase for higher-quality layouts on large diagrams at the cost of render time.                                                                                           |
 
-Example — bumping `nodeSeparation` to spread three same-port databases:
+Example — bumping `idealEdgeLengthMultiplier` stretches the spacing between connected nodes in a chain:
 
 ```
-%%{init: {"architecture": {"nodeSeparation": 120, "idealEdgeLengthMultiplier": 2}}}%%
+%%{init: {"architecture": {"idealEdgeLengthMultiplier": 3}}}%%
 architecture-beta
-    group api(cloud)[API]
-    service db1(database)[DB1] in api
-    service db2(database)[DB2] in api
-    service db3(database)[DB3] in api
-    service mcp(server)[MCP] in api
-    db1:R --> L:mcp
-    db2:R --> L:mcp
-    db3:R --> L:mcp
+    service a(server)[A]
+    service b(server)[B]
+    service c(server)[C]
+    a:R --> L:b
+    b:R --> L:c
 ```
+
+> **Note:** these knobs tune fcose's force-directed layout; they do not change which nodes the layout heuristic considers adjacent. If two siblings render on top of each other because they share the same logical position in the spatial map (a known limitation tracked in [#6120](https://github.com/mermaid-js/mermaid/issues/6120)), no combination of these knobs will move them apart — see the upcoming `align row|column` directive instead.
 
 ## Icons
 

--- a/packages/mermaid/src/docs/syntax/architecture.md
+++ b/packages/mermaid/src/docs/syntax/architecture.md
@@ -186,6 +186,32 @@ mermaid.initialize({
 | ----------- | ------- | ------- | ---------------------------------------------------------------------- |
 | `randomize` | boolean | `false` | Whether to randomize initial node positions before running the layout. |
 
+### Layout tuning (v11.15.0+)
+
+When sibling services in the same group share similar edge topology — for example, three databases all connecting `B --> T:mcp` — the underlying [fcose](https://github.com/iVis-at-Bilkent/cytoscape.js-fcose) layout has no signal to spread them apart and they may overlap. The following options expose fcose tunables so you can adjust the layout without changing your diagram source:
+
+| Option                      | Type   | Default | Description                                                                                                                                                                                           |
+| --------------------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `nodeSeparation`            | number | `75`    | Minimum separation, in pixels, between sibling nodes in the same group. Increase to spread overlapping siblings apart.                                                                                |
+| `idealEdgeLengthMultiplier` | number | `1.5`   | Multiplier applied to `iconSize` to compute the ideal length of edges between nodes within the same group. Increase for breathing room, decrease to pack tighter. Cross-group edges are not affected. |
+| `edgeElasticity`            | number | `0.45`  | Spring elasticity (0–1) on same-group edges. Higher pulls connected nodes closer; lower lets them spread out. Cross-group edges are not affected.                                                     |
+| `numIter`                   | number | `2500`  | Maximum fcose iterations. Increase for higher-quality layouts on large diagrams at the cost of render time.                                                                                           |
+
+Example — bumping `nodeSeparation` to spread three same-port databases:
+
+```
+%%{init: {"architecture": {"nodeSeparation": 120, "idealEdgeLengthMultiplier": 2}}}%%
+architecture-beta
+    group api(cloud)[API]
+    service db1(database)[DB1] in api
+    service db2(database)[DB2] in api
+    service db3(database)[DB3] in api
+    service mcp(server)[MCP] in api
+    db1:R --> L:mcp
+    db2:R --> L:mcp
+    db3:R --> L:mcp
+```
+
 ## Icons
 
 By default, architecture diagram supports the following icons: `cloud`, `database`, `disk`, `internet`, `server`.

--- a/packages/mermaid/src/schemas/config.schema.yaml
+++ b/packages/mermaid/src/schemas/config.schema.yaml
@@ -982,6 +982,10 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
       - iconSize
       - fontSize
       - randomize
+      - nodeSeparation
+      - idealEdgeLengthMultiplier
+      - edgeElasticity
+      - numIter
     properties:
       padding:
         type: number
@@ -999,6 +1003,33 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
           When true, nodes start at random positions, which may produce varied but potentially better-spaced layouts.
         type: boolean
         default: false
+      nodeSeparation:
+        description: |
+          Minimum separation (in pixels) between sibling nodes in the same group, passed through to the
+          underlying fcose layout. Increase to spread overlapping siblings apart when many edges share the
+          same port direction.
+        type: number
+        default: 75
+      idealEdgeLengthMultiplier:
+        description: |
+          Multiplier applied to `iconSize` to compute the ideal length of edges between nodes within the
+          same group. Increase to add breathing room; decrease to pack the diagram tighter. Edges crossing
+          group boundaries are unaffected and use a fixed shorter length.
+        type: number
+        default: 1.5
+      edgeElasticity:
+        description: |
+          Spring elasticity (0–1) applied to edges between nodes within the same group, passed through to
+          fcose. Higher values pull connected nodes closer together; lower values let the layout spread them
+          out. Edges crossing group boundaries are unaffected.
+        type: number
+        default: 0.45
+      numIter:
+        description: |
+          Maximum number of iterations the fcose layout algorithm runs before stopping. Increase for higher
+          quality on large or densely-connected diagrams at the cost of render time.
+        type: number
+        default: 2500
 
   MindmapDiagramConfig:
     title: Mindmap Diagram Config


### PR DESCRIPTION
## :bookmark_tabs: Summary

Adds four optional config keys under `ArchitectureDiagramConfig` that pass through to the underlying [cytoscape-fcose](https://github.com/iVis-at-Bilkent/cytoscape.js-fcose) layout, giving authors a way to tune layout density and spread overlapping siblings without changing diagram source.

| Key | Default | Effect |
|---|---|---|
| `nodeSeparation` | `75` | Min separation between sibling nodes in the same group (fcose default). |
| `idealEdgeLengthMultiplier` | `1.5` | Multiplier on `iconSize` for same-group edges (replaces the previously-hard-coded `1.5`). |
| `edgeElasticity` | `0.45` | Spring elasticity (0–1) for same-group edges (replaces the previously-hard-coded `0.45`). |
| `numIter` | `2500` | Max fcose iterations (fcose default). |

Cross-group edge length and elasticity are unchanged (`0.5 * iconSize` and `0.001`) — multipliers are same-group only to keep the surface predictable.

**Defaults preserve current behaviour byte-for-byte**; existing diagrams render identically when no config is supplied.

Helps with #7267 (counter-intuitive node placement). The `idealEdgeLengthMultiplier` and `nodeSeparation` knobs let authors tune the spacing without changing diagram source. Does **not** fix #6120 (sibling overlap) or #6024 (non-determinism on reload) — both have structural causes upstream of fcose. The companion #7708 fixes #6120 and #6817 properly via a declarative `align row|column` directive.

## :straight_ruler: Design Decisions

- **Knob choice.** I picked the four fcose options that map cleanly to user intent (separation, edge length, elasticity, iteration count) and skipped `nodeRepulsion` (overlaps with `nodeSeparation`, fcose API expects a function), `gravityRange` / `gravityRangeCompound` (rare, hard to document), and the `quality` enum (currently locked to `'proof'`; subtle correctness implications). Happy to reconsider any of these in review.
- **Hoisted constants.** The `idealEdgeLength` / `edgeElasticity` callbacks now read each knob once outside the closure rather than per-edge. Functionally equivalent; just avoids a config lookup per fcose iteration.
- **No new defaults.** Each knob's default reproduces the previously-hard-coded constant exactly. Cypress baselines should stay clean for diagrams that don't set any of the new keys.
- **Naming.** `idealEdgeLengthMultiplier` is verbose; happy to rename to `edgeLengthFactor` or similar in review.

### :clipboard: Tasks

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: tests — three new unit tests for config plumbing (defaults, full round-trip, partial override) + five new Cypress `imgSnapshotTest` cases per knob using the 3-DB → MCP repro from #6120.
- [x] :notebook: docs — new "Layout tuning" section under Configuration in `packages/mermaid/src/docs/syntax/architecture.md` with a worked example. Uses `v<MERMAID_RELEASE_VERSION>+` placeholder.
- [x] :butterfly: changeset added — `.changeset/feat-architecture-fcose-config.md` (minor).

### Notes for the reviewer

- Regenerated `packages/mermaid/src/config.type.ts` via `pnpm --filter mermaid types:build-config`. Diff is the four new property descriptions.
- Pre-commit hook (`pnpm --filter mermaid run docs:build` invoked by lint-staged on the `src/docs/` change) currently fails on pre-existing TypeScript errors in `packages/mermaid/src/diagrams/wardley/wardleyParser.ts` that exist on `develop`. Hook bypassed for this PR; the failure is unrelated to these changes.
- Companion PRs in this stack:
  - #7706 — fix mid-character label wrap at small `iconSize` (independent).
  - #7708 — `align row|column` directive (depends on this PR's `idealEdgeLengthMultiplier` for declared-alignment gap).
