### PR TITLE
docs: Remove dead ecosystem links

### DIFF
--- a/docs/ecosystem/integrations-community.md
+++ b/docs/ecosystem/integrations-community.md
@@ -48,7 +48,6 @@ To add an integration to this list, see the [Integrations - create page](./integ
 - [Forgejo](https://forgejo.org/) ✅
 - [GitBook](https://gitbook.com)
   - [Mermaid Plugin](https://github.com/JozoVilcek/gitbook-plugin-mermaid)
-  - [Mermaid plugin for GitBook](https://github.com/wwformat/gitbook-plugin-mermaid-pdf)
   - [Markdown with Mermaid CLI](https://github.com/miao1007/gitbook-plugin-mermaid-cli)
 - [Gitea](https://gitea.io) ✅
 - [GitHub](https://github.com) ✅

--- a/docs/ecosystem/tutorials.md
+++ b/docs/ecosystem/tutorials.md
@@ -28,7 +28,7 @@ The definitions that can be generated the Live-Editor are also backwards-compati
 
 ## Mermaid with OpenAI
 
-[Elle Neal: Mind Mapping with AI: An Accessible Approach for Neurodiverse Learners Tutorial:](https://medium.com/@elle.neal_71064/mind-mapping-with-ai-an-accessible-approach-for-neurodiverse-learners-1a74767359ff), [Demo:](https://databutton.com/v/jk9vrghc)
+[Elle Neal: Mind Mapping with AI: An Accessible Approach for Neurodiverse Learners Tutorial:](https://medium.com/@elle.neal_71064/mind-mapping-with-ai-an-accessible-approach-for-neurodiverse-learners-1a74767359ff)
 
 ## Mermaid with HTML
 

--- a/packages/mermaid/src/docs/ecosystem/integrations-community.md
+++ b/packages/mermaid/src/docs/ecosystem/integrations-community.md
@@ -43,7 +43,6 @@ To add an integration to this list, see the [Integrations - create page](./integ
 - [Forgejo](https://forgejo.org/) ✅
 - [GitBook](https://gitbook.com)
   - [Mermaid Plugin](https://github.com/JozoVilcek/gitbook-plugin-mermaid)
-  - [Mermaid plugin for GitBook](https://github.com/wwformat/gitbook-plugin-mermaid-pdf)
   - [Markdown with Mermaid CLI](https://github.com/miao1007/gitbook-plugin-mermaid-cli)
 - [Gitea](https://gitea.io) ✅
 - [GitHub](https://github.com) ✅

--- a/packages/mermaid/src/docs/ecosystem/tutorials.md
+++ b/packages/mermaid/src/docs/ecosystem/tutorials.md
@@ -22,7 +22,7 @@ The definitions that can be generated the Live-Editor are also backwards-compati
 
 ## Mermaid with OpenAI
 
-[Elle Neal: Mind Mapping with AI: An Accessible Approach for Neurodiverse Learners Tutorial:](https://medium.com/@elle.neal_71064/mind-mapping-with-ai-an-accessible-approach-for-neurodiverse-learners-1a74767359ff), [Demo:](https://databutton.com/v/jk9vrghc)
+[Elle Neal: Mind Mapping with AI: An Accessible Approach for Neurodiverse Learners Tutorial:](https://medium.com/@elle.neal_71064/mind-mapping-with-ai-an-accessible-approach-for-neurodiverse-learners-1a74767359ff)
 
 ## Mermaid with HTML
 


### PR DESCRIPTION
## Summary

- Remove dead `gitbook-plugin-mermaid-pdf` entry from the GitBook integrations list — repo is 404.
- Remove the dead `databutton.com` demo link from the Elle Neal mind-mapping tutorial entry — the demo URL is 404. Tutorial article link is kept.

## Test plan

- [ ] CI passes
- [ ] No remaining link-check failures for the two URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)