### PR TITLE
chore: use `crypto.randomUUID`

### DIFF
--- a/.changeset/twelve-shoes-relax.md
+++ b/.changeset/twelve-shoes-relax.md
@@ -1,5 +1,5 @@
 ---
-"mermaid": patch
+'mermaid': patch
 ---
 
 Removes `uuid` dependency in favour of native `crypto.randomUUID`

--- a/.changeset/twelve-shoes-relax.md
+++ b/.changeset/twelve-shoes-relax.md
@@ -1,0 +1,5 @@
+---
+"mermaid": patch
+---
+
+Removes `uuid` dependency in favour of native `crypto.randomUUID`

--- a/packages/mermaid/src/diagrams/mindmap/mindmapDb.ts
+++ b/packages/mermaid/src/diagrams/mindmap/mindmapDb.ts
@@ -1,5 +1,4 @@
 import { getConfig } from '../../diagram-api/diagramAPI.js';
-import { v4 } from 'uuid';
 import type { D3Element } from '../../types.js';
 import { sanitizeText } from '../../diagrams/common/common.js';
 import { log } from '../../logger.js';
@@ -403,7 +402,7 @@ export class MindmapDB {
       shapes: Object.fromEntries(shapes),
       // Additional properties that layout algorithms might expect
       type: 'mindmap',
-      diagramId: 'mindmap-' + v4(),
+      diagramId: 'mindmap-' + crypto.randomUUID(),
     };
   }
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

Removes `uuid` dependency in favour of native `crypto.randomUUID`


## :straight_ruler: Design Decisions

N/A


### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Replaced the `uuid` dependency with the native `crypto.randomUUID()` API for Mindmap diagram IDs.
- Added a Changesets entry for a `mermaid` patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->