### PR TITLE
feat(examples): add relatable examples for every diagram type

### DIFF
--- a/.changeset/examples-relatable-examples.md
+++ b/.changeset/examples-relatable-examples.md
@@ -1,0 +1,9 @@
+---
+'@mermaid-js/examples': minor
+---
+
+Add relatable, real-world examples for every diagram type, showcasing each diagram's strengths
+
+- Most diagrams now ship multiple examples: a relatable default plus examples that highlight distinctive features (e.g. flowchart subgraphs and expanded node shapes, sequence `alt`/`par`/`loop` blocks, state composite states and concurrency, gantt milestones and dependencies, git tags and cherry-picks, ER keys and comments, quadrant point styling, treemap value formatting, architecture junctions).
+- Replaced placeholder content (abstract `A/B/C` nodes, lorem-ipsum-style boards) with realistic scenarios such as checkout flows, sprint boards, budgets, release workflows, and root-cause analyses.
+- Every example is now parse-validated in the package test suite and rendered in the Cypress rendering tests.

--- a/cypress/integration/rendering/examples.spec.ts
+++ b/cypress/integration/rendering/examples.spec.ts
@@ -1,0 +1,19 @@
+import { diagramData } from '../../../packages/examples/src/index.ts';
+import { imgSnapshotTest } from '../../helpers/util.ts';
+
+describe('diagram examples', () => {
+  for (const diagram of diagramData) {
+    describe(diagram.name, () => {
+      for (const example of diagram.examples) {
+        it(`renders ${example.title}`, () => {
+          imgSnapshotTest(example.code, {
+            // Example titles can contain characters that are unsafe in
+            // screenshot file names (e.g. `/`), so build a sanitized name
+            // instead of relying on the test title.
+            name: `examples-${diagram.id}-${example.title}`.replace(/\W+/g, '-'),
+          });
+        });
+      }
+    });
+  }
+});

