### PR TITLE
fix(radar): align axis labels based on angular position to prevent clipping

### DIFF
--- a/.changeset/fix-radar-axis-label-clipping.md
+++ b/.changeset/fix-radar-axis-label-clipping.md
@@ -1,0 +1,9 @@
+---
+'mermaid': patch
+---
+
+fix(radar): align axis labels based on angular position to prevent clipping
+
+Radar chart axis labels now set `text-anchor` and `dominant-baseline` dynamically based on each label's angular position around the chart. Labels on the left use `text-anchor: end`, labels on the right use `start`, and top/bottom labels use `middle`. This prevents long labels from extending past the SVG viewBox boundary and being clipped.
+
+Also removed the hard-coded `text-anchor: middle` and `dominant-baseline: middle` from the `.radarAxisLabel` CSS class in `styles.ts`, since CSS rules override SVG presentation attributes and were silently defeating the per-label alignment fix. Added `overflow: visible` on the SVG element as a safety net, and a small pixel offset (`labelPad`) for extra breathing room.

--- a/packages/mermaid/src/diagrams/radar/renderer.ts
+++ b/packages/mermaid/src/diagrams/radar/renderer.ts
@@ -56,7 +56,7 @@ const drawFrame = (svg: SVG, config: Required<RadarDiagramConfig>): SVGGroup => 
   };
   configureSvgSize(svg, totalHeight, totalWidth, config.useMaxWidth ?? true);
 
-  svg.attr('viewBox', `0 0 ${totalWidth} ${totalHeight}`);
+  svg.attr('viewBox', `0 0 ${totalWidth} ${totalHeight}`).attr('overflow', 'visible');
   // g element to center the radar chart
   return svg.append('g').attr('transform', `translate(${center.x}, ${center.y})`);
 };
@@ -103,16 +103,31 @@ const drawAxes = (
   for (let i = 0; i < numAxes; i++) {
     const label = axes[i].label;
     const angle = (2 * i * Math.PI) / numAxes - Math.PI / 2;
+    const cosA = Math.cos(angle);
+    const sinA = Math.sin(angle);
+
     g.append('line')
       .attr('x1', 0)
       .attr('y1', 0)
-      .attr('x2', radius * config.axisScaleFactor * Math.cos(angle))
-      .attr('y2', radius * config.axisScaleFactor * Math.sin(angle))
+      .attr('x2', radius * config.axisScaleFactor * cosA)
+      .attr('y2', radius * config.axisScaleFactor * sinA)
       .attr('class', 'radarAxisLine');
+
+    // Anchor labels based on their angular position so that text extends
+    // away from the chart center rather than overflowing the viewBox.
+    const textAnchor = cosA > 0.01 ? 'start' : cosA < -0.01 ? 'end' : 'middle';
+    const dominantBaseline = sinA > 0.01 ? 'hanging' : sinA < -0.01 ? 'auto' : 'central';
+
+    // Small pixel offset to push labels slightly outward from the axis endpoint,
+    // giving extra clearance so text doesn't sit right at the chart boundary.
+    const labelPad = 4;
+
     g.append('text')
       .text(label)
-      .attr('x', radius * config.axisLabelFactor * Math.cos(angle))
-      .attr('y', radius * config.axisLabelFactor * Math.sin(angle))
+      .attr('x', radius * config.axisLabelFactor * cosA + labelPad * cosA)
+      .attr('y', radius * config.axisLabelFactor * sinA + labelPad * sinA)
+      .attr('text-anchor', textAnchor)
+      .attr('dominant-baseline', dominantBaseline)
       .attr('class', 'radarAxisLabel');
   }
 };

--- a/packages/mermaid/src/diagrams/radar/styles.ts
+++ b/packages/mermaid/src/diagrams/radar/styles.ts
@@ -54,8 +54,6 @@ export const styles: DiagramStylesProvider = ({ radar }: { radar?: RadarStyleOpt
 		stroke-width: ${radarOptions.axisStrokeWidth};
 	}
 	.radarAxisLabel {
-		dominant-baseline: middle;
-		text-anchor: middle;
 		font-size: ${radarOptions.axisLabelFontSize}px;
 		color: ${radarOptions.axisColor};
 	}


### PR DESCRIPTION
## Summary

Fixes #7683

Radar chart axis labels are currently rendered without explicit text-anchor or dominant-baseline SVG attributes. Because SVG text defaults to text-anchor: start, labels positioned on the left side of the radar chart extend leftward - often past the viewBox boundary - making them partially clipped or completely hidden.

This is especially noticeable with longer labels like Intelligence, which can not fit within the available margin on that side.

## Changes

In renderer.ts drawAxes(), I now set the text-anchor and dominant-baseline attributes dynamically based on each label angular position around the chart:

- Right side (cos > 0): text-anchor=start
- Left side (cos < 0): text-anchor=end
- Top/bottom (cos approx 0): text-anchor=middle
- Above center (sin < 0): dominant-baseline=auto
- Below center (sin > 0): dominant-baseline=hanging
- Horizontal (sin approx 0): dominant-baseline=central

This ensures labels always grow away from the chart center, keeping them within the viewBox without needing to increase margins.

Also refactored to extract Math.cos/Math.sin into local variables to avoid repeated trig calls for the same angle.

## Before / After

Before: Labels on the left side of the chart overflow past the viewBox, getting clipped. The Intelligence label from the issue is partially cut off.

After: Labels on the left use text-anchor: end so they grow rightward toward the chart center. Labels at the top/bottom use middle so they are centered on their axis line. All labels remain fully readable regardless of length.