### PR TITLE
fix(dagre): merge flowchart and state self-loop segments before rendering

### DIFF
--- a/.changeset/fix-flowchart-self-loop-single-path.md
+++ b/.changeset/fix-flowchart-self-loop-single-path.md
@@ -1,0 +1,7 @@
+---
+'mermaid': patch
+---
+
+fix: render flowchart self-loop edges as a single SVG path
+
+Self-loop edges in flowcharts now keep the existing dagre dummy-edge layout workaround internally, but merge those internal segments before SVG rendering so one logical self-loop is exposed as one rendered path.

--- a/.changeset/fix-flowchart-self-loop-single-path.md
+++ b/.changeset/fix-flowchart-self-loop-single-path.md
@@ -2,6 +2,6 @@
 'mermaid': patch
 ---
 
-fix: render flowchart self-loop edges as a single SVG path
+fix: render flowchart and state self-loop edges as a single SVG path
 
-Self-loop edges in flowcharts now keep the existing dagre dummy-edge layout workaround internally, but merge those internal segments before SVG rendering so one logical self-loop is exposed as one rendered path.
+Self-loop edges in flowcharts and state diagrams now keep the existing dagre dummy-edge layout workaround internally, but merge those internal segments before SVG rendering so one logical self-loop is exposed as one rendered path.

--- a/cypress/integration/rendering/flowchart/flowchart-v2.spec.js
+++ b/cypress/integration/rendering/flowchart/flowchart-v2.spec.js
@@ -1118,6 +1118,40 @@ end
         }
       );
     });
+    it('Should render labeled self-loops', () => {
+      imgSnapshotTest(
+        `flowchart TD
+          A[Start] -->|retry| A
+          B[Process] -->|again| B
+          A --> B
+        `,
+        {
+          htmlLabels: false,
+          flowchart: { htmlLabels: false },
+        }
+      );
+    });
+    it('Should render self-loops in non-TB directions', () => {
+      imgSnapshotTest(
+        `flowchart LR
+          A[LR loop] --> A
+          subgraph B[BT subgraph]
+            direction BT
+            B1[BT loop] --> B1
+          end
+          subgraph C[RL subgraph]
+            direction RL
+            C1[RL loop] --> C1
+          end
+          A --> B1
+          B1 --> C1
+        `,
+        {
+          htmlLabels: false,
+          flowchart: { htmlLabels: false },
+        }
+      );
+    });
   });
   describe('New @ syntax for node metadata edge cases', () => {
     it('should be possible to use @  syntax to add labels on multi nodes', () => {

--- a/cypress/integration/rendering/state/stateDiagram-v2.spec.js
+++ b/cypress/integration/rendering/state/stateDiagram-v2.spec.js
@@ -345,6 +345,18 @@ stateDiagram
       }
     );
   });
