### PR TITLE
fix(wardley): fix unnecessary sanitization of text

### DIFF
--- a/.changeset/few-loops-shake.md
+++ b/.changeset/few-loops-shake.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix(wardley): fix unnecessary sanitization of text

--- a/packages/mermaid/src/diagrams/wardley/wardleyDb.ts
+++ b/packages/mermaid/src/diagrams/wardley/wardleyDb.ts
@@ -1,5 +1,4 @@
 import { getConfig as getGlobalConfig } from '../../diagram-api/diagramAPI.js';
-import { sanitizeText } from '../common/common.js';
 import {
   clear as commonClear,
   getAccDescription,
@@ -13,11 +12,6 @@ import type { WardleyAxesConfig } from './wardleyBuilder.js';
 import { WardleyBuilder } from './wardleyBuilder.js';
 
 const builder = new WardleyBuilder();
-
-function textSanitizer(text: string) {
-  const config = getGlobalConfig();
-  return sanitizeText(text.trim(), config);
-}
 
 function getConfig() {
   return getGlobalConfig()['wardley-beta'];
@@ -36,7 +30,7 @@ function addNode(
 ) {
   builder.addNode({
     id,
-    label: textSanitizer(label),
+    label,
     x,
     y,
     className,
@@ -58,7 +52,7 @@ function addLink(
     source: sourceId,
     target: targetId,
     dashed,
-    label: label ? textSanitizer(label) : undefined,
+    label,
     flow,
   });
 }
@@ -71,13 +65,13 @@ function addAnnotation(number: number, coordinates: { x: number; y: number }[], 
   builder.addAnnotation({
     number,
     coordinates,
-    text: text ? textSanitizer(text) : undefined,
+    text,
   });
 }
 
 function addNote(text: string, x: number, y: number) {
   builder.addNote({
-    text: textSanitizer(text),
+    text,
     x,
     y,
   });
@@ -85,7 +79,7 @@ function addNote(text: string, x: number, y: number) {
 
 function addAccelerator(name: string, x: number, y: number) {
   builder.addAccelerator({
-    name: textSanitizer(name),
+    name,
     x,
     y,
   });
@@ -93,7 +87,7 @@ function addAccelerator(name: string, x: number, y: number) {
 
 function addDeaccelerator(name: string, x: number, y: number) {
   builder.addDeaccelerator({
-    name: textSanitizer(name),
+    name,
     x,
     y,
   });
@@ -116,20 +110,7 @@ function addPipelineComponent(pipelineNodeId: string, componentId: string) {
 }
 
 function updateAxes(partial: WardleyAxesConfig) {
-  const sanitized: WardleyAxesConfig = {};
-  if (partial.xLabel) {
-    sanitized.xLabel = textSanitizer(partial.xLabel);
-  }
-  if (partial.yLabel) {
-    sanitized.yLabel = textSanitizer(partial.yLabel);
-  }
-  if (partial.stages) {
-    sanitized.stages = partial.stages.map((stage) => textSanitizer(stage));
-  }
-  if (partial.stageBoundaries) {
-    sanitized.stageBoundaries = partial.stageBoundaries;
-  }
-  builder.setAxes(sanitized);
+  builder.setAxes(partial);
 }
 
 function getNode(id: string) {

--- a/packages/mermaid/src/diagrams/wardley/wardleyRenderer.ts
+++ b/packages/mermaid/src/diagrams/wardley/wardleyRenderer.ts
@@ -6,6 +6,9 @@ import { selectSvgElement } from '../../rendering-util/selectSvgElement.js';
 import { configureSvgSize } from '../../setupGraphViewbox.js';
 import type { WardleyBuildResult, WardleyNode } from './wardleyBuilder.js';
 
+// Wardley DB does not sanitize text, so we can only use `.text()` for labels.
+/* eslint no-restricted-properties: ["error", {"property": "html"}] */
+
 const DEFAULT_STAGES = ['Genesis', 'Custom Built', 'Product', 'Commodity'];
 
 type WardleyText = d3.Selection<SVGTextElement, unknown, Element | null, unknown>;


### PR DESCRIPTION
## :bookmark_tabs: Summary

> [!Note]
>
> This PR targets the `release/11.15.0` branch, not `develop`.

The `wardleyRenderer` file never uses `.html()` or `.innerHTML` to set items within the HTML. Instead, it only ever uses D3 Selection's `.text`, which works `textContent`. This makes it immune to XSS attacks.

When we over-sanitize this text, the diagram will show `&lt;` instead of `<` in labels.

Fixes https://github.com/mermaid-js/mermaid/commit/38582cae7844df1cbf1754219e7f3dd86c47a5a2

## :straight_ruler: Design Decisions

Although I believe everything in the `wardleyRenderer` file is currently safe, I've made sure to add a `/* eslint no-restricted-properties: ["error", {"property": "html"}] */` check to that file to make it a bit less likely that somebody would accidentally add a `.html()` call that would be dangerous.

Additionally, `getDiagramTitle` is still returning the sanitized text:

https://github.com/mermaid-js/mermaid/blob/497ffde9fef294a9199e0dcec0e281c6ec1b516e/packages/mermaid/src/diagrams/common/commonDb.ts#L32

However, since this is part of the `commonDb.ts`, changing this would affect many diagram types, so I've left it alone.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
  - Covered by existing Argos visual regression test, see https://github.com/mermaid-js/mermaid/blob/288a6b3a4169c02813cdf3be27be4172dffdfed9/cypress/integration/rendering/wardley/wardley.spec.js#L96-L119
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
  - `fix` to the `mermaid` package.