### PR TITLE
docs(wardley): fix component label offset order in "Complete Example"

### DIFF
--- a/docs/syntax/wardley.md
+++ b/docs/syntax/wardley.md
@@ -629,7 +629,7 @@ evolution Genesis@0.25 -> Custom@0.5 -> Product@0.75 -> Commodity@1.0
 anchor Customer [0.90, 0.95]
 
 component "Mobile App" [0.80, 0.85] (build)
-component "Web App" [0.75, 0.80] (build) label [-60, 10]
+component "Web App" [0.75, 0.80] label [-60, 10] (build)
 component "API Gateway" [0.70, 0.65] (buy)
 component "Auth Service" [0.60, 0.55] (outsource)
 component "Database" [0.50, 0.45] (buy) (inertia)
@@ -668,7 +668,7 @@ evolution Genesis@0.25 -> Custom@0.5 -> Product@0.75 -> Commodity@1.0
 anchor Customer [0.90, 0.95]
 
 component "Mobile App" [0.80, 0.85] (build)
-component "Web App" [0.75, 0.80] (build) label [-60, 10]
+component "Web App" [0.75, 0.80] label [-60, 10] (build)
 component "API Gateway" [0.70, 0.65] (buy)
 component "Auth Service" [0.60, 0.55] (outsource)
 component "Database" [0.50, 0.45] (buy) (inertia)

--- a/packages/mermaid/src/docs/syntax/wardley.md
+++ b/packages/mermaid/src/docs/syntax/wardley.md
@@ -397,7 +397,7 @@ evolution Genesis@0.25 -> Custom@0.5 -> Product@0.75 -> Commodity@1.0
 anchor Customer [0.90, 0.95]
 
 component "Mobile App" [0.80, 0.85] (build)
-component "Web App" [0.75, 0.80] (build) label [-60, 10]
+component "Web App" [0.75, 0.80] label [-60, 10] (build)
 component "API Gateway" [0.70, 0.65] (buy)
 component "Auth Service" [0.60, 0.55] (outsource)
 component "Database" [0.50, 0.45] (buy) (inertia)


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fix a syntax error in the "Complete Example" section of the Wardley Maps docs. The `label [x, y]` offset was placed after the source-strategy decorator `(build)`, which the grammar does not accept.

Resolves #7768

## :straight_ruler: Design Decisions

The `wardley.langium` Component rule defines `label=Label? decorator=Decorator?`, meaning `label` must precede the decorator. The fix swaps the order in the one affected line.

```diff
- component "Web App" [0.75, 0.80] (build) label [-60, 10]
+ component "Web App" [0.75, 0.80] label [-60, 10] (build)
```

### :clipboard: Tasks

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/releasing.html) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