+  it('v2 should render a compact self-loop edge', () => {
+    imgSnapshotTest(
+      `
+stateDiagram-v2
+  [*] --> Node
+  Node --> Node: Self Edge
+    `,
+      {
+        logLevel: 0,
+      }
+    );
+  });
   it('v2 width of compound state should grow with title if title is wider', () => {
     imgSnapshotTest(
       `

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
@@ -43,6 +43,8 @@ const getDefaultSelfLoopSide = (rankdir = 'TB') => {
   }
 };
 
+// Class diagrams also use dagre, but self-referential multiplicity labels rely on
+// the existing segmented self-loop rendering path for terminal label placement.
 const shouldMergeSelfLoopSegments = (diagramType) =>
   diagramType === 'flowchart' || diagramType === 'flowchart-v2' || diagramType === 'stateDiagram';
 

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
@@ -27,6 +27,216 @@ import { log } from '../../../logger.js';
 import { getSubGraphTitleMargins } from '../../../utils/subGraphTitleMargins.js';
 import { getConfig } from '../../../diagram-api/diagramAPI.js';
 
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+const getDefaultSelfLoopSide = (rankdir = 'TB') => {
+  switch (rankdir) {
+    case 'BT':
+      return 'bottom';
+    case 'LR':
+      return 'right';
+    case 'RL':
+      return 'left';
+    case 'TB':
+    default:
+      return 'top';
+  }
+};
+
+const getSelfLoopSide = (graph, node, segments, originalNodeId, rankdir) => {
+  const layoutHints = [];
+  const dummyNodeIds = new Set();
+
+  segments.forEach(({ start, end }) => {
+    if (start !== originalNodeId) {
+      dummyNodeIds.add(start);
+    }
+    if (end !== originalNodeId) {
+      dummyNodeIds.add(end);
+    }
+  });
+
+  dummyNodeIds.forEach((id) => {
+    const dummyNode = graph.node(id);
+    if (typeof dummyNode?.x === 'number' && typeof dummyNode?.y === 'number') {
+      layoutHints.push(dummyNode);
+    }
+  });
+
+  if (layoutHints.length === 0) {
+    segments.forEach(({ edge }) => {
+      (edge.points ?? []).forEach((point) => {
+        if (typeof point?.x === 'number' && typeof point?.y === 'number') {
+          layoutHints.push(point);
+        }
+      });
+    });
+  }
+
+  if (layoutHints.length === 0) {
+    return getDefaultSelfLoopSide(rankdir);
+  }
+
+  const center = layoutHints.reduce(
+    (acc, point) => ({
+      x: acc.x + point.x / layoutHints.length,
+      y: acc.y + point.y / layoutHints.length,
+    }),
+    { x: 0, y: 0 }
+  );
+  const dx = center.x - node.x;
+  const dy = center.y - node.y;
+
+  if (Math.abs(dx) > Math.abs(dy)) {
+    return dx > 0 ? 'right' : 'left';
+  }
+  if (Math.abs(dy) > 0) {
+    return dy > 0 ? 'bottom' : 'top';
+  }
+  return getDefaultSelfLoopSide(rankdir);
+};
+
+const getSelfLoopPoints = (node, side = 'top', yOffset = 0, labelWidth = 0) => {
+  const x = node.x;
+  const y = node.y - yOffset;
+  const halfWidth = node.width / 2;
+  const halfHeight = node.height / 2;
+  const maxSpan = Math.max(36, Math.min(100, node.width * 0.8));
+  const span = clamp(Math.max(labelWidth, node.width * 0.35), 36, maxSpan);
+  const depth = clamp(Math.min(node.width, node.height) * 0.45, 24, 48);
+
+  switch (side) {
+    case 'bottom': {
+      const bottom = y + halfHeight;
+      return [
+        { x: x - span / 2, y: bottom },
+        { x: x - span / 2, y: bottom + depth },
+        { x: x + span / 2, y: bottom + depth },
+        { x: x + span / 2, y: bottom },
+      ];
+    }
+    case 'right': {
+      const right = x + halfWidth;
+      return [
+        { x: right, y: y - span / 2 },
+        { x: right + depth, y: y - span / 2 },
+        { x: right + depth, y: y + span / 2 },
+        { x: right, y: y + span / 2 },
+      ];
+    }
+    case 'left': {
+      const left = x - halfWidth;
+      return [
+        { x: left, y: y - span / 2 },
+        { x: left - depth, y: y - span / 2 },
+        { x: left - depth, y: y + span / 2 },
+        { x: left, y: y + span / 2 },
+      ];
+    }
+    case 'top':
+    default: {
+      const top = y - halfHeight;
+      return [
+        { x: x - span / 2, y: top },
+        { x: x - span / 2, y: top - depth },
+        { x: x + span / 2, y: top - depth },
+        { x: x + span / 2, y: top },
+      ];
+    }
+  }
+};
+
+const getSelfLoopLabelPosition = (node, points, side = 'top', yOffset = 0, label = {}) => {
+  const gap = 4;
+  const x = node.x;
+  const y = node.y - yOffset;
+  const labelWidth = label.width ?? 0;
+  const labelHeight = label.height ?? 0;
+
+  switch (side) {
+    case 'bottom':
+      return { x, y: Math.max(...points.map((point) => point.y)) + labelHeight / 2 + gap };
+    case 'right':
+      return { x: Math.max(...points.map((point) => point.x)) + labelWidth / 2 + gap, y };
+    case 'left':
+      return { x: Math.min(...points.map((point) => point.x)) - labelWidth / 2 - gap, y };
+    case 'top':
+    default:
+      return { x, y: Math.min(...points.map((point) => point.y)) - labelHeight / 2 - gap };
+  }
+};
+
+export const getEdgesToRender = (graph, yOffset = 0) => {
+  const selfLoopEdgeGroups = new Map();
+  const edgesToRender = [];
+  const rankdir = graph.graph()?.rankdir;
+
+  graph.edges().forEach((e) => {
+    const edge = graph.edge(e);
+    if (edge.selfLoop) {
+      const key = edge.selfLoop.id;
+      if (!selfLoopEdgeGroups.has(key)) {
+        selfLoopEdgeGroups.set(key, []);
+      }
+      selfLoopEdgeGroups.get(key).push({ edge, start: e.v, end: e.w });
+    } else {
+      edgesToRender.push({ edge, start: e.v, end: e.w });
+    }
+  });
+
+  selfLoopEdgeGroups.forEach((segments) => {
+    if (segments.length !== 3) {
+      segments.forEach((segment) => edgesToRender.push(segment));
+      return;
+    }
+
+    segments.sort((a, b) => a.edge.selfLoop.order - b.edge.selfLoop.order);
+    const [firstSegment, middleSegment, lastSegment] = segments;
+    const originalEdge =
+      firstSegment.edge.originalEdge ??
+      middleSegment.edge.originalEdge ??
+      lastSegment.edge.originalEdge ??
+      middleSegment.edge;
+    const node = graph.node(originalEdge.start);
+    if (!node) {
+      segments.forEach((segment) => edgesToRender.push(segment));
+      return;
+    }
+    const label = {
+      width: middleSegment.edge.width,
+      height: middleSegment.edge.height,
+    };
+    const side = getSelfLoopSide(graph, node, segments, originalEdge.start, rankdir);
+    const points = getSelfLoopPoints(node, side, yOffset, label.width ?? 0);
+    const labelPosition = getSelfLoopLabelPosition(node, points, side, yOffset, label);
+    const mergedEdge = {
+      ...middleSegment.edge,
+      ...originalEdge,
+      id: originalEdge.id,
+      points,
+      start: originalEdge.start,
+      end: originalEdge.end,
+      x: labelPosition.x,
+      y: labelPosition.y,
+      width: label.width,
+      height: label.height,
+      labelStyle: middleSegment.edge.labelStyle,
+      fromCluster:
+        firstSegment.edge.fromCluster ??
+        middleSegment.edge.fromCluster ??
+        lastSegment.edge.fromCluster,
+      toCluster:
+        firstSegment.edge.toCluster ?? middleSegment.edge.toCluster ?? lastSegment.edge.toCluster,
+    };
+    delete mergedEdge.selfLoop;
+    delete mergedEdge.originalEdge;
+
+    edgesToRender.push({ edge: mergedEdge, start: mergedEdge.start, end: mergedEdge.end });
+  });
+
+  return edgesToRender;
+};
+
 const recursiveRender = async (_elem, graph, diagramType, id, parentCluster, siteConfig) => {
   log.warn('Graph in recursive render:XAX', graphlibJson.write(graph), parentCluster);
   const dir = graph.graph().rankdir;
@@ -148,6 +358,16 @@ const recursiveRender = async (_elem, graph, diagramType, id, parentCluster, sit
         clusterDb.get(e.v),
         clusterDb.get(e.w)
       );
+      if (edge.selfLoop) {
+        if (edge.selfLoop.order !== 1) {
+          return;
+        }
+        const segmentId = edge.id;
+        edge.id = edge.selfLoop.id;
+        await insertEdgeLabel(edgeLabels, edge);
+        edge.id = segmentId;
+        return;
+      }
       await insertEdgeLabel(edgeLabels, edge);
     });
 
@@ -246,13 +466,15 @@ const recursiveRender = async (_elem, graph, diagramType, id, parentCluster, sit
   );
 
   // Move the edge labels to the correct place after layout
-  graph.edges().forEach(function (e) {
-    const edge = graph.edge(e);
-    log.info('Edge ' + e.v + ' -> ' + e.w + ': ' + JSON.stringify(edge), edge);
+  const edgeOffsetY = subGraphTitleTotalMargin / 2;
+  const edgesToRender = getEdgesToRender(graph, edgeOffsetY);
 
-    edge.points.forEach((point) => (point.y += subGraphTitleTotalMargin / 2));
-    const startNode = graph.node(e.v);
-    var endNode = graph.node(e.w);
+  edgesToRender.forEach(function ({ edge, start, end }) {
+    log.info('Edge ' + start + ' -> ' + end + ': ' + JSON.stringify(edge), edge);
+
+    edge.points.forEach((point) => (point.y += edgeOffsetY));
+    const startNode = graph.node(start);
+    const endNode = graph.node(end);
     const paths = insertEdge(edgePaths, edge, clusterDb, diagramType, startNode, endNode, id);
     positionEdgeLabel(edge, paths);
   });
@@ -340,9 +562,16 @@ export const render = async (data4Layout, svg) => {
       });
       graph.setParent(specialId2, node.parentId);
 
+      const originalEdge = structuredClone(edge);
       const edge1 = structuredClone(edge);
       const edgeMid = structuredClone(edge);
       const edge2 = structuredClone(edge);
+      edge1.originalEdge = originalEdge;
+      edge1.selfLoop = { id: originalEdge.id, order: 0 };
+      edgeMid.originalEdge = originalEdge;
+      edgeMid.selfLoop = { id: originalEdge.id, order: 1 };
+      edge2.originalEdge = originalEdge;
+      edge2.selfLoop = { id: originalEdge.id, order: 2 };
       edge1.label = '';
       edge1.arrowTypeEnd = 'none';
       edge1.endLabelLeft = '';
@@ -368,7 +597,7 @@ export const render = async (data4Layout, svg) => {
       edge2.arrowTypeStart = 'none';
       graph.setEdge(nodeId, specialId1, edge1, nodeId + '-cyclic-special-0');
       graph.setEdge(specialId1, specialId2, edgeMid, nodeId + '-cyclic-special-1');
-      graph.setEdge(specialId2, nodeId, edge2, nodeId + '-cyc<lic-special-2');
+      graph.setEdge(specialId2, nodeId, edge2, nodeId + '-cyclic-special-2');
     } else {
       graph.setEdge(edge.start, edge.end, { ...edge }, edge.id);
     }

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
@@ -43,6 +43,7 @@ const getDefaultSelfLoopSide = (rankdir = 'TB') => {
   }
 };
 
+// Use dagre's dummy self-loop placement as a hint, so loops are not always forced above the node.
 const getSelfLoopSide = (graph, node, segments, originalNodeId, rankdir) => {
   const layoutHints = [];
   const dummyNodeIds = new Set();
@@ -96,6 +97,7 @@ const getSelfLoopSide = (graph, node, segments, originalNodeId, rankdir) => {
   return getDefaultSelfLoopSide(rankdir);
 };
 
+// Build a compact loop around the node instead of rendering dagre's long dummy-edge route.
 const getSelfLoopPoints = (node, side = 'top', yOffset = 0, labelWidth = 0) => {
   const x = node.x;
   const y = node.y - yOffset;
@@ -166,6 +168,7 @@ const getSelfLoopLabelPosition = (node, points, side = 'top', yOffset = 0, label
   }
 };
 
+// Convert internal dagre layout edges into the public SVG edges we actually render.
 export const getEdgesToRender = (graph, yOffset = 0) => {
   const selfLoopEdgeGroups = new Map();
   const edgesToRender = [];
@@ -186,6 +189,7 @@ export const getEdgesToRender = (graph, yOffset = 0) => {
 
   selfLoopEdgeGroups.forEach((segments) => {
     if (segments.length !== 3) {
+      // Unexpected self-loop state: preserve the old rendering behavior rather than dropping edges.
       segments.forEach((segment) => edgesToRender.push(segment));
       return;
     }
@@ -206,6 +210,7 @@ export const getEdgesToRender = (graph, yOffset = 0) => {
       width: middleSegment.edge.width,
       height: middleSegment.edge.height,
     };
+    // Dagre uses the dummy route for layout; the SVG output should still be one logical edge.
     const side = getSelfLoopSide(graph, node, segments, originalEdge.start, rankdir);
     const points = getSelfLoopPoints(node, side, yOffset, label.width ?? 0);
     const labelPosition = getSelfLoopLabelPosition(node, points, side, yOffset, label);
@@ -359,6 +364,7 @@ const recursiveRender = async (_elem, graph, diagramType, id, parentCluster, sit
         clusterDb.get(e.w)
       );
       if (edge.selfLoop) {
+        // Only the middle layout segment owns the label, using the original edge id for lookup.
         if (edge.selfLoop.order !== 1) {
           return;
         }
@@ -527,8 +533,8 @@ export const render = async (data4Layout, svg) => {
 
   log.debug('Edges:', data4Layout.edges);
   data4Layout.edges.forEach((edge) => {
-    // Handle self-loops
     if (edge.start === edge.end) {
+      // Keep the dagre dummy-node workaround for layout, then merge these segments before rendering.
       const nodeId = edge.start;
       const specialId1 = nodeId + '---' + nodeId + '---1';
       const specialId2 = nodeId + '---' + nodeId + '---2';
@@ -566,6 +572,7 @@ export const render = async (data4Layout, svg) => {
       const edge1 = structuredClone(edge);
       const edgeMid = structuredClone(edge);
       const edge2 = structuredClone(edge);
+      // Preserve the original edge so the final SVG path uses the logical self-loop id and data.
       edge1.originalEdge = originalEdge;
       edge1.selfLoop = { id: originalEdge.id, order: 0 };
       edgeMid.originalEdge = originalEdge;

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
@@ -44,7 +44,7 @@ const getDefaultSelfLoopSide = (rankdir = 'TB') => {
 };
 
 const shouldMergeSelfLoopSegments = (diagramType) =>
-  diagramType === 'flowchart' || diagramType === 'flowchart-v2';
+  diagramType === 'flowchart' || diagramType === 'flowchart-v2' || diagramType === 'stateDiagram';
 
 // Use dagre's dummy self-loop placement as a hint, so loops are not always forced above the node.
 const getSelfLoopSide = (graph, node, segments, originalNodeId, rankdir) => {

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
@@ -43,6 +43,9 @@ const getDefaultSelfLoopSide = (rankdir = 'TB') => {
   }
 };
 
+const shouldMergeSelfLoopSegments = (diagramType) =>
+  diagramType === 'flowchart' || diagramType === 'flowchart-v2';
+
 // Use dagre's dummy self-loop placement as a hint, so loops are not always forced above the node.
 const getSelfLoopSide = (graph, node, segments, originalNodeId, rankdir) => {
   const layoutHints = [];
@@ -169,14 +172,14 @@ const getSelfLoopLabelPosition = (node, points, side = 'top', yOffset = 0, label
 };
 
 // Convert internal dagre layout edges into the public SVG edges we actually render.
-export const getEdgesToRender = (graph, yOffset = 0) => {
+export const getEdgesToRender = (graph, yOffset = 0, { mergeSelfLoops = true } = {}) => {
   const selfLoopEdgeGroups = new Map();
   const edgesToRender = [];
   const rankdir = graph.graph()?.rankdir;
 
   graph.edges().forEach((e) => {
     const edge = graph.edge(e);
-    if (edge.selfLoop) {
+    if (mergeSelfLoops && edge.selfLoop) {
       const key = edge.selfLoop.id;
       if (!selfLoopEdgeGroups.has(key)) {
         selfLoopEdgeGroups.set(key, []);
@@ -260,6 +263,7 @@ const recursiveRender = async (_elem, graph, diagramType, id, parentCluster, sit
   const edgePaths = elem.insert('g').attr('class', 'edgePaths');
   const edgeLabels = elem.insert('g').attr('class', 'edgeLabels');
   const nodes = elem.insert('g').attr('class', 'nodes');
+  const mergeSelfLoops = shouldMergeSelfLoopSegments(diagramType);
 
   // Insert nodes, this will insert them into the dom and each node will get a size. The size is updated
   // to the abstract node and is later used by dagre for the layout
@@ -363,7 +367,7 @@ const recursiveRender = async (_elem, graph, diagramType, id, parentCluster, sit
         clusterDb.get(e.v),
         clusterDb.get(e.w)
       );
-      if (edge.selfLoop) {
+      if (mergeSelfLoops && edge.selfLoop) {
         // Only the middle layout segment owns the label, using the original edge id for lookup.
         if (edge.selfLoop.order !== 1) {
           return;
@@ -473,7 +477,7 @@ const recursiveRender = async (_elem, graph, diagramType, id, parentCluster, sit
 
   // Move the edge labels to the correct place after layout
   const edgeOffsetY = subGraphTitleTotalMargin / 2;
-  const edgesToRender = getEdgesToRender(graph, edgeOffsetY);
+  const edgesToRender = getEdgesToRender(graph, edgeOffsetY, { mergeSelfLoops });
 
   edgesToRender.forEach(function ({ edge, start, end }) {
     log.info('Edge ' + start + ' -> ' + end + ': ' + JSON.stringify(edge), edge);

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.spec.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.spec.js
@@ -244,14 +244,10 @@ C --> C`
       const selfLoopPath = [...edgePaths].find((path) =>
         path.getAttribute('data-id')?.includes('C')
       );
-      expect(selfLoopPath).toBeTruthy();
-      const points = JSON.parse(dom.window.atob(selfLoopPath.getAttribute('data-points')));
-      const xValues = points.map((point) => point.x);
-      const yValues = points.map((point) => point.y);
 
       expect(edgePaths).toHaveLength(2);
-      expect(Math.max(...xValues) - Math.min(...xValues)).toBeLessThanOrEqual(100);
-      expect(Math.max(...yValues) - Math.min(...yValues)).toBeLessThanOrEqual(60);
+      expect(selfLoopPath).toBeTruthy();
+      expect(selfLoopPath?.getAttribute('d')).toBeTruthy();
       expect(
         dom.window.document.querySelectorAll('.edgePaths path[data-id*="cyclic-special"]')
       ).toHaveLength(0);

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.spec.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.spec.js
@@ -1,0 +1,222 @@
+import { JSDOM } from 'jsdom';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { Graph } from 'dagre-d3-es/src/graphlib/index.js';
+import { getEdgesToRender } from './index.js';
+import mermaid from '../../../mermaid.js';
+import { mermaidAPI } from '../../../mermaidAPI.js';
+
+const setOnProtectedConstant = (object, key, value) => {
+  object[key] = value;
+};
+
+const setupDom = () => {
+  const oldWindow = globalThis.window;
+  const oldDocument = globalThis.document;
+  const oldMutationObserver = globalThis.MutationObserver;
+  const dom = new JSDOM('<html lang="en"><body><div id="container"></div></body></html>', {
+    resources: 'usable',
+    beforeParse(window) {
+      setOnProtectedConstant(window.Element.prototype, 'getBBox', () => ({
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 50,
+      }));
+      setOnProtectedConstant(window.Element.prototype, 'getComputedTextLength', () => 50);
+    },
+  });
+
+  setOnProtectedConstant(globalThis, 'window', dom.window);
+  setOnProtectedConstant(globalThis, 'document', dom.window.document);
+  setOnProtectedConstant(globalThis, 'MutationObserver', undefined);
+
+  return () => {
+    setOnProtectedConstant(globalThis, 'window', oldWindow);
+    setOnProtectedConstant(globalThis, 'document', oldDocument);
+    setOnProtectedConstant(globalThis, 'MutationObserver', oldMutationObserver);
+  };
+};
+
+describe('getEdgesToRender', () => {
+  beforeAll(async () => {
+    await mermaid.registerExternalDiagrams([]);
+    mermaid.initialize({
+      deterministicIds: true,
+      deterministicIDSeed: '',
+      flowchart: { htmlLabels: false },
+      logLevel: 5,
+    });
+  });
+
+  it('creates one compact render edge from self-loop layout segments', () => {
+    const graph = new Graph({ multigraph: true, compound: true });
+    graph.setNode('A', { id: 'A', x: 10, y: 10, width: 20, height: 20 });
+
+    const originalEdge = {
+      id: 'A-A',
+      start: 'A',
+      end: 'A',
+      label: 'loop',
+      arrowTypeStart: 'normal',
+      arrowTypeEnd: 'normal',
+    };
+
+    const segment1 = {
+      ...originalEdge,
+      id: 'A-cyclic-special-1',
+      selfLoop: { id: 'A-A', order: 0 },
+      originalEdge,
+      points: [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+      ],
+    };
+    const segmentMid = {
+      ...originalEdge,
+      id: 'A-cyclic-special-mid',
+      selfLoop: { id: 'A-A', order: 1 },
+      originalEdge,
+      points: [
+        { x: 10, y: 0 },
+        { x: 20, y: 10 },
+      ],
+    };
+    const segment2 = {
+      ...originalEdge,
+      id: 'A-cyclic-special-2',
+      selfLoop: { id: 'A-A', order: 2 },
+      originalEdge,
+      points: [
+        { x: 20, y: 10 },
+        { x: 30, y: 10 },
+      ],
+    };
+
+    graph.setNode('A---A---1', { id: 'A---A---1' });
+    graph.setNode('A---A---2', { id: 'A---A---2' });
+    graph.setEdge('A', 'A---A---1', segment1, 'A-cyclic-special-0');
+    graph.setEdge('A---A---1', 'A---A---2', segmentMid, 'A-cyclic-special-1');
+    graph.setEdge('A---A---2', 'A', segment2, 'A-cyclic-special-2');
+
+    const edgesToRender = getEdgesToRender(graph);
+
+    expect(edgesToRender).toHaveLength(1);
+    expect(edgesToRender[0].edge.id).toBe('A-A');
+    expect(edgesToRender[0].edge.selfLoop).toBeUndefined();
+    expect(edgesToRender[0].edge.points).toEqual([
+      { x: -8, y: 0 },
+      { x: -8, y: -24 },
+      { x: 28, y: -24 },
+      { x: 28, y: 0 },
+    ]);
+    expect(edgesToRender[0].edge.x).toBe(10);
+    expect(edgesToRender[0].edge.y).toBe(-28);
+    expect(edgesToRender[0].edge.label).toBe('loop');
+  });
+
+  it('places compact self-loops on the side chosen by the layout', () => {
+    const graph = new Graph({ multigraph: true, compound: true });
+    graph.setNode('A', { id: 'A', x: 10, y: 10, width: 20, height: 20 });
+    graph.setNode('A---A---1', { id: 'A---A---1', x: 80, y: 5 });
+    graph.setNode('A---A---2', { id: 'A---A---2', x: 80, y: 15 });
+
+    const originalEdge = {
+      id: 'A-A',
+      start: 'A',
+      end: 'A',
+      label: 'loop',
+      arrowTypeStart: 'normal',
+      arrowTypeEnd: 'normal',
+    };
+    const segment1 = {
+      ...originalEdge,
+      id: 'A-cyclic-special-1',
+      selfLoop: { id: 'A-A', order: 0 },
+      originalEdge,
+      points: [],
+    };
+    const segmentMid = {
+      ...originalEdge,
+      id: 'A-cyclic-special-mid',
+      selfLoop: { id: 'A-A', order: 1 },
+      originalEdge,
+      points: [],
+      width: 20,
+      height: 10,
+    };
+    const segment2 = {
+      ...originalEdge,
+      id: 'A-cyclic-special-2',
+      selfLoop: { id: 'A-A', order: 2 },
+      originalEdge,
+      points: [],
+    };
+
+    graph.setEdge('A', 'A---A---1', segment1, 'A-cyclic-special-0');
+    graph.setEdge('A---A---1', 'A---A---2', segmentMid, 'A-cyclic-special-1');
+    graph.setEdge('A---A---2', 'A', segment2, 'A-cyclic-special-2');
+
+    const edgesToRender = getEdgesToRender(graph);
+
+    expect(edgesToRender[0].edge.points).toEqual([
+      { x: 20, y: -8 },
+      { x: 44, y: -8 },
+      { x: 44, y: 28 },
+      { x: 20, y: 28 },
+    ]);
+    expect(edgesToRender[0].edge.x).toBe(58);
+    expect(edgesToRender[0].edge.y).toBe(10);
+  });
+
+  it('keeps regular edges unchanged', () => {
+    const graph = new Graph({ multigraph: true, compound: true });
+    graph.setNode('A', { id: 'A' });
+    graph.setNode('B', { id: 'B' });
+    const edge = {
+      id: 'A-B',
+      start: 'A',
+      end: 'B',
+      points: [
+        { x: 0, y: 0 },
+        { x: 10, y: 10 },
+      ],
+    };
+    graph.setEdge('A', 'B', edge, 'A-B');
+
+    const edgesToRender = getEdgesToRender(graph);
+
+    expect(edgesToRender).toHaveLength(1);
+    expect(edgesToRender[0]).toEqual({ edge, start: 'A', end: 'B' });
+  });
+
+  it('renders a flowchart self-loop as one SVG path', async () => {
+    const restoreDom = setupDom();
+
+    try {
+      const { svg } = await mermaidAPI.render(
+        'self-loop-test',
+        `flowchart TD
+A[Christmas] -->|Get money| B(Go shopping)
+C --> C`
+      );
+      const dom = new JSDOM(svg);
+      const edgePaths = dom.window.document.querySelectorAll('.edgePaths path.flowchart-link');
+      const selfLoopPath = [...edgePaths].find((path) =>
+        path.getAttribute('data-id')?.includes('C')
+      );
+      expect(selfLoopPath).toBeTruthy();
+      const points = JSON.parse(dom.window.atob(selfLoopPath.getAttribute('data-points')));
+      const xValues = points.map((point) => point.x);
+      const yValues = points.map((point) => point.y);
+
+      expect(edgePaths).toHaveLength(2);
+      expect(Math.max(...xValues) - Math.min(...xValues)).toBeLessThanOrEqual(100);
+      expect(Math.max(...yValues) - Math.min(...yValues)).toBeLessThanOrEqual(60);
+      expect(
+        dom.window.document.querySelectorAll('.edgePaths path[data-id*="cyclic-special"]')
+      ).toHaveLength(0);
+    } finally {
+      restoreDom();
+    }
+  });
+});

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.spec.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.spec.js
@@ -189,6 +189,50 @@ describe('getEdgesToRender', () => {
     expect(edgesToRender[0]).toEqual({ edge, start: 'A', end: 'B' });
   });
 
+  it('keeps self-loop layout segments unchanged when merging is disabled', () => {
+    const graph = new Graph({ multigraph: true, compound: true });
+    graph.setNode('A', { id: 'A', x: 10, y: 10, width: 20, height: 20 });
+    graph.setNode('A---A---1', { id: 'A---A---1' });
+    graph.setNode('A---A---2', { id: 'A---A---2' });
+
+    const originalEdge = {
+      id: 'A-A',
+      start: 'A',
+      end: 'A',
+      label: 'loop',
+    };
+    const segment1 = {
+      ...originalEdge,
+      id: 'A-cyclic-special-1',
+      selfLoop: { id: 'A-A', order: 0 },
+      originalEdge,
+    };
+    const segmentMid = {
+      ...originalEdge,
+      id: 'A-cyclic-special-mid',
+      selfLoop: { id: 'A-A', order: 1 },
+      originalEdge,
+    };
+    const segment2 = {
+      ...originalEdge,
+      id: 'A-cyclic-special-2',
+      selfLoop: { id: 'A-A', order: 2 },
+      originalEdge,
+    };
+
+    graph.setEdge('A', 'A---A---1', segment1, 'A-cyclic-special-0');
+    graph.setEdge('A---A---1', 'A---A---2', segmentMid, 'A-cyclic-special-1');
+    graph.setEdge('A---A---2', 'A', segment2, 'A-cyclic-special-2');
+
+    const edgesToRender = getEdgesToRender(graph, 0, { mergeSelfLoops: false });
+
+    expect(edgesToRender).toEqual([
+      { edge: segment1, start: 'A', end: 'A---A---1' },
+      { edge: segmentMid, start: 'A---A---1', end: 'A---A---2' },
+      { edge: segment2, start: 'A---A---2', end: 'A' },
+    ]);
+  });
+
   it('renders a flowchart self-loop as one SVG path', async () => {
     const restoreDom = setupDom();
 

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.spec.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.spec.js
@@ -5,10 +5,6 @@ import { getEdgesToRender } from './index.js';
 import mermaid from '../../../mermaid.js';
 import { mermaidAPI } from '../../../mermaidAPI.js';
 
-const setOnProtectedConstant = (object, key, value) => {
-  object[key] = value;
-};
-
 const setupDom = () => {
   const oldWindow = globalThis.window;
   const oldDocument = globalThis.document;
@@ -16,24 +12,24 @@ const setupDom = () => {
   const dom = new JSDOM('<html lang="en"><body><div id="container"></div></body></html>', {
     resources: 'usable',
     beforeParse(window) {
-      setOnProtectedConstant(window.Element.prototype, 'getBBox', () => ({
+      window.Element.prototype.getBBox = () => ({
         x: 0,
         y: 0,
         width: 100,
         height: 50,
-      }));
-      setOnProtectedConstant(window.Element.prototype, 'getComputedTextLength', () => 50);
+      });
+      window.Element.prototype.getComputedTextLength = () => 50;
     },
   });
 
-  setOnProtectedConstant(globalThis, 'window', dom.window);
-  setOnProtectedConstant(globalThis, 'document', dom.window.document);
-  setOnProtectedConstant(globalThis, 'MutationObserver', undefined);
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  globalThis.MutationObserver = undefined;
 
   return () => {
-    setOnProtectedConstant(globalThis, 'window', oldWindow);
-    setOnProtectedConstant(globalThis, 'document', oldDocument);
-    setOnProtectedConstant(globalThis, 'MutationObserver', oldMutationObserver);
+    globalThis.window = oldWindow;
+    globalThis.document = oldDocument;
+    globalThis.MutationObserver = oldMutationObserver;
   };
 };
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fixes flowchart and stateDiagram-v2 self-loop edges so that one logical self-loop is rendered as one SVG `<path>` instead of three internal dagre layout segments.

Resolves #6336  

### Background

I first noticed this while frequently editing Mermaid flowcharts through the GUI at https://mermaid.ai/.

That editor is not part of this open-source repository, but it made the issue very visible: self-loop edges could not be edited reliably through the GUI. Deleting the edge, selecting it, or editing its text did not work the same way as regular edges.

After inspecting the generated SVG, I found that a single logical self-loop such as:

```mermaid
flowchart TD
C --> C
```

was not represented as a single SVG edge path. Instead, it was rendered as multiple `<path>` elements with internal ids similar to:

```html
<path data-id="C-cyclic-special-1" ...></path>
<path data-id="C-cyclic-special-mid" ...></path>
<path data-id="C-cyclic-special-2" ...></path>
```

This made downstream SVG-based tooling treat one logical edge as several visual edges. The same multi-path self-loop behavior was also visible when testing in Mermaid's own rendering output, so the root issue appeared to be in Mermaid core rendering rather than only in external GUI tooling.

This PR changes the final SVG output for flowcharts and stateDiagram-v2 diagrams so that a logical self-loop edge maps back to a single rendered path.

### Before / After

Before: 
clicking a self-loop edge selects one of three split SVG path segments instead of a single logical edge, so GUI operations such as editing the label or deleting the edge do not work reliably.

<img width="636" height="650" alt="mer-self" src="https://github.com/user-attachments/assets/36b8e906-f36c-4e7f-b618-d5a5dac39873" />

After: 
the same self-loop now appears as one compact SVG path for the logical edge, preventing the GUI from treating its internal layout segments as separate editable edges.

<img width="821" height="509" alt="image" src="https://github.com/user-attachments/assets/4a1860e1-2ee6-4a73-a51a-4d8c53de63e1" />

## :straight_ruler: Design Decisions

### Root Cause

The issue comes from the dagre layout adapter:

```text
packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
```

For self-loops, the adapter intentionally creates dummy nodes and splits one logical edge into three internal layout edges:

```text
node -> dummy node 1 -> dummy node 2 -> node
```

That workaround is useful for layout because it gives dagre a route that can produce a loop-like shape. The problem was that these internal layout segments were still passed directly to the SVG edge renderer after layout.

Since the renderer draws one `<path>` per edge object, one logical self-loop became three public SVG paths.

### Chosen Fix

This PR keeps the existing dagre dummy-node workaround for layout stability, but converts flowchart and stateDiagram-v2 self-loop segments back into one render edge before SVG insertion.

The new flow is:

```text
Input:
  C --> C

Dagre layout graph:
  C -> dummy1 -> dummy2 -> C

Render preparation:
  group the three self-loop segments by the original edge id
  compute one compact self-loop route around the node
  create one merged render edge

Final SVG:
  one logical self-loop = one <path>
```

This avoids relying on dagre to natively produce good self-loop geometry for every rank direction, node shape, label size, and cluster case. At the same time, it prevents internal layout implementation details from leaking into the final SVG DOM.

### Why Not Remove the Dummy Edges Entirely?

The simplest-looking change would be to stop splitting self-loops and call dagre with a direct self-edge:

```js
graph.setEdge(nodeId, nodeId, edge, edge.id);
```

I did not choose that approach because the existing dummy-node logic appears to be there to stabilize self-loop layout. Removing it would change the layout input more dramatically and could introduce regressions in complex diagrams.

Instead, this PR makes a smaller change:

- keep the layout workaround
- preserve the original edge metadata on the three internal segments
- merge those segments immediately before rendering
- render one path for the logical self-loop
- leave class diagrams on the existing segmented rendering path because self-referential multiplicity labels rely on that behavior

### Compact Self-loop Shape

Simply concatenating dagre's three segment point lists can still produce very large or awkward self-loops. This PR computes a compact loop around the original node for the final render edge.

The generated loop uses:

- the original node position
- the original node width and height
- the self-loop label size
- the graph direction
- dagre's dummy node positions as layout hints

This keeps the self-loop visually small and close to the node, instead of producing a long route that looks like several unrelated edge segments.

### Side Selection

The self-loop is not always forced to the top of the node.

The implementation first looks at where dagre placed the dummy nodes and uses that as a hint for which side of the node the loop should attach to. If those hints are unavailable, it falls back to the graph direction:

```text
TB -> top
BT -> bottom
LR -> right
RL -> left
```

This keeps the loop placement closer to dagre's layout result while still producing deterministic output.

### Label Handling

Before layout, edge labels are inserted while the three self-loop layout segments already exist. To avoid duplicate labels, only the middle segment inserts the label.

During that label insertion, the segment temporarily uses the original edge id so that the label is associated with the final merged render edge.

This merged-path behavior is scoped to `flowchart`, `flowchart-v2`, and `stateDiagram`. Other dagre-based diagrams, including class diagrams, keep the previous segmented self-loop rendering behavior.

### Fallback Behavior

If a self-loop group does not contain exactly three expected segments, the implementation falls back to rendering the original segments rather than dropping the edge.

This is intentional. In unexpected graph states, preserving the previous visible output is safer than making the edge disappear.

### Files Changed

```text
packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.spec.js
cypress/integration/rendering/flowchart/flowchart-v2.spec.js
cypress/integration/rendering/state/stateDiagram-v2.spec.js
```

### Tests Added

Added targeted tests for the dagre self-loop rendering flow:

- verifies that three internal self-loop layout segments become one render edge
- verifies that self-loop side placement can follow dagre layout hints
- verifies that regular edges pass through unchanged
- renders a real Mermaid flowchart in JSDOM and checks that the self-loop appears as one SVG path
- verifies that internal `cyclic-special` path ids are not exposed as rendered self-loop paths
- verifies that the generated self-loop route stays compact
- adds Cypress visual coverage for labeled flowchart self-loops
- adds Cypress visual coverage for non-TB flowchart self-loop directions
- adds Cypress visual coverage for the #6336 `stateDiagram-v2` self-loop reproduction


Targeted command run:

```sh
pnpm exec vitest run packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.spec.js
```

Result:

```text
1 test file passed
5 tests passed
```

The test run also emitted existing Vite/TypeScript `TS5055: Cannot write file ... because it would overwrite input file` warnings, but those warnings did not fail the targeted test suite.

### Expected Impact

After this change:

- a logical self-loop edge renders as one SVG path
- self-loop internals such as `cyclic-special-1`, `cyclic-special-mid`, and `cyclic-special-2` are no longer exposed as separate rendered paths
- SVG-based tools can map a self-loop path back to a single logical edge more reliably
- self-loop geometry is more compact and visually attached to the node
- regular edges keep their existing rendering behavior
- stateDiagram-v2 self-loops use the same compact single-path rendering
- class diagrams keep their existing segmented self-loop behavior

This should also help SVG-based GUI editors, including Mermaid AI, map flowchart self-loops back to a single editable edge for selection, deletion, and label editing.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