--- a/cypress/integration/rendering/examples.spec.ts
+++ b/cypress/integration/rendering/examples.spec.ts
@@ -6,7 +6,11 @@ describe('diagram examples', () => {
     describe(diagram.name, () => {
       for (const example of diagram.examples) {
         it(`renders ${example.title}`, () => {
-          imgSnapshotTest(example.code, {
+          // The e2e viewer injects the diagram code into the page with
+          // innerHTML, so a raw `<` (e.g. class annotations like
+          // `<<interface>>`) would be parsed as an HTML tag and corrupt the
+          // source. Escape it like the handwritten rendering specs do.
+          imgSnapshotTest(example.code.replace(/</g, '&lt;'), {
             // Example titles can contain characters that are unsafe in
             // screenshot file names (e.g. `/`), so build a sanitized name
             // instead of relying on the test title.

--- a/packages/examples/src/example.spec.ts
+++ b/packages/examples/src/example.spec.ts
@@ -32,4 +32,17 @@ describe('examples', () => {
       expect(data.examples.filter((e) => e.isDefault).length).toBe(1);
     }
   });
+
+  describe('should have valid examples', () => {
+    for (const diagram of diagramData) {
+      for (const example of diagram.examples) {
+        it(`${diagram.name}: ${example.title}`, async () => {
+          await expect(
+            mermaid.parse(example.code),
+            `Example "${example.title}" of ${diagram.id} does not parse`
+          ).resolves.toBeTruthy();
+        });
+      }
+    }
+  });
 });

--- a/packages/examples/src/examples/architecture.ts
+++ b/packages/examples/src/examples/architecture.ts
@@ -20,5 +20,38 @@ export default {
     disk1:T -- B:server
     disk2:T -- B:db`,
     },
+    {
+      title: 'Web App with Frontend and Backend Groups',
+      code: `architecture-beta
+    group frontend(cloud)[Frontend]
+    group backend(cloud)[Backend]
+
+    service web(internet)[Website] in frontend
+    service mobile(internet)[Mobile App] in frontend
+    service api(server)[API Server] in backend
+    service auth(server)[Auth Service] in backend
+    service db(database)[Database] in backend
+    service files(disk)[File Storage] in backend
+
+    web:R --> L:api
+    mobile:R --> L:api
+    api:R --> L:auth
+    api:B --> T:db
+    db:R -- L:files`,
+    },
+    {
+      title: 'Load Balancing with Junctions',
+      code: `architecture-beta
+    service user(internet)[User]
+    service lb(server)[Load Balancer]
+    service app1(server)[App Server 1]
+    service app2(server)[App Server 2]
+    junction fanout
+
+    user:R -- L:lb
+    lb:R -- L:fanout
+    app1:B -- T:fanout
+    app2:T -- B:fanout`,
+    },
   ],
 } satisfies DiagramMetadata;

--- a/packages/examples/src/examples/block.ts
+++ b/packages/examples/src/examples/block.ts
@@ -6,8 +6,23 @@ export default {
   description: 'Create block-based visualizations with beta styling',
   examples: [
     {
-      title: 'Basic Block Layout',
+      title: 'Three-Tier Web Architecture',
       isDefault: true,
+      code: `block-beta
+  columns 3
+  user(("User")):3
+  space:3
+  ui["Web UI"] api["API Server"] db[("Database")]
+
+  user --> ui
+  ui --> api
+  api --> db
+
+  style user fill:#ffe0b2,stroke:#fb8c00
+  style db fill:#bbdefb,stroke:#1e88e5`,
+    },
+    {
+      title: 'Block Arrows and Nested Blocks',
       code: `block-beta
 columns 1
   db(("DB"))

--- a/packages/examples/src/examples/c4.ts
+++ b/packages/examples/src/examples/c4.ts
@@ -43,5 +43,31 @@ export default {
     Rel(SystemAA, SystemC, "Sends e-mails", "SMTP")
     Rel(SystemC, customerA, "Sends e-mails to")`,
     },
+    {
+      title: 'Internet Banking Container Diagram',
+      code: `C4Container
+    title Container diagram for Internet Banking System
+
+    Person(customer, "Banking Customer", "A customer of the bank, with personal bank accounts")
+    System_Ext(email_system, "E-Mail System", "The internal Microsoft Exchange system")
+
+    Container_Boundary(c1, "Internet Banking") {
+        Container(web_app, "Web Application", "JavaScript, React", "Delivers the static content and the SPA")
+        Container(spa, "Single-Page App", "JavaScript, React", "Provides all banking functionality via the browser")
+        Container(mobile_app, "Mobile App", "C#, Xamarin", "Provides a subset of banking functionality")
+        ContainerDb(database, "Database", "SQL Database", "Stores user registration, hashed auth credentials, access logs")
+        Container(backend_api, "API Application", "Java, Docker", "Provides banking functionality via JSON/HTTPS API")
+    }
+
+    Rel(customer, web_app, "Uses", "HTTPS")
+    Rel(customer, spa, "Uses", "HTTPS")
+    Rel(customer, mobile_app, "Uses")
+    Rel(web_app, spa, "Delivers")
+    Rel(spa, backend_api, "Makes API calls to", "JSON/HTTPS")
+    Rel(mobile_app, backend_api, "Makes API calls to", "JSON/HTTPS")
+    Rel(backend_api, database, "Reads from and writes to", "JDBC")
+    Rel(email_system, customer, "Sends e-mails to")
+    Rel(backend_api, email_system, "Sends e-mails using", "SMTP")`,
+    },
   ],
 } satisfies DiagramMetadata;

--- a/packages/examples/src/examples/class.ts
+++ b/packages/examples/src/examples/class.ts
@@ -30,5 +30,52 @@ export default {
       +run()
     }`,
     },
+    {
+      title: 'E-commerce Domain Model',
+      code: `classDiagram
+    direction LR
+    class Customer {
+        +String name
+        +String email
+        +register()
+        +placeOrder() Order
+    }
+    class Order {
+        +Date createdAt
+        +List~OrderItem~ items
+        +addItem(Product product, int quantity)
+        +total() float
+    }
+    class OrderItem {
+        +int quantity
+        +float unitPrice
+    }
+    class Product {
+        +String name
+        +float price
+    }
+    class PaymentMethod {
+        <<interface>>
+        +authorize(float amount) bool
+    }
+    class CreditCard {
+        +String maskedNumber
+        +authorize(float amount) bool
+    }
+    class GiftCard {
+        +float balance
+        +authorize(float amount) bool
+    }
+
+    Customer "1" --> "0..*" Order : places
+    Order "1" *-- "1..*" OrderItem : contains
+    OrderItem "0..*" --> "1" Product : refers to
+    PaymentMethod <|.. CreditCard
+    PaymentMethod <|.. GiftCard
+    Order --> PaymentMethod : paid via
+
+    note for PaymentMethod "New payment providers only
+need to implement authorize()"`,
+    },
   ],
 } satisfies DiagramMetadata;

--- a/packages/examples/src/examples/cynefin.ts
+++ b/packages/examples/src/examples/cynefin.ts
@@ -33,5 +33,31 @@ export default {
   clear --> chaotic : "Complacency"
 `,
     },
+    {
+      title: 'Product Strategy with Domain Transitions',
+      code: `cynefin-beta
+  title Product Strategy
+
+  complex
+    "New market entry"
+    "Pricing experiments"
+
+  complicated
+    "Competitive analysis"
+    "Capacity planning"
+
+  clear
+    "Standard onboarding"
+    "Invoice processing"
+
+  chaotic
+    "PR crisis response"
+
+  complex --> complicated : "Patterns emerge"
+  complicated --> clear : "Playbook written"
+  clear --> chaotic : "Complacency"
+  chaotic --> complex : "Stabilized"
+`,
+    },
   ],
 } satisfies DiagramMetadata;

--- a/packages/examples/src/examples/er.ts
+++ b/packages/examples/src/examples/er.ts
@@ -32,5 +32,48 @@ export default {
         float price
     }`,
     },
+    {
+      title: 'Streaming Service with Keys and Comments',
+      code: `erDiagram
+    USER ||--o{ SUBSCRIPTION : has
+    PLAN ||--o{ SUBSCRIPTION : "subscribed via"
+    USER ||--o{ WATCH_HISTORY : logs
+    EPISODE ||--o{ WATCH_HISTORY : "appears in"
+    SHOW ||--|{ EPISODE : contains
+    USER {
+        string id PK
+        string email UK "Used for login"
+        string country
+    }
+    SUBSCRIPTION {
+        string id PK
+        string userId FK
+        string planId FK
+        date startedAt
+        bool autoRenew
+    }
+    PLAN {
+        string id PK
+        string name "Basic, Standard or Premium"
+        float monthlyPrice
+    }
+    SHOW {
+        string id PK
+        string title
+        string genre
+    }
+    EPISODE {
+        string id PK
+        string showId FK
+        int seasonNumber
+        int episodeNumber
+    }
+    WATCH_HISTORY {
+        string userId FK
+        string episodeId FK
+        date watchedAt
+        int secondsWatched
+    }`,
+    },
   ],
 } satisfies DiagramMetadata;

--- a/packages/examples/src/examples/eventmodeling.ts
+++ b/packages/examples/src/examples/eventmodeling.ts
@@ -7,15 +7,42 @@ export default {
     'Describe systems using an example of how information has changed within them over time',
   examples: [
     {
-      title: 'Event Modeling',
+      title: 'Shopping Cart Story',
       isDefault: true,
       code: `eventmodeling
 
-tf 01 ui CartUI
-tf 02 cmd AddItem
+tf 01 ui ShopUI
+tf 02 cmd AddItemToCart
 tf 03 evt ItemAdded
-tf 04 rmo CartItems ->> 03
-tf 05 evt AccountingItemAdded
+tf 04 rmo CartView ->> 03
+tf 05 ui CheckoutUI
+tf 06 cmd PlaceOrder
+tf 07 evt OrderPlaced
+tf 08 rmo OrderStatus ->> 07
+`,
+    },
+    {
+      title: 'Cross-System Flow with Data',
+      code: `eventmodeling
+
+tf 01 ui CartUI
+tf 02 cmd AddItem [[AddItem01]]
+tf 03 evt ItemAdded [[ItemAdded]]
+
+rf 04 evt Warehouse.StockChanged
+tf 05 pcr StockProcessor
+tf 06 cmd UpdateAvailability
+tf 07 evt Shop.AvailabilityUpdated
+
+data AddItem01 {
+  sku: 'SHIRT-M'
+  quantity: 2
+}
+
+data ItemAdded {
+  sku: string
+  quantity: number
+}
 `,
     },
   ],

--- a/packages/examples/src/examples/flowchart.ts
+++ b/packages/examples/src/examples/flowchart.ts
@@ -15,5 +15,61 @@ export default {
     C -->|Two| E[iPhone]
     C -->|Three| F[fa:fa-car Car]`,
     },
+    {
+      title: 'Online Checkout Flow',
+      code: `flowchart TD
+    Start([Visit online store]) --> Browse[Browse products]
+    Browse --> Cart[Add items to cart]
+    Cart --> Decide{Ready to check out?}
+    Decide -->|Keep shopping| Browse
+    Decide -->|Yes| Pay[Enter payment details]
+    Pay --> Valid{Payment accepted?}
+    Valid -->|No| Retry[Show error message]
+    Retry --> Pay
+    Valid -->|Yes| Confirm[Order confirmed]
+    Confirm --> Done([Email receipt])
+
+    style Start fill:#e8f5e9,stroke:#43a047
+    style Done fill:#e8f5e9,stroke:#43a047
+    style Valid fill:#fff3e0,stroke:#fb8c00`,
+    },
+    {
+      title: 'CI/CD Pipeline with Subgraphs',
+      code: `flowchart LR
+    subgraph dev[Development]
+        Code[Write code] --> PR[Open pull request]
+    end
+
+    subgraph ci[Continuous Integration]
+        Build[Build] --> Test[Run tests]
+        Test --> Gate{Tests pass?}
+    end
+
+    subgraph cd[Deployment]
+        Stage[Deploy to staging] --> Approve[Manual approval]
+        Approve --> Prod[Deploy to production]
+    end
+
+    PR --> Build
+    Gate -->|Yes| Stage
+    Gate -->|No| Code`,
+    },
+    {
+      title: 'Expanded Node Shapes',
+      code: `flowchart TD
+    Form@{ shape: manual-input, label: "User fills in form" }
+    Docs@{ shape: docs, label: "Uploaded documents" }
+    Check@{ shape: procs, label: "Automated checks" }
+    Decision@{ shape: diam, label: "Application approved?" }
+    DB@{ shape: cyl, label: "Customer database" }
+    Letter@{ shape: stadium, label: "Send welcome email" }
+
+    Form --> Docs
+    Docs --> Check
+    Check --> Decision
+    Decision -->|Yes| DB
+    Decision -->|No| Form
+    DB --> Letter`,
+    },
   ],
 } satisfies DiagramMetadata;

