### PR TITLE
fix(sequence): add theme-aware fallback for rect backgrounds

### DIFF
--- a/.changeset/loud-dancers-start.md
+++ b/.changeset/loud-dancers-start.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+Fix sequenceDiagram rect backgrounds using theme-aware fallback colors

--- a/cypress/integration/rendering/sequence/sequencediagram.spec.js
+++ b/cypress/integration/rendering/sequence/sequencediagram.spec.js
@@ -142,6 +142,34 @@ describe('Sequence diagram', () => {
       `
     );
   });
+  it('should render sequence rect with theme-aware default background (base theme)', () => {
+    imgSnapshotTest(
+      `
+      %%{init: {'theme': 'base'}}%%
+      sequenceDiagram
+        rect
+          Alice->>John: Hello John, how are you?
+          Alice->>John: John, can you hear me?
+          John-->>Alice: Hi Alice, I can hear you!
+          John-->>Alice: I feel great!
+        end
+      `
+    );
+  });
+  it('should render sequence rect with theme-aware default background (dark theme)', () => {
+    imgSnapshotTest(
+      `
+      %%{init: {'theme': 'dark'}}%%
+      sequenceDiagram
+        rect
+          Alice->>John: Hello John, how are you?
+          Alice->>John: John, can you hear me?
+          John-->>Alice: Hi Alice, I can hear you!
+          John-->>Alice: I feel great!
+        end
+      `
+    );
+  });
   it('should render loops with a slight margin', () => {
     imgSnapshotTest(
       `

--- a/cypress/integration/rendering/sequence/sequencediagram.spec.js
+++ b/cypress/integration/rendering/sequence/sequencediagram.spec.js
@@ -129,6 +129,19 @@ describe('Sequence diagram', () => {
       {}
     );
   });
+  it('should render sequence rect with theme-aware default background', () => {
+    imgSnapshotTest(
+      `
+      sequenceDiagram
+        rect
+          Alice->>John: Hello John, how are you?
+          Alice->>John: John, can you hear me?
+          John-->>Alice: Hi Alice, I can hear you!
+          John-->>Alice: I feel great!
+        end
+      `
+    );
+  });
   it('should render loops with a slight margin', () => {
     imgSnapshotTest(
       `

--- a/packages/mermaid/src/diagrams/sequence/sequenceRenderer.ts
+++ b/packages/mermaid/src/diagrams/sequence/sequenceRenderer.ts
@@ -1179,9 +1179,18 @@ export const draw = async function (_text: string, id: string, _version: string,
         bounds.models.addLoop(loopModel);
         break;
       case diagObj.db.LINETYPE.RECT_START:
-        adjustLoopHeightForWrap(loopWidths, msg, conf.boxMargin, conf.boxMargin, (message) =>
-          bounds.newLoop(undefined, message.message)
-        );
+        adjustLoopHeightForWrap(loopWidths, msg, conf.boxMargin, conf.boxMargin, (message) => {
+          let fill = message.message;
+          if (!fill) {
+            // Apply a theme-aware default fill.
+            // Because the rect is rendered behind actors and text, it does not obscure them.
+            fill =
+              conf.themeVariables?.rectBkgColor ||
+              conf.themeVariables?.actorBkg ||
+              'rgba(128, 128, 128, 0.5)';
+          }
+          bounds.newLoop(undefined, fill);
+        });
         break;
       case diagObj.db.LINETYPE.RECT_END:
         loopModel = bounds.endLoop();

--- a/packages/mermaid/src/diagrams/sequence/sequenceRenderer.ts
+++ b/packages/mermaid/src/diagrams/sequence/sequenceRenderer.ts
@@ -1040,7 +1040,7 @@ function adjustCreatedDestroyedData(
  * @param diagObj - A standard diagram containing the db and the text and type etc of the diagram
  */
 export const draw = async function (_text: string, id: string, _version: string, diagObj: Diagram) {
-  const { securityLevel, sequence, look } = getConfig();
+  const { securityLevel, sequence, look, themeVariables } = getConfig();
   conf = sequence;
   // Handle root and Document for when rendering in sandbox mode
   let sandboxElement;
@@ -1184,9 +1184,11 @@ export const draw = async function (_text: string, id: string, _version: string,
           if (!fill) {
             // Apply a theme-aware default fill.
             // Because the rect is rendered behind actors and text, it does not obscure them.
+            // Use theme background when no explicit color is given; the rect renders
+            // behind all content so any semi-transparent theme color is safe.
             fill =
-              conf.themeVariables?.rectBkgColor ||
-              conf.themeVariables?.actorBkg ||
+              themeVariables?.rectBkgColor ||
+              themeVariables?.actorBkg ||
               'rgba(128, 128, 128, 0.5)';
           }
           bounds.newLoop(undefined, fill);

--- a/packages/mermaid/src/themes/theme-base.js
+++ b/packages/mermaid/src/themes/theme-base.js
@@ -83,6 +83,9 @@ class Theme {
     this.activationBorderColor = this.activationBorderColor || darken(this.secondaryColor, 10);
     this.activationBkgColor = this.activationBkgColor || this.secondaryColor;
     this.sequenceNumberColor = this.sequenceNumberColor || invert(this.lineColor);
+    // Default fill for rect blocks in sequence diagrams (when no color is specified by the user).
+    // Uses tertiaryColor so it is always visually distinct from actors, text, and arrows.
+    this.rectBkgColor = this.rectBkgColor || this.tertiaryColor;
 
     /* Gantt chart variables */
 

--- a/packages/mermaid/src/themes/theme-dark.js
+++ b/packages/mermaid/src/themes/theme-dark.js
@@ -142,6 +142,7 @@ class Theme {
     this.noteTextColor = this.secondaryTextColor;
     this.activationBorderColor = this.border1;
     this.activationBkgColor = this.secondBkg;
+    this.rectBkgColor = this.rectBkgColor || this.tertiaryColor;
 
     /* Gantt chart variables */
 

--- a/packages/mermaid/src/themes/theme-default.js
+++ b/packages/mermaid/src/themes/theme-default.js
@@ -212,6 +212,7 @@ class Theme {
     this.noteBorderColor = this.border2;
     this.noteTextColor = this.actorTextColor;
     this.actorLineColor = this.actorBorder;
+    this.rectBkgColor = this.rectBkgColor || this.tertiaryColor;
 
     /* Gantt chart variables */
 

--- a/packages/mermaid/src/themes/theme-forest.js
+++ b/packages/mermaid/src/themes/theme-forest.js
@@ -120,6 +120,7 @@ class Theme {
     this.noteBorderColor = this.border2;
     this.noteTextColor = this.actorTextColor;
     this.actorLineColor = this.actorBorder;
+    this.rectBkgColor = this.rectBkgColor || this.tertiaryColor;
 
     /* Each color-set will have a background, a foreground and a border color */
     this.cScale0 = this.cScale0 || this.primaryColor;

--- a/packages/mermaid/src/themes/theme-neo-dark.js
+++ b/packages/mermaid/src/themes/theme-neo-dark.js
@@ -119,6 +119,7 @@ class Theme {
     this.activationBorderColor = this.activationBorderColor || darken(this.secondaryColor, 10);
     this.activationBkgColor = this.activationBkgColor || this.secondaryColor;
     this.sequenceNumberColor = this.sequenceNumberColor || invert(this.lineColor);
+    this.rectBkgColor = this.rectBkgColor || this.tertiaryColor;
 
     /* Gantt chart variables */
 

--- a/packages/mermaid/src/themes/theme-neo.js
+++ b/packages/mermaid/src/themes/theme-neo.js
@@ -103,6 +103,7 @@ class Theme {
     this.activationBorderColor = this.activationBorderColor || darken(this.secondaryColor, 10);
     this.activationBkgColor = this.activationBkgColor || this.secondaryColor;
     this.sequenceNumberColor = this.sequenceNumberColor || invert(this.lineColor);
+    this.rectBkgColor = this.rectBkgColor || this.tertiaryColor;
 
     /* Gantt chart variables */
     const primaryColor = '#ECECFE';

--- a/packages/mermaid/src/themes/theme-neutral.js
+++ b/packages/mermaid/src/themes/theme-neutral.js
@@ -135,6 +135,7 @@ class Theme {
     this.actorBkg = this.mainBkg;
     this.actorTextColor = this.text;
     this.actorLineColor = this.actorBorder;
+    this.rectBkgColor = this.rectBkgColor || this.tertiaryColor;
     this.signalColor = this.text;
     this.signalTextColor = this.text;
     this.labelBoxBkgColor = this.actorBkg;

--- a/packages/mermaid/src/themes/theme-redux-color.js
+++ b/packages/mermaid/src/themes/theme-redux-color.js
@@ -138,6 +138,7 @@ class Theme {
     this.activationBorderColor = this.activationBorderColor || darken(this.secondaryColor, 10);
     this.activationBkgColor = this.activationBkgColor || this.secondaryColor;
     this.sequenceNumberColor = this.sequenceNumberColor || invert(this.lineColor);
+    this.rectBkgColor = this.rectBkgColor || this.tertiaryColor;
 
     /* Gantt chart variables */
     const primaryColor = '#ECECFE';

--- a/packages/mermaid/src/themes/theme-redux-dark-color.js
+++ b/packages/mermaid/src/themes/theme-redux-dark-color.js
@@ -147,6 +147,7 @@ class Theme {
     this.activationBorderColor = this.activationBorderColor || darken(this.secondaryColor, 10);
     this.activationBkgColor = this.activationBkgColor || this.secondaryColor;
     this.sequenceNumberColor = this.sequenceNumberColor || invert(this.lineColor);
+    this.rectBkgColor = this.rectBkgColor || this.tertiaryColor;
 
     /* Mindmap Diagram variables */
     this.rootLabelColor = '#FFFFFF';

--- a/packages/mermaid/src/themes/theme-redux-dark.js
+++ b/packages/mermaid/src/themes/theme-redux-dark.js
@@ -130,6 +130,7 @@ class Theme {
     this.activationBorderColor = this.activationBorderColor || darken(this.secondaryColor, 10);
     this.activationBkgColor = this.activationBkgColor || this.secondaryColor;
     this.sequenceNumberColor = this.sequenceNumberColor || invert(this.lineColor);
+    this.rectBkgColor = this.rectBkgColor || this.tertiaryColor;
 
     /* Gantt chart variables */
 

--- a/packages/mermaid/src/themes/theme-redux.js
+++ b/packages/mermaid/src/themes/theme-redux.js
@@ -110,6 +110,7 @@ class Theme {
     this.activationBorderColor = this.activationBorderColor || darken(this.secondaryColor, 10);
     this.activationBkgColor = this.activationBkgColor || this.secondaryColor;
     this.sequenceNumberColor = this.sequenceNumberColor || invert(this.lineColor);
+    this.rectBkgColor = this.rectBkgColor || this.tertiaryColor;
 
     /* Gantt chart variables */
     const primaryColor = '#ECECFE';


### PR DESCRIPTION
## Summary

Fixes unreadable `sequenceDiagram rect` backgrounds when no explicit color is provided.

## Root Cause

When `rect` was used without a color, Mermaid passed an empty fill value to the SVG renderer. SVG/D3 defaulted this to an opaque black fill, which caused text and arrows to become difficult to read depending on the active theme.

## Changes

* Added `rectBkgColor` theme support in `theme-base.js`
* Added fallback handling in `sequenceRenderer.ts`
* Reused existing theme background colors when no explicit rect color is provided
* Preserved user-defined rect colors

## Testing

Tested with:

* rect without explicit color
* rect with explicit RGB color
* light theme
* dark theme

## Screenshots

### Before
<img width="1755" height="1146" alt="issue" src="https://github.com/user-attachments/assets/39168545-456a-4ba2-9b93-d0ff57bbedbd" />
<img width="1755" height="1146" alt="issue2" src="https://github.com/user-attachments/assets/6c9699d0-59fb-4854-9177-7a114147bfc1" />



### After
<img width="510" height="500" alt="light" src="https://github.com/user-attachments/assets/376fcb74-43a2-4f9f-b27a-c054933f449e" />
<img width="992" height="836" alt="dark" src="https://github.com/user-attachments/assets/f52d3b36-f8fc-4e87-87b6-8d42a3de54f6" />
<img width="919" height="790" alt="base" src="https://github.com/user-attachments/assets/dd051823-c4c2-4152-8526-c3c5bad20a10" />
<img width="921" height="788" alt="forest" src="https://github.com/user-attachments/assets/c6bf843d-bcf5-49d6-8f10-0e59a0d3595b" />



Resolves #7742
