### PR TITLE
docs: improve `.changeset`s for v11.15.0 release

### DIFF
--- a/.changeset/cold-mails-fly.md
+++ b/.changeset/cold-mails-fly.md
@@ -1,5 +1,0 @@
----
-'@mermaid-js/parser': major
----
-
-enforce eventmodeling connection invariants via Langium validator

--- a/.changeset/cold-snakes-attend.md
+++ b/.changeset/cold-snakes-attend.md
@@ -2,4 +2,4 @@
 'mermaid': patch
 ---
 
-fix: updated the parser to require a new line boundary before the "end note" keyword to ensure it is only matched when used as an actual note terminator.
+fix(stateDiagram): `end note` now only closes a note when used on a new line

--- a/.changeset/dark-bats-build.md
+++ b/.changeset/dark-bats-build.md
@@ -2,4 +2,6 @@
 'mermaid': minor
 ---
 
-feat: Added support for decimal start and increment values in the `autonumber` directive.
+feat(sequence): Add support for decimal start and increment values in the `autonumber` directive
+
+commit: 0aca21739c0d1fcaaa206e04a6cd574ebc415483

--- a/.changeset/eager-cobras-slide.md
+++ b/.changeset/eager-cobras-slide.md
@@ -2,6 +2,6 @@
 'mermaid': minor
 ---
 
-feat: add datastore shape for flowchart
+feat(flowchart): add datastore shape
 
-In Data flow diagrams, a datastore/warehouse/file/database is used to represent data persistence. It is denoted by a rectangle with top and bottom border. This change adds that as a shape in flowcharts.
+In Data flow diagrams, a datastore/warehouse/file/database is used to represent data persistence. It is denoted by a rectangle with only top and bottom borders, and can be used in flowcharts with `A@{ shape: datastore, label: "Datastore" }`.

--- a/.changeset/event-modeling-diagram.md
+++ b/.changeset/event-modeling-diagram.md
@@ -3,3 +3,6 @@
 ---
 
 feat: add Event Modeling diagram
+
+author: @yordis
+author: @lgazo

--- a/.changeset/feat-architecture-fcose-config.md
+++ b/.changeset/feat-architecture-fcose-config.md
@@ -2,4 +2,4 @@
 'mermaid': minor
 ---
 
-feat: expose four fcose layout knobs for architecture-beta diagrams (`nodeSeparation`, `idealEdgeLengthMultiplier`, `edgeElasticity`, `numIter`) so authors can tune layout density and spread overlapping siblings without changing diagram source
+feat(architecture): expose four fcose layout knobs for `architecture-beta` diagrams (`nodeSeparation`, `idealEdgeLengthMultiplier`, `edgeElasticity`, `numIter`) so authors can tune layout density and spread overlapping siblings without changing diagram source

--- a/.changeset/feat-nested-namespaces.md
+++ b/.changeset/feat-nested-namespaces.md
@@ -2,4 +2,4 @@
 'mermaid': minor
 ---
 
-feat: add nested namespace support for class diagrams via dot notation and syntactic nesting
+feat(class): add nested namespace support for class diagrams via dot notation and syntactic nesting

--- a/.changeset/fix-7560-self-referential-multiplicity.md
+++ b/.changeset/fix-7560-self-referential-multiplicity.md
@@ -2,6 +2,6 @@
 'mermaid': patch
 ---
 
-fix: self-referential class multiplicity labels no longer rendered multiple times
+fix(class): self-referential class multiplicity labels no longer rendered multiple times
 
 Fixes #7560. Resolves an issue where cardinality labels on self-referential class relationships were rendered three times due to edge splitting in the dagre layout. The fix ensures that each sub-edge only carries its relevant label positions.

--- a/.changeset/fix-alt-else-label-box.md
+++ b/.changeset/fix-alt-else-label-box.md
@@ -2,4 +2,4 @@
 'mermaid': patch
 ---
 
-fix: add background box behind alt/else section title labels in sequence diagrams
+fix(sequence): add background box behind alt/else section title labels in sequence diagrams

--- a/.changeset/fix-block-beta-width.md
+++ b/.changeset/fix-block-beta-width.md
@@ -2,4 +2,4 @@
 'mermaid': patch
 ---
 
-fix(block-beta): normalize width before comparison in getMaxChildSize to prevent column widths from shrinking when mixing different column spans
+fix(block): prevent column widths from shrinking when mixing different column spans