--- a/packages/examples/src/examples/gantt.ts
+++ b/packages/examples/src/examples/gantt.ts
@@ -6,17 +6,45 @@ export default {
   description: 'Visualize project schedules and timelines',
   examples: [
     {
-      title: 'Basic Project Timeline',
+      title: 'Product Launch Plan',
       isDefault: true,
       code: `gantt
-    title A Gantt Diagram
-    dateFormat  YYYY-MM-DD
-    section Section
-    A task           :a1, 2014-01-01, 30d
-    Another task     :after a1  , 20d
-    section Another
-    Task in sec      :2014-01-12  , 12d
-    another task      : 24d`,
+    title Product Launch Plan
+    dateFormat YYYY-MM-DD
+    section Planning
+        Market research      :done, research, 2024-03-01, 10d
+        Define requirements  :done, reqs, after research, 7d
+    section Build
+        Design prototype     :active, proto, after reqs, 14d
+        User testing         :testing, after proto, 7d
+    section Launch
+        Marketing campaign   :marketing, after proto, 14d
+        Release day          :milestone, after testing, 0d`,
+    },
+    {
+      title: 'Website Redesign with Dependencies',
+      code: `gantt
+    title Website Redesign Project
+    dateFormat YYYY-MM-DD
+    excludes weekends
+
+    section Discovery
+        Stakeholder interviews :done, interviews, 2024-01-08, 5d
+        Competitive analysis   :done, analysis, 2024-01-10, 4d
+
+    section Design
+        Wireframes             :active, wireframes, after interviews, 7d
+        Visual design          :design, after wireframes, 10d
+        Design sign-off        :milestone, after design, 0d
+
+    section Development
+        Frontend build         :crit, frontend, after design, 15d
+        CMS integration        :cms, after wireframes, 12d
+        Content migration      :content, after cms, 5d
+
+    section Launch
+        QA testing             :qa, after frontend content, 5d
+        Go live                :milestone, after qa, 0d`,
     },
   ],
 } satisfies DiagramMetadata;

--- a/packages/examples/src/examples/git.ts
+++ b/packages/examples/src/examples/git.ts
@@ -24,5 +24,35 @@ export default {
     checkout main
     merge feature`,
     },
+    {
+      title: 'Release and Hotfix Workflow',
+      code: `gitGraph
+    commit id: "initial setup"
+    branch develop
+    commit id: "feat: login page"
+    commit id: "feat: search"
+    checkout main
+    merge develop tag: "v1.0.0"
+    checkout develop
+    commit id: "feat: user profile"
+    checkout main
+    branch hotfix
+    commit id: "fix: crash on load"
+    checkout main
+    merge hotfix tag: "v1.0.1"
+    checkout develop
+    cherry-pick id: "fix: crash on load"
+    commit id: "feat: dark mode"
+    checkout main
+    merge develop tag: "v1.1.0"`,
+    },
+    {
+      title: 'Highlighted Commits',
+      code: `gitGraph TB:
+    commit id: "v2 groundwork"
+    commit id: "schema migration" type: HIGHLIGHT
+    commit id: "revert experiment" type: REVERSE
+    commit id: "stabilize" tag: "v2.0.0-rc1"`,
+    },
   ],
 } satisfies DiagramMetadata;

