### PR TITLE
fix(frontmatter): tolerate leading whitespace before YAML delimiters

### DIFF
--- a/.changeset/blue-insects-act.md
+++ b/.changeset/blue-insects-act.md
@@ -1,0 +1,9 @@
+---
+'mermaid': patch
+---
+
+fix(frontmatter): tolerate leading horizontal whitespace before YAML frontmatter delimiters
+
+Mermaid blocks captured with surrounding indentation (for example when extracted from indented HTML or markdown) previously failed with "Syntax error in text" because `^---` had to sit at column zero. The frontmatter regex now anchors the closing delimiter to the same indent as the opening one, and the YAML body is dedented before parsing so tab-indented blocks work too.
+
+Closes mermaid-js/mermaid#7613

--- a/packages/mermaid/src/diagram-api/frontmatter.spec.ts
+++ b/packages/mermaid/src/diagram-api/frontmatter.spec.ts
@@ -136,6 +136,52 @@ describe('extractFrontmatter', () => {
     expect(() => extractFrontMatter(text)).toThrow('tag suffix cannot contain exclamation marks');
   });
 
+  it('handles leading horizontal whitespace before delimiters (issue #7613)', () => {
+    const text = `   ---\n   title: foo\n   ---\n   diagram`;
+    expect(extractFrontMatter(text)).toMatchInlineSnapshot(`
+      {
+        "metadata": {
+          "title": "foo",
+        },
+        "text": "   diagram",
+      }
+    `);
+  });
+
+  it('handles tab indentation before delimiters (issue #7613)', () => {
+    const text = `\t---\n\ttitle: foo\n\t---\n\tdiagram`;
+    expect(extractFrontMatter(text)).toMatchInlineSnapshot(`
+      {
+        "metadata": {
+          "title": "foo",
+        },
+        "text": "\tdiagram",
+      }
+    `);
+  });
+
+  it('handles indented frontmatter with config (issue #7613)', () => {
+    const text = `   ---\n   config:\n     sankey:\n       showValues: true\n   ---\n   sankey\n   a,b,8`;
+    expect(extractFrontMatter(text)).toMatchInlineSnapshot(`
+      {
+        "metadata": {
+          "config": {
+            "sankey": {
+              "showValues": true,
+            },
+          },
+        },
+        "text": "   sankey
+         a,b,8",
+      }
+    `);
+  });
+
+  it('does not match an indented closing delimiter when opening is at column zero', () => {
+    const text = `---\ntitle: foo\n   ---\n   diagram`;
+    expect(extractFrontMatter(text).metadata).toEqual({});
+  });
+
   it('handles frontmatter with config', () => {
     const text = `---
 title: hello

--- a/packages/mermaid/src/diagram-api/frontmatter.ts
+++ b/packages/mermaid/src/diagram-api/frontmatter.ts
@@ -30,8 +30,17 @@ export function extractFrontMatter(text: string): FrontMatterResult {
     };
   }
 
+  // Dedent by the captured indent — js-yaml rejects tab-indented documents.
+  const indent = matches[1];
+  const yamlBody = indent
+    ? matches[2]
+        .split('\n')
+        .map((line) => (line.startsWith(indent) ? line.slice(indent.length) : line))
+        .join('\n')
+    : matches[2];
+
   let parsed: FrontMatterMetadata =
-    yaml.load(matches[1], {
+    yaml.load(yamlBody, {
       // To support config, we need JSON schema.
       // https://www.yaml.org/spec/1.2/spec.html#id2803231
       schema: yaml.JSON_SCHEMA,

--- a/packages/mermaid/src/diagram-api/regexes.ts
+++ b/packages/mermaid/src/diagram-api/regexes.ts
@@ -3,7 +3,8 @@
 // Note that JS doesn't support the "\A" anchor, which means we can't use
 // multiline mode.
 // Relevant YAML spec: https://yaml.org/spec/1.2.2/#914-explicit-documents
-export const frontMatterRegex = /^-{3}\s*[\n\r](.*?)[\n\r]-{3}\s*[\n\r]+/s;
+// The \1 backreference anchors closing `---` to the same indent as the opening one, guards against indented `---` inside multi-line YAML scalars (#7613).
+export const frontMatterRegex = /^([^\S\n\r]*)-{3}\s*[\n\r](.*?)[\n\r]\1-{3}\s*[\n\r]+/s;
 
 export const directiveRegex =
   /%{2}{\s*(?:(\w+)\s*:|(\w+))\s*(?:(\w+)|((?:(?!}%{2}).|\r?\n)*))?\s*(?:}%{2})?/gi;


### PR DESCRIPTION
## :bookmark_tabs: Summary

YAML frontmatter is no longer rejected when the entire mermaid block sits inside indented HTML or markdown. Both space- and tab-indented delimiters now parse correctly, restoring the diagram instead of throwing "Syntax error in text".

Resolves #7613

## :straight_ruler: Design Decisions

```diff
  - /^-{3}\s*[\n\r](.*?)[\n\r]-{3}\s*[\n\r]+/s
  + /^([^\S\n\r]*)-{3}\s*[\n\r](.*?)[\n\r]\1-{3}\s*[\n\r]+/s
  ```

The `\1` backreference is load-bearing: without it, an indented `---` inside a multi-line YAML scalar (existing test) would be matched as the closing delimiter. js-yaml tolerates uniform space indents but rejects tabs, so the captured indent is stripped from each YAML line before parsing.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
