### PR TITLE
fix: use stable commit IDs in git graph example

### DIFF
--- a/packages/examples/src/examples/git.ts
+++ b/packages/examples/src/examples/git.ts
@@ -9,20 +9,20 @@ export default {
       title: 'Basic Git Flow',
       isDefault: true,
       code: `gitGraph
-    commit
+    commit id: "a3f82c1"
     branch develop
     checkout develop
-    commit
-    commit
+    commit id: "b7e41d9"
+    commit id: "c9d52e4"
     checkout main
-    merge develop
-    commit
+    merge develop id: "d4e8f3a"
+    commit id: "e1b6c90"
     branch feature
     checkout feature
-    commit
-    commit
+    commit id: "f2a8d17"
+    commit id: "a8c3f54"
     checkout main
-    merge feature`,
+    merge feature id: "b9d7e21"`,
     },
     {
       title: 'Release and Hotfix Workflow',


### PR DESCRIPTION
## Summary
- Assign explicit abbreviated-SHA-style IDs to every commit and merge in the `Basic Git Flow` git graph example (`packages/examples/src/examples/git.ts`)
- Prevents flaky `examples.spec.ts` visual regression snapshots caused by GitGraph's random auto-generated commit IDs

## Test plan
- [x] `pnpm vitest run packages/examples/src/example.spec.ts -t "Git Graph: Basic Git Flow"`
- [ ] CI e2e (`examples.spec.ts` git graph snapshot)


Made with [Cursor](https://cursor.com)