### PR TITLE
docs: fix typos in comments and test descriptions

### DIFF
--- a/cypress/integration/rendering/flowchart/flowchart-v2.spec.js
+++ b/cypress/integration/rendering/flowchart/flowchart-v2.spec.js
@@ -1304,7 +1304,7 @@ end
     );
   });
 
-  describe('when rendering unsuported markdown', () => {
+  describe('when rendering unsupported markdown', () => {
     const graph = `flowchart TB
     mermaid{"What is\nyourmermaid version?"} --> v10["<11"] --"\`<**1**1\`"--> fine["No bug"]
     mermaid --> v11[">= v11"] -- ">= v11" --> broken["Affected by https://github.com/mermaid-js/mermaid/issues/5824"]

--- a/packages/mermaid-layout-elk/src/render.ts
+++ b/packages/mermaid-layout-elk/src/render.ts
@@ -153,7 +153,7 @@ export const render = async (
         // Give some padding for elk
         labelData.height = bbox.height - 2;
         labelData.labelNode = shapeSvg.node();
-        // We need the label hight to be able to size the subgraph;
+        // We need the label height to be able to size the subgraph;
         shapeSvg.remove();
       } else {
         // Subgraph without label

--- a/packages/mermaid/src/dagre-wrapper/blockArrowHelper.ts
+++ b/packages/mermaid/src/dagre-wrapper/blockArrowHelper.ts
@@ -135,7 +135,7 @@ export const getArrowPoints = (
     return [
       // Bottom center
       { x: width / 2, y: 0 },
-      // Left pont of bottom arrow
+      // Left point of bottom arrow
       { x: 0, y: -padding },
       { x: midpoint, y: -padding },
       // Left top over vertical section
@@ -231,7 +231,7 @@ export const getArrowPoints = (
     return [
       // Bottom center
       { x: width / 2, y: 0 },
-      // Left pont of bottom arrow
+      // Left point of bottom arrow
       { x: 0, y: -padding },
       { x: midpoint, y: -padding },
       // Left top over vertical section


### PR DESCRIPTION
﻿Fixes minor typos in source code comments and a test description.

- `packages/mermaid-layout-elk/src/render.ts`: `hight` -> `height` (comment)
- `cypress/integration/rendering/flowchart/flowchart-v2.spec.js`: `unsuported` -> `unsupported` (test `describe` label)
- `packages/mermaid/src/dagre-wrapper/blockArrowHelper.ts`: `pont` -> `point` (two comments)

No functional changes.