--- a/.changeset/fix-mindmap-tidy-tree-root-edges.md
+++ b/.changeset/fix-mindmap-tidy-tree-root-edges.md
@@ -1,6 +1,5 @@
 ---
 '@mermaid-js/layout-tidy-tree': patch
-'mermaid': patch
 ---
 
 fix: keep mindmap edges connected to a non-circular root when using the tidy-tree layout

--- a/.changeset/fix-sequence-messagealign-rtl-arrows.md
+++ b/.changeset/fix-sequence-messagealign-rtl-arrows.md
@@ -2,4 +2,4 @@
 'mermaid': patch
 ---
 
-fix: correct messageAlign label position for right-to-left arrows in sequence diagrams
+fix(sequence): correct messageAlign label position for right-to-left arrows in sequence diagrams

--- a/.changeset/fix-zenuml-svg-renderer.md
+++ b/.changeset/fix-zenuml-svg-renderer.md
@@ -1,5 +1,4 @@
 ---
-'mermaid': patch
 '@mermaid-js/mermaid-zenuml': patch
 ---
 

--- a/.changeset/fruity-ghosts-watch.md
+++ b/.changeset/fruity-ghosts-watch.md
@@ -2,4 +2,4 @@
 'mermaid': patch
 ---
 
-fix: Arrow blocks in block-beta diagrams not spanning the specified number of columns when using :n syntax.
+fix(block): Arrow blocks in block-beta diagrams not spanning the specified number of columns when using `:n` syntax.

--- a/.changeset/green-peas-search.md
+++ b/.changeset/green-peas-search.md
@@ -1,5 +1,0 @@
----
-'mermaid': patch
----
-
-docs: add Wardley diagram link to sidebar

--- a/.changeset/grumpy-singers-cheer.md
+++ b/.changeset/grumpy-singers-cheer.md
@@ -2,4 +2,4 @@
 'mermaid': patch
 ---
 
-fix: Ensure block diagram hexagon blocks respect column spanning syntax
+fix(block): Ensure block diagram hexagon blocks respect column spanning syntax

--- a/.changeset/olive-signs-pull.md
+++ b/.changeset/olive-signs-pull.md
@@ -2,4 +2,4 @@
 'mermaid': patch
 ---
 
-fix: add support for all arrow types in block diagrams
+fix(block): add support for all arrow types in block diagrams

--- a/.changeset/three-melons-argue.md
+++ b/.changeset/three-melons-argue.md
@@ -1,6 +1,0 @@
----
-'mermaid': major
-'@mermaid-js/parser': major
----
-
-fix: replace Event Modeling `screen` / `scn` terminology with `ui`

--- a/.changeset/yummy-moose-wait.md
+++ b/.changeset/yummy-moose-wait.md
@@ -2,4 +2,6 @@
 'mermaid': patch
 ---
 
-fix: updated the parser to only treat comments starting with %%.
+fix(stateDiagram): comments starting with one `%` are no longer treated as comments
+
+Switch to using two `%%` if you want to write a comment.


### PR DESCRIPTION
## :bookmark_tabs: Summary

> [!Note]
>
> This PR targets the `release/11.15.0` branch!

Cleans up the `.changeset` files to prepare for the v11.15.0 release.

## :straight_ruler: Design Decisions

Please see the `git log` and commits for details of each change, but to summarize:

- I've removed/added changesets that only touched `@mermaid-js/parser` or didn't touch `mermaid`, so they're only mentioned in their relevant CHANGELOG.md
- I've removed the event modelling changesets except for just the `feat: add Event Modeling diagram` changeset. It doesn't make sense to have changesets saying that we've updated event modelling, when the event modelling diagram hasn't been released yet.
- ~I've removed the `@mermaid-js/mermaid-local-editor` changeset, since it's a private package.~ _Edit_: Dropped now that we're targeting the `release/11.15.0` branch that doesn't include this PR.
- I've added diagram prefixes to most changesets that only touch one diagram, e.g. instead of having `feat: add XYZ feature to flowcharts`, I've standardized them to `feat(flowchart): add XYZ feature to flowcharts`. This also means that we are always mentioning which diagram types are affected by a fix/feature.
    - Personally, I think this is cleaner and easier to understand, but this one is a bit personal preference, so I'd understand if you want to change it. If you like it, we could even update the changeset instructions to encourage this.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
