### PR TITLE
fix(cynefin): make boundary waviness deterministic via cynefin.seed

### DIFF
--- a/.changeset/cynefin-seed.md
+++ b/.changeset/cynefin-seed.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: add a `cynefin.seed` config option to make Cynefin diagram rendering deterministic. The boundary waviness PRNG was previously seeded from the SVG element id, which varies per render and made visual regression tests flaky. The default value `0` preserves the existing per-id randomization; setting any non-zero number produces reproducible boundaries across renders. Resolves #7727.

--- a/cypress/helpers/util.ts
+++ b/cypress/helpers/util.ts
@@ -31,6 +31,9 @@ export const mermaidUrl = (
   api: boolean
 ): string => {
   options.handDrawnSeed = 1;
+  // Make Cynefin boundary waviness deterministic. Tests can still override
+  // by passing { cynefin: { seed: N } } in their own options.
+  options.cynefin = { seed: 1, ...(options.cynefin ?? {}) };
   const codeObject: CodeObject = {
     code: graphStr,
     mermaid: options,

--- a/cypress/integration/rendering/cynefin/cynefin.spec.js
+++ b/cypress/integration/rendering/cynefin/cynefin.spec.js
@@ -1,6 +1,6 @@
 import { imgSnapshotTest } from '../../../helpers/util';
 
-describe.skip('cynefin framework', () => {
+describe('cynefin framework', () => {
   it('should render a simple cynefin diagram with all five domains', () => {
     imgSnapshotTest(
       `cynefin-beta
@@ -203,6 +203,27 @@ describe.skip('cynefin framework', () => {
         chaotic
           "Incident"
       `
+    );
+  });
+
+  it('should render cynefin deterministically with an explicit seed override', () => {
+    // Exercises the cynefin.seed config knob added for #7727. The default
+    // helper-injected seed is 1; using a different value here proves the
+    // config plumbing reaches the boundary RNG.
+    imgSnapshotTest(
+      `cynefin-beta
+        title Seeded Boundaries
+
+        complex
+          "Probe"
+        complicated
+          "Analyse"
+        clear
+          "Categorise"
+        chaotic
+          "Act"
+      `,
+      { cynefin: { seed: 42 } }
     );
   });
 });

--- a/docs/syntax/cynefin.md
+++ b/docs/syntax/cynefin.md
@@ -216,13 +216,14 @@ cynefin-beta
 
 Cynefin diagrams accept the following configuration under the `cynefin` key in the mermaid config:
 
-| Option                   | Type    | Default | Description                                                                       |
-| ------------------------ | ------- | ------- | --------------------------------------------------------------------------------- |
-| `width`                  | number  | `800`   | Width of the diagram in pixels                                                    |
-| `height`                 | number  | `600`   | Height of the diagram in pixels                                                   |
-| `padding`                | number  | `40`    | Padding around the diagram                                                        |
-| `showDomainDescriptions` | boolean | `true`  | Show decision model and practice type subtitles per domain                        |
-| `boundaryAmplitude`      | number  | `8`     | Waviness amplitude of domain boundaries in pixels (set to `0` for straight lines) |
+| Option                   | Type    | Default | Description                                                                                                                                                                                                                  |
+| ------------------------ | ------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `width`                  | number  | `800`   | Width of the diagram in pixels                                                                                                                                                                                               |
+| `height`                 | number  | `600`   | Height of the diagram in pixels                                                                                                                                                                                              |
+| `padding`                | number  | `40`    | Padding around the diagram                                                                                                                                                                                                   |
+| `showDomainDescriptions` | boolean | `true`  | Show decision model and practice type subtitles per domain                                                                                                                                                                   |
+| `boundaryAmplitude`      | number  | `8`     | Waviness amplitude of domain boundaries in pixels (set to `0` for straight lines)                                                                                                                                            |
+| `seed`                   | number  | `0`     | Deterministic seed for boundary waviness. `0` (default) hashes the diagram's SVG id so each diagram looks unique. Set any non-zero number to lock the waviness across renders — required for stable visual regression tests. |
 
 Example:
 

--- a/packages/mermaid/src/config.type.ts
+++ b/packages/mermaid/src/config.type.ts
@@ -1876,6 +1876,14 @@ export interface CynefinDiagramConfig extends BaseDiagramConfig {
    * Waviness amplitude of domain boundaries (0 for straight).
    */
   boundaryAmplitude?: number;
+  /**
+   * Deterministic seed for boundary waviness. When 0 (default) the seed is derived
+   * from the diagram's SVG element id, which varies per render. Set any non-zero
+   * number to produce identical boundaries on every render — required for visual
+   * regression tests to be stable.
+   *
+   */
+  seed?: number;
 }
 /**
  * Configuration for Railroad (Syntax) Diagrams

--- a/packages/mermaid/src/diagrams/cynefin/cynefin.spec.ts
+++ b/packages/mermaid/src/diagrams/cynefin/cynefin.spec.ts
@@ -4,6 +4,7 @@ import { db } from './cynefinDb.js';
 import {
   seededRandom,
   hashString,
+  resolveSeed,
   generateFoldPath,
   generateHorizontalBoundary,
   generateCliffPath,
@@ -158,5 +159,33 @@ describe('Cynefin Boundaries', () => {
     expect(path).toContain('350'); // cx - rx = 400 - 50
     expect(path).toContain('450'); // cx + rx = 400 + 50
     expect(path).toContain('300'); // cy
+  });
+});
+
+describe('resolveSeed', () => {
+  it('returns the configured seed when it is a non-zero number', () => {
+    expect(resolveSeed(42, 'mermaid-1')).toBe(42);
+    expect(resolveSeed(-3, 'mermaid-2')).toBe(-3);
+  });
+
+  it('falls back to hashString(id) when the configured seed is 0', () => {
+    expect(resolveSeed(0, 'mermaid-1')).toBe(hashString('mermaid-1'));
+  });
+
+  it('falls back to hashString(id) when the configured seed is undefined', () => {
+    expect(resolveSeed(undefined, 'mermaid-1')).toBe(hashString('mermaid-1'));
+  });
+
+  it('ignores the id when an explicit seed is configured', () => {
+    expect(resolveSeed(7, 'a')).toBe(resolveSeed(7, 'b'));
+  });
+
+  it('produces different fallback seeds for different ids', () => {
+    expect(resolveSeed(0, 'mermaid-1')).not.toBe(resolveSeed(0, 'mermaid-2'));
+  });
+
+  it('treats NaN / Infinity as unconfigured and falls back to hashString(id)', () => {
+    expect(resolveSeed(Number.NaN, 'mermaid-1')).toBe(hashString('mermaid-1'));
+    expect(resolveSeed(Number.POSITIVE_INFINITY, 'mermaid-1')).toBe(hashString('mermaid-1'));
   });
 });

--- a/packages/mermaid/src/diagrams/cynefin/cynefinBoundaries.ts
+++ b/packages/mermaid/src/diagrams/cynefin/cynefinBoundaries.ts
@@ -23,6 +23,24 @@ export function hashString(str: string): number {
 }
 
 /**
+ * Resolve the boundary-waviness seed. A non-zero configured seed takes
+ * precedence so renders are reproducible (visual regression tests). When the
+ * configured seed is 0 or absent we fall back to hashing the SVG element id,
+ * which gives each rendered diagram its own waviness pattern at the cost of
+ * being unstable across renders.
+ */
+export function resolveSeed(configuredSeed: number | undefined, id: string): number {
+  if (
+    typeof configuredSeed === 'number' &&
+    Number.isFinite(configuredSeed) &&
+    configuredSeed !== 0
+  ) {
+    return configuredSeed;
+  }
+  return hashString(id);
+}
+
+/**
  * Generate a vertical wavy line (the "fold") through the center of the diagram.
  * Uses cubic bezier segments with alternating control point offsets.
  * @param width - diagram width

--- a/packages/mermaid/src/diagrams/cynefin/cynefinRenderer.ts
+++ b/packages/mermaid/src/diagrams/cynefin/cynefinRenderer.ts
@@ -12,7 +12,7 @@ import {
   generateHorizontalBoundary,
   generateCliffPath,
   generateConfusionPath,
-  hashString,
+  resolveSeed,
 } from './cynefinBoundaries.js';
 
 interface DomainMeta {
@@ -112,7 +112,7 @@ const draw: DrawDefinition = (_text, id, _version, diagram: Diagram) => {
   const root = svg.append('g').attr('transform', `translate(${padding}, ${padding})`);
 
   const layouts = getDomainLayouts(width, height);
-  const seed = hashString(id);
+  const seed = resolveSeed(config.seed, id);
 
   // 1. Domain background rectangles
   const bgGroup = root.append('g').attr('class', 'cynefin-backgrounds');

--- a/packages/mermaid/src/docs/syntax/cynefin.md
+++ b/packages/mermaid/src/docs/syntax/cynefin.md
@@ -155,13 +155,14 @@ cynefin-beta
 
 Cynefin diagrams accept the following configuration under the `cynefin` key in the mermaid config:
 
-| Option                   | Type    | Default | Description                                                                       |
-| ------------------------ | ------- | ------- | --------------------------------------------------------------------------------- |
-| `width`                  | number  | `800`   | Width of the diagram in pixels                                                    |
-| `height`                 | number  | `600`   | Height of the diagram in pixels                                                   |
-| `padding`                | number  | `40`    | Padding around the diagram                                                        |
-| `showDomainDescriptions` | boolean | `true`  | Show decision model and practice type subtitles per domain                        |
-| `boundaryAmplitude`      | number  | `8`     | Waviness amplitude of domain boundaries in pixels (set to `0` for straight lines) |
+| Option                   | Type    | Default | Description                                                                                                                                                                                                                  |
+| ------------------------ | ------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `width`                  | number  | `800`   | Width of the diagram in pixels                                                                                                                                                                                               |
+| `height`                 | number  | `600`   | Height of the diagram in pixels                                                                                                                                                                                              |
+| `padding`                | number  | `40`    | Padding around the diagram                                                                                                                                                                                                   |
+| `showDomainDescriptions` | boolean | `true`  | Show decision model and practice type subtitles per domain                                                                                                                                                                   |
+| `boundaryAmplitude`      | number  | `8`     | Waviness amplitude of domain boundaries in pixels (set to `0` for straight lines)                                                                                                                                            |
+| `seed`                   | number  | `0`     | Deterministic seed for boundary waviness. `0` (default) hashes the diagram's SVG id so each diagram looks unique. Set any non-zero number to lock the waviness across renders — required for stable visual regression tests. |
 
 Example:
 

--- a/packages/mermaid/src/schemas/config.schema.yaml
+++ b/packages/mermaid/src/schemas/config.schema.yaml
@@ -2625,6 +2625,14 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
         minimum: 0
         maximum: 50
         default: 8
+      seed:
+        description: |
+          Deterministic seed for boundary waviness. When 0 (default) the seed is derived
+          from the diagram's SVG element id, which varies per render. Set any non-zero
+          number to produce identical boundaries on every render — required for visual
+          regression tests to be stable.
+        type: number
+        default: 0
 
   RailroadDiagramConfig:
     title: Railroad Diagram Config


### PR DESCRIPTION
## Summary

Resolves #7727. Re-enables the Cynefin cypress suite that #7728 disabled pending this fix.

- Adds a `cynefin.seed` config option (default `0` → existing behavior; any non-zero value locks boundary waviness across renders).
- Extracts a `resolveSeed(configuredSeed, id)` helper next to the existing mulberry32 PRNG and `hashString`. Hardened against non-finite numbers (`NaN`/`Infinity` fall back to the id hash).
- Cypress helper now injects `cynefin: { seed: 1 }` alongside the existing `handDrawnSeed = 1`, so all Cynefin Argos baselines are stable.
- Removes `describe.skip` from `cypress/integration/rendering/cynefin/cynefin.spec.js` and adds one explicit test that overrides `cynefin.seed` to prove the config knob is wired through.
- Documents the new option in both the source doc (`packages/mermaid/src/docs/syntax/cynefin.md`) and the generated mirror (`docs/syntax/cynefin.md`).

## Classification

- **Change type:** config schema + renderer (cynefin only)
- **Breaking change:** no — `seed: 0` default preserves the prior \`hashString(id)\` behavior exactly
- **Shared code touched:** no (\`rendering-util/\` is untouched)

## Verification

- [x] **TDD:** 5 of 5 \`resolveSeed\` unit tests failed before the helper existed (\`resolveSeed is not a function\`); all 42 cynefin unit + integration tests pass after the implementation
- [x] **Lint:** \`pnpm lint\` clean (eslint + jison + prettier)
- [x] **Unit tests:** 42/42 pass (\`pnpm vitest run packages/mermaid/src/diagrams/cynefin/\`)
- [x] **E2E snapshot test:** re-enabled 11 previously disabled cases + added one explicit \`cynefin.seed=42\` override case
- [x] **comp-review-changes:** PASSED (architecture, isolation, XSS, tests, breaking, conventions, codegen). Two soft recommendations were applied before opening this PR (added docs row, added \`Number.isFinite\` guard).
- [x] **Visual spot-check:** rendered the spot diagram against the local dev server at \`seed=42\` (twice) and \`seed=99\`. The two \`seed=42\` renders produced byte-identical PNGs (sha256 \`c2b0260…\`); \`seed=99\` produced a different hash and visibly different boundary curvature — confirming both determinism and that the config plumbing reaches the boundary RNG.
- [ ] **Full Cypress e2e:** not run locally — Argos will lock in the new Cynefin baselines on the first CI run. That's the intended behavior of the fix.
- [x] **Changeset:** \`.changeset/cynefin-seed.md\` (\`mermaid\` patch, \`fix:\` prefix)

## Notes for reviewers

- Cypress baselines for the re-enabled Cynefin suite will be generated on first CI run via Argos — please approve any new baselines that look correct.
- The default of \`seed: 0\` means existing diagrams not using this option continue to render with per-id waviness, so adopters see no behavior change unless they opt in.

🤖 Generated with [Claude Code](https://claude.ai/code)