### PR TITLE
fix(xychart): truncate plot data to match x-axis category count

### DIFF
--- a/.changeset/fix-xychart-orphan-data.md
+++ b/.changeset/fix-xychart-orphan-data.md
@@ -1,0 +1,5 @@
+---
+"mermaid": patch
+---
+
+fix(xychart): truncate plot data to match x-axis category count

--- a/.changeset/fix-xychart-orphan-data.md
+++ b/.changeset/fix-xychart-orphan-data.md
@@ -1,5 +1,5 @@
 ---
-"mermaid": patch
+'mermaid': patch
 ---
 
 fix(xychart): truncate plot data to match x-axis category count

--- a/packages/mermaid/src/diagrams/xychart/xychartDb.spec.ts
+++ b/packages/mermaid/src/diagrams/xychart/xychartDb.spec.ts
@@ -27,8 +27,8 @@ describe('xychartDb', () => {
       const chartData = db.getXYChartData();
       // Should only have 3 data points matching the 3 categories
       expect(chartData.plots).toHaveLength(1);
-      expect(chartData.plots[0]!.data).toHaveLength(3);
-      expect(chartData.plots[0]!.data).toEqual([
+      expect(chartData.plots[0].data).toHaveLength(3);
+      expect(chartData.plots[0].data).toEqual([
         ['cat1', 10],
         ['cat2', 20],
         ['cat3', 30],
@@ -44,8 +44,8 @@ describe('xychartDb', () => {
 
       const chartData = db.getXYChartData();
       expect(chartData.plots).toHaveLength(1);
-      expect(chartData.plots[0]!.data).toHaveLength(2);
-      expect(chartData.plots[0]!.data).toEqual([
+      expect(chartData.plots[0].data).toHaveLength(2);
+      expect(chartData.plots[0].data).toEqual([
         ['A', 100],
         ['B', 200],
       ]);
@@ -60,8 +60,8 @@ describe('xychartDb', () => {
       db.setBarData({ text: 'exact', type: 'text' }, pts(5, 10, 15));
 
       const chartData = db.getXYChartData();
-      expect(chartData.plots[0]!.data).toHaveLength(3);
-      expect(chartData.plots[0]!.data).toEqual([
+      expect(chartData.plots[0].data).toHaveLength(3);
+      expect(chartData.plots[0].data).toEqual([
         ['X', 5],
         ['Y', 10],
         ['Z', 15],
@@ -79,7 +79,7 @@ describe('xychartDb', () => {
 
       const chartData = db.getXYChartData();
       // categories.map produces entries for all 4 categories, with undefined for missing data
-      expect(chartData.plots[0]!.data).toHaveLength(4);
+      expect(chartData.plots[0].data).toHaveLength(4);
     });
 
     it('should compute y-axis range only from visible (truncated) data', () => {

--- a/packages/mermaid/src/diagrams/xychart/xychartDb.spec.ts
+++ b/packages/mermaid/src/diagrams/xychart/xychartDb.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import db from './xychartDb.js';
+
+/**
+ * Helper to build ParsedDataPoint[] from plain numbers,
+ * matching the shape the parser produces at runtime.
+ */
+function pts(...values: number[]) {
+  return values.map((v) => ({ value: v, label: '' }));
+}
+
+describe('xychartDb', () => {
+  beforeEach(() => {
+    db.clear();
+  });
+
+  describe('data length validation with band axis', () => {
+    it('should truncate bar data when it exceeds the number of x-axis categories', () => {
+      // Set up 3 categories but provide 5 data points
+      db.setXAxisBand([
+        { text: 'cat1', type: 'text' },
+        { text: 'cat2', type: 'text' },
+        { text: 'cat3', type: 'text' },
+      ]);
+      db.setBarData({ text: 'testBar', type: 'text' }, pts(10, 20, 30, 40, 50));
+
+      const chartData = db.getXYChartData();
+      // Should only have 3 data points matching the 3 categories
+      expect(chartData.plots).toHaveLength(1);
+      expect(chartData.plots[0]!.data).toHaveLength(3);
+      expect(chartData.plots[0]!.data).toEqual([
+        ['cat1', 10],
+        ['cat2', 20],
+        ['cat3', 30],
+      ]);
+    });
+
+    it('should truncate line data when it exceeds the number of x-axis categories', () => {
+      db.setXAxisBand([
+        { text: 'A', type: 'text' },
+        { text: 'B', type: 'text' },
+      ]);
+      db.setLineData({ text: 'testLine', type: 'text' }, pts(100, 200, 300, 400));
+
+      const chartData = db.getXYChartData();
+      expect(chartData.plots).toHaveLength(1);
+      expect(chartData.plots[0]!.data).toHaveLength(2);
+      expect(chartData.plots[0]!.data).toEqual([
+        ['A', 100],
+        ['B', 200],
+      ]);
+    });
+
+    it('should not affect data when data length matches category count', () => {
+      db.setXAxisBand([
+        { text: 'X', type: 'text' },
+        { text: 'Y', type: 'text' },
+        { text: 'Z', type: 'text' },
+      ]);
+      db.setBarData({ text: 'exact', type: 'text' }, pts(5, 10, 15));
+
+      const chartData = db.getXYChartData();
+      expect(chartData.plots[0]!.data).toHaveLength(3);
+      expect(chartData.plots[0]!.data).toEqual([
+        ['X', 5],
+        ['Y', 10],
+        ['Z', 15],
+      ]);
+    });
+
+    it('should not affect data when data length is less than category count', () => {
+      db.setXAxisBand([
+        { text: 'A', type: 'text' },
+        { text: 'B', type: 'text' },
+        { text: 'C', type: 'text' },
+        { text: 'D', type: 'text' },
+      ]);
+      db.setBarData({ text: 'short', type: 'text' }, pts(1, 2));
+
+      const chartData = db.getXYChartData();
+      // categories.map produces entries for all 4 categories, with undefined for missing data
+      expect(chartData.plots[0]!.data).toHaveLength(4);
+    });
+
+    it('should compute y-axis range only from visible (truncated) data', () => {
+      db.setXAxisBand([
+        { text: 'Q1', type: 'text' },
+        { text: 'Q2', type: 'text' },
+      ]);
+      // Provide 4 values but only 2 categories. The value 999 should NOT
+      // affect the y-axis range since it belongs to an orphaned data point.
+      db.setBarData({ text: 'sales', type: 'text' }, pts(10, 50, 999, 800));
+
+      const chartData = db.getXYChartData();
+      // y-axis max should be 50, not 999
+      if (chartData.yAxis.type === 'linear') {
+        expect(chartData.yAxis.max).toBe(50);
+      }
+    });
+  });
+});

--- a/packages/mermaid/src/diagrams/xychart/xychartDb.ts
+++ b/packages/mermaid/src/diagrams/xychart/xychartDb.ts
@@ -132,6 +132,14 @@ function transformDataWithoutCategory(data: number[]): SimplePlotDataType {
     const prevMaxValue = isLinearAxisData(xyChartData.xAxis) ? xyChartData.xAxis.max : -Infinity;
     setXAxisRangeData(Math.min(prevMinValue, 1), Math.max(prevMaxValue, data.length));
   }
+
+  // When a band axis is defined, truncate data to match the number of categories
+  // to prevent orphaned bars/lines from rendering in unlabeled chart space.
+  // This also ensures the Y-axis range is computed only from visible data points.
+  if (isBandAxisData(xyChartData.xAxis) && data.length > xyChartData.xAxis.categories.length) {
+    data = data.slice(0, xyChartData.xAxis.categories.length);
+  }
+
   if (!hasSetYAxis) {
     setYAxisRangeFromPlotData(data);
   }


### PR DESCRIPTION
## Summary

Fixes #7650 — When a band x-axis defines N categories but a bar or line plot provides M > N data points, the extra points currently render into unlabeled chart space as orphaned bars/lines. The Y-axis range also gets skewed by data values that aren't visible against any category.

## Problem

`transformDataWithoutCategory()` in `xychartDb.ts` calls `setYAxisRangeFromPlotData(data)` with the **full** data array before building the category→value pairs. Even though `categories.map()` only maps up to `categories.length` entries, the Y-axis scale already accounts for the excess values, and the renderer draws bars/lines for all data points — resulting in orphaned elements outside the labeled axis area.

### Reproduction (from the issue)

```text
xychart
    title "Basic xychart with many categories"
    x-axis "this is x axis" [category1, "category 2", category3, category4, category5, category6, category7]
    y-axis yaxisText 10 --> 150
    bar "sample bar" [52, 96, 35, 10, 87, 34, 67, 99]
```

The 8th value (99) renders as an orphaned bar with no x-axis label beneath it.

## Fix

Added a bounds check in `transformDataWithoutCategory()` **before** computing the Y-axis range. When the x-axis is a band axis with fewer categories than data points, the data array is truncated to match the category count. This:

1. Prevents orphaned bars/lines from rendering in unlabeled space
2. Ensures the Y-axis range reflects only visible data points (e.g. a value of 999 in position 8 won't stretch the Y-axis when only 7 categories exist)

The fix is intentionally minimal — a 4-line guard clause — to keep the change focused and reviewable.

## Tests

Added `xychartDb.spec.ts` covering:
- Bar data truncation when exceeding category count
- Line data truncation when exceeding category count
- Exact match (no truncation) — regression guard
- Fewer data points than categories — no truncation
- Y-axis range computed only from visible (truncated) data

### Checklist

- [x] Have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] Added necessary unit tests
- [x] Changeset added via `.changeset/fix-xychart-orphan-data.md`