--- a/packages/examples/src/examples/ishikawa.ts
+++ b/packages/examples/src/examples/ishikawa.ts
@@ -31,5 +31,26 @@ ishikawa-beta
         Too dark
 `,
     },
+    {
+      title: 'Late Food Delivery Root Causes',
+      code: `
+ishikawa-beta
+    Late Food Delivery
+    Process
+        Orders batched too long
+        Kitchen queue not prioritized
+    People
+        Not enough drivers on shift
+        New cook still in training
+    Equipment
+        Oven capacity too small
+        Delivery bags lose heat
+    Environment
+        Heavy rain
+        Road construction on main route
+    Measurement
+        No alert when prep time exceeds target
+`,
+    },
   ],
 } satisfies DiagramMetadata;

--- a/packages/examples/src/examples/kanban.ts
+++ b/packages/examples/src/examples/kanban.ts
@@ -6,32 +6,37 @@ export default {
   description: 'Visualize work items in a Kanban board',
   examples: [
     {
-      title: 'Kanban Diagram',
+      title: 'Sprint Board',
       isDefault: true,
       code: `---
 config:
   kanban:
-    ticketBaseUrl: 'https://github.com/mermaid-js/mermaid/issues/#TICKET#'
+    ticketBaseUrl: 'https://github.com/your-org/your-repo/issues/#TICKET#'
 ---
 kanban
+  todo[Backlog]
+    t1[Design new landing page]
+    t2[Update API documentation]@{ priority: 'Low' }
+  doing[In Progress]
+    t3[Fix login redirect bug]@{ ticket: 1234, assigned: 'alice', priority: 'Very High' }
+    t4[Migrate database to v2]@{ assigned: 'bob' }
+  review[In Review]
+    t5[Add dark mode support]@{ ticket: 1198, assigned: 'carol', priority: 'High' }
+  done[Done]
+    t6[Set up CI pipeline]
+    t7[Release v2.1.0]@{ ticket: 1150 }`,
+    },
+    {
+      title: 'Personal Task Board',
+      code: `kanban
   Todo
-    [Create Documentation]
-    docs[Create Blog about the new diagram]
+    [Buy groceries]
+    [Book dentist appointment]
   [In progress]
-    id6[Create renderer so that it works in all cases. We also add some extra text here for testing purposes. And some more just for the extra flare.]
-  id9[Ready for deploy]
-    id8[Design grammar]@{ assigned: 'knsv' }
-  id10[Ready for test]
-    id4[Create parsing tests]@{ ticket: 2038, assigned: 'K.Sveidqvist', priority: 'High' }
-    id66[last item]@{ priority: 'Very Low', assigned: 'knsv' }
-  id11[Done]
-    id5[define getData]
-    id2[Title of diagram is more than 100 chars when user duplicates diagram with 100 char]@{ ticket: 2036, priority: 'Very High'}
-    id3[Update DB function]@{ ticket: 2037, assigned: knsv, priority: 'High' }
-
-  id12[Can't reproduce]
-    id3[Weird flickering in Firefox]
-`,
+    [Plan weekend trip]
+  Done
+    [Pay electricity bill]
+    [Renew gym membership]`,
     },
   ],
 } satisfies DiagramMetadata;

