### PR TITLE
fix(architecture): make fcose layout deterministic via architecture.seed

### DIFF
--- a/.changeset/architecture-seed.md
+++ b/.changeset/architecture-seed.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: add `architecture.seed` config option to make architecture diagrams render deterministically. The underlying `cytoscape-fcose` layout calls `Math.random()` internally even with `randomize: false`, so visual regression tests failed on every CI run. The renderer now temporarily seeds `Math.random` with a mulberry32 seeded generator while `fcose` runs and restores it immediately after. Default seed is `1`, making architecture layouts deterministic by default — set `architecture.seed: 0` to opt out of seeding and recover the pre-fix non-deterministic behavior. Resolves #7729.

--- a/cypress/helpers/util.ts
+++ b/cypress/helpers/util.ts
@@ -31,6 +31,9 @@ export const mermaidUrl = (
   api: boolean
 ): string => {
   options.handDrawnSeed = 1;
+  // Make the architecture fcose layout deterministic. Tests can still override
+  // by passing { architecture: { seed: N } } in their own options.
+  options.architecture = { seed: 1, ...(options.architecture ?? {}) };
   const codeObject: CodeObject = {
     code: graphStr,
     mermaid: options,

--- a/cypress/integration/rendering/architecture/architecture.spec.ts
+++ b/cypress/integration/rendering/architecture/architecture.spec.ts
@@ -242,7 +242,7 @@ describe('architecture diagram', () => {
       `
     );
   });
-  it.skip('should render a deterministic layout for a complex deeply-nested diagram', () => {
+  it('should render a deterministic layout for a complex deeply-nested diagram', () => {
     imgSnapshotTest(
       `architecture-beta
                 group sub1(cloud)[Subscription A]
@@ -282,6 +282,26 @@ describe('architecture diagram', () => {
                 vm1:R --> L:pe2
             `,
       { architecture: { randomize: false } }
+    );
+  });
+  it('should render a deterministic layout with an explicit seed override', () => {
+    // Exercises the architecture.seed config knob added for #7729. The default
+    // helper-injected seed is 1; using a different value here proves the config
+    // plumbing reaches the layout RNG.
+    imgSnapshotTest(
+      `architecture-beta
+        group sub1(cloud)[Subscription A]
+        group vnet1(cloud)[VNet A] in sub1
+        service vm1(server)[VM] in vnet1
+
+        group sub2(cloud)[Subscription B]
+        service web(server)[Web App] in sub2
+        service db(database)[Registry] in sub2
+
+        vm1:R --> L:web
+        web:R --> L:db
+      `,
+      { architecture: { seed: 42 } }
     );
   });
   it('should render edges at correct length', () => {

--- a/docs/syntax/architecture.md
+++ b/docs/syntax/architecture.md
@@ -195,9 +195,9 @@ architecture-beta
 
 ### `randomize` (v11.14.0+)
 
-By default, architecture diagrams produce a deterministic layout: the same diagram source always renders with the same node positions. This is because the `randomize` option defaults to `false`.
+By default, architecture diagrams start nodes at deterministic seed positions (`randomize: false`). Setting `randomize` to `true` randomizes initial node positions before running the layout algorithm, which may produce varied but potentially better-spaced layouts on each render.
 
-Setting `randomize` to `true` randomizes initial node positions before running the layout algorithm, which may produce varied but potentially better-spaced layouts on each render.
+> Note: `randomize: false` alone is not enough to guarantee identical renders — the underlying fcose layout still calls `Math.random()` during its constraint solver. Use the `seed` option (described below) to lock the layout fully.
 
 Via frontmatter:
 
@@ -228,12 +228,13 @@ mermaid.initialize({
 
 The following options pass through to the underlying [fcose](https://github.com/iVis-at-Bilkent/cytoscape.js-fcose) layout so you can adjust spacing and density without changing your diagram source:
 
-| Option                      | Type   | Default | Description                                                                                                                                                                                           |
-| --------------------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `nodeSeparation`            | number | `75`    | Minimum separation, in pixels, between sibling nodes in the same group. Pass-through to fcose.                                                                                                        |
-| `idealEdgeLengthMultiplier` | number | `1.5`   | Multiplier applied to `iconSize` to compute the ideal length of edges between nodes within the same group. Increase for breathing room, decrease to pack tighter. Cross-group edges are not affected. |
-| `edgeElasticity`            | number | `0.45`  | Spring elasticity (0–1) on same-group edges. Higher pulls connected nodes closer; lower lets them spread out. Cross-group edges are not affected.                                                     |
-| `numIter`                   | number | `2500`  | Maximum fcose iterations. Increase for higher-quality layouts on large diagrams at the cost of render time.                                                                                           |
+| Option                      | Type   | Default | Description                                                                                                                                                                                                                                      |
+| --------------------------- | ------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `nodeSeparation`            | number | `75`    | Minimum separation, in pixels, between sibling nodes in the same group. Pass-through to fcose.                                                                                                                                                   |
+| `idealEdgeLengthMultiplier` | number | `1.5`   | Multiplier applied to `iconSize` to compute the ideal length of edges between nodes within the same group. Increase for breathing room, decrease to pack tighter. Cross-group edges are not affected.                                            |
+| `edgeElasticity`            | number | `0.45`  | Spring elasticity (0–1) on same-group edges. Higher pulls connected nodes closer; lower lets them spread out. Cross-group edges are not affected.                                                                                                |
+| `numIter`                   | number | `2500`  | Maximum fcose iterations. Increase for higher-quality layouts on large diagrams at the cost of render time.                                                                                                                                      |
+| `seed`                      | number | `1`     | Deterministic seed for fcose. Defaults to `1` so the same diagram always renders with the same layout. Set to `0` to opt out and use native (non-deterministic) `Math.random`. Any other number selects a different reproducible layout variant. |
 
 Example — bumping `idealEdgeLengthMultiplier` stretches the spacing between connected nodes in a chain:
 

--- a/packages/mermaid/src/config.type.ts
+++ b/packages/mermaid/src/config.type.ts
@@ -1120,8 +1120,11 @@ export interface ArchitectureDiagramConfig extends BaseDiagramConfig {
   fontSize?: number;
   /**
    * Whether to randomize initial node positions before running the layout algorithm.
-   * When false (default), the layout is deterministic and produces identical results on every render.
-   * When true, nodes start at random positions, which may produce varied but potentially better-spaced layouts.
+   * When false (default), nodes start at deterministic seed positions. When true, nodes
+   * start at random positions, which may produce varied but potentially better-spaced
+   * layouts. Note: `randomize: false` alone does NOT guarantee identical renders, because
+   * the underlying fcose layout still uses `Math.random()` internally during its
+   * constraint solver — use the `seed` option for full determinism.
    *
    */
   randomize?: boolean;
@@ -1152,6 +1155,15 @@ export interface ArchitectureDiagramConfig extends BaseDiagramConfig {
    *
    */
   numIter?: number;
+  /**
+   * Deterministic seed for the fcose layout. Defaults to 1, which makes every render of the
+   * same diagram produce the same layout — required for visual regression tests to be stable.
+   * Set to 0 to opt out and use the unstubbed Math.random (the layout will still differ
+   * slightly between renders, matching pre-fix behavior). Any other number selects a
+   * different reproducible layout variant.
+   *
+   */
+  seed?: number;
 }
 /**
  * The object containing configurations specific for mindmap diagrams

--- a/packages/mermaid/src/diagrams/architecture/architectureRenderer.ts
+++ b/packages/mermaid/src/diagrams/architecture/architectureRenderer.ts
@@ -1,6 +1,7 @@
 import type { LayoutOptions, Position } from 'cytoscape';
 import cytoscape from 'cytoscape';
 import fcose from 'cytoscape-fcose';
+import { withSeededRandom } from './architectureSeed.js';
 import { select } from 'd3';
 import type { DrawDefinition, SVG } from '../../diagram-api/types.js';
 import type { Diagram } from '../../Diagram.js';
@@ -410,6 +411,9 @@ function layoutArchitecture(
     const sameGroupIdealLength = db.getConfigField('idealEdgeLengthMultiplier') * iconSize;
     const crossGroupIdealLength = 0.5 * iconSize;
     const sameGroupElasticity = db.getConfigField('edgeElasticity');
+    // Wrap each layout.run() with withSeededRandom so fcose's internal
+    // Math.random() calls produce reproducible results. See architectureSeed.ts.
+    const seed = db.getConfigField('seed');
 
     const layout = cy.layout({
       name: 'fcose',
@@ -506,9 +510,9 @@ function layoutArchitecture(
         }
       }
       cy.endBatch();
-      layout.run();
+      withSeededRandom(seed, () => layout.run());
     });
-    layout.run();
+    withSeededRandom(seed, () => layout.run());
 
     cy.ready((e) => {
       log.info('Ready', e);

--- a/packages/mermaid/src/diagrams/architecture/architectureSeed.spec.ts
+++ b/packages/mermaid/src/diagrams/architecture/architectureSeed.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { withSeededRandom } from './architectureSeed.js';
+
+describe('withSeededRandom', () => {
+  it('produces identical Math.random sequences for the same seed', () => {
+    const draw = () => [Math.random(), Math.random(), Math.random(), Math.random()];
+    const a = withSeededRandom(42, draw);
+    const b = withSeededRandom(42, draw);
+    expect(a).toEqual(b);
+  });
+
+  it('produces different sequences for different seeds', () => {
+    const draw = () => [Math.random(), Math.random(), Math.random()];
+    expect(withSeededRandom(1, draw)).not.toEqual(withSeededRandom(2, draw));
+  });
+
+  it('returns Math.random values in [0, 1)', () => {
+    const values = withSeededRandom(123, () => Array.from({ length: 32 }, () => Math.random()));
+    for (const v of values) {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+
+  it('restores the original Math.random after the callback returns', () => {
+    const original = Math.random;
+    withSeededRandom(7, () => Math.random());
+    expect(Math.random).toBe(original);
+  });
+
+  it('restores the original Math.random even when the callback throws', () => {
+    const original = Math.random;
+    expect(() =>
+      withSeededRandom(7, () => {
+        throw new Error('boom');
+      })
+    ).toThrow('boom');
+    expect(Math.random).toBe(original);
+  });
+
+  it('returns the callback result', () => {
+    expect(withSeededRandom(1, () => 'hello')).toBe('hello');
+    expect(withSeededRandom(1, () => 42)).toBe(42);
+  });
+
+  it('does not stub Math.random when seed is 0 (opt-out into native randomness)', () => {
+    const original = Math.random;
+    const observed = withSeededRandom(0, () => Math.random);
+    expect(observed).toBe(original);
+    expect(Math.random).toBe(original);
+  });
+});

--- a/packages/mermaid/src/diagrams/architecture/architectureSeed.ts
+++ b/packages/mermaid/src/diagrams/architecture/architectureSeed.ts
@@ -1,0 +1,31 @@
+/**
+ * Temporarily replace `Math.random` with a mulberry32-seeded PRNG for the
+ * duration of `fn`, then restore the original. Used to make the
+ * cytoscape-fcose layout deterministic — fcose calls `Math.random` internally
+ * in its constraint solver and exposes no `seed` option of its own, so the
+ * only reliable way to get repeatable layouts is to swap the global at the
+ * narrowest possible scope.
+ *
+ * A seed of `0` is treated as "opt out": the global is left alone and `fn`
+ * runs against the real `Math.random`. This preserves the pre-fix behavior
+ * for any caller that explicitly wants layout variety per render.
+ */
+export function withSeededRandom<T>(seed: number, fn: () => T): T {
+  if (seed === 0) {
+    return fn();
+  }
+  const original = Math.random;
+  let state = seed >>> 0;
+  Math.random = function () {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+  try {
+    return fn();
+  } finally {
+    Math.random = original;
+  }
+}

--- a/packages/mermaid/src/docs/syntax/architecture.md
+++ b/packages/mermaid/src/docs/syntax/architecture.md
@@ -157,9 +157,9 @@ architecture-beta
 
 ### `randomize` (v11.14.0+)
 
-By default, architecture diagrams produce a deterministic layout: the same diagram source always renders with the same node positions. This is because the `randomize` option defaults to `false`.
+By default, architecture diagrams start nodes at deterministic seed positions (`randomize: false`). Setting `randomize` to `true` randomizes initial node positions before running the layout algorithm, which may produce varied but potentially better-spaced layouts on each render.
 
-Setting `randomize` to `true` randomizes initial node positions before running the layout algorithm, which may produce varied but potentially better-spaced layouts on each render.
+> Note: `randomize: false` alone is not enough to guarantee identical renders — the underlying fcose layout still calls `Math.random()` during its constraint solver. Use the `seed` option (described below) to lock the layout fully.
 
 Via frontmatter:
 
@@ -190,12 +190,13 @@ mermaid.initialize({
 
 The following options pass through to the underlying [fcose](https://github.com/iVis-at-Bilkent/cytoscape.js-fcose) layout so you can adjust spacing and density without changing your diagram source:
 
-| Option                      | Type   | Default | Description                                                                                                                                                                                           |
-| --------------------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `nodeSeparation`            | number | `75`    | Minimum separation, in pixels, between sibling nodes in the same group. Pass-through to fcose.                                                                                                        |
-| `idealEdgeLengthMultiplier` | number | `1.5`   | Multiplier applied to `iconSize` to compute the ideal length of edges between nodes within the same group. Increase for breathing room, decrease to pack tighter. Cross-group edges are not affected. |
-| `edgeElasticity`            | number | `0.45`  | Spring elasticity (0–1) on same-group edges. Higher pulls connected nodes closer; lower lets them spread out. Cross-group edges are not affected.                                                     |
-| `numIter`                   | number | `2500`  | Maximum fcose iterations. Increase for higher-quality layouts on large diagrams at the cost of render time.                                                                                           |
+| Option                      | Type   | Default | Description                                                                                                                                                                                                                                      |
+| --------------------------- | ------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `nodeSeparation`            | number | `75`    | Minimum separation, in pixels, between sibling nodes in the same group. Pass-through to fcose.                                                                                                                                                   |
+| `idealEdgeLengthMultiplier` | number | `1.5`   | Multiplier applied to `iconSize` to compute the ideal length of edges between nodes within the same group. Increase for breathing room, decrease to pack tighter. Cross-group edges are not affected.                                            |
+| `edgeElasticity`            | number | `0.45`  | Spring elasticity (0–1) on same-group edges. Higher pulls connected nodes closer; lower lets them spread out. Cross-group edges are not affected.                                                                                                |
+| `numIter`                   | number | `2500`  | Maximum fcose iterations. Increase for higher-quality layouts on large diagrams at the cost of render time.                                                                                                                                      |
+| `seed`                      | number | `1`     | Deterministic seed for fcose. Defaults to `1` so the same diagram always renders with the same layout. Set to `0` to opt out and use native (non-deterministic) `Math.random`. Any other number selects a different reproducible layout variant. |
 
 Example — bumping `idealEdgeLengthMultiplier` stretches the spacing between connected nodes in a chain:
 

--- a/packages/mermaid/src/schemas/config.schema.yaml
+++ b/packages/mermaid/src/schemas/config.schema.yaml
@@ -990,6 +990,7 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
       - idealEdgeLengthMultiplier
       - edgeElasticity
       - numIter
+      - seed
     properties:
       padding:
         type: number
@@ -1003,8 +1004,11 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
       randomize:
         description: |
           Whether to randomize initial node positions before running the layout algorithm.
-          When false (default), the layout is deterministic and produces identical results on every render.
-          When true, nodes start at random positions, which may produce varied but potentially better-spaced layouts.
+          When false (default), nodes start at deterministic seed positions. When true, nodes
+          start at random positions, which may produce varied but potentially better-spaced
+          layouts. Note: `randomize: false` alone does NOT guarantee identical renders, because
+          the underlying fcose layout still uses `Math.random()` internally during its
+          constraint solver — use the `seed` option for full determinism.
         type: boolean
         default: false
       nodeSeparation:
@@ -1034,6 +1038,15 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
           quality on large or densely-connected diagrams at the cost of render time.
         type: number
         default: 2500
+      seed:
+        description: |
+          Deterministic seed for the fcose layout. Defaults to 1, which makes every render of the
+          same diagram produce the same layout — required for visual regression tests to be stable.
+          Set to 0 to opt out and use the unstubbed Math.random (the layout will still differ
+          slightly between renders, matching pre-fix behavior). Any other number selects a
+          different reproducible layout variant.
+        type: number
+        default: 1
 
   MindmapDiagramConfig:
     title: Mindmap Diagram Config


### PR DESCRIPTION
## Summary

Resolves #7729. Re-enables the architecture visual test that #7728 disabled pending this fix.

The `cytoscape-fcose` layout calls `Math.random()` internally in its constraint solver, so `randomize: false` alone never produced a fully deterministic render — coordinates drifted by a few pixels every run and Argos failed every CI run on the complex deeply-nested test.

- Adds an `architecture.seed` config option (default `1`). The renderer temporarily seeds `Math.random` with a mulberry32 generator around the two `layout.run()` invocations and restores it in a `finally` block.
- `seed: 0` opts out of the swap and recovers the pre-fix non-deterministic behavior for callers who actively want layout variety per render.
- Cypress helper injects `architecture: { seed: 1 }` alongside the existing `handDrawnSeed = 1`, locking baselines for every architecture test.
- Removes `it.skip` from the previously disabled `should render a deterministic layout for a complex deeply-nested diagram` test and adds an explicit `seed: 42` override test that proves the config knob reaches the RNG.
- Updates `randomize` documentation to correct the previous (misleading) claim that `randomize: false` guarantees identical renders.

## Classification

- **Change type:** config schema + renderer (architecture only)
- **Breaking change:** **non-breaking API**; visible behavioral default change — existing architecture diagrams now render fully-deterministically (was: slight jitter every render). Documented in the changeset; opt-out via `architecture.seed: 0`.
- **Shared code touched:** no (no `rendering-util/`)

## Verification

- [x] **TDD:** the spec couldn't even import `withSeededRandom` before the helper existed; 7/7 helper tests pass after.
- [x] **Lint:** \`pnpm lint\` clean (eslint + jison + prettier + cspell).
- [x] **Unit tests:** 27/27 pass (\`pnpm vitest run packages/mermaid/src/diagrams/architecture/\`).
- [x] **E2E snapshot test:** re-enabled the original test (line 245) + added one explicit seed-override test (line 287).
- [x] **comp-review-changes:** PASSED.
- [x] **Visual spot-check:** with default \`seed: 1\`, three consecutive renders produced byte-identical PNGs (sha256 \`1332ebc4…\`, 51,911 bytes each). \`seed: 0\` produced two different hashes across two renders, proving the opt-out path. \`seed: 42\` produced a third distinct hash, proving the knob reaches the layout.
- [ ] **Full Cypress e2e:** not run locally — Argos will lock the new architecture baselines on the first CI run. This is the intended behavior of the fix.
- [x] **Changeset:** \`.changeset/architecture-seed.md\` (\`mermaid\` patch, \`fix:\` prefix).

## Notes for reviewers

- All existing architecture baselines on Argos will need to be re-approved on first CI run because the layout has shifted from "near-deterministic with sub-pixel drift" to "fully deterministic at seed=1". The visual content is the same — only sub-pixel positions change.
- The stub scope is narrow on purpose: only the two \`layout.run()\` calls inside \`layoutArchitecture\` are wrapped, and \`Math.random\` is restored even if the layout throws (verified by spec test).

🤖 Generated with [Claude Code](https://claude.ai/code)