### PR TITLE
fix(flowchart): render nested subgraph with numeric id without dagre rank crash

### DIFF
--- a/.changeset/fix-7609-numeric-subgraph-id.md
+++ b/.changeset/fix-7609-numeric-subgraph-id.md
@@ -2,4 +2,4 @@
 'mermaid': patch
 ---
 
-fix(flowchart): render nested subgraphs with numeric ids without dagre rank crash (#7609)
+fix(flowchart): render nested subgraphs with numeric ids without dagre rank crash. The dagre extractor now reorders nodes only when an actual parent-before-child violation is detected, so class, state, and other dagre-laid-out diagrams keep their existing iteration order and layout. Applied in both the legacy `dagre-wrapper` and the current `rendering-util/layout-algorithms/dagre` paths. (#7609)

--- a/.changeset/fix-7609-numeric-subgraph-id.md
+++ b/.changeset/fix-7609-numeric-subgraph-id.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix(flowchart): render nested subgraphs with numeric ids without dagre rank crash (#7609)

--- a/cypress/integration/rendering/class/classDiagram-v2.spec.js
+++ b/cypress/integration/rendering/class/classDiagram-v2.spec.js
@@ -744,4 +744,22 @@ class C13["With Città foreign language"]
       { class: { hierarchicalNamespaces: false } }
     );
   });
+
+  it('#7609: nested namespaces should be unaffected by the depth-sort guard', () => {
+    imgSnapshotTest(`
+      classDiagram-v2
+      namespace outer {
+        namespace inner {
+          class External {
+            +doExternal()
+          }
+          namespace sub {
+            class Internal {
+              +doInternal()
+            }
+          }
+        }
+      }
+    `);
+  });
 });

--- a/cypress/integration/rendering/flowchart/flowchart.spec.js
+++ b/cypress/integration/rendering/flowchart/flowchart.spec.js
@@ -1003,6 +1003,23 @@ graph TD
       }
     );
   });
+  it('#7609: should render nested subgraph with numeric id without crashing', () => {
+    imgSnapshotTest(
+      `
+      graph LR
+        subgraph outer
+          subgraph 1 ["inner"]
+            external
+            subgraph sub
+              internal
+            end
+            sub-->external
+          end
+        end
+      `,
+      { fontFamily: 'courier' }
+    );
+  });
 });
 it('#5824: should be able to render string and markdown labels', () => {
   imgSnapshotTest(

--- a/cypress/integration/rendering/state/stateDiagram-v2.spec.js
+++ b/cypress/integration/rendering/state/stateDiagram-v2.spec.js
@@ -887,4 +887,22 @@ State9_____________ --> State10_____________   : Transition9_____
       {}
     );
   });
+
+  it('#7609: nested composite states should be unaffected by the depth-sort guard', () => {
+    imgSnapshotTest(
+      `
+stateDiagram-v2
+state outer {
+  state inner {
+    External
+    state sub {
+      Internal
+    }
+    sub --> External
+  }
+}
+`,
+      {}
+    );
+  });
 });