--- a/packages/examples/src/examples/kanban.ts
+++ b/packages/examples/src/examples/kanban.ts
@@ -6,25 +6,25 @@ export default {
   description: 'Visualize work items in a Kanban board',
   examples: [
     {
-      title: 'Sprint Board',
+      title: 'Mermaid Sprint Board',
       isDefault: true,
       code: `---
 config:
   kanban:
-    ticketBaseUrl: 'https://github.com/your-org/your-repo/issues/#TICKET#'
+    ticketBaseUrl: 'https://github.com/mermaid-js/mermaid/issues/#TICKET#'
 ---
 kanban
-  todo[Backlog]
-    t1[Design new landing page]
-    t2[Update API documentation]@{ priority: 'Low' }
-  doing[In Progress]
-    t3[Fix login redirect bug]@{ ticket: 1234, assigned: 'alice', priority: 'Very High' }
-    t4[Migrate database to v2]@{ assigned: 'bob' }
-  review[In Review]
-    t5[Add dark mode support]@{ ticket: 1198, assigned: 'carol', priority: 'High' }
+  todo[Todo]
+    docs[Create documentation]
+    blog[Write blog post about the new diagram]@{ priority: 'Low' }
+  inProgress[In progress]
+    renderer[Improve renderer for edge cases]@{ assigned: 'knsv', priority: 'High' }
+  readyForTest[Ready for test]
+    parserTests[Create parsing tests]@{ ticket: 2038, assigned: 'K.Sveidqvist', priority: 'High' }
   done[Done]
-    t6[Set up CI pipeline]
-    t7[Release v2.1.0]@{ ticket: 1150 }`,
+    grammar[Design grammar]@{ assigned: 'knsv' }
+    longTitle[Title of diagram is more than 100 chars when user duplicates diagram with 100 char]@{ ticket: 2036, priority: 'Very High' }
+    dbFunction[Update DB function]@{ ticket: 2037, assigned: 'knsv', priority: 'High' }`,
     },
     {
       title: 'Personal Task Board',

--- a/packages/examples/src/examples/mindmap.ts
+++ b/packages/examples/src/examples/mindmap.ts
@@ -26,6 +26,29 @@ export default {
       Pen and paper
       Mermaid`,
     },
+    {
+      title: 'Trip Planning with Shapes and Icons',
+      code: `mindmap
+  root((Summer Trip))
+    Destination
+      Beach town
+      Mountain village
+    Budget
+      ::icon(fa fa-wallet)
+      Flights
+      Hotel
+      Food and activities
+    Packing
+      Documents
+        Passport
+        Travel insurance
+      reminder{{Sunscreen!}}
+    Activities
+      ::icon(fa fa-person-hiking)
+      Hiking
+      Snorkeling
+      Local food tour`,
+    },
   ],
 } satisfies DiagramMetadata;
 

--- a/packages/examples/src/examples/packet.ts
+++ b/packages/examples/src/examples/packet.ts
@@ -30,5 +30,15 @@ packet
 160-191: "(Options and Padding)"
 192-255: "Data (variable length)"`,
     },
+    {
+      title: 'UDP Packet with Relative Bits',
+      code: `packet
+title UDP Packet
++16: "Source Port"
++16: "Destination Port"
++16: "Length"
++16: "Checksum"
+64-95: "Data (variable length)"`,
+    },
   ],
 } satisfies DiagramMetadata;

--- a/packages/examples/src/examples/pie.ts
+++ b/packages/examples/src/examples/pie.ts
@@ -13,5 +13,14 @@ export default {
     "Cats" : 85
     "Rats" : 15`,
     },
+    {
+      title: 'Workday Breakdown with Values',
+      code: `pie showData title Where the workday goes (minutes)
+    "Focused work" : 210
+    "Meetings" : 120
+    "Email and chat" : 90
+    "Breaks" : 45
+    "Context switching" : 15`,
+    },
   ],
 } satisfies DiagramMetadata;

--- a/packages/examples/src/examples/quadrant-chart.ts
+++ b/packages/examples/src/examples/quadrant-chart.ts
@@ -23,5 +23,23 @@ export default {
     Campaign E: [0.40, 0.34]
     Campaign F: [0.35, 0.78]`,
     },
+    {
+      title: 'Eisenhower Matrix with Styled Points',
+      code: `quadrantChart
+    title Task Prioritization
+    x-axis Not Urgent --> Urgent
+    y-axis Not Important --> Important
+    quadrant-1 Do first
+    quadrant-2 Schedule
+    quadrant-3 Eliminate
+    quadrant-4 Delegate
+    Fix production outage: [0.88, 0.92] radius: 9
+    Plan next quarter: [0.28, 0.85]
+    Renew passport: [0.65, 0.75]
+    Answer routine emails: [0.78, 0.28]
+    Tidy desktop folders: [0.18, 0.12]
+    classDef urgent color: #ff3300
+    Book dentist appointment:::urgent: [0.72, 0.62]`,
+    },
   ],
 } satisfies DiagramMetadata;

--- a/packages/examples/src/examples/radar.ts
+++ b/packages/examples/src/examples/radar.ts
@@ -21,5 +21,20 @@ radar-beta
   min 0
 `,
     },
+    {
+      title: 'Framework Comparison with Polygon Grid',
+      code: `radar-beta
+  title Frontend Framework Comparison
+  axis perf["Performance"], dx["Dev Experience"], eco["Ecosystem"]
+  axis learn["Easy to Learn"], docs["Documentation"]
+
+  curve react["React"]{4, 4, 5, 3, 4}
+  curve vue["Vue"]{4, 5, 4, 4, 5}
+  curve svelte["Svelte"]{5, 5, 3, 4, 4}
+
+  graticule polygon
+  max 5
+  min 0`,
+    },
   ],
 } satisfies DiagramMetadata;

--- a/packages/examples/src/examples/railroad-abnf.ts
+++ b/packages/examples/src/examples/railroad-abnf.ts
@@ -6,7 +6,7 @@ export default {
   description: 'Visualize grammar rules using RFC 5234 ABNF notation',
   examples: [
     {
-      title: 'URI Scheme',
+      title: 'Email Address',
       isDefault: true,
       code: `railroad-abnf
     title Email Address
@@ -15,6 +15,15 @@ export default {
     local-part = 1*( ALPHA / DIGIT / "." / "-" ) ;
     domain = label *( "." label ) ;
     label = 1*( ALPHA / DIGIT / "-" ) ;`,
+    },
+    {
+      title: 'Phone Number',
+      code: `railroad-abnf
+    title Phone Number
+
+    phone = [ "+" country-code ] subscriber ;
+    country-code = 1*DIGIT ;
+    subscriber = 1*( DIGIT / "-" / " " ) ;`,
     },
   ],
 } satisfies DiagramMetadata;

