### PR TITLE
docs: update "Adding Mermaid as a dependency" - Node v16 EOL, yarn-only instructions

### DIFF
--- a/docs/intro/getting-started.md
+++ b/docs/intro/getting-started.md
@@ -301,22 +301,32 @@ In this example, `mermaid.js` is referenced in `src` as a separate JavaScript fi
 
 Below are the steps for adding Mermaid as a dependency:
 
-1. Install `node v16`
+1. Install [Node.js](https://nodejs.org/) v20 or higher (LTS recommended).
 
 > **Note**
 > To learn more about downloading and installing `Node.js` and `npm`, visit the [npm Docs website](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
 
-1. Install `yarn` using `npm` with this command:
+2. Add Mermaid using your preferred package manager:
 
-   `npm install -g yarn`
+   **npm**
 
-2. After yarn installs, enter this command:
+   `npm install mermaid`
+
+   **yarn**
 
    `yarn add mermaid`
 
-3. To add Mermaid as a dev dependency, enter this command:
+   **pnpm**
 
-   `yarn add --dev mermaid`
+   `pnpm add mermaid`
+
+3. To add Mermaid as a dev dependency instead, append the dev flag:
+
+   **npm:** `npm install --save-dev mermaid`
+
+   **yarn:** `yarn add --dev mermaid`
+
+   **pnpm:** `pnpm add --save-dev mermaid`
 
 ## Closing note
 

--- a/packages/mermaid/src/docs/intro/getting-started.md
+++ b/packages/mermaid/src/docs/intro/getting-started.md
@@ -294,23 +294,33 @@ In this example, `mermaid.js` is referenced in `src` as a separate JavaScript fi
 
 Below are the steps for adding Mermaid as a dependency:
 
-1. Install `node v16`
+1. Install [Node.js](https://nodejs.org/) v20 or higher (LTS recommended).
 
 ```note
 To learn more about downloading and installing `Node.js` and `npm`, visit the [npm Docs website](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
 ```
 
-1. Install `yarn` using `npm` with this command:
+2. Add Mermaid using your preferred package manager:
 
-   `npm install -g yarn`
+   **npm**
 
-1. After yarn installs, enter this command:
+   `npm install mermaid`
+
+   **yarn**
 
    `yarn add mermaid`
 
-1. To add Mermaid as a dev dependency, enter this command:
+   **pnpm**
 
-   `yarn add --dev mermaid`
+   `pnpm add mermaid`
+
+3. To add Mermaid as a dev dependency instead, append the dev flag:
+
+   **npm:** `npm install --save-dev mermaid`
+
+   **yarn:** `yarn add --dev mermaid`
+
+   **pnpm:** `pnpm add --save-dev mermaid`
 
 ## Closing note
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

Update the "Adding Mermaid as a dependency" section in the Getting Started guide. The previous instructions referenced Node v16 (EOL since September 2023) and only covered Yarn, requiring users to install it globally via npm install -g yarn. This replaces that with Node v20+, and shows npm, yarn, and pnpm as parallel options for both regular and dev dependencies.

Resolves #7662

## :straight_ruler: Design Decisions

No structural changes to the page, only the content of Section 5 was updated. Package manager options are listed as flat steps rather than tabs to stay consistent with the existing formatting style used elsewhere in the file.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
