### PR TITLE
fix: revert endEdgeLabelLeft/endEdgeLabelRight change

### DIFF
--- a/packages/mermaid/src/dagre-wrapper/edges.js
+++ b/packages/mermaid/src/dagre-wrapper/edges.js
@@ -119,8 +119,9 @@ export const insertEdgeLabel = async (elem, edge) => {
   }
   if (edge.endLabelLeft) {
     const endEdgeLabelLeft = elem.insert('g').attr('class', 'edgeTerminals');
+    // TODO: Remove? `inner` is not used
     const inner = endEdgeLabelLeft.insert('g').attr('class', 'inner');
-    const endLabelElement = await createLabel(inner, edge.endLabelLeft, edge.labelStyle);
+    const endLabelElement = await createLabel(endEdgeLabelLeft, edge.endLabelLeft, edge.labelStyle);
     fo = endLabelElement;
     let slBox = endLabelElement.getBBox();
     if (useHtmlLabels) {
@@ -140,8 +141,13 @@ export const insertEdgeLabel = async (elem, edge) => {
   }
   if (edge.endLabelRight) {
     const endEdgeLabelRight = elem.insert('g').attr('class', 'edgeTerminals');
+    // TODO: Remove? `inner` is not used
     const inner = endEdgeLabelRight.insert('g').attr('class', 'inner');
-    const endLabelElement = await createLabel(inner, edge.endLabelRight, edge.labelStyle);
+    const endLabelElement = await createLabel(
+      endEdgeLabelRight,
+      edge.endLabelRight,
+      edge.labelStyle
+    );
     fo = endLabelElement;
     let slBox = endLabelElement.getBBox();
     if (useHtmlLabels) {

--- a/packages/mermaid/src/rendering-util/rendering-elements/edges.js
+++ b/packages/mermaid/src/rendering-util/rendering-elements/edges.js
@@ -176,9 +176,10 @@ export const insertEdgeLabel = async (elem, edge) => {
   }
   if (edge.endLabelLeft) {
     const endEdgeLabelLeft = elem.insert('g').attr('class', 'edgeTerminals');
+    // TODO: Remove? `inner` is not used
     const inner = endEdgeLabelLeft.insert('g').attr('class', 'inner');
     const endLabelElement = await createLabel(
-      inner,
+      endEdgeLabelLeft,
       edge.endLabelLeft,
       getLabelStyles(edge.labelStyle) || '',
       false,
@@ -203,9 +204,10 @@ export const insertEdgeLabel = async (elem, edge) => {
   }
   if (edge.endLabelRight) {
     const endEdgeLabelRight = elem.insert('g').attr('class', 'edgeTerminals');
+    // TODO: Remove? `inner` is not used
     const inner = endEdgeLabelRight.insert('g').attr('class', 'inner');
     const endLabelElement = await createLabel(
-      inner,
+      endEdgeLabelRight,
       edge.endLabelRight,
       getLabelStyles(edge.labelStyle) || '',
       false,


### PR DESCRIPTION
## :bookmark_tabs: Summary

> [!Note]
>
> This PR targets the `release/11.15.0` branch, not `develop`.

fedf70cc3c38c6d62890f5e1522b88494e941beb changed how `endLabel`s were rendered, by
preventing them from being rendered within their `endEdgeLabelLeft` or `endLabelRight` elements, when they existed.

Although when looking at the code, this seems correct (as otherwise `inner` is not used), this actually causes the labels to render on top of the edges, which makes the class diagrams look worse. This commit reverts that change, to avoid any visaul regression differences.

Fixes: fedf70cc3c38c6d62890f5e1522b88494e941beb

## :straight_ruler: Design Decisions

Since the `inner` element is now unused, I've added a `// TODO` comment to remind us to fully remove it in the future.

The code was previously doing:

```ts
const endLabelElement = await createLabel(inner, edge.endLabelLeft, edge.labelStyle);
// some other stuff
endEdgeLabelLeft.node().appendChild(endLabelElement);
```

But since `createLabel` automatically adds the created label to it's first parameter, we can rewrite the above code to `const endLabelElement = await createLabel(endEdgeLabelLeft, edge.endLabelLeft, edge.labelStyle);`

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
  - Covered by existing visual regression tests that will show a difference.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
  - No change, fedf70cc3c38c6d62890f5e1522b88494e941beb hasn't yet been released, so there's no need for a changeset.
