### PR TITLE
Add documentation for maxTextSize configuration option

### DIFF
--- a/docs/config/faq.md
+++ b/docs/config/faq.md
@@ -15,3 +15,17 @@
 7. [How to have special characters in link text?](https://github.com/mermaid-js/mermaid/issues/407#issuecomment-329944735)
 8. [How to change Flowchart curve style?](https://github.com/mermaid-js/mermaid/issues/580#issuecomment-373929046)
 9. [How to create a Flowchart end-Node that says "End"](https://github.com/mermaid-js/mermaid/issues/1444#issuecomment-639528897)
+10. **Why is my large diagram showing "Maximum text size in diagram exceeded"?**
+    Mermaid has a default text size limit of 50,000 characters for performance reasons. To increase this limit:
+
+    ```javascript
+    mermaid.initialize({ maxTextSize: 200000 });
+    ```
+
+    To disable the limit entirely (use with caution):
+
+    ```javascript
+    mermaid.initialize({ maxTextSize: 0 });
+    ```
+
+    For more details, see [Handling Large Diagrams](../config/usage.md#handling-large-diagrams).

--- a/docs/config/usage.md
+++ b/docs/config/usage.md
@@ -380,6 +380,36 @@ The list of configuration objects are described [in the mermaidAPI documentation
 > **Note**
 > This is the preferred way of configuring mermaid.
 
+### Handling Large Diagrams
+
+By default, Mermaid limits diagram source text to 50,000 characters to ensure good performance and prevent browser slowdowns. If your diagram exceeds this limit, it will be replaced with an error diagram displaying "Maximum text size in diagram exceeded".
+
+You can increase this limit via `mermaid.initialize`:
+
+```javascript
+mermaid.initialize({
+  maxTextSize: 200000,
+});
+```
+
+To disable the limit entirely, set `maxTextSize` to `0`:
+
+```javascript
+mermaid.initialize({
+  maxTextSize: 0,
+});
+```
+
+| Parameter   | Description                                                | Type   | Default |
+| ----------- | ---------------------------------------------------------- | ------ | ------- |
+| maxTextSize | Maximum allowed size of diagram source text, in characters | Number | 50000   |
+
+> **Warning**
+> `maxTextSize` is a secure configuration key. It can only be changed via `mermaid.initialize` and cannot be overridden with frontmatter or directives.
+
+> **Note**
+> Setting `maxTextSize` to `0` disables the limit entirely. Extremely large diagrams may impact browser performance and memory usage. For production use, test with your typical diagram sizes to find an optimal balance.
+
 ### The following methods are deprecated and are kept only for backwards compatibility.
 
 ## Using the mermaid object

--- a/docs/intro/getting-started.md
+++ b/docs/intro/getting-started.md
@@ -235,9 +235,10 @@ b. The importing of the Mermaid library through the `mermaid.esm.mjs` or `mermai
 
 `startOnLoad` is one of the parameters that can be defined by `mermaid.initialize()`
 
-| Parameter   | Description                       | Type    | Values      |
-| ----------- | --------------------------------- | ------- | ----------- |
-| startOnLoad | Toggle for Rendering upon loading | Boolean | true, false |
+| Parameter   | Description                                                  | Type    | Values      |
+| ----------- | ------------------------------------------------------------ | ------- | ----------- |
+| startOnLoad | Toggle for Rendering upon loading                            | Boolean | true, false |
+| maxTextSize | Maximum size of diagram text in characters (default: 50,000) | Number  | Any number  |
 
 In this example, the `mermaidAPI` is being called through the `CDN`:
 

--- a/packages/mermaid/src/docs/config/faq.md
+++ b/packages/mermaid/src/docs/config/faq.md
@@ -9,3 +9,17 @@
 1. [How to have special characters in link text?](https://github.com/mermaid-js/mermaid/issues/407#issuecomment-329944735)
 1. [How to change Flowchart curve style?](https://github.com/mermaid-js/mermaid/issues/580#issuecomment-373929046)
 1. [How to create a Flowchart end-Node that says "End"](https://github.com/mermaid-js/mermaid/issues/1444#issuecomment-639528897)
+1. **Why is my large diagram showing "Maximum text size in diagram exceeded"?**
+   Mermaid has a default text size limit of 50,000 characters for performance reasons. To increase this limit:
+
+   ```javascript
+   mermaid.initialize({ maxTextSize: 200000 });
+   ```
+
+   To disable the limit entirely (use with caution):
+
+   ```javascript
+   mermaid.initialize({ maxTextSize: 0 });
+   ```
+
+   For more details, see [Handling Large Diagrams](../config/usage.md#handling-large-diagrams).

--- a/packages/mermaid/src/docs/config/usage.md
+++ b/packages/mermaid/src/docs/config/usage.md
@@ -377,6 +377,38 @@ The list of configuration objects are described [in the mermaidAPI documentation
 This is the preferred way of configuring mermaid.
 ```
 
+### Handling Large Diagrams
+
+By default, Mermaid limits diagram source text to 50,000 characters to ensure good performance and prevent browser slowdowns. If your diagram exceeds this limit, it will be replaced with an error diagram displaying "Maximum text size in diagram exceeded".
+
+You can increase this limit via `mermaid.initialize`:
+
+```javascript
+mermaid.initialize({
+  maxTextSize: 200000,
+});
+```
+
+To disable the limit entirely, set `maxTextSize` to `0`:
+
+```javascript
+mermaid.initialize({
+  maxTextSize: 0,
+});
+```
+
+| Parameter   | Description                                                | Type   | Default |
+| ----------- | ---------------------------------------------------------- | ------ | ------- |
+| maxTextSize | Maximum allowed size of diagram source text, in characters | Number | 50000   |
+
+```warning
+`maxTextSize` is a secure configuration key. It can only be changed via `mermaid.initialize` and cannot be overridden with frontmatter or directives.
+```
+
+```note
+Setting `maxTextSize` to `0` disables the limit entirely. Extremely large diagrams may impact browser performance and memory usage. For production use, test with your typical diagram sizes to find an optimal balance.
+```
+
 ### The following methods are deprecated and are kept only for backwards compatibility.
 
 ## Using the mermaid object

--- a/packages/mermaid/src/docs/intro/getting-started.md
+++ b/packages/mermaid/src/docs/intro/getting-started.md
@@ -228,9 +228,10 @@ Rendering in Mermaid is initialized by the `mermaid.initialize()` call. However,
 
 `startOnLoad` is one of the parameters that can be defined by `mermaid.initialize()`
 
-| Parameter   | Description                       | Type    | Values      |
-| ----------- | --------------------------------- | ------- | ----------- |
-| startOnLoad | Toggle for Rendering upon loading | Boolean | true, false |
+| Parameter   | Description                                                  | Type    | Values      |
+| ----------- | ------------------------------------------------------------ | ------- | ----------- |
+| startOnLoad | Toggle for Rendering upon loading                            | Boolean | true, false |
+| maxTextSize | Maximum size of diagram text in characters (default: 50,000) | Number  | Any number  |
 
 In this example, the `mermaidAPI` is being called through the `CDN`:
 

--- a/packages/mermaid/src/mermaidAPI.ts
+++ b/packages/mermaid/src/mermaidAPI.ts
@@ -28,7 +28,7 @@ import { toBase64 } from './utils/base64.js';
 
 const MAX_TEXTLENGTH = 50_000;
 const MAX_TEXTLENGTH_EXCEEDED_MSG =
-  'graph TB;a[Maximum text size in diagram exceeded];style a fill:#faa';
+  'graph TB;a["Diagram exceeds max text size (50,000 chars). Set maxTextSize in initialize config"];style a fill:#faa';
 
 const SECURITY_LVL_SANDBOX = 'sandbox';
 const SECURITY_LVL_LOOSE = 'loose';


### PR DESCRIPTION



## :bookmark_tabs: Summary

Users encountering the "Maximum text size in diagram exceeded" error had no documentation explaining how to resolve it. The `maxTextSize` config option (default: 50,000 chars) existed in the codebase but was absent from all user-facing docs. The error message itself gave no actionable guidance.

This PR adds `maxTextSize` documentation to the usage guide, getting started guide, and FAQ. It also improves the rendered error message to tell users what config key to change.

Fixes #7778

## :straight_ruler: Design Decisions

- Documentation goes in `packages/mermaid/src/docs/` (not `/docs`, which is auto-generated).
- The new "Handling Large Diagrams" section is placed under the existing "Configuration" heading in `usage.md`, since that's where users look for `mermaid.initialize` options.
- The FAQ entry includes inline code examples rather than linking to a GitHub issue, since this is a configuration question with a deterministic fix.
- The `warning` admonition calls out that `maxTextSize` is a **secure** config key — it cannot be overridden via frontmatter or directives. This is a common gotcha for documentation authors.
- The error message in `mermaidAPI.ts` uses quoted node labels (`a["..."]`) to safely include parentheses in the mermaid diagram syntax.

### Files changed

| File | Change |
|---|---|
| `packages/mermaid/src/docs/config/usage.md` | Added "Handling Large Diagrams" section with code examples, parameter table, secure-key warning, and performance notes |
| `packages/mermaid/src/docs/intro/getting-started.md` | Added `maxTextSize` row to the `mermaid.initialize()` parameters table |
| `packages/mermaid/src/docs/config/faq.md` | Added troubleshooting entry for the error message with fix examples and cross-link to usage.md |
| `packages/mermaid/src/mermaidAPI.ts` | Improved `MAX_TEXTLENGTH_EXCEEDED_MSG` to include the limit value and config key name |

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.