### PR TITLE
feat: Ship editor selection testB design with live_2026 UTM

### DIFF
--- a/packages/mermaid/src/docs/.vitepress/components/EditorSelectionModal.vue
+++ b/packages/mermaid/src/docs/.vitepress/components/EditorSelectionModal.vue
@@ -1,25 +1,28 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref } from 'vue';
+import { onMounted, onUnmounted, ref, type Component } from 'vue';
+import AtlassianIcon from '~icons/logos/atlassian';
+import AmazonIcon from '~icons/logos/aws';
+import GoogleIcon from '~icons/logos/google';
+import MicrosoftIcon from '~icons/logos/microsoft';
 import { trackPlausibleEvent } from '../theme/plausible.js';
 
 interface Feature {
-  iconUrl: string;
-  featureName: string;
+  title: string;
+  description: string;
 }
 
-const mermaidPlusFeatures: Feature[] = [
-  { iconUrl: '/icons/whiteboard.svg', featureName: 'Visual editor' },
-  { iconUrl: '/icons/ai-diagram.svg', featureName: '300 AI credits' },
-  { iconUrl: '/icons/folder.svg', featureName: 'Unlimited diagram storage' },
-  { iconUrl: '/icons/presentation.svg', featureName: 'Limitless diagram size' },
-  { iconUrl: '/icons/comment.svg', featureName: 'View & comment collaboration' },
+const features: Feature[] = [
+  { title: 'AI diagram generation', description: 'Describe what you need, AI builds it' },
+  { title: 'Visual drag-and-drop editor', description: 'Edit diagrams without writing code' },
+  { title: 'Unlimited diagram storage', description: 'Save and organize all your diagrams' },
+  { title: 'Team collaboration', description: 'Share, comment, and edit together in real-time' },
 ];
 
-const openSourceFeatures: Feature[] = [
-  { iconUrl: '/icons/public.svg', featureName: 'Diagram stored in URL' },
-  { iconUrl: '/icons/terminal.svg', featureName: 'Code editor' },
-  { iconUrl: '/icons/open-source.svg', featureName: 'Open source' },
-  { iconUrl: '/icons/version-history.svg', featureName: 'Version history' },
+const trustedLogos: { name: string; icon: Component }[] = [
+  { name: 'Google', icon: GoogleIcon },
+  { name: 'Microsoft', icon: MicrosoftIcon },
+  { name: 'Atlassian', icon: AtlassianIcon },
+  { name: 'Amazon', icon: AmazonIcon },
 ];
 
 const isVisible = ref(false);
@@ -32,21 +35,15 @@ const handleStartTrial = () => {
   void trackPlausibleEvent('editor-pick', { props: { choice: 'mermaid-plus' } });
   close();
   window.open(
-    'https://mermaid.ai/app/sign-up?utm_source=mermaid_js&utm_medium=2_editor_selection&utm_campaign=start_plus&redirect=%2Fapp%2Fuser%2Fbilling%2Fcheckout%3FisFromMermaid%3Dtrue%26tier%3Dplus',
+    'https://mermaid.ai/app/sign-up?utm_source=mermaid_js&utm_medium=editorSelection&utm_campaign=live_2026&redirect=%2Fapp%2Fuser%2Fbilling%2Fcheckout%3FisFromMermaid%3Dtrue%26tier%3Dplus',
     '_blank'
   );
 };
 
-const handleStartFree = () => {
+const handleStayOnLive = () => {
   void trackPlausibleEvent('editor-pick', { props: { choice: 'open-source' } });
   close();
   window.open('https://mermaid.live/edit', '_blank');
-};
-
-const handleContinueToNewHome = () => {
-  void trackPlausibleEvent('editor-pick', { props: { choice: 'new-home' } });
-  close();
-  window.open('https://mermaid.ai/live/edit', '_blank');
 };
 
 const handleMouseDown = (e: MouseEvent) => {
@@ -73,103 +70,68 @@ onUnmounted(() => {
 <template>
   <div
     v-if="isVisible"
-    class="fixed top-0 left-0 z-50 flex h-screen w-screen backdrop-blur-sm items-center justify-center bg-[#8585A4]/40"
+    class="fixed top-0 left-0 z-50 flex h-screen w-screen items-center justify-center bg-[#8585A4]/40 backdrop-blur-sm"
     @click.self="close"
   >
     <div
-      class="flex max-w-2xl flex-col gap-6 bg-[#FFF1F2] p-6 rounded-3xl shadow overflow-y-auto max-h-full"
+      class="flex max-h-full w-full max-w-lg flex-col gap-3 overflow-y-auto rounded-3xl bg-white p-8 shadow"
     >
       <!-- Header -->
-      <div class="text-center">
-        <h2 class="text-2xl font-semibold text-[#1E1A2E]">Choose your editor</h2>
+      <div class="flex flex-col items-start gap-2">
+        <img src="/favicon.svg" alt="Mermaid" class="size-10 rounded-lg" />
+        <h2 class="pt-2 text-2xl font-bold text-[#1E1A2E]">Try the full Mermaid experience</h2>
+        <p class="text-xs font-light text-[#6B7280]">
+          Free forever, with Plus features free for 7 days.
+        </p>
       </div>
 
-      <div class="grid gap-4 sm:grid-cols-2">
-        <!-- Mermaid Plus Card -->
-        <div
-          class="relative flex flex-col overflow-hidden rounded-xl border-2 border-[#E0095F] bg-white shadow"
+      <!-- Features -->
+      <ul class="mt-2 flex flex-col gap-3">
+        <li
+          v-for="feature in features"
+          :key="feature.title"
+          class="flex items-center gap-3 rounded-lg border border-[#E5E7EB] p-3"
         >
-          <div class="bg-[#E0095F] px-6 py-2 text-center text-sm font-semibold text-white">
-            Recommended
+          <span class="size-2 shrink-0 rounded-full bg-[#E0095F]" />
+          <div class="flex flex-col gap-0.5">
+            <p class="text-xs text-[#1E1A2E]">{{ feature.title }}</p>
+            <p class="text-xs font-light text-[#6B7280]">{{ feature.description }}</p>
           </div>
+        </li>
+      </ul>
 
-          <div class="flex flex-col gap-4 p-6">
-            <div>
-              <h3 class="text-xl font-bold text-[#1E1A2E]">Mermaid Plus</h3>
-              <p class="text-sm text-[#6B7280]">Unlock AI, storage and collaboration</p>
-            </div>
+      <!-- Actions -->
+      <div class="mt-2 flex items-center gap-3">
+        <button
+          class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-[#E0095F] px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-[#B0134A] focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50 cursor-pointer"
+          @click="handleStartTrial"
+        >
+          Start free trial
+        </button>
+        <button
+          class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md border border-solid border-[#E5E7EB] bg-white px-4 py-2 text-sm font-medium text-[#1E1A2E] shadow-sm transition-colors hover:bg-[#E0095F] hover:text-white focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50 cursor-pointer"
+          @click="handleStayOnLive"
+        >
+          Stay on mermaid.live
+        </button>
+      </div>
 
-            <div class="flex flex-col gap-2">
-              <div class="flex justify-center">
-                <span
-                  class="rounded-full bg-[#FCE7F3] px-3 py-0.5 text-xs font-semibold text-[#BE185D]"
-                >
-                  10% off with code JS26
-                </span>
-              </div>
-
-              <button
-                class="inline-flex w-full items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50 bg-[#E0095F] text-white hover:bg-[#B0134A] shadow-sm h-9 px-4 py-2 cursor-pointer"
-                @click="handleStartTrial"
-              >
-                Start free trial
-              </button>
-            </div>
-
-            <ul class="space-y-3 text-sm text-[#1E1A2E]">
-              <li
-                v-for="{ iconUrl, featureName } in mermaidPlusFeatures"
-                :key="featureName"
-                class="flex items-center gap-2"
-              >
-                <img :src="iconUrl" :alt="featureName" class="size-4 shrink-0 opacity-60" />
-                {{ featureName }}
-              </li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Open Source Card -->
-        <div class="flex flex-col gap-4 rounded-xl border border-[#E5E7EB] bg-white p-6 shadow">
-          <div class="flex flex-col pt-9">
-            <h3 class="text-xl font-bold text-[#1E1A2E]">Open Source</h3>
-            <p class="text-sm text-[#6B7280]">Code only, no login, always free</p>
-          </div>
-
-          <div class="flex flex-col gap-2">
-            <p class="mt-2 text-sm text-[#6B7280]">Mermaid has a new home</p>
-            <button
-              class="inline-flex w-full items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50 border-solid border border-[#E0095F] bg-white text-[#1E1A2E] hover:bg-[#E0095F] hover:text-white shadow-sm h-9 px-4 py-2 cursor-pointer"
-              @click="handleContinueToNewHome"
-            >
-              Continue to mermaid.ai/live
-              <svg class="size-4" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z" />
-              </svg>
-            </button>
-            <button
-              class="inline-flex w-full items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50 border-solid border border-[#E5E7EB] bg-white text-[#1E1A2E] hover:bg-[#E0095F] hover:text-white shadow-md h-9 px-4 py-2 cursor-pointer"
-              @click="handleStartFree"
-            >
-              Stay on mermaid.live
-            </button>
-          </div>
-
-          <ul class="space-y-3 text-sm text-[#1E1A2E]">
-            <li
-              v-for="{ iconUrl, featureName } in openSourceFeatures"
-              :key="featureName"
-              class="flex items-center gap-2"
-            >
-              <img :src="iconUrl" :alt="featureName" class="size-4 shrink-0 opacity-60" />
-              {{ featureName }}
-            </li>
-          </ul>
+      <!-- Trusted by -->
+      <div class="mt-3 flex flex-col items-start gap-4">
+        <p class="text-xs text-[#1E1A2E]">Trusted by 5M people and over 200k companies</p>
+        <div class="flex w-full items-center justify-between gap-2">
+          <component
+            :is="logo.icon"
+            v-for="logo in trustedLogos"
+            :key="logo.name"
+            class="h-6 w-auto grayscale"
+            :aria-label="logo.name"
+          />
         </div>
       </div>
 
       <!-- Privacy Policy Link -->
-      <div class="text-center">
+      <div class="mt-2 text-center">
         <a
           href="https://mermaid.ai/privacy-policy"
           target="_blank"

--- a/packages/mermaid/src/docs/.vitepress/components/EditorSelectionModal.vue
+++ b/packages/mermaid/src/docs/.vitepress/components/EditorSelectionModal.vue
@@ -112,7 +112,7 @@ onUnmounted(() => {
           class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md border border-solid border-[#E5E7EB] bg-white px-4 py-2 text-sm font-medium text-[#1E1A2E] shadow-sm transition-colors hover:bg-[#E0095F] hover:text-white focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50 cursor-pointer"
           @click="handleStayOnLive"
         >
-          Stay on mermaid.live
+          Go to mermaid.live
         </button>
       </div>
 

--- a/packages/mermaid/src/docs/package.json
+++ b/packages/mermaid/src/docs/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@iconify-json/carbon": "^1.2.14",
+    "@iconify-json/logos": "^1.2.11",
     "@iconify-json/material-symbols": "^1.2.67",
     "@unocss/reset": "^66.5.9",
     "@vite-pwa/vitepress": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -505,6 +505,9 @@ importers:
       '@iconify-json/carbon':
         specifier: ^1.2.14
         version: 1.2.14
+      '@iconify-json/logos':
+        specifier: ^1.2.11
+        version: 1.2.11
       '@iconify-json/material-symbols':
         specifier: ^1.2.67
         version: 1.2.73
@@ -2492,6 +2495,9 @@ packages:
 
   '@iconify-json/carbon@1.2.14':
     resolution: {integrity: sha512-33u6uGiYJ79Dfp72peT+PBMcjxzi+NyJLpqYRX8pnw0zchsUW7Us2xecgvkWgD83KYcbe6hufyWlHFU9y7fb/Q==}
+
+  '@iconify-json/logos@1.2.11':
+    resolution: {integrity: sha512-fOo4pGEatuyuCFNL+cwquYMa2Im0oJHRHV7lt/Qqs5Ode/lPImHCQcfTtPzZj7qYMPb/h8YHN3TG54uEowrjNQ==}
 
   '@iconify-json/material-symbols@1.2.73':
     resolution: {integrity: sha512-XCZ9PiO47hofN9p8VTfLyCCJXd95OH4gIkkplkBfeZpz3K6cWYDj7oCy+rnc1AVMmoFyDEyjdEVvr+Oqz9yVTA==}
@@ -12619,6 +12625,10 @@ snapshots:
   '@humanwhocodes/retry@0.4.3': {}
 
   '@iconify-json/carbon@1.2.14':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify-json/logos@1.2.11':
     dependencies:
       '@iconify/types': 2.0.0
 


### PR DESCRIPTION
## Summary

Adapts [mermaid-live-editor#1965](https://github.com/mermaid-js/mermaid-live-editor/pull/1965) to the docs editor selection modal (`EditorSelectionModal.vue`).

- Ends the editor chooser A/B test and ships the single **"Try the full Mermaid experience"** layout — feature list + trusted-by logos — to all traffic (replaces the old two-card "Choose your editor" control design).
- Routes the **Start free trial** CTA through `utm_campaign=live_2026` with `utm_medium=editorSelection`.
- **Stay on mermaid.live** opens the open-source live editor.
- Adds `@iconify-json/logos` for the trusted-by brand logos (Google, Microsoft, Atlassian, AWS), rendered grayscale via `~icons/logos/*`.

## Test plan

- [ ] Run docs dev server, click **Try Editor** / **💻 Open Editor** and confirm the new modal appears
- [ ] Click **Start free trial** and verify the URL includes `utm_campaign=live_2026&utm_medium=editorSelection`
- [ ] Click **Stay on mermaid.live** and confirm it opens `mermaid.live/edit`
- [ ] Confirm trusted-by logos render grayscale

Made with [Cursor](https://cursor.com)