### PR TITLE
fix: preserve run script argument boundaries

### DIFF
--- a/run
+++ b/run
@@ -10,12 +10,12 @@ red()           { ansi 31 "$@"; }
 
 name=$(basename $0)
 command=$1
-args=${@:2}
+args=("${@:2}")
 
 case $command in
 
 build)
-docker compose build $args
+docker compose build "${args[@]}"
 ;;
 
 sh)
@@ -23,7 +23,7 @@ $RUN mermaid sh
 ;;
 
 pnpm)
-$RUN mermaid sh -c "pnpm $args"
+$RUN mermaid sh -c 'pnpm "$@"' sh "${args[@]}"
 ;;
 
 dev)
@@ -35,7 +35,7 @@ $RUN --service-ports mermaid sh -c "pnpm run --filter mermaid docs:dev:docker"
 ;;
 
 cypress)
-$RUN cypress $args
+$RUN cypress "${args[@]}"
 ;;
 
 help|"")


### PR DESCRIPTION
## Description

This PR fixes argument forwarding in the root `run` helper script.

The script previously assigned forwarded arguments with `args=${@:2}`, which converted the remaining positional parameters into a scalar string. This could lose the original argument boundaries when forwarding arguments to Docker, pnpm, or Cypress commands.

This change stores forwarded arguments in a Bash array and expands them safely where needed.

## Related Issue

Fixes #7797

## Validation

- Ran `bash -n run` to verify the script syntax.