### PR TITLE
fix(ci): use pull_request.head.sha in validate-lockfile git diff

### DIFF
--- a/.github/workflows/validate-lockfile.yml
+++ b/.github/workflows/validate-lockfile.yml
@@ -34,7 +34,7 @@ jobs:
           fi
 
           # 3) Lockfile only changes when package.json changes
-          git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} > changed.txt
+          git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} > changed.txt
           if grep -q '^pnpm-lock.yaml$' changed.txt && ! grep -q 'package.json' changed.txt; then
             issues+=("• pnpm-lock.yaml changed without any package.json modification")
           fi


### PR DESCRIPTION
## Problem

In a `pull_request_target` workflow, `${{ github.sha }}` resolves to the **base branch HEAD** (i.e. `develop`), not the PR head commit. The checkout step correctly uses `${{ github.event.pull_request.head.sha }}` to check out the fork's code, but the subsequent `git diff` command still uses `${{ github.sha }}`:

```bash
git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} > changed.txt
```

When a PR comes from a fork, `${{ github.sha }}` refers to a commit that does not exist in the fork's cloned history. This causes:

```
fatal: bad object <sha-of-upstream-develop>
```

Because the script runs under `set -e`, it exits immediately — before the `issues` array is ever populated. The workflow then posts a "Lockfile Validation Failed" comment with a **blank body**, causing confusion and a false-positive failure on every fork PR that touches `pnpm-lock.yaml` or `package.json`.

## Fix

Replace `${{ github.sha }}` → `${{ github.event.pull_request.head.sha }}` so the diff compares the correct two commits: the PR base vs the PR head.

```diff
- git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} > changed.txt
+ git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} > changed.txt
```

## Verification

This was originally diagnosed while investigating CI failures on PR #7700 (a fork PR touching `package.json`). Checked manually: all three lockfile validations pass; only the `git diff` step fails with the bad object error.

The `actions/checkout` step on the line immediately above already uses `github.event.pull_request.head.sha` — consistency is also improved by this change.