--- a/packages/examples/src/examples/railroad-ebnf.ts
+++ b/packages/examples/src/examples/railroad-ebnf.ts
@@ -17,5 +17,19 @@ export default {
     number = digit+ ;
     digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;`,
     },
+    {
+      title: 'Semantic Version',
+      code: `railroad-ebnf
+    title Semantic Version
+
+    version = core ( "-" prerelease )? ( "+" build )? ;
+    core = number "." number "." number ;
+    prerelease = identifier ( "." identifier )* ;
+    build = identifier ( "." identifier )* ;
+    number = digit+ ;
+    identifier = ( letter | digit )+ ;
+    letter = "a" | "b" | "c" ;
+    digit = "0" | "1" | "2" ;`,
+    },
   ],
 } satisfies DiagramMetadata;

--- a/packages/examples/src/examples/railroad-peg.ts
+++ b/packages/examples/src/examples/railroad-peg.ts
@@ -17,5 +17,14 @@ export default {
     Number <- Digit+ ;
     Digit <- "0" / "1" / "2" / "3" / "4" / "5" / "6" / "7" / "8" / "9" ;`,
     },
+    {
+      title: 'Identifiers with Predicates',
+      code: `railroad-peg
+    title Identifiers (keywords excluded)
+
+    Identifier <- !Keyword Letter Letter* ;
+    Keyword <- "if" / "else" / "while" ;
+    Letter <- "a" / "b" / "c" / "_" ;`,
+    },
   ],
 } satisfies DiagramMetadata;

