### PR TITLE
docs(flowchart): add section on styling arrow text labels

### DIFF
--- a/docs/syntax/flowchart.md
+++ b/docs/syntax/flowchart.md
@@ -1813,6 +1813,68 @@ It is also possible to add style to multiple links in a single statement, by sep
 linkStyle 1,2,7 color:blue;
 ```
 
+### Styling arrow text
+
+The `color` property in `linkStyle` controls the color of the text label on a link.
+
+#### Style all arrow labels at once
+
+Use `linkStyle default` to apply a color to every arrow label in the diagram:
+
+```mermaid-example
+flowchart LR
+    A -->|hello| B
+    B -->|world| C
+    linkStyle default color:red
+```
+
+```mermaid
+flowchart LR
+    A -->|hello| B
+    B -->|world| C
+    linkStyle default color:red
+```
+
+#### Style a specific arrow label
+
+Reference the link by its zero-based index (the order it appears in the diagram):
+
+```mermaid-example
+flowchart LR
+    A -->|first| B
+    B -->|second| C
+    linkStyle 1 color:blue
+```
+
+```mermaid
+flowchart LR
+    A -->|first| B
+    B -->|second| C
+    linkStyle 1 color:blue
+```
+
+In this example only the second arrow label ("second") is styled blue.
+
+#### Style individual arrow labels using Edge IDs (v11.10.0+)
+
+Assign an ID to an edge and use `classDef` to apply styles. This approach is more readable when targeting specific links in a complex diagram:
+
+```mermaid-example
+flowchart LR
+    classDef redLabel color:red,stroke:#f00,stroke-width:2px
+    A myEdge@-->|styled| B
+    A -->|unstyled| C
+    class myEdge redLabel
+```
+
+```mermaid
+flowchart LR
+    classDef redLabel color:red,stroke:#f00,stroke-width:2px
+    A myEdge@-->|styled| B
+    A -->|unstyled| C
+    class myEdge redLabel
+```
+
 ### Styling line curves
 
 It is possible to style the type of curve used for lines between items, if the default method does not meet your needs.

--- a/packages/mermaid/src/docs/syntax/flowchart.md
+++ b/packages/mermaid/src/docs/syntax/flowchart.md
@@ -1141,6 +1141,46 @@ It is also possible to add style to multiple links in a single statement, by sep
 linkStyle 1,2,7 color:blue;
 ```
 
+### Styling arrow text
+
+The `color` property in `linkStyle` controls the color of the text label on a link.
+
+#### Style all arrow labels at once
+
+Use `linkStyle default` to apply a color to every arrow label in the diagram:
+
+```mermaid-example
+flowchart LR
+    A -->|hello| B
+    B -->|world| C
+    linkStyle default color:red
+```
+
+#### Style a specific arrow label
+
+Reference the link by its zero-based index (the order it appears in the diagram):
+
+```mermaid-example
+flowchart LR
+    A -->|first| B
+    B -->|second| C
+    linkStyle 1 color:blue
+```
+
+In this example only the second arrow label ("second") is styled blue.
+
+#### Style individual arrow labels using Edge IDs (v11.10.0+)
+
+Assign an ID to an edge and use `classDef` to apply styles. This approach is more readable when targeting specific links in a complex diagram:
+
+```mermaid-example
+flowchart LR
+    classDef redLabel color:red,stroke:#f00,stroke-width:2px
+    A myEdge@-->|styled| B
+    A -->|unstyled| C
+    class myEdge redLabel
+```
+
 ### Styling line curves
 
 It is possible to style the type of curve used for lines between items, if the default method does not meet your needs.


### PR DESCRIPTION
## :bookmark_tabs: Summary

Add a new "Styling arrow text" subsection to the flowchart documentation, explaining how to change the color of edge label text using `linkStyle`.

Resolves #7763

## :straight_ruler: Design Decisions

The new section is placed directly after the existing "Styling links" subsection since it extends that topic. Three approaches are documented in order of increasing specificity:

1. `linkStyle default color:red` — applies to all arrow labels globally
2. `linkStyle N color:blue` — targets a specific link by its zero-based index
3. Edge ID + `classDef` (v11.10.0+) — class-based styling for individual edges, useful in complex diagrams

All examples use `mermaid-example` blocks so they render live in the docs.

### :clipboard: Tasks

- [x] :book: have read the contribution guidelines
- [ ] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation.
- [ ] :butterfly: changeset — not applicable (documentation-only change, no package behavior changed)