### PR TITLE
chore: Disable failing visual tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -31,6 +31,11 @@ export default eyesPlugin(
           registerArgosTask(on, config, {
             // Enable upload to Argos only when it runs on CI.
             uploadToArgos: !!process.env.CI,
+            // Mark as a subset build when only a scoped set of specs ran.
+            // This tells Argos to ignore missing screenshots (they were not
+            // run, not deleted) and prevents the baseline from being replaced
+            // by a partial run. Mirrors the ARGOS_SUBSET env var set in e2e.yml.
+            subset: process.env.ARGOS_SUBSET === 'true',
           });
         } else {
           addMatchImageSnapshotPlugin(on, config);

--- a/cypress/integration/rendering/architecture/architecture.spec.ts
+++ b/cypress/integration/rendering/architecture/architecture.spec.ts
@@ -242,7 +242,7 @@ describe('architecture diagram', () => {
       `
     );
   });
-  it('should render a deterministic layout for a complex deeply-nested diagram', () => {
+  it.skip('should render a deterministic layout for a complex deeply-nested diagram', () => {
     imgSnapshotTest(
       `architecture-beta
                 group sub1(cloud)[Subscription A]

--- a/cypress/integration/rendering/cynefin/cynefin.spec.js
+++ b/cypress/integration/rendering/cynefin/cynefin.spec.js
@@ -1,6 +1,6 @@
 import { imgSnapshotTest } from '../../../helpers/util';
 
-describe('cynefin framework', () => {
+describe.skip('cynefin framework', () => {
   it('should render a simple cynefin diagram with all five domains', () => {
     imgSnapshotTest(
       `cynefin-beta


### PR DESCRIPTION
## :bookmark_tabs: Summary

The visual test 'should render a deterministic layout for a complex deeply-nested diagram' for Architecture diagrams is disabled since it fails in CI

The visual tests for Cynefin diagrams are disabled since they fail in CI.

During work with this PR, a problem was found that handling of subset screenshots was correct. In this PR a minor fix for that is added
Note: Separate issues are be raised to fix the failing tests. See [https://github.com/mermaid-js/mermaid/issues/7727](url) and [https://github.com/mermaid-js/mermaid/issues/7729](url)


## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [ ] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
