### PR TITLE
ci: correct checks of e2e-status in scoped mode

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -72,23 +72,7 @@ jobs:
           mv stats cypress/snapshots/stats/base
 
   # Detect which diagram(s) the PR touches and determine the minimal set of
-  # Cypress specs to run. Runs in parallel with the `cache` job so it does not
-  # add to the critical path.
-  #
-  # Kill-switch: set the repository variable E2E_SCOPE_BY_DIAGRAM to 'false'
-  # (Settings → Variables → Actions) to disable diagram-scoped test selection.
-  # Scoping is ON by default so that fork PRs (where repository variables are
-  # not exposed) still benefit from it.
-  #
-  # When scoping is active and all changes are confined to a single diagram,
-  # the matrix is reduced to a single container that runs only that diagram's
-  # specs. Containers 2-5 are not scheduled at all. Any change to shared
-  # rendering code, themes, config, or the parser falls back to the full
-  # suite (all five containers run).
-  #
-  # Branch protection: require the aggregator job `e2e-required` (defined at
-  # the bottom of this file) rather than the per-matrix `e2e (N)` checks,
-  # since the matrix size is no longer constant across runs.
+  # Cypress specs to run.
   detect-scope:
     runs-on: ubuntu-latest
     outputs:
@@ -107,8 +91,6 @@ jobs:
 
       - name: Detect e2e scope
         id: scope
-        # The detection script is pure Node.js ESM (no npm install required).
-        # It reads changed file paths from stdin and prints the --spec value.
         run: |
           # Kill-switch: set the repo variable E2E_SCOPE_BY_DIAGRAM to 'false'
           # to disable scoping.  Scoping is ON by default so that fork PRs
@@ -132,9 +114,6 @@ jobs:
           fi
 
           # Fetch the target branch so we can find the true merge-base.
-          # Using merge-base rather than the raw base SHA from the event payload
-          # avoids picking up commits that landed on the base branch after the
-          # PR was last synchronized (which would widen the diff incorrectly).
           git fetch origin develop --depth=1 2>/dev/null || true
           MERGE_BASE=$(git merge-base HEAD origin/develop 2>/dev/null || echo "")
 
@@ -152,9 +131,7 @@ jobs:
                  | node scripts/e2e-diagram-scope.mjs \
                  || echo "")
 
-          # Scoped runs use a single-entry matrix so containers 2-5 are not
-          # scheduled. The SKIP case also uses [1] because the job-level `if:`
-          # on the e2e job skips the entire job anyway.
+          # Check and set required no of containers to run
           if [ "$SPEC" = "SKIP" ]; then
             echo "spec_pattern=SKIP" >> "$GITHUB_OUTPUT"
             echo "matrix=[1]" >> "$GITHUB_OUTPUT"
@@ -178,8 +155,6 @@ jobs:
 
   e2e:
     # Skip the entire e2e job when only docs/ignorable files changed.
-    # Scoping is handled by the matrix size from detect-scope: scoped runs use
-    # a single container, full runs use five.
     if: needs.detect-scope.outputs.spec_pattern != 'SKIP'
     runs-on: ubuntu-latest
     container:
@@ -234,19 +209,13 @@ jobs:
           wait-on: 'http://localhost:9000'
           browser: chrome
           # When detect-scope produced a pattern, run only those specs.
-          # An empty string means "run all specs" (cypress-io/github-action
-          # omits the --spec flag when the value is empty).
           spec: ${{ needs.detect-scope.outputs.spec_pattern }}
           # Disable recording if we don't have an API key
           # e.g. if this action was run from a fork
           record: ${{ env.RUN_VISUAL_TEST == 'true' && secrets.CYPRESS_RECORD_KEY != '' }}
         env:
           # For scoped runs (only a subset of specs executed), mark the Argos
-          # build as a "subset build". This tells Argos to ignore missing
-          # screenshots (they were simply not run, not deleted) and only report
-          # changed/added screenshots. Subset builds are never used as a
-          # baseline, so the full-suite baseline on develop is always preserved.
-          # See: https://argos-ci.com/docs/subset-builds
+          # build as a "subset build".
           ARGOS_SUBSET: "${{ needs.detect-scope.outputs.spec_pattern != '' }}"
           ARGOS_PARALLEL: ${{ env.RUN_VISUAL_TEST == 'true' }}
           ARGOS_PARALLEL_TOTAL: ${{ env.RUN_VISUAL_TEST == 'true' && strategy.job-total || 1 }}
@@ -270,14 +239,6 @@ jobs:
           verbose: true
           token: 6845cc80-77ee-4e17-85a1-026cd95e0766
 
