### PR TITLE
fix: add cylinder shape support in swimlane diagrams

### DIFF
--- a/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
@@ -449,6 +449,8 @@ vertex:  idString SQS text SQE
         {$$ = $idString;yy.addVertex($idString,$text,'round');}
     | idString DIAMOND_START text DIAMOND_STOP
         {$$ = $idString;yy.addVertex($idString,$text,'diamond');}
+        | idString DIAMOND_START PS text PE DIAMOND_STOP
+        {$$ = $idString;yy.addVertex($idString,$text,'cylinder');}
     | idString DIAMOND_START DIAMOND_START text DIAMOND_STOP DIAMOND_STOP
         {$$ = $idString;yy.addVertex($idString,$text,'hexagon');}
     | idString TAGEND text SQE


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fixes the parse error that occurs when using cylinder shape syntax `{(text)}` in swimlane diagrams.

Resolves #7802

## :straight_ruler: Design Decisions

The flowchart parser (`flow.jison`) was missing a grammar rule for the cylinder shape token sequence `DIAMOND_START PS text PE DIAMOND_STOP`. Added the missing rule to handle `{(text)}` syntax and render it as a cylinder shape.

## :clipboard: Tasks

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added necessary documentation.
- [x] :butterfly: This is a bug fix (patch)