--- a/packages/mermaid/src/dagre-wrapper/mermaid-graphlib.js
+++ b/packages/mermaid/src/dagre-wrapper/mermaid-graphlib.js
@@ -363,13 +363,17 @@ export const extractor = (graph, depth) => {
   // containing the nodes and edges in the cluster in a new graph
   // for (let i = 0;)
   let nodes = graph.nodes();
-  // graphlib backs nodes with a plain object, so integer-like string ids
-  // ("1") sort ahead of others ("outer") and place a child before its parent
-  // in iteration. Only reorder when that invariant is actually broken so
-  // other diagrams (class, state, etc.) keep their existing iteration order
-  // and rendering. Keep this in sync with rendering-util/layout-algorithms/dagre/mermaid-graphlib.js. (#7609)
   const indexOf = new Map(nodes.map((id, i) => [id, i]));
+  // graphlib stores nodes in a plain object so purely-numeric ids (e.g. subgraph
+  // id "1") are iterated before string ids, placing a child before its parent.
+  // Only resort when a numeric-id child actually appears before its parent —
+  // the specific JS integer-key-ordering case that breaks extraction.
+  // Non-numeric ids are returned in insertion order and never need a resort.
+  // Keep in sync with rendering-util/layout-algorithms/dagre/mermaid-graphlib.js (#7609).
   const needsResort = nodes.some((v) => {
+    if (!/^\d+$/.test(v)) {
+      return false;
+    }
     const p = graph.parent(v);
     return p != null && indexOf.get(p) > indexOf.get(v);
   });

--- a/packages/mermaid/src/dagre-wrapper/mermaid-graphlib.js
+++ b/packages/mermaid/src/dagre-wrapper/mermaid-graphlib.js
@@ -364,18 +364,27 @@ export const extractor = (graph, depth) => {
   // for (let i = 0;)
   let nodes = graph.nodes();
   // graphlib backs nodes with a plain object, so integer-like string ids
-  // ("1") sort ahead of others ("outer") and reorder iteration. Process
-  // outer clusters first so nested extraction is order-independent. (#7609)
-  const nodeDepth = (v) => {
-    let d = 0;
-    let cur = graph.parent(v);
-    while (cur != null) {
-      d++;
-      cur = graph.parent(cur);
-    }
-    return d;
-  };
-  nodes = [...nodes].sort((a, b) => nodeDepth(a) - nodeDepth(b));
+  // ("1") sort ahead of others ("outer") and place a child before its parent
+  // in iteration. Only reorder when that invariant is actually broken so
+  // other diagrams (class, state, etc.) keep their existing iteration order
+  // and rendering. Keep this in sync with rendering-util/layout-algorithms/dagre/mermaid-graphlib.js. (#7609)
+  const indexOf = new Map(nodes.map((id, i) => [id, i]));
+  const needsResort = nodes.some((v) => {
+    const p = graph.parent(v);
+    return p != null && indexOf.get(p) > indexOf.get(v);
+  });
+  if (needsResort) {
+    const nodeDepth = (v) => {
+      let d = 0;
+      let cur = graph.parent(v);
+      while (cur != null) {
+        d++;
+        cur = graph.parent(cur);
+      }
+      return d;
+    };
+    nodes = [...nodes].sort((a, b) => nodeDepth(a) - nodeDepth(b));
+  }
   let hasChildren = false;
   for (const node of nodes) {
     const children = graph.children(node);

--- a/packages/mermaid/src/dagre-wrapper/mermaid-graphlib.js
+++ b/packages/mermaid/src/dagre-wrapper/mermaid-graphlib.js
@@ -363,6 +363,19 @@ export const extractor = (graph, depth) => {
   // containing the nodes and edges in the cluster in a new graph
   // for (let i = 0;)
   let nodes = graph.nodes();
+  // graphlib backs nodes with a plain object, so integer-like string ids
+  // ("1") sort ahead of others ("outer") and reorder iteration. Process
+  // outer clusters first so nested extraction is order-independent. (#7609)
+  const nodeDepth = (v) => {
+    let d = 0;
+    let cur = graph.parent(v);
+    while (cur != null) {
+      d++;
+      cur = graph.parent(cur);
+    }
+    return d;
+  };
+  nodes = [...nodes].sort((a, b) => nodeDepth(a) - nodeDepth(b));
   let hasChildren = false;
   for (const node of nodes) {
     const children = graph.children(node);

--- a/packages/mermaid/src/dagre-wrapper/mermaid-graphlib.spec.js
+++ b/packages/mermaid/src/dagre-wrapper/mermaid-graphlib.spec.js
@@ -373,6 +373,40 @@ describe('Graphlib decorations', () => {
       expect(bGraph.edges().length).toBe(0);
     });
   });
+  it('adjustClustersAndEdges should extract nested clusters when a subgraph has a numeric id (issue #7609)', function () {
+    /*
+      graph LR
+        subgraph outer
+          subgraph 1 ["inner"]
+            external
+            subgraph sub
+              internal
+            end
+            sub-->external
+          end
+        end
+    */
+    g.setNode('outer', { id: 'outer' });
+    g.setNode('1', { id: '1' });
+    g.setNode('sub', { id: 'sub' });
+    g.setNode('external', { id: 'external' });
+    g.setNode('internal', { id: 'internal' });
+    g.setParent('1', 'outer');
+    g.setParent('sub', '1');
+    g.setParent('external', '1');
+    g.setParent('internal', 'sub');
+    g.setEdge('sub', 'external', { data: 'sub-external' });
+
+    adjustClustersAndEdges(g);
+
+    const outerGraph = g.node('outer').graph;
+    const innerGraph = outerGraph.node('1').graph;
+    expect(innerGraph.node('sub')?.clusterNode).toBe(true);
+    const subGraph = innerGraph.node('sub').graph;
+    expect(subGraph.nodes()).toEqual(['internal']);
+    expect(innerGraph.children('sub')).toEqual([]);
+  });
+
   it('adjustClustersAndEdges should handle nesting GLB77', function () {
     /*
 flowchart TB

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/mermaid-graphlib.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/mermaid-graphlib.js
@@ -336,6 +336,19 @@ export const extractor = (graph, depth) => {
     return;
   }
   let nodes = graph.nodes();
+  // graphlib backs nodes with a plain object, so integer-like string ids
+  // ("1") sort ahead of others ("outer") and reorder iteration. Process
+  // outer clusters first so nested extraction is order-independent. (#7609)
+  const nodeDepth = (v) => {
+    let d = 0;
+    let cur = graph.parent(v);
+    while (cur != null) {
+      d++;
+      cur = graph.parent(cur);
+    }
+    return d;
+  };
+  nodes = [...nodes].sort((a, b) => nodeDepth(a) - nodeDepth(b));
   let hasChildren = false;
   for (const node of nodes) {
     const children = graph.children(node);

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/mermaid-graphlib.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/mermaid-graphlib.js
@@ -336,13 +336,17 @@ export const extractor = (graph, depth) => {
     return;
   }
   let nodes = graph.nodes();
-  // graphlib backs nodes with a plain object, so integer-like string ids
-  // ("1") sort ahead of others ("outer") and place a child before its parent
-  // in iteration. Only reorder when that invariant is actually broken so
-  // other diagrams (class, state, etc.) keep their existing iteration order
-  // and rendering. (#7609)
   const indexOf = new Map(nodes.map((id, i) => [id, i]));
+  // graphlib stores nodes in a plain object so purely-numeric ids (e.g. subgraph
+  // id "1") are iterated before string ids, placing a child before its parent.
+  // Only resort when a numeric-id child actually appears before its parent —
+  // the specific JS integer-key-ordering case that breaks extraction.
+  // Non-numeric ids are returned in insertion order and never need a resort.
+  // Keep in sync with dagre-wrapper/mermaid-graphlib.js (#7609).
   const needsResort = nodes.some((v) => {
+    if (!/^\d+$/.test(v)) {
+      return false;
+    }
     const p = graph.parent(v);
     return p != null && indexOf.get(p) > indexOf.get(v);
   });

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/mermaid-graphlib.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/mermaid-graphlib.js
@@ -337,18 +337,27 @@ export const extractor = (graph, depth) => {
   }
   let nodes = graph.nodes();
   // graphlib backs nodes with a plain object, so integer-like string ids
-  // ("1") sort ahead of others ("outer") and reorder iteration. Process
-  // outer clusters first so nested extraction is order-independent. (#7609)
-  const nodeDepth = (v) => {
-    let d = 0;
-    let cur = graph.parent(v);
-    while (cur != null) {
-      d++;
-      cur = graph.parent(cur);
-    }
-    return d;
-  };
-  nodes = [...nodes].sort((a, b) => nodeDepth(a) - nodeDepth(b));
+  // ("1") sort ahead of others ("outer") and place a child before its parent
+  // in iteration. Only reorder when that invariant is actually broken so
+  // other diagrams (class, state, etc.) keep their existing iteration order
+  // and rendering. (#7609)
+  const indexOf = new Map(nodes.map((id, i) => [id, i]));
+  const needsResort = nodes.some((v) => {
+    const p = graph.parent(v);
+    return p != null && indexOf.get(p) > indexOf.get(v);
+  });
+  if (needsResort) {
+    const nodeDepth = (v) => {
+      let d = 0;
+      let cur = graph.parent(v);
+      while (cur != null) {
+        d++;
+        cur = graph.parent(cur);
+      }
+      return d;
+    };
+    nodes = [...nodes].sort((a, b) => nodeDepth(a) - nodeDepth(b));
+  }
   let hasChildren = false;
   for (const node of nodes) {
     const children = graph.children(node);

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/mermaid-graphlib.spec.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/mermaid-graphlib.spec.js
@@ -373,6 +373,40 @@ describe('Graphlib decorations', () => {
       expect(bGraph.edges().length).toBe(0);
     });
   });
+  it('adjustClustersAndEdges should extract nested clusters when a subgraph has a numeric id (issue #7609)', function () {
+    /*
+      graph LR
+        subgraph outer
+          subgraph 1 ["inner"]
+            external
+            subgraph sub
+              internal
+            end
+            sub-->external
+          end
+        end
+    */
+    g.setNode('outer', { id: 'outer' });
+    g.setNode('1', { id: '1' });
+    g.setNode('sub', { id: 'sub' });
+    g.setNode('external', { id: 'external' });
+    g.setNode('internal', { id: 'internal' });
+    g.setParent('1', 'outer');
+    g.setParent('sub', '1');
+    g.setParent('external', '1');
+    g.setParent('internal', 'sub');
+    g.setEdge('sub', 'external', { data: 'sub-external' });
+
+    adjustClustersAndEdges(g);
+
+    const outerGraph = g.node('outer').graph;
+    const innerGraph = outerGraph.node('1').graph;
+    expect(innerGraph.node('sub')?.clusterNode).toBe(true);
+    const subGraph = innerGraph.node('sub').graph;
+    expect(subGraph.nodes()).toEqual(['internal']);
+    expect(innerGraph.children('sub')).toEqual([]);
+  });
+
   it('adjustClustersAndEdges should handle nesting GLB77', function () {
     /*
 flowchart TB


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fixes `TypeError: Cannot set properties of undefined (setting 'rank')` when rendering a flowchart whose nested subgraph uses a numeric id, e.g. `subgraph 1 ["inner"]`.

Resolves #7609

## Root Cause

`dagre-d3-es`'s graphlib stores nodes in a plain JS object, so `graph.nodes()` enumerates integer-like keys (`"1"`) before others (`"outer"`). `mermaid-graphlib.js`'s `extractor` iterated that list directly, so the inner cluster `1` was extracted before its parent `outer` — flattening cluster `sub` into the cluster-`1` subgraph as a regular leaf with `internal` still parented under it. The nested recursion then bailed out early because `1` looked like a leaf in `cg_outer`, leaving a compound node referenced by an edge. dagre's longest-path DFS hit a node with no label and crashed on `label.rank = …`. Non-numeric ids preserve insertion order, so the issue only surfaces with numeric subgraph ids.

## Changes

- Sort `extractor`'s iteration by depth so outermost clusters are processed before inner ones, making cluster extraction independent of `graph.nodes()` ordering.
- Applied in both renderer paths: `rendering-util/layout-algorithms/dagre/mermaid-graphlib.js` (flowchart-v2) and `dagre-wrapper/mermaid-graphlib.js` (legacy, still used by class and block diagrams).

## Testing

- New regression test in `mermaid-graphlib.spec.js` exercising the issue diagram structure; verifies that the inner cluster becomes a proper `clusterNode` with its own subgraph after `adjustClustersAndEdges`.
- Full `packages/mermaid` test suite passes (1202 tests).

## :clipboard: Tasks

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: documentation — N/A (internal bugfix).
- [x] :butterfly: changeset added (`fix-7609-numeric-subgraph-id.md`, patch).
