### PR TITLE
ci: fix `release-preview-publish.yml` action

### DIFF
--- a/.github/workflows/release-preview-publish.yml
+++ b/.github/workflows/release-preview-publish.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - 'release/**'
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   publish-preview:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-preview-publish.yml
+++ b/.github/workflows/release-preview-publish.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Install Packages
         run: |
+          # Use hoisted mode to avoid `bundleDependencies` issues
+          echo 'nodeLinker: "hoisted"' >> pnpm-workspace.yaml
           pnpm install --frozen-lockfile
         env:
           CYPRESS_CACHE_FOLDER: .cache/Cypress
@@ -45,7 +47,10 @@ jobs:
           npm set registry https://npm.pkg.github.com/mermaid-js
           json -I -f package.json -e 'this.name="@mermaid-js/mermaid"' # Package name needs to be set to a scoped one because GitHub registry requires this
           json -I -f package.json -e 'this.repository="git://github.com/mermaid-js/mermaid"' # Repo url needs to have a specific format too
-          npm --tag preview publish
+          # We don't publish a separate `@mermaid-js/parser` so bundle it instead
+          json -I -f package.json -e 'this.bundleDependencies??=[]' -e 'this.bundleDependencies.push("@mermaid-js/parser")'
+          pnpm pack
+          npm publish --tag preview *.tgz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Prevent `npm publish` from failing if the docs verification fails.

--- a/.github/workflows/release-preview-publish.yml
+++ b/.github/workflows/release-preview-publish.yml
@@ -45,7 +45,7 @@ jobs:
           npm set registry https://npm.pkg.github.com/mermaid-js
           json -I -f package.json -e 'this.name="@mermaid-js/mermaid"' # Package name needs to be set to a scoped one because GitHub registry requires this
           json -I -f package.json -e 'this.repository="git://github.com/mermaid-js/mermaid"' # Repo url needs to have a specific format too
-          npm publish
+          npm --tag preview publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Prevent `npm publish` from failing if the docs verification fails.

--- a/.github/workflows/release-preview-publish.yml
+++ b/.github/workflows/release-preview-publish.yml
@@ -44,3 +44,5 @@ jobs:
           npm publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Prevent `npm publish` from failing if the docs verification fails.
+          ONLY_WARN_ON_VERIFY_ERROR: 'true'

--- a/packages/mermaid/scripts/update-release-version.mts
+++ b/packages/mermaid/scripts/update-release-version.mts
@@ -17,6 +17,10 @@ import {
 
 const verifyOnly: boolean = process.argv.includes('--verify');
 const versionPlaceholder = '<MERMAID_RELEASE_VERSION>';
+/**
+ * This is so we can run `npm publish` for previews, without blocking the release.
+ */
+const onlyWarnOnVerifyError = process.env.ONLY_WARN_ON_VERIFY_ERROR === 'true';
 
 const verifyDocumentation = async () => {
   const fileContent = await readFile('./src/docs/community/contributing.md', 'utf-8');
@@ -51,7 +55,7 @@ const main = async () => {
     console.log(
       `${mdFilesWithPlaceholder.length} file(s) were found with the placeholder ${versionPlaceholder}. Run \`pnpm --filter mermaid docs:release-version\` to update them.`
     );
-    process.exit(1);
+    process.exit(onlyWarnOnVerifyError ? 0 : 1);
   }
 
   for (const mdFile of mdFilesWithPlaceholder) {


### PR DESCRIPTION
## :bookmark_tabs: Summary

> [!Note]
>
> This PR targets `release/11.15.0` so we can use it straight away.

The `release-preview-publish.yml` action is often failing for recent v11 releases, see https://github.com/mermaid-js/mermaid/actions/runs/25491214960/job/74799431314 for an example.

`npm publish` now runs `pnpm docs:verify-version`, which will generally fail since we'd only update the docs to fix `<MERMAID_RELEASE_VERSION>` with the actual changeset PR.

I've updated this action to ignore this, and also bundle the `@mermaid-js/parser` package within the `@mermaid-js/mermaid` preview package we publish, so we don't have to mess with publishing a second version of that somewhere.

## :straight_ruler: Design Decisions

See the `git log` and each individual commit for more information!

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