-  # Aggregator job that produces a single stable status check for branch
-  # protection. Succeeds when the e2e matrix succeeded OR was legitimately
-  # skipped (only docs/ignorable files changed). Fails when any matrix entry
-  # failed or was cancelled.
-  #
-  # Configure GitHub branch protection to require this check (`e2e-required`)
-  # rather than the per-matrix `e2e (N)` checks, since the matrix size varies
-  # between scoped runs (1 entry) and full runs (5 entries).
   e2e-required:
     if: always()
     needs: [detect-scope, e2e]

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,13 +75,20 @@ jobs:
   # Cypress specs to run. Runs in parallel with the `cache` job so it does not
   # add to the critical path.
   #
-  # Feature flag: set the repository variable E2E_SCOPE_BY_DIAGRAM to 'true'
-  # (Settings → Variables → Actions) to enable diagram-scoped test selection.
-  # When the flag is not set or is 'false', the full 5-container matrix runs.
+  # Kill-switch: set the repository variable E2E_SCOPE_BY_DIAGRAM to 'false'
+  # (Settings → Variables → Actions) to disable diagram-scoped test selection.
+  # Scoping is ON by default so that fork PRs (where repository variables are
+  # not exposed) still benefit from it.
   #
   # When scoping is active and all changes are confined to a single diagram,
-  # only that diagram's specs run in a single container. Any change to shared
-  # rendering code, themes, config, or the parser falls back to the full suite.
+  # the matrix is reduced to a single container that runs only that diagram's
+  # specs. Containers 2-5 are not scheduled at all. Any change to shared
+  # rendering code, themes, config, or the parser falls back to the full
+  # suite (all five containers run).
+  #
+  # Branch protection: require the aggregator job `e2e-required` (defined at
+  # the bottom of this file) rather than the per-matrix `e2e (N)` checks,
+  # since the matrix size is no longer constant across runs.
   detect-scope:
     runs-on: ubuntu-latest
     outputs:
@@ -145,6 +152,9 @@ jobs:
                  | node scripts/e2e-diagram-scope.mjs \
                  || echo "")
 
+          # Scoped runs use a single-entry matrix so containers 2-5 are not
+          # scheduled. The SKIP case also uses [1] because the job-level `if:`
+          # on the e2e job skips the entire job anyway.
           if [ "$SPEC" = "SKIP" ]; then
             echo "spec_pattern=SKIP" >> "$GITHUB_OUTPUT"
             echo "matrix=[1]" >> "$GITHUB_OUTPUT"
@@ -168,6 +178,8 @@ jobs:
 
   e2e:
     # Skip the entire e2e job when only docs/ignorable files changed.
+    # Scoping is handled by the matrix size from detect-scope: scoped runs use
+    # a single container, full runs use five.
     if: needs.detect-scope.outputs.spec_pattern != 'SKIP'
     runs-on: ubuntu-latest
     container:
@@ -257,3 +269,35 @@ jobs:
           fail_ci_if_error: false
           verbose: true
           token: 6845cc80-77ee-4e17-85a1-026cd95e0766
+
+  # Aggregator job that produces a single stable status check for branch
+  # protection. Succeeds when the e2e matrix succeeded OR was legitimately
+  # skipped (only docs/ignorable files changed). Fails when any matrix entry
+  # failed or was cancelled.
+  #
+  # Configure GitHub branch protection to require this check (`e2e-required`)
+  # rather than the per-matrix `e2e (N)` checks, since the matrix size varies
+  # between scoped runs (1 entry) and full runs (5 entries).
+  e2e-required:
+    if: always()
+    needs: [detect-scope, e2e]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify e2e outcome
+        env:
+          E2E_RESULT: ${{ needs.e2e.result }}
+          SCOPE_RESULT: ${{ needs.detect-scope.result }}
+          SPEC_PATTERN: ${{ needs.detect-scope.outputs.spec_pattern }}
+        run: |
+          echo "detect-scope result: ${SCOPE_RESULT}"
+          echo "detect-scope spec_pattern: ${SPEC_PATTERN}"
+          echo "e2e result: ${E2E_RESULT}"
+          case "${E2E_RESULT}" in
+            success|skipped)
+              echo "OK — required check satisfied."
+              ;;
+            *)
+              echo "FAIL — e2e matrix did not complete successfully."
+              exit 1
+              ;;
+          esac


### PR DESCRIPTION
## :bookmark_tabs: Summary

1. Set the number of e2e()-containers dynamically. When running scoped e2e-test, e2e(1) is created. For full scope, e2e(1),e2e(2),..., e2e(5) are created
2. Added a job, e2e-required, that fails when any e2e-matrix entry fails or was cancelled. Otherwise the job succeeds. 

Resolves 
Currently when the e2e runs in scoped mode, the e2e(2),...,e2e(5) lingers and no status is returned, which stalls the check PR status is CI. This PR contains fixes for that

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [ ] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
