### PR TITLE
feat(er): support optional attribute types

### DIFF
--- a/.changeset/er-optional-attribute-types.md
+++ b/.changeset/er-optional-attribute-types.md
@@ -1,0 +1,5 @@
+---
+'mermaid': minor
+---
+
+feat(er): support optional ER attribute types with a `?` suffix

--- a/docs/syntax/entityRelationshipDiagram.md
+++ b/docs/syntax/entityRelationshipDiagram.md
@@ -247,6 +247,28 @@ erDiagram
 
 The `type` values must begin with an alphabetic character and may contain digits, hyphens, underscores, parentheses and square brackets. The `name` values follow a similar format to `type`, but may start with an asterisk as another option to indicate an attribute is a primary key. Other than that, there are no restrictions, and there is no implicit set of valid data types.
 
+#### Optional attribute types (v\<MERMAID_RELEASE_VERSION>+)
+
+Attribute `type` values may end with `?` to indicate an optional or nullable type.
+
+```mermaid-example
+erDiagram
+    PERSON {
+        string firstName
+        string? middleName
+        string lastName
+    }
+```
+
+```mermaid
+erDiagram
+    PERSON {
+        string firstName
+        string? middleName
+        string lastName
+    }
+```
+
 ### Entity Name Aliases
 
 An alias can be added to an entity using square brackets. If provided, the alias will be showed in the diagram instead of the entity name. Alias names follow all of the same rules as entity names.

--- a/packages/mermaid/src/diagrams/er/parser/erDiagram.jison
+++ b/packages/mermaid/src/diagrams/er/parser/erDiagram.jison
@@ -259,6 +259,7 @@ attribute
 
 attributeType
     : ATTRIBUTE_WORD { $$=$1; }
+    | ATTRIBUTE_WORD '?' { $$=$1 + $2; }
     ;
 
 attributeName

--- a/packages/mermaid/src/diagrams/er/parser/erDiagram.spec.js
+++ b/packages/mermaid/src/diagrams/er/parser/erDiagram.spec.js
@@ -266,6 +266,31 @@ describe('when parsing ER diagram it...', function () {
       expect(entities.get(entity).attributes[0].type).toBe('my.type');
       expect(entities.get(entity).attributes[0].name).toBe('address');
     });
+
+    it('should allow a question mark suffix on an attribute type', function () {
+      const entity = 'PERSON';
+      const attribute = 'string? alias';
+
+      erDiagram.parser.parse(`erDiagram\n${entity} {\n${attribute}\n}`);
+      const entities = erDb.getEntities();
+      expect(entities.size).toBe(1);
+      expect(entities.get(entity).attributes.length).toBe(1);
+      expect(entities.get(entity).attributes[0].type).toBe('string?');
+      expect(entities.get(entity).attributes[0].name).toBe('alias');
+    });
+
+    it('should allow a question mark suffix on an attribute type with a key and comment', function () {
+      const entity = 'PERSON';
+      const attribute = 'string? alias UK "optional display name"';
+
+      erDiagram.parser.parse(`erDiagram\n${entity} {\n${attribute}\n}`);
+      const entities = erDb.getEntities();
+      expect(entities.size).toBe(1);
+      expect(entities.get(entity).attributes.length).toBe(1);
+      expect(entities.get(entity).attributes[0].type).toBe('string?');
+      expect(entities.get(entity).attributes[0].keys).toEqual(['UK']);
+      expect(entities.get(entity).attributes[0].comment).toBe('optional display name');
+    });
   });
 
   it('should allow an entity with a single attribute to be defined', function () {

--- a/packages/mermaid/src/docs/syntax/entityRelationshipDiagram.md
+++ b/packages/mermaid/src/docs/syntax/entityRelationshipDiagram.md
@@ -173,6 +173,19 @@ erDiagram
 
 The `type` values must begin with an alphabetic character and may contain digits, hyphens, underscores, parentheses and square brackets. The `name` values follow a similar format to `type`, but may start with an asterisk as another option to indicate an attribute is a primary key. Other than that, there are no restrictions, and there is no implicit set of valid data types.
 
+#### Optional attribute types (v<MERMAID_RELEASE_VERSION>+)
+
+Attribute `type` values may end with `?` to indicate an optional or nullable type.
+
+```mermaid-example
+erDiagram
+    PERSON {
+        string firstName
+        string? middleName
+        string lastName
+    }
+```
+
 ### Entity Name Aliases
 
 An alias can be added to an entity using square brackets. If provided, the alias will be showed in the diagram instead of the entity name. Alias names follow all of the same rules as entity names.


### PR DESCRIPTION
## :bookmark_tabs: Summary

Adds support for ER diagram attribute types with a trailing `?`, such as `string? alias`, so diagrams can express optional or nullable columns directly in the type column.

Resolves #7319

## :straight_ruler: Design Decisions

The parser now accepts `?` only as a suffix on `attributeType` by parsing `ATTRIBUTE_WORD "?"`. This keeps the existing attribute name rules unchanged while preserving the literal `?` in the rendered type text.

The PR also adds parser coverage for optional types with a key/comment, updates ER syntax docs, and includes a minor changeset for the new feature.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the contribution guidelines
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure `MERMAID_RELEASE_VERSION` is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Validation:

- `pnpm install --frozen-lockfile`
- `pnpm vitest run packages/mermaid/src/diagrams/er/parser/erDiagram.spec.js`
- `pnpm lint:jison`
- `pnpm prettier --check .changeset/er-optional-attribute-types.md docs/syntax/entityRelationshipDiagram.md packages/mermaid/src/docs/syntax/entityRelationshipDiagram.md packages/mermaid/src/diagrams/er/parser/erDiagram.spec.js`
- `git diff --check`
- pre-commit `lint-staged` hook, including `pnpm --filter mermaid run docs:build --git`