--- a/packages/examples/src/examples/requirement.ts
+++ b/packages/examples/src/examples/requirement.ts
@@ -6,22 +6,53 @@ export default {
   description: 'Visualize system requirements and their relationships',
   examples: [
     {
-      title: 'Basic Requirements',
+      title: 'E-Bike Braking System',
+      isDefault: true,
       code: `requirementDiagram
 
-    requirement test_req {
-    id: 1
-    text: the test text.
-    risk: high
-    verifymethod: test
+    requirement rider_safety {
+        id: 1
+        text: Riders must be able to stop safely in all conditions.
+        risk: high
+        verifymethod: test
     }
 
-    element test_entity {
-    type: simulation
+    functionalRequirement brake_response {
+        id: 1.1
+        text: Brakes engage within 100 ms of lever pull.
+        risk: medium
+        verifymethod: test
     }
 
-    test_entity - satisfies -> test_req`,
-      isDefault: true,
+    performanceRequirement stopping_distance {
+        id: 1.2
+        text: Stop from 25 km/h within 4 m on dry pavement.
+        risk: medium
+        verifymethod: demonstration
+    }
+
+    designConstraint water_resistance {
+        id: 1.3
+        text: Brake electronics must be IP67 rated.
+        risk: low
+        verifymethod: inspection
+    }
+
+    element brake_controller {
+        type: hardware
+        docRef: "specs/brake-controller"
+    }
+
+    element road_test_suite {
+        type: "test suite"
+        docRef: "qa/road-tests"
+    }
+
+    rider_safety - contains -> brake_response
+    rider_safety - contains -> stopping_distance
+    brake_response - derives -> water_resistance
+    brake_controller - satisfies -> brake_response
+    road_test_suite - verifies -> stopping_distance`,
     },
   ],
 } satisfies DiagramMetadata;

--- a/packages/examples/src/examples/sankey.ts
+++ b/packages/examples/src/examples/sankey.ts
@@ -6,8 +6,34 @@ export default {
   description: 'Visualize flow quantities between different stages or processes',
   examples: [
     {
-      title: 'Energy Flow',
+      title: 'Monthly Budget Flow',
       isDefault: true,
+      code: `sankey-beta
+
+Salary,Budget,3000
+Freelance work,Budget,1200
+Budget,Rent,1300
+Budget,Groceries,600
+Budget,Transport,250
+Budget,Fun,350
+Budget,Savings,1700`,
+    },
+    {
+      title: 'Job Application Funnel',
+      code: `sankey-beta
+
+Applications,Screening,120
+Screening,Rejected early,70
+Screening,Phone interview,50
+Phone interview,Rejected,20
+Phone interview,Technical interview,30
+Technical interview,Rejected late,12
+Technical interview,Offer,18
+Offer,Declined,4
+Offer,Hired,14`,
+    },
+    {
+      title: 'Energy Flow (UK)',
       code: `---
 config:
   sankey:

--- a/packages/examples/src/examples/sequence.ts
+++ b/packages/examples/src/examples/sequence.ts
@@ -14,5 +14,52 @@ export default {
     John-->>-Alice: Hi Alice, I can hear you!
     John-->>-Alice: I feel great!`,
     },
+    {
+      title: 'Online Payment Flow',
+      code: `sequenceDiagram
+    autonumber
+    actor Customer
+    participant Shop as Web Shop
+    participant Pay as Payment Service
+    participant Bank
+
+    Customer->>Shop: Place order
+    activate Shop
+    Shop->>Pay: Create payment request
+    activate Pay
+    Pay->>Bank: Authorize card
+    Bank-->>Pay: Authorization result
+    alt Payment approved
+        Pay-->>Shop: Payment confirmed
+        Shop-->>Customer: Show receipt
+    else Payment declined
+        Pay-->>Shop: Payment failed
+        Shop-->>Customer: Ask for another card
+    end
+    deactivate Pay
+    deactivate Shop`,
+    },
+    {
+      title: 'Food Delivery with Parallel Actions',
+      code: `sequenceDiagram
+    participant App as Mobile App
+    participant API as Order Service
+    participant Kitchen
+    actor Courier
+
+    App->>API: Submit order
+    Note right of API: Validate items,<br/>charge payment
+    par Notify kitchen
+        API->>Kitchen: New order ticket
+    and Confirm to customer
+        API-->>App: Order accepted, ETA 30 min
+    end
+    Kitchen-->>API: Order ready
+    API->>Courier: Request pickup
+    loop Until delivered
+        Courier->>App: Share live location
+    end
+    Courier-->>App: Order delivered`,
+    },
   ],
 } satisfies DiagramMetadata;

--- a/packages/examples/src/examples/state.ts
+++ b/packages/examples/src/examples/state.ts
@@ -16,5 +16,51 @@ export default {
     Crash --> [*]`,
       isDefault: true,
     },
+    {
+      title: 'Order Lifecycle with Composite States',
+      code: `stateDiagram-v2
+    direction LR
+    [*] --> Placed
+    Placed --> Paid : payment received
+    Placed --> Cancelled : customer cancels
+    Paid --> Fulfilment
+
+    state Fulfilment {
+        [*] --> Packing
+        Packing --> Shipped : handed to courier
+        Shipped --> [*]
+    }
+
+    Fulfilment --> Delivered : courier confirms
+    Delivered --> [*]
+    Cancelled --> [*]
+
+    note right of Paid
+        Payment can be card,
+        wallet, or bank transfer
+    end note`,
+    },
+    {
+      title: 'Choice and Concurrency',
+      code: `stateDiagram-v2
+    state battery_check <<choice>>
+    [*] --> PowerOn
+    PowerOn --> battery_check
+    battery_check --> LowPowerMode : battery < 20%
+    battery_check --> Active : battery >= 20%
+
+    state Active {
+        [*] --> Playing
+        Playing --> Paused : pause
+        Paused --> Playing : play
+        --
+        [*] --> ScreenOn
+        ScreenOn --> ScreenDimmed : idle 30s
+        ScreenDimmed --> ScreenOn : touch
+    }
+
+    LowPowerMode --> [*] : power off
+    Active --> [*] : power off`,
+    },
   ],
 } satisfies DiagramMetadata;

--- a/packages/examples/src/examples/timeline.ts
+++ b/packages/examples/src/examples/timeline.ts
@@ -16,5 +16,18 @@ export default {
     2005 : YouTube
     2006 : Twitter`,
     },
+    {
+      title: 'Product Roadmap with Sections',
+      code: `timeline
+    title Product Roadmap 2024
+    section Q1 Foundations
+        January : Team hired : Tech stack chosen
+        February : MVP scoped
+        March : Alpha release
+    section Q2 Growth
+        April : Beta program opens
+        May : Mobile app : Public API
+        June : v1.0 launch`,
+    },
   ],
 } satisfies DiagramMetadata;

--- a/packages/examples/src/examples/tree-view.ts
+++ b/packages/examples/src/examples/tree-view.ts
@@ -6,23 +6,8 @@ export default {
   description: 'Visualize hierarchical data as a tree structure',
   examples: [
     {
-      title: 'Basic TreeView',
+      title: 'Project File Structure',
       isDefault: true,
-      code: `treeView-beta
-            "docs"
-                "build"
-                "make.bat"
-                "Makefile"
-                "out"
-                "source"
-                    "build"
-                    "static"
-                        "_templates"
-                        "div. Files"`,
-    },
-    {
-      title: 'File Tree with Icons',
-      isDefault: false,
       code: `treeView-beta
             my-project/
                 src/
@@ -34,6 +19,19 @@ export default {
                 .gitignore
                 package.json
                 README.md`,
+    },
+    {
+      title: 'Shared Drive with Quoted Names',
+      isDefault: false,
+      code: `treeView-beta
+            "Team Drive"
+                "Quarterly Reports"
+                    "Q1 Review.pdf"
+                    "Q2 Review.pdf"
+                "Brand Assets"
+                    "logo.svg"
+                    "style guide.md"
+                "Meeting Notes"`,
     },
     {
       title: 'Annotations',

--- a/packages/examples/src/examples/treemap.ts
+++ b/packages/examples/src/examples/treemap.ts
@@ -6,16 +6,44 @@ export default {
   description: 'Visualize hierarchical data as nested rectangles',
   examples: [
     {
-      title: 'Treemap',
+      title: 'Monthly Household Budget',
       isDefault: true,
+      code: `---
+config:
+  treemap:
+    valueFormat: '$0,0'
+---
+treemap-beta
+"Monthly Budget"
+    "Housing"
+        "Rent": 1400
+        "Utilities": 220
+        "Internet": 60
+    "Food"
+        "Groceries": 480
+        "Dining out": 180
+    "Transport"
+        "Car payment": 320
+        "Fuel": 140
+    "Savings"
+        "Emergency fund": 300
+        "Retirement": 400`,
+    },
+    {
+      title: 'Disk Usage with Styling',
       code: `treemap-beta
-"Section 1"
-    "Leaf 1.1": 12
-    "Section 1.2"
-      "Leaf 1.2.1": 12
-"Section 2"
-    "Leaf 2.1": 20
-    "Leaf 2.2": 25`,
+"Storage Used"
+    "Media":::warning
+        "Videos": 120
+        "Photos": 80
+        "Music": 25
+    "Documents"
+        "Work": 35
+        "Personal": 15
+    "Apps": 60
+    "System": 40
+
+classDef warning fill:#f96,stroke:#333;`,
     },
   ],
 } satisfies DiagramMetadata;

