### PR TITLE
fix: Update landing popup signup URL to /sign-up

### DIFF
--- a/packages/mermaid/src/docs/.vitepress/components/LandingIntentModal.vue
+++ b/packages/mermaid/src/docs/.vitepress/components/LandingIntentModal.vue
@@ -26,7 +26,7 @@ type LandingOption = {
 
 const links: Record<Exclude<LandingPopUpChoice, 'skip'>, string> = {
   'full-editor':
-    'https://mermaid.ai/app/sign_up?utm_source=mermaid_js&utm_medium=landing_pop_up&utm_campaign=editor_v1',
+    'https://mermaid.ai/app/sign-up?utm_source=mermaid_js&utm_medium=landing_pop_up&utm_campaign=editor_v1',
   'browse-docs':
     'https://mermaid.ai/open-source/intro/index.html?utm_source=mermaid_js&utm_medium=landing_pop_up&utm_campaign=docs_v1',
   'live-editor': 'https://mermaid.live',


### PR DESCRIPTION
## Summary

- Update the full-editor CTA in the landing popup from `mermaid.ai/app/sign_up` to `mermaid.ai/app/sign-up` (path was renamed on the app side).
- UTM tracking params for the landing-popup → signup attribution are preserved.

## Test plan

- [ ] Click "Start free" in the landing popup and confirm it lands on `mermaid.ai/app/sign-up` with the expected UTM params

🤖 Generated with [Claude Code](https://claude.com/claude-code)