--- a/packages/examples/src/examples/user-journey.ts
+++ b/packages/examples/src/examples/user-journey.ts
@@ -18,5 +18,21 @@ export default {
       Go downstairs: 5: Me
       Sit down: 5: Me`,
     },
+    {
+      title: 'Online Grocery Shopping',
+      code: `journey
+    title Ordering groceries online
+    section Browse and select
+      Search for items: 6: Customer
+      Compare prices: 4: Customer
+      Add to basket: 7: Customer
+    section Checkout
+      Choose delivery slot: 5: Customer
+      Pay for order: 3: Customer
+    section Fulfilment
+      Pick items in store: 4: Store staff
+      Deliver groceries: 5: Driver
+      Unpack at home: 7: Customer`,
+    },
   ],
 } satisfies DiagramMetadata;

--- a/packages/examples/src/examples/venn.ts
+++ b/packages/examples/src/examples/venn.ts
@@ -6,22 +6,32 @@ export default {
   description: 'Represent relationships in overlapping circles',
   examples: [
     {
-      title: 'Sales Revenue',
+      title: 'Product Sweet Spot',
       isDefault: true,
       code: `venn-beta
-    title "Three overlapping sets"
-    set A
-    set B
-    set C
-    union A,B["AB"]
-    union B,C["BC"]
-    union A,C["AC"]
-    union A,B,C["ABC"]
-    style A,B fill:skyblue
-    style B,C fill:orange
-    style A,C fill:lightgreen
-    style A,B,C fill:white, color:red
-    `,
+    title "Finding the Product Sweet Spot"
+    set Desirable
+    set Feasible
+    set Viable
+    union Desirable,Feasible["Worth prototyping"]
+    union Feasible,Viable["Cheap to run"]
+    union Desirable,Viable["Hard to build"]
+    union Desirable,Feasible,Viable["Sweet spot"]`,
+    },
+    {
+      title: 'Team Skill Overlap with Sizes and Styles',
+      code: `venn-beta
+    title "Where our teams overlap"
+    set FE["Frontend"]:18
+        text fe1["React"]
+        text fe2["CSS"]
+    set BE["Backend"]:22
+        text be1["Databases"]
+        text be2["APIs"]
+    union FE,BE["Full-stack"]:8
+        text fs1["TypeScript"]
+    style FE fill:skyblue
+    style BE fill:lightgreen`,
     },
   ],
 } satisfies DiagramMetadata;

--- a/packages/examples/src/examples/xychart.ts
+++ b/packages/examples/src/examples/xychart.ts
@@ -15,5 +15,33 @@ export default {
     bar [5000, 6000, 7500, 8200, 9500, 10500, 11000, 10200, 9200, 8500, 7000, 6000]
     line [5000, 6000, 7500, 8200, 9500, 10500, 11000, 10200, 9200, 8500, 7000, 6000]`,
     },
+    {
+      title: 'Coffee Sales with Data Labels',
+      code: `---
+config:
+  xyChart:
+    showDataLabel: true
+---
+xychart-beta
+    title "Cups sold per day"
+    x-axis [Espresso, Latte, "Cold Brew", Mocha, Tea]
+    y-axis "Cups" 0 --> 120
+    bar [95, 110, 68, 45, 30]`,
+    },
+    {
+      title: 'Sign-ups vs Churn',
+      code: `---
+config:
+  themeVariables:
+    xyChart:
+      plotColorPalette: '#2563eb, #dc2626'
+---
+xychart-beta
+    title "Sign-ups vs churned users"
+    x-axis [Q1, Q2, Q3, Q4]
+    y-axis "Users" 0 --> 500
+    line [120, 260, 380, 470]
+    line [40, 60, 90, 110]`,
+    },
   ],
 } satisfies DiagramMetadata;


### PR DESCRIPTION
# Enhance `@mermaid-js/examples` with relatable, feature-showcasing examples

## 📑 Summary

Expands the examples package from 38 to 74 examples across all 32 diagram types, so tools like mermaid.live can offer a relatable default plus feature-showcasing alternatives for each diagram.

- **Relatable defaults replace placeholder content**: gantt opens with a product launch plan instead of unnamed 2014 tasks, kanban is a clean sprint board (the old one had duplicate node IDs and test-flavored copy), requirement models an e-bike braking system instead of `test_req`, sankey defaults to a compact budget flow (the 70-line UK energy dataset is kept as a secondary example), venn gets a Desirable/Feasible/Viable sweet spot and loses its mislabeled "Sales Revenue" title, and the ABNF example titled "URI Scheme" now matches its actual email grammar.
- **New examples showcase each diagram's strengths**: flowchart subgraphs and `@{ shape }` syntax, sequence `autonumber`/activations/`alt`/`par`/`loop`, class interfaces + generics + cardinality, state composite states + `<<choice>>` + concurrency, ER `PK`/`FK`/`UK` keys with comments, git tags + cherry-pick, C4 container diagram, architecture junctions, quadrant styled points (Eisenhower matrix), xychart data labels, pie `showData`, radar polygon graticule, packet relative bits, treemap `valueFormat` + `classDef`, railroad EBNF/ABNF/PEG additions including PEG predicates, and more.
- **Validation**:
  - `example.spec.ts` now runs `mermaid.parse()` on every example (75 tests). This caught a real gotcha: requirement `docRef` values cannot contain unquoted hyphens.
  - New Cypress spec `cypress/integration/rendering/examples.spec.ts` renders every example from `diagramData` with snapshot-safe screenshot names, so examples stay render-valid going forward.

Wardley and railroad-IR already had rich multi-example coverage and are unchanged.

## 📏 Design Decisions

- Each diagram keeps exactly one `isDefault` example (enforced by the existing spec), preserving the `getSampleDiagrams()` contract used by mermaid.live.
- The Cypress spec imports `diagramData` from the package source; the bundled TypeScript preprocessor resolves the `.js` specifiers in `index.ts` via `extensionAlias`.
- Screenshot names are sanitized in the spec because example titles may contain characters like `/` (e.g. "CI/CD Pipeline with Subgraphs").

## 📋 Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts.

https://claude.ai/code/session_015rUgHChBEkquLu77fMxmQ6

---
_Generated by [Claude Code](https://claude.ai/code/session_015rUgHChBEkquLu77fMxmQ6)_