### PR TITLE
test: enforce -beta suffix policy for new diagrams

### DIFF
--- a/.changeset/railroad-diagram-support.md
+++ b/.changeset/railroad-diagram-support.md
@@ -3,4 +3,4 @@
 '@mermaid-js/parser': minor
 ---
 
-feat: Add support for Railroad Diagrams (Syntax Diagrams) with four input syntaxes: IR (railroad-diagram), EBNF (railroad-ebnf), ABNF (railroad-abnf), and PEG (railroad-peg). The IR layer provides direct layout control via function-call primitives, while EBNF, ABNF, and PEG front-ends transform grammar notation into the shared IR for rendering.
+feat: Add support for Railroad Diagrams (Syntax Diagrams) with four input syntaxes: IR (railroad-beta), EBNF (railroad-ebnf-beta), ABNF (railroad-abnf-beta), and PEG (railroad-peg-beta). The IR layer provides direct layout control via function-call primitives, while EBNF, ABNF, and PEG front-ends transform grammar notation into the shared IR for rendering.

--- a/cypress/integration/rendering/railroad/railroad.spec.ts
+++ b/cypress/integration/rendering/railroad/railroad.spec.ts
@@ -8,10 +8,10 @@ function shouldHaveRailroadContent($svg: JQuery<SVGSVGElement>) {
 }
 
 describe('railroad diagrams', () => {
-  describe('IR syntax (railroad-diagram)', () => {
+  describe('IR syntax (railroad-beta)', () => {
     it('renders a simple rule', () => {
       imgSnapshotTest(
-        `railroad-diagram
+        `railroad-beta
 digit = terminal("0") ;
         `,
         {},
@@ -22,7 +22,7 @@ digit = terminal("0") ;
 
     it('renders sequences and choices', () => {
       imgSnapshotTest(
-        `railroad-diagram
+        `railroad-beta
 expression = sequence(
     nonterminal("term"),
     zeroOrMore(choice(
@@ -42,7 +42,7 @@ digit = choice(terminal("0"), terminal("1"), terminal("2")) ;
 
     it('renders optional and repetition operators', () => {
       imgSnapshotTest(
-        `railroad-diagram
+        `railroad-beta
 sign = choice(terminal("+"), terminal("-")) ;
 number = sequence(optional(nonterminal("sign")), oneOrMore(nonterminal("digit"))) ;
 list = sequence(terminal("["), optional(sequence(nonterminal("number"), zeroOrMore(sequence(terminal(","), nonterminal("number"))))), terminal("]")) ;
@@ -56,7 +56,7 @@ digit = choice(terminal("0"), terminal("1"), terminal("2"), terminal("3")) ;
 
     it('renders multiple rules in one diagram', () => {
       imgSnapshotTest(
-        `railroad-diagram
+        `railroad-beta
 json = nonterminal("element") ;
 element = choice(nonterminal("object"), nonterminal("array"), nonterminal("string"), nonterminal("number"), terminal("true"), terminal("false"), terminal("null")) ;
 object = sequence(terminal("{"), optional(sequence(nonterminal("member"), zeroOrMore(sequence(terminal(","), nonterminal("member"))))), terminal("}")) ;
@@ -73,7 +73,7 @@ digit = choice(terminal("0"), terminal("1"), terminal("2"), terminal("3"), termi
 
     it('adapts to dark theme colors', () => {
       imgSnapshotTest(
-        `railroad-diagram
+        `railroad-beta
 value = choice(nonterminal("string"), nonterminal("number"), nonterminal("object"), nonterminal("array"), terminal("true"), terminal("false"), terminal("null")) ;
 number = oneOrMore(nonterminal("digit")) ;
 digit = choice(terminal("0"), terminal("1"), terminal("2"), terminal("3")) ;
@@ -85,10 +85,10 @@ digit = choice(terminal("0"), terminal("1"), terminal("2"), terminal("3")) ;
     });
   });
 
-  describe('EBNF syntax (railroad-ebnf)', () => {
+  describe('EBNF syntax (railroad-ebnf-beta)', () => {
     it('renders sequences and choices', () => {
       imgSnapshotTest(
-        `railroad-ebnf
+        `railroad-ebnf-beta
 expression = term ( "+" term | "-" term )* ;
 term = number | "(" expression ")" ;
 number = digit+ ;
@@ -102,7 +102,7 @@ digit = "0" | "1" | "2" ;
 
     it('renders ISO 14977 notation', () => {
       imgSnapshotTest(
-        `railroad-ebnf
+        `railroad-ebnf-beta
 identifier = letter , { letter | digit | "_" } ;
 letter = "a" | "b" | "c" ;
 digit = "0" | "1" | "2" ;
@@ -114,10 +114,10 @@ digit = "0" | "1" | "2" ;
     });
   });
 
-  describe('ABNF syntax (railroad-abnf)', () => {
+  describe('ABNF syntax (railroad-abnf-beta)', () => {
     it('renders alternation and repetition', () => {
       imgSnapshotTest(
-        `railroad-abnf
+        `railroad-abnf-beta
 scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) ;
 digit = "0" / "1" / "2" / "3" ;
         `,
@@ -128,10 +128,10 @@ digit = "0" / "1" / "2" / "3" ;
     });
   });
 
-  describe('PEG syntax (railroad-peg)', () => {
+  describe('PEG syntax (railroad-peg-beta)', () => {
     it('renders ordered choice and suffixes', () => {
       imgSnapshotTest(
-        `railroad-peg
+        `railroad-peg-beta
 Expression <- Term (("+" / "-") Term)* ;
 Term <- Factor (("*" / "/") Factor)* ;
 Factor <- Number / "(" Expression ")" ;

--- a/cypress/integration/rendering/swimlanes/swimlanes.spec.ts
+++ b/cypress/integration/rendering/swimlanes/swimlanes.spec.ts
@@ -30,7 +30,7 @@ const asStandaloneSwimlanes = (source: string): string => {
   // diagram type directly, so it is rendered as-is. This guard keeps that
   // invariant — a fixture authored as flowchart/graph would fail here.
   expect(source, 'fixture should declare the standalone swimlane diagram type').to.match(
-    /^\s*swimlane\s/m
+    /^\s*swimlane-beta\s/m
   );
   return source;
 };
@@ -117,7 +117,7 @@ describe('Swimlanes diagram', () => {
 
   it('defaults to the swimlanes layout without an explicit layout config', () => {
     renderSwimlanes(
-      `swimlane LR
+      `swimlane-beta LR
         subgraph Intake
           A[Request]
         end
@@ -135,7 +135,7 @@ describe('Swimlanes diagram', () => {
 
   it('applies custom theme variables', () => {
     renderSwimlanes(
-      `swimlane LR
+      `swimlane-beta LR
         subgraph ThemeLane
           A[Themed node]
           B[Next node]
@@ -167,7 +167,7 @@ describe('Swimlanes diagram', () => {
 
   it('applies flowchart style and linkStyle statements', () => {
     renderSwimlanes(
-      `swimlane LR
+      `swimlane-beta LR
         subgraph StyledLane
           A[Styled node]
           B[Linked node]
@@ -195,7 +195,7 @@ describe('Swimlanes diagram', () => {
 
   it('applies classDef and class statements', () => {
     renderSwimlanes(
-      `swimlane LR
+      `swimlane-beta LR
         subgraph ClassLane
           A[Classed node]
           B[Default node]
@@ -218,7 +218,7 @@ describe('Swimlanes diagram', () => {
 
   it('puts nodes without an explicit subgraph into a default swimlane', () => {
     renderSwimlanes(
-      `swimlane LR
+      `swimlane-beta LR
         subgraph OwnedLane
           A[Owned node]
         end

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/1-simple.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/1-simple.mmd
@@ -1,4 +1,4 @@
-swimlane LR
+swimlane-beta LR
       subgraph Dep1
         Start
         Process1

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/1-simple.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/1-simple.sizes.json
@@ -23,7 +23,7 @@
   ],
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "d9e7c899d00f546398de0cb0bd664297aecea10f32c33c4fc3fced902336e2e7",
+    "sourceSha256": "b3bbf73ac4f50d74d2216abee4eaf8cf16ac2cf0b40c1afd9270072bb0130624",
     "capturedAt": "2026-05-06T00:00:00.000Z",
     "capturedFrom": "browser-dev layout-tests/swimlanes/1-simple.mmd theme=default look=classic"
   }

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/10-node-placement.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/10-node-placement.mmd
@@ -1,5 +1,5 @@
 
-swimlane LR
+swimlane-beta LR
 
   subgraph S["Sales"]
     T5["Confirm with customer"]

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/10-node-placement.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/10-node-placement.sizes.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "6f256b5a9eb0983b44dbcee584e104bcf931a9f473b4d30fcfb099adcf44bd8b",
+    "sourceSha256": "28141aec516ccf19595ea7150e9bda09711d8286c43cac1901490e9e5950a57b",
     "capturedAt": "2026-05-07T08:55:30.334Z",
     "capturedFrom": "/knsv3.html"
   },

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/12-disagree-exits-b-c.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/12-disagree-exits-b-c.mmd
@@ -4,7 +4,7 @@ config:
   look: neo
 ---
 
-swimlane TD
+swimlane-beta TD
 subgraph X1
   A(Start)
   B{{B------}}

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/12-disagree-exits-b-c.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/12-disagree-exits-b-c.sizes.json
@@ -88,7 +88,7 @@
   ],
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "e67bec03cc86f09167a8fb061178d113a7a471477fb787fe84f8e3349d44ba12",
+    "sourceSha256": "2f356ee26b02799c57c7ca13a1d56824360c5734038952d9815efbb1df1737fb",
     "capturedAt": "2026-06-08T09:36:41.146Z",
     "capturedFrom": "dev-explorer layout-tests/swimlanes/12-disagree-exits-b-c.mmd theme=redux look=neo layout=swimlane"
   }

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/13-disagree-exits-b-c-d.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/13-disagree-exits-b-c-d.mmd
@@ -4,7 +4,7 @@ config:
   look: neo
 ---
 
-swimlane TD
+swimlane-beta TD
 subgraph X1
   A(Start)
   B{{B------}}

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/13-disagree-exits-b-c-d.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/13-disagree-exits-b-c-d.sizes.json
@@ -93,7 +93,7 @@
   ],
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "4d6dc2fd2e0bfd4ebfea82ff0f6d87d789390f880e13d91e1be3be443915dbb9",
+    "sourceSha256": "8d81773b11c8907c180f985ba2881d1114ca63764b7b0c6abdfb6a57eb3416fa",
     "capturedAt": "2026-06-08T09:36:48.853Z",
     "capturedFrom": "dev-explorer layout-tests/swimlanes/13-disagree-exits-b-c-d.mmd theme=redux look=neo layout=swimlane"
   }

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/14-messy-layout.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/14-messy-layout.mmd
@@ -5,7 +5,7 @@ config:
   swimlane:
     automaticLaneOrdering: true
 ---
-swimlane TD
+swimlane-beta TD
 
 subgraph Requestor
   1([START])

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/14-messy-layout.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/14-messy-layout.sizes.json
@@ -233,7 +233,7 @@
   ],
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "c7f7df1c9a02f12e0e1207fb1f912b8e569dafaf2a7b6262e1a6ca4757402ef6",
+    "sourceSha256": "6b57271592c65dd22ef5279dfba5cd62a60e884a0221eb8bd5f349c7d130e654",
     "capturedAt": "2026-06-08T10:21:30.240Z",
     "capturedFrom": "dev-explorer layout-tests/swimlanes/14-disagree-exits-b-c-d copy.mmd theme=redux look=neo layout=swimlane"
   }

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/15-border-hugging-lr.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/15-border-hugging-lr.mmd
@@ -3,7 +3,7 @@ config:
   theme: redux
   look: neo
 ---
-swimlane LR
+swimlane-beta LR
 
 subgraph Requestor
 

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/15-border-hugging-lr.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/15-border-hugging-lr.sizes.json
@@ -33,7 +33,7 @@
   ],
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "a6badaf541315a18019756fc4aa691ca05d3333d2b9919a319690646e8571e46",
+    "sourceSha256": "02ed2d7a0ab0de85e5f7c8f4b1dbf2df791a6108450abf608dd53ef5970b1e1b",
     "capturedAt": "2026-06-08T13:28:32.834Z",
     "capturedFrom": "dev-explorer layout-tests/swimlanes/15-border-hugging-lr.mmd theme=redux look=neo layout=swimlane"
   }

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/15-border-hugging.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/15-border-hugging.mmd
@@ -3,7 +3,7 @@ config:
   theme: redux
   look: neo
 ---
-swimlane TD
+swimlane-beta TD
 
 subgraph Requestor
 

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/15-border-hugging.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/15-border-hugging.sizes.json
@@ -33,7 +33,7 @@
   ],
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "f1052f7901c1a4f1fa0667ceca4940e84e3b74499540fd5ea4df7cb58e9d7a39",
+    "sourceSha256": "268f27fee5dc35ad2a0ceb02244bc945cd8d8b99c6085244a2f3c931f0c3f4a2",
     "capturedAt": "2026-06-08T12:22:25.692Z",
     "capturedFrom": "dev-explorer layout-tests/swimlanes/15-border-hugging.mmd theme=redux look=neo layout=swimlane"
   }

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/2-decisions-lr.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/2-decisions-lr.mmd
@@ -1,4 +1,4 @@
-swimlane LR
+swimlane-beta LR
         subgraph Dep1
           Start
         end

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/2-decisions-lr.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/2-decisions-lr.sizes.json
@@ -53,7 +53,7 @@
   ],
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "1ba9758d476916676cf551736e3bdb0240d8fa7542ae9d7387c6aa1aa10e5fa4",
+    "sourceSha256": "1f8d434214b88742b169fcbf91dd48e399b28a6a79f12f3c0798559d92e7535b",
     "capturedAt": "2026-05-06T00:00:00.000Z",
     "capturedFrom": "browser-dev layout-tests/swimlanes/2-decisions-lr.mmd theme=default look=classic"
   }

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/3-decisions-tb.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/3-decisions-tb.mmd
@@ -1,4 +1,4 @@
-swimlane LR
+swimlane-beta LR
         subgraph Dep1
           Start
         end

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/3-decisions-tb.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/3-decisions-tb.sizes.json
@@ -53,7 +53,7 @@
   ],
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "1ba9758d476916676cf551736e3bdb0240d8fa7542ae9d7387c6aa1aa10e5fa4",
+    "sourceSha256": "1f8d434214b88742b169fcbf91dd48e399b28a6a79f12f3c0798559d92e7535b",
     "capturedAt": "2026-05-06T00:00:00.000Z",
     "capturedFrom": "browser-dev layout-tests/swimlanes/3-decisions-tb.mmd theme=default look=classic"
   }

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/4-car-fun-sales-tb.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/4-car-fun-sales-tb.mmd
@@ -1,4 +1,4 @@
-swimlane TD
+swimlane-beta TD
         A --> B --> C --> D --> E --> F --> G
         D --> H --> I --Yes--> J --> E
         I --No--> K --> L --> M & N

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/4-car-fun-sales-tb.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/4-car-fun-sales-tb.sizes.json
@@ -83,7 +83,7 @@
   ],
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "2e3daf42a3ae6af442c5964285d122054528c39521de776aaa0b570a287d35de",
+    "sourceSha256": "ea3409d1caf4b9082ae19f6eacd36c099b8fb31ef63296d6b207532a6f55dead",
     "capturedAt": "2026-05-06T00:00:00.000Z",
     "capturedFrom": "browser-dev layout-tests/swimlanes/4-car-fun-sales-tb.mmd theme=default look=classic"
   }

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/5-car-fun-sales-wide-tb.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/5-car-fun-sales-wide-tb.mmd
@@ -5,7 +5,7 @@ config:
     ignoreCrossLaneEdges: true
     optimizeRanksByCrossings: true
 ---
-swimlane TD
+swimlane-beta TD
         A --> B --> C --> D --> E --> F --> G
         D --> H --> I --Yes but with a long label that will wrap to the next line --> J --> E
         I -- No --> K --> L --> M & N

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/5-car-fun-sales-wide-tb.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/5-car-fun-sales-wide-tb.sizes.json
@@ -83,7 +83,7 @@
   ],
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "bb29b03b0c38f52a81d2ccc19b2fe4c2b901a68458a740001927361f58bfa61d",
+    "sourceSha256": "33ceffa6ec79bb0004b59fbb094344072ec670195df4fb91790f56a888da4493",
     "capturedAt": "2026-05-06T00:00:00.000Z",
     "capturedFrom": "browser-dev layout-tests/swimlanes/5-car-fun-sales-wide-tb.mmd theme=default look=classic"
   }

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/6-legal-constr-sales.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/6-legal-constr-sales.mmd
@@ -1,5 +1,5 @@
 
-swimlane LR
+swimlane-beta LR
         A --> B --> C --> D --> E --> F --> G
         D --> H --> I --Yes but with a long label that will wrap to the next line --> J --> E
         I -- No --> K --> L --> M & N

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/6-legal-constr-sales.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/6-legal-constr-sales.sizes.json
@@ -83,7 +83,7 @@
   ],
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "0401ee1f841a77569fe7d074ac009e635b1a4882a64a8522aabb238fcf6da6aa",
+    "sourceSha256": "1fb52bacc99e19806933bc7cccbd2d70028fad6d98bfa6d52b90fe505da0b836",
     "capturedAt": "2026-05-29T06:27:24.032Z",
     "capturedFrom": "dev-explorer layout-tests/swimlanes/6-legal-constr-sales.mmd theme=redux-dark look=classic layout=swimlane"
   }

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/7-car-sales-constr.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/7-car-sales-constr.mmd
@@ -5,7 +5,7 @@ config:
     ignoreCrossLaneEdges: true
     optimizeRanksByCrossings: true
 ---
-swimlane TD
+swimlane-beta TD
         A --> B --> C --> D --> E --> F --> G
         D --> H --> I --Yes--> J --> E
         I --No--> K --> L --> M & N

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/7-car-sales-constr.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/7-car-sales-constr.sizes.json
@@ -83,7 +83,7 @@
   ],
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "f0ab245ef6cf9bf1d802a6b9a26bdea0559f4c5e58472618f5b3af95fb90d56e",
+    "sourceSha256": "e09627ba3cdfba2ec7bfabf47128876d29a62f5cf0a9dad02052efd3854d6336",
     "capturedAt": "2026-05-06T00:00:00.000Z",
     "capturedFrom": "browser-dev layout-tests/swimlanes/7-car-sales-constr.mmd theme=default look=classic"
   }

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/8-query-process-2.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/8-query-process-2.mmd
@@ -2,7 +2,7 @@
 config:
   layout: swimlane
 ---
-swimlane LR
+swimlane-beta LR
 
   subgraph StatusSeeker
     A(Incoming query)

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/8-query-process-2.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/8-query-process-2.sizes.json
@@ -73,7 +73,7 @@
   ],
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "b3e0e1217c6ab7d04a3fc8e850ab02cdcabc41a450833b424f28ba4d7ced54c2",
+    "sourceSha256": "9bc9c74eca6bca18996067bc89ba5ffd5ce092e6ade93020827d9923d8e53e57",
     "capturedAt": "2026-05-06T00:00:00.000Z",
     "capturedFrom": "browser-dev layout-tests/swimlanes/8-query-process-2.mmd theme=default look=classic"
   }

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/9-edge-labels.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/9-edge-labels.mmd
@@ -1,4 +1,4 @@
-      swimlane LR
+      swimlane-beta LR
       subgraph Dep1
         Start
         Process1

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/commant.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/commant.mmd
@@ -1,4 +1,4 @@
-swimlane LR
+swimlane-beta LR
    subgraph customer
     sales_process(sales_process: sales process)
     places_order[places order]

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/commant.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/commant.sizes.json
@@ -68,7 +68,7 @@
   ],
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "ed3c491640227e605745e34439fa409718885dcf71e4c40d4d9296d3761cf2fd",
+    "sourceSha256": "1e455f5516f2383d9f328b39db36392a66ad7c1ffe6a0f66b39ea82d8ad74f20",
     "capturedAt": "2026-05-29T12:24:36.365Z",
     "capturedFrom": "dev-explorer layout-tests/swimlanes/commant.mmd theme=redux-dark look=neo layout=swimlane"
   }

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/intake-review-complete.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/intake-review-complete.mmd
@@ -1,4 +1,4 @@
-swimlane LR
+swimlane-beta LR
   subgraph Intake
     start([Start])
     task[Do work]

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/intake-review-complete.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/intake-review-complete.sizes.json
@@ -38,7 +38,7 @@
   ],
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "ff52d9063be4e293f5db4e34e06cc9b7a96a3ce29f2927a416ee04ed711f5a22",
+    "sourceSha256": "aa3016964e4787fc4f09e0f38d9255cc0906cdd7c32aded850d5bab023f22491",
     "capturedAt": "2026-05-29T10:37:56.108Z",
     "capturedFrom": "dev-explorer layout-tests/swimlanes/intake-review-complete.mmd theme=redux-dark look=classic layout=swimlane"
   }

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/issue-7802-1.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/issue-7802-1.mmd
@@ -1,4 +1,4 @@
-swimlane TD
+swimlane-beta TD
 subgraph X1
   A(Start)
   B{{B------}}

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/issue-7802-1.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/issue-7802-1.sizes.json
@@ -63,7 +63,7 @@
   ],
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "cc4bec97bf6971bee5525737e5e2850d96d2b4b66e9bde25cb836f90a911c7bf",
+    "sourceSha256": "6c48d0063206cfac5234912c87899368ba6ac322049f04516790f550f191bf85",
     "capturedAt": "2026-06-04T14:52:29.021Z",
     "capturedFrom": "dev-explorer layout-tests/swimlanes/issue-7802-1.mmd theme=default look=classic layout=swimlane"
   }

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/issue-7802-2.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/issue-7802-2.mmd
@@ -1,4 +1,4 @@
-swimlane TD
+swimlane-beta TD
 subgraph X1
   A(Start)
   B{{B------}}

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/issue-7802-2.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/issue-7802-2.sizes.json
@@ -63,7 +63,7 @@
   ],
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "2eb22285dd1d974aad93ea56e167849ed9437d6be11c8e796eb6a468bd41c975",
+    "sourceSha256": "a958c46601bd99673e01b684f37dd23a638ef182060fca49ec694f207c8af948",
     "capturedAt": "2026-06-04T14:52:33.048Z",
     "capturedFrom": "dev-explorer layout-tests/swimlanes/issue-7802-2.mmd theme=default look=classic layout=swimlane"
   }

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/issue-7802-3.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/issue-7802-3.mmd
@@ -1,4 +1,4 @@
-swimlane TD
+swimlane-beta TD
 subgraph X1
   A(Start)
   B{{B------}}

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/issue-7802-3.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/issue-7802-3.sizes.json
@@ -63,7 +63,7 @@
   ],
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "e6b10764d5844f763477600cb8182346595741ef7d934e24d95d70cb1daf0198",
+    "sourceSha256": "1f9e023d45b37b419ef39191e5537127a1a3ead970292409564c27a673853358",
     "capturedAt": "2026-06-04T14:52:35.520Z",
     "capturedFrom": "dev-explorer layout-tests/swimlanes/issue-7802-3.mmd theme=default look=classic layout=swimlane"
   }

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/issue-7802-4.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/issue-7802-4.mmd
@@ -3,7 +3,7 @@ config:
   theme: redux
   look: neo
 ---
-  swimlane TD
+  swimlane-beta TD
 subgraph X1
   A(Start)
   B{{B------}}

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/issue-7802-4.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/issue-7802-4.sizes.json
@@ -83,7 +83,7 @@
   ],
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "559c7a98e2d4a94ad98e5c07b8157d548a17702bcb3d221ea461a838a145ae87",
+    "sourceSha256": "dec5891c8b38fb6e3ae57798f8fe9dc1a60a095f127e40fdf9a514f91efbbcf6",
     "capturedAt": "2026-06-05T08:18:05.928Z",
     "capturedFrom": "dev-explorer layout-tests/swimlanes/issue-7802-4.mmd theme=default look=classic layout=swimlane"
   }

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/issue-7802-5.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/issue-7802-5.mmd
@@ -1,4 +1,4 @@
-swimlane TD
+swimlane-beta TD
 subgraph X1
   A(Start)
   B{{B------}}

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/issue-7802-5.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/issue-7802-5.sizes.json
@@ -83,7 +83,7 @@
   ],
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "a6bb7d9af3548fa4947460fd2993845bf512218d3b8d4ba47559cbccfdfc1a53",
+    "sourceSha256": "8aac33d59d633f95d8acf6eeb29c3bb3ebebd2736482197a1da68fd763ee3d7f",
     "capturedAt": "2026-06-05T08:18:08.534Z",
     "capturedFrom": "dev-explorer layout-tests/swimlanes/issue-7802-5.mmd theme=default look=classic layout=swimlane"
   }

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/issue-7802-6.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/issue-7802-6.mmd
@@ -1,4 +1,4 @@
-swimlane TD
+swimlane-beta TD
 subgraph X1
   A(Start)
   B{{B------}}

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/mermaid-work.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/mermaid-work.mmd
@@ -5,7 +5,7 @@ config:
     ignoreCrossLaneEdges: false
     optimizeRanksByCrossings: false
 ---
-swimlane LR
+swimlane-beta LR
 
   subgraph L1[Community / Users]
     A1[Report issue]

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/mermaid-work.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/mermaid-work.sizes.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "94a2db152e5f3e04e36778482ec2190637dd518d6934e7138f8210af75d8f092",
+    "sourceSha256": "4b6422acfb3b81e1e808b0e63741e8940a424dc1483863c6e6b9758882060340",
     "capturedAt": "2026-05-06T11:53:21.591Z",
     "capturedFrom": "/knsv3.html"
   },

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/pebr-1-duplicate-process-in-substate-no-render.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/pebr-1-duplicate-process-in-substate-no-render.mmd
@@ -1,4 +1,4 @@
-swimlane LR
+swimlane-beta LR
       subgraph Dep1
         Start
         Process1

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/pebr-1-duplicate-process-in-substate-no-render.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/pebr-1-duplicate-process-in-substate-no-render.sizes.json
@@ -33,7 +33,7 @@
   ],
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "434bf2aad8953355312cd350787b9540b2ab912132b30e135b807b5f55d6862a",
+    "sourceSha256": "84d5000d82dff5c7df93bc1ecf5d376fe7ac87cfa7ac1ef947937fc496defe43",
     "capturedAt": "2026-06-08T13:52:23.183Z",
     "capturedFrom": "dev-explorer layout-tests/swimlanes/pebr-1-duplicate-process-in-substate-no-render.mmd theme=default look=classic layout=swimlane"
   }

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/pebr-2-edge-intrudes-lane-label.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/pebr-2-edge-intrudes-lane-label.mmd
@@ -1,4 +1,4 @@
-swimlane LR
+swimlane-beta LR
       subgraph Dep1
         Dep1.Proc1
         Dep1.Proc2

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/pebr-3-process-too-wide-in-lane.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/pebr-3-process-too-wide-in-lane.mmd
@@ -1,4 +1,4 @@
-swimlane TD
+swimlane-beta TD
       subgraph Dep1
         Dep1.Proc1
         Dep1.Proc2

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/pebr-3-process-too-wide-in-lane.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/pebr-3-process-too-wide-in-lane.sizes.json
@@ -18,7 +18,7 @@
   ],
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "8e84d859eb98c49922319eb014a582d03860ebf74bd607e5345e12d624db64af",
+    "sourceSha256": "c5e0670f5ee0282f9c324b689073e847e07a8e1b6ba34b841745e89e9b37d47e",
     "capturedAt": "2026-06-08T14:18:15.818Z",
     "capturedFrom": "dev-explorer layout-tests/swimlanes/pebr-3-process-too-wide-in-lane.mmd theme=default look=classic layout=swimlane"
   }

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/query-process.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/query-process.mmd
@@ -5,7 +5,7 @@ config:
     ignoreCrossLaneEdges: true
     optimizeRanksByCrossings: true
 ---
-swimlane LR
+swimlane-beta LR
 
 
 

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/query-process.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/query-process.sizes.json
@@ -73,7 +73,7 @@
   ],
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "23bb4c13ae0accdcd55407c590fe9d684b901d1fee09ae3d04ad18458f95f2d6",
+    "sourceSha256": "7c679a22697d2cff0229cf82d5ad064870a64473a4c452a4e8fb8114cbb3b6dd",
     "capturedAt": "2026-05-06T00:00:00.000Z",
     "capturedFrom": "browser-dev layout-tests/swimlanes/query-process.mmd theme=default look=classic"
   }

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/sales-process.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/sales-process.mmd
@@ -1,4 +1,4 @@
-swimlane LR
+swimlane-beta LR
   subgraph C["Customer"]
     C1(["Customer requests help or reports errors"])
     C2["More feedback"]

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/simple-2.mmd
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/simple-2.mmd
@@ -1,4 +1,4 @@
-      swimlane TD
+      swimlane-beta TD
 
         subgraph lane1
         B

--- a/cypress/platform/dev-diagrams/layout-tests/swimlanes/simple-2.sizes.json
+++ b/cypress/platform/dev-diagrams/layout-tests/swimlanes/simple-2.sizes.json
@@ -38,7 +38,7 @@
   ],
   "metadata": {
     "captureVersion": 1,
-    "sourceSha256": "0bbb903f55ea4e8d9bdf3d662c06275d728529e986e65a10ac3f103123679850",
+    "sourceSha256": "ed7c3818d0b785b1f753ef7ee3a2f8d36a76f987f4678e2e92600531cf6f4802",
     "capturedAt": "2026-05-06T00:00:00.000Z",
     "capturedFrom": "browser-dev layout-tests/swimlanes/simple-2.mmd theme=default look=classic"
   }

--- a/cypress/platform/knsv3.html
+++ b/cypress/platform/knsv3.html
@@ -409,7 +409,7 @@ flowchart LR
 
     </pre>
     <pre class="mermaid">
-swimlane LR
+swimlane-beta LR
   subgraph Customer
     request[Request service]
     receive[Receive update]

--- a/demos/railroad.html
+++ b/demos/railroad.html
@@ -16,13 +16,13 @@
     <h1>Railroad diagram demos</h1>
 
     <pre class="mermaid">
-railroad-diagram
+railroad-beta
 digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
     </pre>
     <hr />
 
     <pre class="mermaid">
-railroad-diagram
+railroad-beta
 title "Identifier Grammar"
 
 identifier = letter ( letter | digit | "_" )* ;
@@ -32,7 +32,7 @@ digit = "0" | "1" | "2" ;
     <hr />
 
     <pre class="mermaid">
-railroad-diagram
+railroad-beta
 title "Optional Sign"
 
 sign = "+" | "-" ;
@@ -42,7 +42,7 @@ digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
     <hr />
 
     <pre class="mermaid">
-railroad-diagram
+railroad-beta
 title "Expression Grammar"
 
 expression = term ( ( "+" | "-" ) term )* ;
@@ -54,7 +54,7 @@ digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
     <hr />
 
     <pre class="mermaid">
-railroad-diagram
+railroad-beta
 title "JSON Grammar"
 
 json = element ;
@@ -66,7 +66,7 @@ member = string ":" element ;
     <hr />
 
     <pre class="mermaid">
-railroad-diagram
+railroad-beta
 title "URL Grammar"
 
 url = protocol "://" domain path? ;
@@ -78,7 +78,7 @@ path = "/" segment ( "/" segment )* ;
     <hr />
 
     <pre class="mermaid">
-railroad-diagram
+railroad-beta
 title "ISO Style Notation"
 
 list = "[" element { "," element } "]" ;
@@ -89,7 +89,7 @@ digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
     <hr />
 
     <pre class="mermaid">
-railroad-diagram
+railroad-beta
 title "BNF Style Definition"
 
 rule ::= "A" | "B" ;

--- a/docs/syntax/railroad.md
+++ b/docs/syntax/railroad.md
@@ -6,63 +6,68 @@
 
 # Railroad Diagrams (v\<MERMAID_RELEASE_VERSION>+)
 
-> Railroad diagrams (also known as syntax diagrams or grammar diagrams) are a visual representation of context-free grammars using EBNF (Extended Backus-Naur Form) notation. They provide a graphical way to understand and document language syntax, making complex grammar rules easier to comprehend.
+> Railroad diagrams (also known as syntax diagrams or grammar diagrams) are a visual representation of context-free grammars. They provide a graphical way to understand and document language syntax, making complex grammar rules easier to comprehend.
 
 Railroad diagrams were first popularized by Niklaus Wirth in his "Pascal User Manual" (1974) and remain widely used today, notably on [JSON.org](https://www.json.org/) for documenting the JSON syntax.
 
-Mermaid can render Railroad diagram visualizations from EBNF notation.
+Mermaid can render railroad diagrams from several grammar notations. Pick the keyword that matches the notation you want to write in:
+
+| Diagram type    | Keyword              | Notation                                                                         |
+| --------------- | -------------------- | -------------------------------------------------------------------------------- |
+| EBNF            | `railroad-ebnf-beta` | Extended Backus–Naur Form (W3C and ISO 14977 styles)                             |
+| ABNF            | `railroad-abnf-beta` | Augmented Backus–Naur Form (RFC 5234)                                            |
+| PEG             | `railroad-peg-beta`  | Parsing Expression Grammar                                                       |
+| IR (primitives) | `railroad-beta`      | Mermaid's railroad intermediate representation, written as explicit constructors |
 
 ```mermaid-example
-railroad-beta
+railroad-ebnf-beta
 title "Digit Definition"
 
 digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
 ```
 
 ```mermaid
-railroad-beta
+railroad-ebnf-beta
 title "Digit Definition"
 
 digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
 ```
 
-## Syntax
+## Common Structure
 
-Railroad diagrams use EBNF (Extended Backus-Naur Form) notation to define grammar rules. Mermaid supports both W3C and ISO 14977 EBNF notation styles.
+All four diagram types share the same outer structure:
 
-### Basic Structure
+- Start with the diagram-type keyword on the first line (for example `railroad-ebnf-beta`).
+- Optionally add a `title` followed by a string.
+- Optionally add `accTitle:` and `accDescr:` for accessibility metadata.
+- Define one grammar rule per statement; each rule ends with a semicolon (`;`).
 
-- Start with `railroad-beta` keyword to begin the diagram
-- Optionally add a `title` followed by a quoted string
-- Define grammar rules using the format: `rule_name = definition ;`
-- Each rule must end with a semicolon (`;`)
+The rule assignment operator and the operators used inside a definition depend on the notation, and are described per type below.
 
-### EBNF Notation
+## EBNF (`railroad-ebnf-beta`)
 
-#### Terminals and Non-terminals
+EBNF (Extended Backus-Naur Form) is the most common notation. Mermaid supports both W3C and ISO 14977 EBNF styles. Rules are written as `rule_name = definition ;` (the `::=` assignment operator is also accepted).
 
-Terminals are literal strings enclosed in quotes:
+### Terminals and Non-terminals
 
-- `"text"` - double quotes
-- `'text'` - single quotes
+Terminals are literal strings enclosed in quotes; non-terminals are identifiers that reference other rules:
 
-Non-terminals are identifiers that reference other rules:
-
-- `identifier` - references another rule
+- `"text"` or `'text'` - terminal (literal string)
+- `identifier` - non-terminal (rule reference)
 
 ```mermaid-example
-railroad-beta
+railroad-ebnf-beta
 letter = "a" | "b" | "c" ;
 identifier = letter ;
 ```
 
 ```mermaid
-railroad-beta
+railroad-ebnf-beta
 letter = "a" | "b" | "c" ;
 identifier = letter ;
 ```
 
-#### Sequence (Concatenation)
+### Sequence (Concatenation)
 
 Elements appearing one after another define a sequence:
 
@@ -70,30 +75,30 @@ Elements appearing one after another define a sequence:
 - ISO 14977 notation: `A , B , C`
 
 ```mermaid-example
-railroad-beta
+railroad-ebnf-beta
 greeting = "Hello" " " "World" ;
 ```
 
 ```mermaid
-railroad-beta
+railroad-ebnf-beta
 greeting = "Hello" " " "World" ;
 ```
 
-#### Choice (Alternation)
+### Choice (Alternation)
 
 The pipe symbol (`|`) indicates alternatives:
 
 ```mermaid-example
-railroad-beta
+railroad-ebnf-beta
 sign = "+" | "-" ;
 ```
 
 ```mermaid
-railroad-beta
+railroad-ebnf-beta
 sign = "+" | "-" ;
 ```
 
-#### Optional Elements
+### Optional Elements
 
 Optional elements can appear zero or one time:
 
@@ -101,7 +106,7 @@ Optional elements can appear zero or one time:
 - ISO 14977 notation: `[ A ]`
 
 ```mermaid-example
-railroad-beta
+railroad-ebnf-beta
 title "Optional Sign"
 
 sign = "+" | "-" ;
@@ -110,7 +115,7 @@ digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
 ```
 
 ```mermaid
-railroad-beta
+railroad-ebnf-beta
 title "Optional Sign"
 
 sign = "+" | "-" ;
@@ -118,7 +123,7 @@ number = sign? digit+ ;
 digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
 ```
 
-#### Repetition
+### Repetition
 
 Zero or more repetitions:
 
@@ -130,7 +135,7 @@ One or more repetitions:
 - W3C notation: `A+`
 
 ```mermaid-example
-railroad-beta
+railroad-ebnf-beta
 title "Identifier with Repetition"
 
 identifier = letter ( letter | digit | "_" )* ;
@@ -139,7 +144,7 @@ digit = "0" | "1" | "2" ;
 ```
 
 ```mermaid
-railroad-beta
+railroad-ebnf-beta
 title "Identifier with Repetition"
 
 identifier = letter ( letter | digit | "_" )* ;
@@ -147,71 +152,61 @@ letter = "a" | "b" | "c" | "d" | "e" ;
 digit = "0" | "1" | "2" ;
 ```
 
-#### Grouping
+### Grouping
 
 Parentheses group elements together:
 
-- `( A B )`
-
 ```mermaid-example
-railroad-beta
+railroad-ebnf-beta
 expression = term ( ( "+" | "-" ) term )* ;
 term = "number" ;
 ```
 
 ```mermaid
-railroad-beta
+railroad-ebnf-beta
 expression = term ( ( "+" | "-" ) term )* ;
 term = "number" ;
 ```
 
-#### Comments
+### Comments
 
-Comments can be added using either style:
+Comments can be added using either style and are ignored during parsing:
 
 - W3C notation: `/* comment */`
 - ISO 14977 notation: `(* comment *)`
 
-Comments are ignored during parsing and do not appear in the rendered diagram.
-
-#### Special Sequences
+### Special Sequences
 
 Special sequences (ISO 14977 only) describe elements that cannot be easily expressed in EBNF:
 
 - `? description ?`
 
-#### Exception
+### Exception
 
 The minus operator excludes certain alternatives:
 
 - `A - B` (match A but not B)
 
-## Examples
+### EBNF Notation Reference
 
-### Simple Number Grammar
+| Feature         | W3C Notation         | ISO 14977 Notation   | Description      |
+| --------------- | -------------------- | -------------------- | ---------------- |
+| Terminal        | `"text"` or `'text'` | `"text"` or `'text'` | Literal string   |
+| Non-terminal    | `identifier`         | `identifier`         | Rule reference   |
+| Sequence        | `A B`                | `A , B`              | Concatenation    |
+| Choice          | `A \| B`             | `A \| B`             | Alternative      |
+| Optional        | `A?`                 | `[ A ]`              | Zero or one      |
+| Repetition (0+) | `A*`                 | `{ A }`              | Zero or more     |
+| Repetition (1+) | `A+`                 | -                    | One or more      |
+| Grouping        | `( A B )`            | `( A B )`            | Group elements   |
+| Comment         | `/* text */`         | `(* text *)`         | Comment          |
+| Special         | -                    | `? text ?`           | Special sequence |
+| Exception       | `A - B`              | `A - B`              | Exclusion        |
 
-```mermaid-example
-railroad-beta
-title "Number Grammar"
-
-sign = "+" | "-" ;
-number = sign? digit+ ;
-digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
-```
-
-```mermaid
-railroad-beta
-title "Number Grammar"
-
-sign = "+" | "-" ;
-number = sign? digit+ ;
-digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
-```
-
-### Expression Grammar
+### EBNF Examples
 
 ```mermaid-example
-railroad-beta
+railroad-ebnf-beta
 title "Arithmetic Expression Grammar"
 
 expression = term ( ( "+" | "-" ) term )* ;
@@ -222,7 +217,7 @@ digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
 ```
 
 ```mermaid
-railroad-beta
+railroad-ebnf-beta
 title "Arithmetic Expression Grammar"
 
 expression = term ( ( "+" | "-" ) term )* ;
@@ -232,10 +227,8 @@ number = digit+ ;
 digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
 ```
 
-### JSON Grammar (Simplified)
-
 ```mermaid-example
-railroad-beta
+railroad-ebnf-beta
 title "JSON Grammar"
 
 json = element ;
@@ -246,7 +239,7 @@ member = string ":" element ;
 ```
 
 ```mermaid
-railroad-beta
+railroad-ebnf-beta
 title "JSON Grammar"
 
 json = element ;
@@ -256,34 +249,174 @@ array = "[" [ element ( "," element )* ] "]" ;
 member = string ":" element ;
 ```
 
-### URL Grammar
+## ABNF (`railroad-abnf-beta`)
+
+ABNF (Augmented Backus-Naur Form, [RFC 5234](https://datatracker.ietf.org/doc/html/rfc5234)) is widely used in IETF specifications. Rules are written as `name = definition ;`.
+
+- Alternation uses `/` (instead of `|`): `A / B`
+- Concatenation is whitespace-separated: `A B`
+- Repetition uses a prefix: `*A` (zero or more), `1*A` (one or more), `2*4A` (between 2 and 4), `3A` (exactly 3)
+- Grouping uses parentheses: `( A B )`
+- Optional groups use brackets: `[ A ]`
+- Terminals can be quoted strings (`"text"`) or numeric values (`%x41`, `%d65`, `%b1000001`, including ranges like `%x30-39`)
+- Comments start with `;` and run to the end of the line
+
+```mermaid-example
+railroad-abnf-beta
+title "Email Address"
+
+address = local-part "@" domain ;
+local-part = 1*( ALPHA / DIGIT / "." / "-" ) ;
+domain = label *( "." label ) ;
+label = 1*( ALPHA / DIGIT / "-" ) ;
+```
+
+```mermaid
+railroad-abnf-beta
+title "Email Address"
+
+address = local-part "@" domain ;
+local-part = 1*( ALPHA / DIGIT / "." / "-" ) ;
+domain = label *( "." label ) ;
+label = 1*( ALPHA / DIGIT / "-" ) ;
+```
+
+```mermaid-example
+railroad-abnf-beta
+title "Phone Number"
+
+phone = [ "+" country-code ] subscriber ;
+country-code = 1*DIGIT ;
+subscriber = 1*( DIGIT / "-" / " " ) ;
+```
+
+```mermaid
+railroad-abnf-beta
+title "Phone Number"
+
+phone = [ "+" country-code ] subscriber ;
+country-code = 1*DIGIT ;
+subscriber = 1*( DIGIT / "-" / " " ) ;
+```
+
+## PEG (`railroad-peg-beta`)
+
+PEG (Parsing Expression Grammar) describes recursive-descent parsers with ordered choice. Rules are written as `Name <- definition ;`.
+
+- Ordered choice uses `/`: `A / B` (tries `A` first, then `B`)
+- Sequence is whitespace-separated: `A B`
+- Suffix operators: `A?` (optional), `A*` (zero or more), `A+` (one or more)
+- Prefix predicates: `&A` (and-predicate, lookahead), `!A` (not-predicate, negative lookahead)
+- Grouping uses parentheses: `( A B )`
+- `.` matches any single character
+- Terminals are quoted strings (`"text"` or `'text'`)
+- Comments start with `#` and run to the end of the line
+
+```mermaid-example
+railroad-peg-beta
+title "Calculator Grammar"
+
+Expression <- Term (("+" / "-") Term)* ;
+Term <- Factor (("*" / "/") Factor)* ;
+Factor <- Number / "(" Expression ")" ;
+Number <- Digit+ ;
+Digit <- "0" / "1" / "2" / "3" / "4" / "5" / "6" / "7" / "8" / "9" ;
+```
+
+```mermaid
+railroad-peg-beta
+title "Calculator Grammar"
+
+Expression <- Term (("+" / "-") Term)* ;
+Term <- Factor (("*" / "/") Factor)* ;
+Factor <- Number / "(" Expression ")" ;
+Number <- Digit+ ;
+Digit <- "0" / "1" / "2" / "3" / "4" / "5" / "6" / "7" / "8" / "9" ;
+```
+
+```mermaid-example
+railroad-peg-beta
+title "Identifiers (keywords excluded)"
+
+Identifier <- !Keyword Letter Letter* ;
+Keyword <- "if" / "else" / "while" ;
+Letter <- "a" / "b" / "c" / "_" ;
+```
+
+```mermaid
+railroad-peg-beta
+title "Identifiers (keywords excluded)"
+
+Identifier <- !Keyword Letter Letter* ;
+Keyword <- "if" / "else" / "while" ;
+Letter <- "a" / "b" / "c" / "_" ;
+```
+
+## IR Primitives (`railroad-beta`)
+
+The `railroad-beta` keyword uses Mermaid's railroad intermediate representation directly. Instead of a grammar notation, each construct is written as an explicit constructor. This gives you direct control over the rendered structure and is useful when you want a layout that does not map cleanly onto a single grammar notation. Rules are written as `rule_name = expression ;`.
+
+| Constructor           | Meaning                       |
+| --------------------- | ----------------------------- |
+| `terminal("text")`    | Terminal (literal string)     |
+| `nonterminal("name")` | Non-terminal (rule reference) |
+| `sequence(a, b, ...)` | Elements in sequence          |
+| `choice(a, b, ...)`   | Alternatives                  |
+| `optional(a)`         | Zero or one                   |
+| `zeroOrMore(a)`       | Zero or more                  |
+| `oneOrMore(a)`        | One or more                   |
+| `special("text")`     | Special sequence              |
 
 ```mermaid-example
 railroad-beta
-title "URL Grammar"
+title Expression Grammar
 
-url = protocol "://" domain path? ;
-protocol = "http" | "https" | "ftp" ;
-domain = label ( "." label )* ;
-label = letter ( letter | digit | "-" )* ;
-path = "/" segment ( "/" segment )* ;
-letter = "a" | "b" | "c" ;
-digit = "0" | "1" | "2" ;
-segment = letter+ ;
+expression = sequence(
+    nonterminal("term"),
+    zeroOrMore(sequence(
+        choice(terminal("+"), terminal("-")),
+        nonterminal("term")
+    ))
+) ;
+term = sequence(
+    nonterminal("factor"),
+    zeroOrMore(sequence(
+        choice(terminal("*"), terminal("/")),
+        nonterminal("factor")
+    ))
+) ;
+factor = choice(
+    nonterminal("number"),
+    sequence(terminal("("), nonterminal("expression"), terminal(")"))
+) ;
+number = oneOrMore(nonterminal("digit")) ;
+digit = choice(terminal("0"), terminal("1"), terminal("2"), terminal("3"), terminal("4"), terminal("5"), terminal("6"), terminal("7"), terminal("8"), terminal("9")) ;
 ```
 
 ```mermaid
 railroad-beta
-title "URL Grammar"
+title Expression Grammar
 
-url = protocol "://" domain path? ;
-protocol = "http" | "https" | "ftp" ;
-domain = label ( "." label )* ;
-label = letter ( letter | digit | "-" )* ;
-path = "/" segment ( "/" segment )* ;
-letter = "a" | "b" | "c" ;
-digit = "0" | "1" | "2" ;
-segment = letter+ ;
+expression = sequence(
+    nonterminal("term"),
+    zeroOrMore(sequence(
+        choice(terminal("+"), terminal("-")),
+        nonterminal("term")
+    ))
+) ;
+term = sequence(
+    nonterminal("factor"),
+    zeroOrMore(sequence(
+        choice(terminal("*"), terminal("/")),
+        nonterminal("factor")
+    ))
+) ;
+factor = choice(
+    nonterminal("number"),
+    sequence(terminal("("), nonterminal("expression"), terminal(")"))
+) ;
+number = oneOrMore(nonterminal("digit")) ;
+digit = choice(terminal("0"), terminal("1"), terminal("2"), terminal("3"), terminal("4"), terminal("5"), terminal("6"), terminal("7"), terminal("8"), terminal("9")) ;
 ```
 
 ## Visual Elements
@@ -305,33 +438,19 @@ Railroad diagrams inherit colors and typography from the active Mermaid theme by
 
 - The hand-drawn look (`look: handDrawn`) is not currently supported for railroad diagrams.
 
-## Notation Reference
-
-| Feature         | W3C Notation         | ISO 14977 Notation   | Description      |
-| --------------- | -------------------- | -------------------- | ---------------- |
-| Terminal        | `"text"` or `'text'` | `"text"` or `'text'` | Literal string   |
-| Non-terminal    | `identifier`         | `identifier`         | Rule reference   |
-| Sequence        | `A B`                | `A , B`              | Concatenation    |
-| Choice          | `A \| B`             | `A \| B`             | Alternative      |
-| Optional        | `A?`                 | `[ A ]`              | Zero or one      |
-| Repetition (0+) | `A*`                 | `{ A }`              | Zero or more     |
-| Repetition (1+) | `A+`                 | -                    | One or more      |
-| Grouping        | `( A B )`            | `( A B )`            | Group elements   |
-| Comment         | `/* text */`         | `(* text *)`         | Comment          |
-| Special         | -                    | `? text ?`           | Special sequence |
-| Exception       | `A - B`              | `A - B`              | Exclusion        |
-
 ## Best Practices
 
 1. Keep rules simple: Break complex rules into smaller, reusable components
 2. Use meaningful names: Choose descriptive names for non-terminals
 3. Add titles: Use the `title` keyword to provide context for the grammar
 4. Group related rules: Define related grammar rules together
-5. Use consistent notation: Stick to either W3C or ISO 14977 notation style throughout your diagram
+5. Use consistent notation: Stick to one notation (and its matching keyword) throughout your diagram
 
 ## References
 
 - [ISO/IEC 14977:1996 - EBNF Standard](https://www.cl.cam.ac.uk/~mgk25/iso-14977.pdf)
 - [W3C EBNF Notation](https://www.w3.org/TR/xml/#sec-notation)
+- [RFC 5234 - Augmented BNF for Syntax Specifications (ABNF)](https://datatracker.ietf.org/doc/html/rfc5234)
+- [Parsing Expression Grammars (Bryan Ford, 2004)](https://bford.info/pub/lang/peg.pdf)
 - [Wikipedia: Extended Backus-Naur Form](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form)
 - [Wikipedia: Syntax Diagram](https://en.wikipedia.org/wiki/Syntax_diagram)

--- a/docs/syntax/railroad.md
+++ b/docs/syntax/railroad.md
@@ -13,14 +13,14 @@ Railroad diagrams were first popularized by Niklaus Wirth in his "Pascal User Ma
 Mermaid can render Railroad diagram visualizations from EBNF notation.
 
 ```mermaid-example
-railroad-diagram
+railroad-beta
 title "Digit Definition"
 
 digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
 ```
 
 ```mermaid
-railroad-diagram
+railroad-beta
 title "Digit Definition"
 
 digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
@@ -32,7 +32,7 @@ Railroad diagrams use EBNF (Extended Backus-Naur Form) notation to define gramma
 
 ### Basic Structure
 
-- Start with `railroad-diagram` keyword to begin the diagram
+- Start with `railroad-beta` keyword to begin the diagram
 - Optionally add a `title` followed by a quoted string
 - Define grammar rules using the format: `rule_name = definition ;`
 - Each rule must end with a semicolon (`;`)
@@ -51,13 +51,13 @@ Non-terminals are identifiers that reference other rules:
 - `identifier` - references another rule
 
 ```mermaid-example
-railroad-diagram
+railroad-beta
 letter = "a" | "b" | "c" ;
 identifier = letter ;
 ```
 
 ```mermaid
-railroad-diagram
+railroad-beta
 letter = "a" | "b" | "c" ;
 identifier = letter ;
 ```
@@ -70,12 +70,12 @@ Elements appearing one after another define a sequence:
 - ISO 14977 notation: `A , B , C`
 
 ```mermaid-example
-railroad-diagram
+railroad-beta
 greeting = "Hello" " " "World" ;
 ```
 
 ```mermaid
-railroad-diagram
+railroad-beta
 greeting = "Hello" " " "World" ;
 ```
 
@@ -84,12 +84,12 @@ greeting = "Hello" " " "World" ;
 The pipe symbol (`|`) indicates alternatives:
 
 ```mermaid-example
-railroad-diagram
+railroad-beta
 sign = "+" | "-" ;
 ```
 
 ```mermaid
-railroad-diagram
+railroad-beta
 sign = "+" | "-" ;
 ```
 
@@ -101,7 +101,7 @@ Optional elements can appear zero or one time:
 - ISO 14977 notation: `[ A ]`
 
 ```mermaid-example
-railroad-diagram
+railroad-beta
 title "Optional Sign"
 
 sign = "+" | "-" ;
@@ -110,7 +110,7 @@ digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
 ```
 
 ```mermaid
-railroad-diagram
+railroad-beta
 title "Optional Sign"
 
 sign = "+" | "-" ;
@@ -130,7 +130,7 @@ One or more repetitions:
 - W3C notation: `A+`
 
 ```mermaid-example
-railroad-diagram
+railroad-beta
 title "Identifier with Repetition"
 
 identifier = letter ( letter | digit | "_" )* ;
@@ -139,7 +139,7 @@ digit = "0" | "1" | "2" ;
 ```
 
 ```mermaid
-railroad-diagram
+railroad-beta
 title "Identifier with Repetition"
 
 identifier = letter ( letter | digit | "_" )* ;
@@ -154,13 +154,13 @@ Parentheses group elements together:
 - `( A B )`
 
 ```mermaid-example
-railroad-diagram
+railroad-beta
 expression = term ( ( "+" | "-" ) term )* ;
 term = "number" ;
 ```
 
 ```mermaid
-railroad-diagram
+railroad-beta
 expression = term ( ( "+" | "-" ) term )* ;
 term = "number" ;
 ```
@@ -191,7 +191,7 @@ The minus operator excludes certain alternatives:
 ### Simple Number Grammar
 
 ```mermaid-example
-railroad-diagram
+railroad-beta
 title "Number Grammar"
 
 sign = "+" | "-" ;
@@ -200,7 +200,7 @@ digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
 ```
 
 ```mermaid
-railroad-diagram
+railroad-beta
 title "Number Grammar"
 
 sign = "+" | "-" ;
@@ -211,7 +211,7 @@ digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
 ### Expression Grammar
 
 ```mermaid-example
-railroad-diagram
+railroad-beta
 title "Arithmetic Expression Grammar"
 
 expression = term ( ( "+" | "-" ) term )* ;
@@ -222,7 +222,7 @@ digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
 ```
 
 ```mermaid
-railroad-diagram
+railroad-beta
 title "Arithmetic Expression Grammar"
 
 expression = term ( ( "+" | "-" ) term )* ;
@@ -235,7 +235,7 @@ digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
 ### JSON Grammar (Simplified)
 
 ```mermaid-example
-railroad-diagram
+railroad-beta
 title "JSON Grammar"
 
 json = element ;
@@ -246,7 +246,7 @@ member = string ":" element ;
 ```
 
 ```mermaid
-railroad-diagram
+railroad-beta
 title "JSON Grammar"
 
 json = element ;
@@ -259,7 +259,7 @@ member = string ":" element ;
 ### URL Grammar
 
 ```mermaid-example
-railroad-diagram
+railroad-beta
 title "URL Grammar"
 
 url = protocol "://" domain path? ;
@@ -273,7 +273,7 @@ segment = letter+ ;
 ```
 
 ```mermaid
-railroad-diagram
+railroad-beta
 title "URL Grammar"
 
 url = protocol "://" domain path? ;

--- a/docs/syntax/swimlanes.md
+++ b/docs/syntax/swimlanes.md
@@ -4,9 +4,7 @@
 >
 > ## Please edit the corresponding file in [/packages/mermaid/src/docs/syntax/swimlanes.md](../../packages/mermaid/src/docs/syntax/swimlanes.md).
 
-# Swimlanes Diagram
-
-> Available since MERMAID_RELEASE_VERSION.
+# Swimlanes Diagram (v\<MERMAID_RELEASE_VERSION>+)
 
 > **Warning**
 > This is a new diagram type in Mermaid. Its syntax may evolve in future versions.
@@ -20,7 +18,7 @@ Use swimlane diagrams when the most important question is not only "what happens
 > The rendered examples on this page use the **Neo** look and the **Redux** theme. Out of the box, swimlanes use your configured default look and theme.
 
 ```mermaid-example
-swimlane LR
+swimlane-beta LR
   subgraph Customer
     request[Request service]
     receive[Receive update]
@@ -44,7 +42,7 @@ swimlane LR
 ```
 
 ```mermaid
-swimlane LR
+swimlane-beta LR
   subgraph Customer
     request[Request service]
     receive[Receive update]
@@ -69,14 +67,14 @@ swimlane LR
 
 ## Syntax
 
-A swimlane diagram starts with the `swimlane` keyword. You can optionally add a direction after the keyword.
+A swimlane diagram starts with the `swimlane-beta` keyword. You can optionally add a direction after the keyword.
 
 ```
-swimlane
+swimlane-beta
 ```
 
 ```
-swimlane LR
+swimlane-beta LR
 ```
 
 The supported directions are:
@@ -96,7 +94,7 @@ If no direction is set, the diagram uses `TB`.
 Use `subgraph` to create a lane. In a swimlane diagram, top-level subgraphs are rendered as swimlanes. A lane ends with `end`.
 
 ```mermaid-example
-swimlane
+swimlane-beta
   subgraph Sales
     lead[Qualify lead]
     quote[Prepare quote]
@@ -104,7 +102,7 @@ swimlane
 ```
 
 ```mermaid
-swimlane
+swimlane-beta
   subgraph Sales
     lead[Qualify lead]
     quote[Prepare quote]
@@ -114,7 +112,7 @@ swimlane
 You can give a lane an internal id and a display label. This is useful when the label contains spaces or when you want a stable id for styling.
 
 ```mermaid-example
-swimlane LR
+swimlane-beta LR
   subgraph sales [Sales team]
     lead[Qualify lead]
     quote[Prepare quote]
@@ -129,7 +127,7 @@ swimlane LR
 ```
 
 ```mermaid
-swimlane LR
+swimlane-beta LR
   subgraph sales [Sales team]
     lead[Qualify lead]
     quote[Prepare quote]
@@ -148,7 +146,7 @@ swimlane LR
 Nodes use flowchart-style shape syntax. The id is written first, and the label is written inside the shape.
 
 ```mermaid-example
-swimlane LR
+swimlane-beta LR
   subgraph Intake
     start([Start])
     task[Do work]
@@ -170,7 +168,7 @@ swimlane LR
 ```
 
 ```mermaid
-swimlane LR
+swimlane-beta LR
   subgraph Intake
     start([Start])
     task[Do work]
@@ -208,7 +206,7 @@ For the complete shape catalog, icons, images, markdown strings, classes, and st
 Edges also use flowchart-style syntax. They can connect nodes in the same lane or across lanes.
 
 ```mermaid-example
-swimlane LR
+swimlane-beta LR
   subgraph Buyer
     choose[Choose product]
     pay[Pay invoice]
@@ -225,7 +223,7 @@ swimlane LR
 ```
 
 ```mermaid
-swimlane LR
+swimlane-beta LR
   subgraph Buyer
     choose[Choose product]
     pay[Pay invoice]
@@ -258,7 +256,7 @@ For the full edge syntax, including multi-directional arrows and minimum link le
 Use `accTitle` and `accDescr` to provide an accessible title and description.
 
 ```mermaid-example
-swimlane LR
+swimlane-beta LR
   accTitle: Support escalation
   accDescr: A request starts with the customer, is triaged by support, and may be escalated to engineering.
 
@@ -278,7 +276,7 @@ swimlane LR
 ```
 
 ```mermaid
-swimlane LR
+swimlane-beta LR
   accTitle: Support escalation
   accDescr: A request starts with the customer, is triaged by support, and may be escalated to engineering.
 
@@ -304,7 +302,7 @@ swimlane LR
 Choose lanes that answer "who owns this step?" Avoid mixing teams, phases, and statuses in the same diagram unless that distinction is the point of the diagram.
 
 ```mermaid-example
-swimlane LR
+swimlane-beta LR
   subgraph Customer
     submit[Submit order]
     confirm[Confirm delivery]
@@ -324,7 +322,7 @@ swimlane LR
 ```
 
 ```mermaid
-swimlane LR
+swimlane-beta LR
   subgraph Customer
     submit[Submit order]
     confirm[Confirm delivery]
@@ -348,7 +346,7 @@ swimlane LR
 A cross-lane arrow is where responsibility changes. Label the arrow when the handoff depends on a document, decision, message, or condition.
 
 ```mermaid-example
-swimlane LR
+swimlane-beta LR
   subgraph Applicant
     apply[Submit application]
     sign[Sign agreement]
@@ -371,7 +369,7 @@ swimlane LR
 ```
 
 ```mermaid
-swimlane LR
+swimlane-beta LR
   subgraph Applicant
     apply[Submit application]
     sign[Sign agreement]
@@ -398,7 +396,7 @@ swimlane LR
 Split a large process into several diagrams when the lanes or handoffs stop fitting in one view. A useful swimlane diagram is usually readable without tracing every arrow twice.
 
 ```mermaid-example
-swimlane TB
+swimlane-beta TB
   subgraph Intake
     collect[Collect request]
     validate[Validate details]
@@ -420,7 +418,7 @@ swimlane TB
 ```
 
 ```mermaid
-swimlane TB
+swimlane-beta TB
   subgraph Intake
     collect[Collect request]
     validate[Validate details]
@@ -446,7 +444,7 @@ swimlane TB
 Use short, meaningful ids for nodes and lanes. The label can change without breaking links, styles, or later references.
 
 ```mermaid-example
-swimlane LR
+swimlane-beta LR
   subgraph ops [Operations]
     intake[Receive request]
     plan[Plan work]
@@ -463,7 +461,7 @@ swimlane LR
 ```
 
 ```mermaid
-swimlane LR
+swimlane-beta LR
   subgraph ops [Operations]
     intake[Receive request]
     plan[Plan work]
@@ -484,7 +482,7 @@ swimlane LR
 Place a decision node in the lane that owns the decision. Then route the outcomes to the lanes that act on the result.
 
 ```mermaid-example
-swimlane LR
+swimlane-beta LR
   subgraph Support
     classify{Can support solve it?}
     respond[Respond to customer]
@@ -503,7 +501,7 @@ swimlane LR
 ```
 
 ```mermaid
-swimlane LR
+swimlane-beta LR
   subgraph Support
     classify{Can support solve it?}
     respond[Respond to customer]

--- a/packages/examples/src/examples/railroad-abnf.ts
+++ b/packages/examples/src/examples/railroad-abnf.ts
@@ -8,7 +8,7 @@ export default {
     {
       title: 'Email Address',
       isDefault: true,
-      code: `railroad-abnf
+      code: `railroad-abnf-beta
     title Email Address
 
     address = local-part "@" domain ;
@@ -18,7 +18,7 @@ export default {
     },
     {
       title: 'Phone Number',
-      code: `railroad-abnf
+      code: `railroad-abnf-beta
     title Phone Number
 
     phone = [ "+" country-code ] subscriber ;

--- a/packages/examples/src/examples/railroad-ebnf.ts
+++ b/packages/examples/src/examples/railroad-ebnf.ts
@@ -8,7 +8,7 @@ export default {
     {
       title: 'Expression Grammar',
       isDefault: true,
-      code: `railroad-ebnf
+      code: `railroad-ebnf-beta
     title Expression Grammar
 
     expression = term ( "+" term | "-" term )* ;
@@ -19,7 +19,7 @@ export default {
     },
     {
       title: 'Semantic Version',
-      code: `railroad-ebnf
+      code: `railroad-ebnf-beta
     title Semantic Version
 
     version = core ( "-" prerelease )? ( "+" build )? ;

--- a/packages/examples/src/examples/railroad-peg.ts
+++ b/packages/examples/src/examples/railroad-peg.ts
@@ -8,7 +8,7 @@ export default {
     {
       title: 'Calculator Grammar',
       isDefault: true,
-      code: `railroad-peg
+      code: `railroad-peg-beta
     title Calculator Grammar
 
     Expression <- Term (("+" / "-") Term)* ;
@@ -19,7 +19,7 @@ export default {
     },
     {
       title: 'Identifiers with Predicates',
-      code: `railroad-peg
+      code: `railroad-peg-beta
     title Identifiers (keywords excluded)
 
     Identifier <- !Keyword Letter Letter* ;

--- a/packages/examples/src/examples/railroad.ts
+++ b/packages/examples/src/examples/railroad.ts
@@ -9,7 +9,7 @@ export default {
     {
       title: 'Expression Grammar',
       isDefault: true,
-      code: `railroad-diagram
+      code: `railroad-beta
     title Expression Grammar
 
     expression = sequence(
@@ -35,7 +35,7 @@ export default {
     },
     {
       title: 'JSON Grammar',
-      code: `railroad-diagram
+      code: `railroad-beta
     title JSON Grammar
 
     json = nonterminal("element") ;

--- a/packages/examples/src/examples/wardley.ts
+++ b/packages/examples/src/examples/wardley.ts
@@ -1,7 +1,7 @@
 import type { DiagramMetadata } from '../types.js';
 
 export default {
-  id: 'wardley-beta',
+  id: 'wardley',
   name: 'Wardley Maps',
   description: 'Visualize business strategy and value chains with component evolution',
   examples: [

--- a/packages/mermaid/src/diagram-api/diagram-beta-policy.spec.ts
+++ b/packages/mermaid/src/diagram-api/diagram-beta-policy.spec.ts
@@ -102,7 +102,7 @@ describe('diagram beta policy', () => {
       expect.fail(
         `New diagram type(s) must require \`-beta\` syntax: ${violations.join(', ')}.\n` +
           'Expected the detector to accept the `-beta` keyword and reject it without the suffix.\n' +
-          'Do not add to GRANDFATHERED_BETA — update the detector instead.'
+          'Do not add to NEVER_BETA_DIAGRAMS — update the detector instead.'
       );
     }
   });

--- a/packages/mermaid/src/diagram-api/diagram-beta-policy.spec.ts
+++ b/packages/mermaid/src/diagram-api/diagram-beta-policy.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * Beta policy for new diagram types:
+ *
+ * - NEVER_BETA_DIAGRAMS: stable diagrams that never had a beta phase (frozen list).
+ * - GRADUATED_DIAGRAMS: diagrams that left beta but keep an optional `-beta` suffix for
+ *   backwards compatibility. The detector must accept both `{id}` and `{id}-beta`.
+ * - Any other registered diagram must require `-beta` in its syntax: the detector accepts
+ *   the `-beta` keyword and rejects the same keyword without the `-beta` suffix. For
+ *   diagrams whose keyword differs from `{id}-beta`, list the keyword in BETA_KEYWORD_OVERRIDES.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { detectors } from './detectType.js';
+import { addDiagrams } from './diagram-orchestration.js';
+
+/**
+ * Stable diagrams that never had a beta phase.
+ *
+ * This list is frozen — it documents the diagrams that predate the `-beta` policy and
+ * were never released under a `-beta` keyword. Do not add new entries.
+ */
+const NEVER_BETA_DIAGRAMS = new Set([
+  'c4',
+  'kanban',
+  'classDiagram',
+  'class',
+  'er',
+  'gantt',
+  'info',
+  'pie',
+  'requirement',
+  'sequence',
+  'flowchart-v2',
+  'flowchart',
+  'timeline',
+  'gitGraph',
+  'stateDiagram',
+  'state',
+  'journey',
+  'quadrantChart',
+  'eventmodeling',
+  'mindmap',
+  'flowchart-elk',
+]);
+
+/**
+ * Diagrams that graduated from beta to stable.
+ *
+ * Their canonical keyword no longer needs `-beta`, but for backwards compatibility the
+ * detector must keep accepting the optional `-beta` suffix. The test below enforces that
+ * both `{id}` and `{id}-beta` are detected.
+ */
+const GRADUATED_DIAGRAMS = new Set([
+  'sankey',
+  'packet',
+  'xychart',
+  'block',
+  'ishikawa',
+  'architecture',
+  'treemap',
+]);
+
+/** Internal or pseudo-diagram types — not subject to beta policy. */
+const EXCLUDED_DIAGRAMS = new Set(['error', '---']);
+
+/**
+ * Beta keyword for diagrams whose registered id differs from the keyword users type
+ * (e.g. id `railroadEbnf` is triggered by `railroad-ebnf-beta`). Diagrams not listed
+ * here are assumed to use `{id}-beta`.
+ */
+const BETA_KEYWORD_OVERRIDES: Record<string, string> = {
+  railroad: 'railroad-beta',
+  railroadEbnf: 'railroad-ebnf-beta',
+  railroadAbnf: 'railroad-abnf-beta',
+  railroadPeg: 'railroad-peg-beta',
+};
+
+describe('diagram beta policy', () => {
+  beforeAll(() => {
+    addDiagrams();
+  });
+
+  it('new diagram types require -beta in syntax', () => {
+    const violations: string[] = [];
+
+    for (const [id, { detector }] of Object.entries(detectors)) {
+      if (NEVER_BETA_DIAGRAMS.has(id) || GRADUATED_DIAGRAMS.has(id) || EXCLUDED_DIAGRAMS.has(id)) {
+        continue;
+      }
+
+      const betaKeyword = BETA_KEYWORD_OVERRIDES[id] ?? `${id}-beta`;
+      const plainKeyword = betaKeyword.replace(/-beta$/, '');
+
+      const acceptsBeta = Boolean(detector(betaKeyword));
+      const rejectsPlain = !detector(plainKeyword);
+
+      if (!acceptsBeta || !rejectsPlain) {
+        violations.push(id);
+      }
+    }
+
+    if (violations.length > 0) {
+      expect.fail(
+        `New diagram type(s) must require \`-beta\` syntax: ${violations.join(', ')}.\n` +
+          'Expected the detector to accept the `-beta` keyword and reject it without the suffix.\n' +
+          'Do not add to GRANDFATHERED_BETA — update the detector instead.'
+      );
+    }
+  });
+
+  it('graduated diagrams accept an optional -beta suffix', () => {
+    const violations: string[] = [];
+
+    for (const id of GRADUATED_DIAGRAMS) {
+      const { detector } = detectors[id] ?? {};
+      if (!detector || !detector(id) || !detector(`${id}-beta`)) {
+        violations.push(id);
+      }
+    }
+
+    expect(
+      violations,
+      `Graduated diagram(s) must accept both \`{id}\` and \`{id}-beta\`: ${violations.join(', ')}`
+    ).toEqual([]);
+  });
+
+  it('beta-policy lists contain no stale or overlapping entries', () => {
+    const registered = new Set(Object.keys(detectors));
+    const lists = {
+      NEVER_BETA_DIAGRAMS,
+      GRADUATED_DIAGRAMS,
+    };
+
+    for (const [name, set] of Object.entries(lists)) {
+      const stale = [...set].filter((id) => !registered.has(id));
+      expect(stale, `Stale ${name}: ${stale.join(', ')}`).toEqual([]);
+    }
+
+    const all = [...NEVER_BETA_DIAGRAMS, ...GRADUATED_DIAGRAMS];
+    const duplicates = all.filter((id, i) => all.indexOf(id) !== i);
+    expect(duplicates, `Diagram(s) listed in multiple sets: ${duplicates.join(', ')}`).toEqual([]);
+  });
+});

--- a/packages/mermaid/src/diagram-api/diagram-orchestration.spec.ts
+++ b/packages/mermaid/src/diagram-api/diagram-orchestration.spec.ts
@@ -19,7 +19,7 @@ describe('diagram-orchestration', () => {
       { text: 'flowchart TD;', expected: 'flowchart-v2' },
       { text: 'flowchart-v2 TD;', expected: 'flowchart-v2' },
       { text: 'flowchart-elk TD;', expected: 'flowchart-elk' },
-      { text: 'swimlane TD;', expected: 'swimlane' },
+      { text: 'swimlane-beta TD;', expected: 'swimlane' },
       { text: 'error', expected: 'error' },
       { text: 'C4Context;', expected: 'c4' },
       { text: 'classDiagram', expected: 'class' },
@@ -71,7 +71,7 @@ describe('diagram-orchestration', () => {
       expect(detectType('flowchart TD; A-->B', { flowchart: { defaultRenderer: 'elk' } })).toBe(
         'flowchart-elk'
       );
-      expect(detectType('swimlane TD; A-->B', { flowchart: { defaultRenderer: 'elk' } })).toBe(
+      expect(detectType('swimlane-beta TD; A-->B', { flowchart: { defaultRenderer: 'elk' } })).toBe(
         'swimlane'
       );
     });

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow-text.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow-text.spec.js
@@ -310,7 +310,6 @@ describe('[Text] when parsing', () => {
       'graph',
       'flowchart',
       'flowchart-elk',
-      'swimlane',
       'style',
       'default',
       'linkStyle',

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
@@ -114,7 +114,7 @@ that id.
 <click>[^\s\n]*          return 'CLICK';
 
 "flowchart-elk"          {if(yy.lex.firstGraph()){this.begin("dir");}  return 'GRAPH';}
-"swimlane"               {if(yy.lex.firstGraph()){this.begin("dir");}  return 'GRAPH';}
+"swimlane-beta"          {if(yy.lex.firstGraph()){this.begin("dir");}  return 'GRAPH';}
 "graph"                  {if(yy.lex.firstGraph()){this.begin("dir");}  return 'GRAPH';}
 "flowchart"              {if(yy.lex.firstGraph()){this.begin("dir");}  return 'GRAPH';}
 "subgraph"               return 'subgraph';

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow.spec.js
@@ -28,8 +28,8 @@ describe('parsing a flow chart', function () {
     expect(edges[0].text).toBe('');
   });
 
-  it('should accept swimlane as a graph keyword', function () {
-    flow.parser.parse('swimlane LR;A-->B;');
+  it('should accept swimlane-beta as a graph keyword', function () {
+    flow.parser.parse('swimlane-beta LR;A-->B;');
 
     const vert = flow.parser.yy.getVertices();
     const edges = flow.parser.yy.getEdges();

--- a/packages/mermaid/src/diagrams/railroad/abnfDetector.spec.ts
+++ b/packages/mermaid/src/diagrams/railroad/abnfDetector.spec.ts
@@ -6,20 +6,20 @@ describe('ABNF Detector', () => {
     expect(railroadAbnf.id).toBe('railroadAbnf');
   });
 
-  it('should detect railroad-abnf keyword', () => {
-    expect(railroadAbnf.detector('railroad-abnf\nrule = "test" ;')).toBe(true);
+  it('should detect railroad-abnf-beta keyword', () => {
+    expect(railroadAbnf.detector('railroad-abnf-beta\nrule = "test" ;')).toBe(true);
   });
 
   it('should detect with leading whitespace', () => {
-    expect(railroadAbnf.detector('  railroad-abnf\nrule = "test" ;')).toBe(true);
+    expect(railroadAbnf.detector('  railroad-abnf-beta\nrule = "test" ;')).toBe(true);
   });
 
   it('should detect case-insensitively', () => {
-    expect(railroadAbnf.detector('RAILROAD-ABNF\nrule = "test" ;')).toBe(true);
+    expect(railroadAbnf.detector('RAILROAD-ABNF-BETA\nrule = "test" ;')).toBe(true);
   });
 
   it('should not detect other diagram types', () => {
-    expect(railroadAbnf.detector('railroad-diagram\nrule = terminal("a") ;')).toBe(false);
+    expect(railroadAbnf.detector('railroad-beta\nrule = terminal("a") ;')).toBe(false);
     expect(railroadAbnf.detector('flowchart TD\nA --> B')).toBe(false);
   });
 

--- a/packages/mermaid/src/diagrams/railroad/abnfDetector.ts
+++ b/packages/mermaid/src/diagrams/railroad/abnfDetector.ts
@@ -7,7 +7,7 @@ import type {
 const id = 'railroadAbnf';
 
 const detector: DiagramDetector = (txt) => {
-  return /^\s*railroad-abnf/i.test(txt);
+  return /^\s*railroad-abnf-beta/i.test(txt);
 };
 
 const loader: DiagramLoader = async () => {

--- a/packages/mermaid/src/diagrams/railroad/ebnfDetector.spec.ts
+++ b/packages/mermaid/src/diagrams/railroad/ebnfDetector.spec.ts
@@ -6,20 +6,20 @@ describe('EBNF Detector', () => {
     expect(railroadEbnf.id).toBe('railroadEbnf');
   });
 
-  it('should detect railroad-ebnf keyword', () => {
-    expect(railroadEbnf.detector('railroad-ebnf\nrule = "test" ;')).toBe(true);
+  it('should detect railroad-ebnf-beta keyword', () => {
+    expect(railroadEbnf.detector('railroad-ebnf-beta\nrule = "test" ;')).toBe(true);
   });
 
   it('should detect with leading whitespace', () => {
-    expect(railroadEbnf.detector('  railroad-ebnf\nrule = "test" ;')).toBe(true);
+    expect(railroadEbnf.detector('  railroad-ebnf-beta\nrule = "test" ;')).toBe(true);
   });
 
   it('should detect case-insensitively', () => {
-    expect(railroadEbnf.detector('RAILROAD-EBNF\nrule = "test" ;')).toBe(true);
+    expect(railroadEbnf.detector('RAILROAD-EBNF-BETA\nrule = "test" ;')).toBe(true);
   });
 
   it('should not detect other diagram types', () => {
-    expect(railroadEbnf.detector('railroad-diagram\nrule = terminal("a") ;')).toBe(false);
+    expect(railroadEbnf.detector('railroad-beta\nrule = terminal("a") ;')).toBe(false);
     expect(railroadEbnf.detector('flowchart TD\nA --> B')).toBe(false);
   });
 

--- a/packages/mermaid/src/diagrams/railroad/ebnfDetector.ts
+++ b/packages/mermaid/src/diagrams/railroad/ebnfDetector.ts
@@ -7,7 +7,7 @@ import type {
 const id = 'railroadEbnf';
 
 const detector: DiagramDetector = (txt) => {
-  return /^\s*railroad-ebnf/i.test(txt);
+  return /^\s*railroad-ebnf-beta/i.test(txt);
 };
 
 const loader: DiagramLoader = async () => {

--- a/packages/mermaid/src/diagrams/railroad/parser/abnfDiagram.spec.ts
+++ b/packages/mermaid/src/diagrams/railroad/parser/abnfDiagram.spec.ts
@@ -10,7 +10,7 @@ describe('ABNF Parser', () => {
   describe('Basic Parsing', () => {
     it('should parse string literal', () => {
       const input = `
-        railroad-abnf
+        railroad-abnf-beta
         rule = "hello" ;
       `;
       void parser.parse(input);
@@ -26,7 +26,7 @@ describe('ABNF Parser', () => {
 
     it('should parse numeric value', () => {
       const input = `
-        railroad-abnf
+        railroad-abnf-beta
         rule = %x41 ;
       `;
       void parser.parse(input);
@@ -39,7 +39,7 @@ describe('ABNF Parser', () => {
 
     it('should parse rule name reference', () => {
       const input = `
-        railroad-abnf
+        railroad-abnf-beta
         rule = other-rule ;
       `;
       void parser.parse(input);
@@ -48,7 +48,7 @@ describe('ABNF Parser', () => {
 
     it('should parse concatenation', () => {
       const input = `
-        railroad-abnf
+        railroad-abnf-beta
         rule = "a" "b" "c" ;
       `;
       void parser.parse(input);
@@ -61,7 +61,7 @@ describe('ABNF Parser', () => {
 
     it('should parse alternation', () => {
       const input = `
-        railroad-abnf
+        railroad-abnf-beta
         rule = "a" / "b" / "c" ;
       `;
       void parser.parse(input);
@@ -74,7 +74,7 @@ describe('ABNF Parser', () => {
 
     it('should parse optional group', () => {
       const input = `
-        railroad-abnf
+        railroad-abnf-beta
         rule = [ "a" ] ;
       `;
       void parser.parse(input);
@@ -83,7 +83,7 @@ describe('ABNF Parser', () => {
 
     it('should parse zero-or-more repetition', () => {
       const input = `
-        railroad-abnf
+        railroad-abnf-beta
         rule = *"a" ;
       `;
       void parser.parse(input);
@@ -96,7 +96,7 @@ describe('ABNF Parser', () => {
 
     it('should parse one-or-more repetition', () => {
       const input = `
-        railroad-abnf
+        railroad-abnf-beta
         rule = 1*"a" ;
       `;
       void parser.parse(input);
@@ -109,7 +109,7 @@ describe('ABNF Parser', () => {
 
     it('should parse title', () => {
       const input = `
-        railroad-abnf
+        railroad-abnf-beta
         title "Test Grammar"
         rule = "a" ;
       `;
@@ -121,7 +121,7 @@ describe('ABNF Parser', () => {
   describe('Real-world Examples', () => {
     it('should parse URI-like grammar', () => {
       const input = `
-        railroad-abnf
+        railroad-abnf-beta
         title "URI"
         URI = scheme ":" hier-part ;
         scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) ;
@@ -143,7 +143,7 @@ describe('ABNF Parser', () => {
     });
 
     it('should throw on missing semicolon', () => {
-      expect(() => parser.parse('railroad-abnf\nrule = "a"')).toThrow();
+      expect(() => parser.parse('railroad-abnf-beta\nrule = "a"')).toThrow();
     });
   });
 });

--- a/packages/mermaid/src/diagrams/railroad/parser/ebnfDiagram.spec.ts
+++ b/packages/mermaid/src/diagrams/railroad/parser/ebnfDiagram.spec.ts
@@ -10,7 +10,7 @@ describe('EBNF Parser', () => {
   describe('Basic Parsing', () => {
     it('should parse simple terminal', () => {
       const input = `
-        railroad-ebnf
+        railroad-ebnf-beta
         rule = "terminal" ;
       `;
       void parser.parse(input);
@@ -26,7 +26,7 @@ describe('EBNF Parser', () => {
 
     it('should parse non-terminal reference', () => {
       const input = `
-        railroad-ebnf
+        railroad-ebnf-beta
         rule = other_rule ;
       `;
       void parser.parse(input);
@@ -38,7 +38,7 @@ describe('EBNF Parser', () => {
 
     it('should parse sequence', () => {
       const input = `
-        railroad-ebnf
+        railroad-ebnf-beta
         rule = "a" "b" "c" ;
       `;
       void parser.parse(input);
@@ -53,7 +53,7 @@ describe('EBNF Parser', () => {
 
     it('should parse choice', () => {
       const input = `
-        railroad-ebnf
+        railroad-ebnf-beta
         rule = "a" | "b" | "c" ;
       `;
       void parser.parse(input);
@@ -68,7 +68,7 @@ describe('EBNF Parser', () => {
 
     it('should parse optional (W3C)', () => {
       const input = `
-        railroad-ebnf
+        railroad-ebnf-beta
         rule = "a"? ;
       `;
       void parser.parse(input);
@@ -77,7 +77,7 @@ describe('EBNF Parser', () => {
 
     it('should parse optional (ISO)', () => {
       const input = `
-        railroad-ebnf
+        railroad-ebnf-beta
         rule = [ "a" ] ;
       `;
       void parser.parse(input);
@@ -86,7 +86,7 @@ describe('EBNF Parser', () => {
 
     it('should parse repetition zero-or-more', () => {
       const input = `
-        railroad-ebnf
+        railroad-ebnf-beta
         rule = "a"* ;
       `;
       void parser.parse(input);
@@ -99,7 +99,7 @@ describe('EBNF Parser', () => {
 
     it('should parse repetition one-or-more', () => {
       const input = `
-        railroad-ebnf
+        railroad-ebnf-beta
         rule = "a"+ ;
       `;
       void parser.parse(input);
@@ -112,7 +112,7 @@ describe('EBNF Parser', () => {
 
     it('should parse ISO repetition', () => {
       const input = `
-        railroad-ebnf
+        railroad-ebnf-beta
         rule = { "a" } ;
       `;
       void parser.parse(input);
@@ -125,7 +125,7 @@ describe('EBNF Parser', () => {
 
     it('should parse title', () => {
       const input = `
-        railroad-ebnf
+        railroad-ebnf-beta
         title "Test Grammar"
         rule = "a" ;
       `;
@@ -135,7 +135,7 @@ describe('EBNF Parser', () => {
 
     it('should parse special sequence', () => {
       const input = `
-        railroad-ebnf
+        railroad-ebnf-beta
         rule = ? special ? ;
       `;
       void parser.parse(input);
@@ -150,7 +150,7 @@ describe('EBNF Parser', () => {
   describe('Real-world Examples', () => {
     it('should parse expression grammar', () => {
       const input = `
-        railroad-ebnf
+        railroad-ebnf-beta
         title "Simple Expression"
         expression = term ( "+" term | "-" term )* ;
         term = factor ( "*" factor | "/" factor )* ;
@@ -172,7 +172,7 @@ describe('EBNF Parser', () => {
     });
 
     it('should throw on missing semicolon', () => {
-      expect(() => parser.parse('railroad-ebnf\nrule = "a"')).toThrow();
+      expect(() => parser.parse('railroad-ebnf-beta\nrule = "a"')).toThrow();
     });
   });
 });

--- a/packages/mermaid/src/diagrams/railroad/parser/pegDiagram.spec.ts
+++ b/packages/mermaid/src/diagrams/railroad/parser/pegDiagram.spec.ts
@@ -10,7 +10,7 @@ describe('PEG Parser', () => {
   describe('Basic Parsing', () => {
     it('should parse literal', () => {
       const input = `
-        railroad-peg
+        railroad-peg-beta
         rule <- "hello" ;
       `;
       void parser.parse(input);
@@ -26,7 +26,7 @@ describe('PEG Parser', () => {
 
     it('should parse identifier reference', () => {
       const input = `
-        railroad-peg
+        railroad-peg-beta
         rule <- other_rule ;
       `;
       void parser.parse(input);
@@ -35,7 +35,7 @@ describe('PEG Parser', () => {
 
     it('should parse sequence', () => {
       const input = `
-        railroad-peg
+        railroad-peg-beta
         rule <- "a" "b" "c" ;
       `;
       void parser.parse(input);
@@ -48,7 +48,7 @@ describe('PEG Parser', () => {
 
     it('should parse ordered choice', () => {
       const input = `
-        railroad-peg
+        railroad-peg-beta
         rule <- "a" / "b" / "c" ;
       `;
       void parser.parse(input);
@@ -61,7 +61,7 @@ describe('PEG Parser', () => {
 
     it('should parse optional suffix', () => {
       const input = `
-        railroad-peg
+        railroad-peg-beta
         rule <- "a"? ;
       `;
       void parser.parse(input);
@@ -70,7 +70,7 @@ describe('PEG Parser', () => {
 
     it('should parse zero-or-more suffix', () => {
       const input = `
-        railroad-peg
+        railroad-peg-beta
         rule <- "a"* ;
       `;
       void parser.parse(input);
@@ -83,7 +83,7 @@ describe('PEG Parser', () => {
 
     it('should parse one-or-more suffix', () => {
       const input = `
-        railroad-peg
+        railroad-peg-beta
         rule <- "a"+ ;
       `;
       void parser.parse(input);
@@ -96,7 +96,7 @@ describe('PEG Parser', () => {
 
     it('should parse any character', () => {
       const input = `
-        railroad-peg
+        railroad-peg-beta
         rule <- . ;
       `;
       void parser.parse(input);
@@ -109,7 +109,7 @@ describe('PEG Parser', () => {
 
     it('should parse lookahead prefix', () => {
       const input = `
-        railroad-peg
+        railroad-peg-beta
         rule <- &"a" ;
       `;
       void parser.parse(input);
@@ -122,7 +122,7 @@ describe('PEG Parser', () => {
 
     it('should parse not-predicate prefix', () => {
       const input = `
-        railroad-peg
+        railroad-peg-beta
         rule <- !"a" ;
       `;
       void parser.parse(input);
@@ -135,7 +135,7 @@ describe('PEG Parser', () => {
 
     it('should parse title', () => {
       const input = `
-        railroad-peg
+        railroad-peg-beta
         title "Test Grammar"
         rule <- "a" ;
       `;
@@ -147,7 +147,7 @@ describe('PEG Parser', () => {
   describe('Real-world Examples', () => {
     it('should parse expression grammar', () => {
       const input = `
-        railroad-peg
+        railroad-peg-beta
         title "Calculator"
         Expression <- Term (("+" / "-") Term)* ;
         Term <- Factor (("*" / "/") Factor)* ;
@@ -170,7 +170,7 @@ describe('PEG Parser', () => {
     });
 
     it('should throw on missing semicolon', () => {
-      expect(() => parser.parse('railroad-peg\nrule <- "a"')).toThrow();
+      expect(() => parser.parse('railroad-peg-beta\nrule <- "a"')).toThrow();
     });
   });
 });

--- a/packages/mermaid/src/diagrams/railroad/parser/railroadDiagram.spec.ts
+++ b/packages/mermaid/src/diagrams/railroad/parser/railroadDiagram.spec.ts
@@ -10,7 +10,7 @@ describe('Railroad Parser', () => {
   describe('Basic Parsing', () => {
     it('should parse terminal', () => {
       const input = `
-        railroad-diagram
+        railroad-beta
         rule = terminal("hello") ;
       `;
       void parser.parse(input);
@@ -26,7 +26,7 @@ describe('Railroad Parser', () => {
 
     it('should parse nonterminal', () => {
       const input = `
-        railroad-diagram
+        railroad-beta
         rule = nonterminal("expression") ;
       `;
       void parser.parse(input);
@@ -41,7 +41,7 @@ describe('Railroad Parser', () => {
 
     it('should parse sequence', () => {
       const input = `
-        railroad-diagram
+        railroad-beta
         rule = sequence(terminal("a"), terminal("b"), terminal("c")) ;
       `;
       void parser.parse(input);
@@ -56,7 +56,7 @@ describe('Railroad Parser', () => {
 
     it('should collapse single-element sequence', () => {
       const input = `
-        railroad-diagram
+        railroad-beta
         rule = sequence(terminal("a")) ;
       `;
       void parser.parse(input);
@@ -68,7 +68,7 @@ describe('Railroad Parser', () => {
 
     it('should parse choice', () => {
       const input = `
-        railroad-diagram
+        railroad-beta
         rule = choice(terminal("a"), terminal("b"), terminal("c")) ;
       `;
       void parser.parse(input);
@@ -83,7 +83,7 @@ describe('Railroad Parser', () => {
 
     it('should collapse single-element choice', () => {
       const input = `
-        railroad-diagram
+        railroad-beta
         rule = choice(terminal("a")) ;
       `;
       void parser.parse(input);
@@ -95,7 +95,7 @@ describe('Railroad Parser', () => {
 
     it('should parse optional', () => {
       const input = `
-        railroad-diagram
+        railroad-beta
         rule = optional(terminal("a")) ;
       `;
       void parser.parse(input);
@@ -107,7 +107,7 @@ describe('Railroad Parser', () => {
 
     it('should parse zeroOrMore', () => {
       const input = `
-        railroad-diagram
+        railroad-beta
         rule = zeroOrMore(terminal("a")) ;
       `;
       void parser.parse(input);
@@ -122,7 +122,7 @@ describe('Railroad Parser', () => {
 
     it('should parse oneOrMore', () => {
       const input = `
-        railroad-diagram
+        railroad-beta
         rule = oneOrMore(terminal("a")) ;
       `;
       void parser.parse(input);
@@ -137,7 +137,7 @@ describe('Railroad Parser', () => {
 
     it('should parse special', () => {
       const input = `
-        railroad-diagram
+        railroad-beta
         rule = special("any character") ;
       `;
       void parser.parse(input);
@@ -152,7 +152,7 @@ describe('Railroad Parser', () => {
 
     it('should parse title', () => {
       const input = `
-        railroad-diagram
+        railroad-beta
         title "Test Grammar"
         rule = terminal("a") ;
       `;
@@ -165,7 +165,7 @@ describe('Railroad Parser', () => {
   describe('Complex Grammars', () => {
     it('should parse multiple rules', () => {
       const input = `
-        railroad-diagram
+        railroad-beta
         rule1 = terminal("a") ;
         rule2 = terminal("b") ;
         rule3 = terminal("c") ;
@@ -181,7 +181,7 @@ describe('Railroad Parser', () => {
 
     it('should handle nested structures', () => {
       const input = `
-        railroad-diagram
+        railroad-beta
         rule = sequence(
             choice(terminal("a"), terminal("b")),
             oneOrMore(choice(terminal("c"), terminal("d")))
@@ -196,7 +196,7 @@ describe('Railroad Parser', () => {
 
     it('should parse complex expression grammar', () => {
       const input = `
-        railroad-diagram
+        railroad-beta
         digit = choice(
             terminal("0"), terminal("1"), terminal("2"),
             terminal("3"), terminal("4"), terminal("5"),
@@ -214,7 +214,7 @@ describe('Railroad Parser', () => {
   });
 
   describe('Error Handling', () => {
-    it('should throw on missing railroad-diagram keyword', () => {
+    it('should throw on missing railroad-beta keyword', () => {
       const input = `
         rule = terminal("a") ;
       `;
@@ -224,7 +224,7 @@ describe('Railroad Parser', () => {
 
     it('should throw on missing semicolon', () => {
       const input = `
-        railroad-diagram
+        railroad-beta
         rule = terminal("a")
       `;
 
@@ -233,7 +233,7 @@ describe('Railroad Parser', () => {
 
     it('should throw on unterminated string', () => {
       const input = `
-        railroad-diagram
+        railroad-beta
         rule = terminal("unclosed) ;
       `;
 
@@ -244,7 +244,7 @@ describe('Railroad Parser', () => {
   describe('Edge Cases', () => {
     it('should handle empty rules list', () => {
       const input = `
-        railroad-diagram
+        railroad-beta
         title "Empty Grammar"
       `;
       void parser.parse(input);
@@ -256,7 +256,7 @@ describe('Railroad Parser', () => {
 
     it('should handle whitespace in strings', () => {
       const input = `
-        railroad-diagram
+        railroad-beta
         rule = terminal("hello world") ;
       `;
       void parser.parse(input);
@@ -270,7 +270,7 @@ describe('Railroad Parser', () => {
 
     it('should handle underscore in rule names', () => {
       const input = `
-        railroad-diagram
+        railroad-beta
         my_rule = terminal("test") ;
       `;
       void parser.parse(input);
@@ -282,7 +282,7 @@ describe('Railroad Parser', () => {
 
     it('should handle numbers in rule names', () => {
       const input = `
-        railroad-diagram
+        railroad-beta
         rule123 = terminal("test") ;
       `;
       void parser.parse(input);
@@ -294,7 +294,7 @@ describe('Railroad Parser', () => {
 
     it('should parse deeply nested IR', () => {
       const input = `
-        railroad-diagram
+        railroad-beta
         rule = sequence(
             choice(terminal("a"), terminal("b")),
             choice(terminal("c"), terminal("d"))
@@ -314,7 +314,7 @@ describe('Railroad Parser', () => {
 
     it('should parse zeroOrMore with choice', () => {
       const input = `
-        railroad-diagram
+        railroad-beta
         rule = zeroOrMore(choice(terminal("a"), terminal("b"))) ;
       `;
       void parser.parse(input);
@@ -329,7 +329,7 @@ describe('Railroad Parser', () => {
 
     it('should parse block comments', () => {
       const input = `
-        railroad-diagram
+        railroad-beta
         /* this is a comment */
         rule = terminal("a") ;
       `;
@@ -347,7 +347,7 @@ describe('Railroad Parser', () => {
   describe('Real-world Examples', () => {
     it('should parse an expression grammar', () => {
       const input = `
-        railroad-diagram
+        railroad-beta
         title "Simple Expression"
         expression = sequence(
             nonterminal("term"),
@@ -388,7 +388,7 @@ describe('Railroad Parser', () => {
 
     it('should parse JSON grammar excerpt', () => {
       const input = `
-        railroad-diagram
+        railroad-beta
         title "JSON Subset"
         value = choice(
             nonterminal("string"),

--- a/packages/mermaid/src/diagrams/railroad/pegDetector.spec.ts
+++ b/packages/mermaid/src/diagrams/railroad/pegDetector.spec.ts
@@ -6,20 +6,20 @@ describe('PEG Detector', () => {
     expect(railroadPeg.id).toBe('railroadPeg');
   });
 
-  it('should detect railroad-peg keyword', () => {
-    expect(railroadPeg.detector('railroad-peg\nrule <- "test" ;')).toBe(true);
+  it('should detect railroad-peg-beta keyword', () => {
+    expect(railroadPeg.detector('railroad-peg-beta\nrule <- "test" ;')).toBe(true);
   });
 
   it('should detect with leading whitespace', () => {
-    expect(railroadPeg.detector('  railroad-peg\nrule <- "test" ;')).toBe(true);
+    expect(railroadPeg.detector('  railroad-peg-beta\nrule <- "test" ;')).toBe(true);
   });
 
   it('should detect case-insensitively', () => {
-    expect(railroadPeg.detector('RAILROAD-PEG\nrule <- "test" ;')).toBe(true);
+    expect(railroadPeg.detector('RAILROAD-PEG-BETA\nrule <- "test" ;')).toBe(true);
   });
 
   it('should not detect other diagram types', () => {
-    expect(railroadPeg.detector('railroad-diagram\nrule = terminal("a") ;')).toBe(false);
+    expect(railroadPeg.detector('railroad-beta\nrule = terminal("a") ;')).toBe(false);
     expect(railroadPeg.detector('flowchart TD\nA --> B')).toBe(false);
   });
 

--- a/packages/mermaid/src/diagrams/railroad/pegDetector.ts
+++ b/packages/mermaid/src/diagrams/railroad/pegDetector.ts
@@ -7,7 +7,7 @@ import type {
 const id = 'railroadPeg';
 
 const detector: DiagramDetector = (txt) => {
-  return /^\s*railroad-peg/i.test(txt);
+  return /^\s*railroad-peg-beta/i.test(txt);
 };
 
 const loader: DiagramLoader = async () => {

--- a/packages/mermaid/src/diagrams/railroad/railroadDetector.spec.ts
+++ b/packages/mermaid/src/diagrams/railroad/railroadDetector.spec.ts
@@ -7,23 +7,23 @@ describe('Railroad Detector', () => {
   });
 
   describe('detector', () => {
-    it('should detect railroad-diagram keyword', () => {
-      const text = 'railroad-diagram\nrule = "test" ;';
+    it('should detect railroad-beta keyword', () => {
+      const text = 'railroad-beta\nrule = "test" ;';
       expect(railroad.detector(text)).toBe(true);
     });
 
-    it('should detect railroad-diagram with leading whitespace', () => {
-      const text = '  railroad-diagram\nrule = "test" ;';
+    it('should detect railroad-beta with leading whitespace', () => {
+      const text = '  railroad-beta\nrule = "test" ;';
       expect(railroad.detector(text)).toBe(true);
     });
 
-    it('should detect railroad-diagram case-insensitively', () => {
-      const text = 'RAILROAD-DIAGRAM\nrule = "test" ;';
+    it('should detect railroad-beta case-insensitively', () => {
+      const text = 'RAILROAD-BETA\nrule = "test" ;';
       expect(railroad.detector(text)).toBe(true);
     });
 
-    it('should detect Railroad-Diagram mixed case', () => {
-      const text = 'Railroad-Diagram\nrule = "test" ;';
+    it('should detect Railroad-Beta mixed case', () => {
+      const text = 'Railroad-Beta\nrule = "test" ;';
       expect(railroad.detector(text)).toBe(true);
     });
 
@@ -32,8 +32,8 @@ describe('Railroad Detector', () => {
       expect(railroad.detector(text)).toBe(false);
     });
 
-    it('should not detect railroad-diagram in middle of text', () => {
-      const text = 'some text railroad-diagram\nrule = "test" ;';
+    it('should not detect railroad-beta in middle of text', () => {
+      const text = 'some text railroad-beta\nrule = "test" ;';
       expect(railroad.detector(text)).toBe(false);
     });
 
@@ -47,8 +47,8 @@ describe('Railroad Detector', () => {
       expect(railroad.detector(text)).toBe(false);
     });
 
-    it('should detect railroad-diagram with newlines before it', () => {
-      const text = '\n\nrailroad-diagram\nrule = "test" ;';
+    it('should detect railroad-beta with newlines before it', () => {
+      const text = '\n\nrailroad-beta\nrule = "test" ;';
       expect(railroad.detector(text)).toBe(true);
     });
   });

--- a/packages/mermaid/src/diagrams/railroad/railroadDetector.ts
+++ b/packages/mermaid/src/diagrams/railroad/railroadDetector.ts
@@ -8,10 +8,10 @@ const id = 'railroad';
 
 /**
  * Detector function to identify Railroad diagrams
- * Looks for 'railroad-diagram' keyword at the start of the text
+ * Looks for 'railroad-beta' keyword at the start of the text
  */
 const detector: DiagramDetector = (txt) => {
-  return /^\s*railroad-diagram/i.test(txt);
+  return /^\s*railroad-beta/i.test(txt);
 };
 
 /**

--- a/packages/mermaid/src/diagrams/railroad/railroadRenderer.spec.ts
+++ b/packages/mermaid/src/diagrams/railroad/railroadRenderer.spec.ts
@@ -32,7 +32,7 @@ describe('Railroad Renderer', () => {
   });
 
   it('sets a viewBox that includes the full rendered diagram height', () => {
-    const text = `railroad-diagram
+    const text = `railroad-beta
 sign = choice(terminal("+"), terminal("-")) ;
 number = sequence(optional(nonterminal("sign")), oneOrMore(nonterminal("digit"))) ;
 list = sequence(terminal("["), optional(sequence(nonterminal("number"), zeroOrMore(sequence(terminal(","), nonterminal("number"))))), terminal("]")) ;
@@ -63,7 +63,7 @@ digit = choice(terminal("0"), terminal("1"), terminal("2"), terminal("3")) ;
   });
 
   it('aligns rule markers with the centerline of tall expressions', () => {
-    const text = `railroad-diagram
+    const text = `railroad-beta
 sign = choice(terminal("+"), terminal("-")) ;
 `;
 
@@ -84,7 +84,7 @@ sign = choice(terminal("+"), terminal("-")) ;
   });
 
   it('connects centered choice alternatives from the left edge', () => {
-    const text = `railroad-diagram
+    const text = `railroad-beta
 term = choice(nonterminal("number"), sequence(terminal("("), nonterminal("expression"), terminal(")"))) ;
 `;
 
@@ -103,7 +103,7 @@ term = choice(nonterminal("number"), sequence(terminal("("), nonterminal("expres
   });
 
   it('connects centered choice alternatives to the right lane before merging', () => {
-    const text = `railroad-diagram
+    const text = `railroad-beta
 identifierPart = choice(nonterminal("letter"), terminal("_")) ;
 `;
 
@@ -126,7 +126,7 @@ identifierPart = choice(nonterminal("letter"), terminal("_")) ;
   });
 
   it('orients choice corner arcs in the direction of travel', () => {
-    const text = `railroad-diagram
+    const text = `railroad-beta
 sign = choice(terminal("+"), terminal("-")) ;
 `;
 
@@ -148,7 +148,7 @@ sign = choice(terminal("+"), terminal("-")) ;
   });
 
   it('orients repetition loop corners in the direction of travel', () => {
-    const text = `railroad-diagram
+    const text = `railroad-beta
 number = oneOrMore(nonterminal("digit")) ;
 `;
 

--- a/packages/mermaid/src/diagrams/swimlanes/detector.ts
+++ b/packages/mermaid/src/diagrams/swimlanes/detector.ts
@@ -7,7 +7,7 @@ import type {
 const id = 'swimlane';
 
 const detector: DiagramDetector = (txt) => {
-  return /^\s*swimlane\b/.test(txt);
+  return /^\s*swimlane-beta\b/.test(txt);
 };
 
 const loader: DiagramLoader = async () => {

--- a/packages/mermaid/src/diagrams/wardley/wardleyDetector.ts
+++ b/packages/mermaid/src/diagrams/wardley/wardleyDetector.ts
@@ -4,7 +4,7 @@ import type {
   ExternalDiagramDefinition,
 } from '../../diagram-api/types.js';
 
-const id = 'wardley-beta';
+const id = 'wardley';
 
 const detector: DiagramDetector = (text) => {
   return /^\s*wardley-beta/i.test(text);

--- a/packages/mermaid/src/docs/syntax/railroad.md
+++ b/packages/mermaid/src/docs/syntax/railroad.md
@@ -1,49 +1,54 @@
 # Railroad Diagrams (v<MERMAID_RELEASE_VERSION>+)
 
-> Railroad diagrams (also known as syntax diagrams or grammar diagrams) are a visual representation of context-free grammars using EBNF (Extended Backus-Naur Form) notation. They provide a graphical way to understand and document language syntax, making complex grammar rules easier to comprehend.
+> Railroad diagrams (also known as syntax diagrams or grammar diagrams) are a visual representation of context-free grammars. They provide a graphical way to understand and document language syntax, making complex grammar rules easier to comprehend.
 
 Railroad diagrams were first popularized by Niklaus Wirth in his "Pascal User Manual" (1974) and remain widely used today, notably on [JSON.org](https://www.json.org/) for documenting the JSON syntax.
 
-Mermaid can render Railroad diagram visualizations from EBNF notation.
+Mermaid can render railroad diagrams from several grammar notations. Pick the keyword that matches the notation you want to write in:
+
+| Diagram type    | Keyword              | Notation                                                                         |
+| --------------- | -------------------- | -------------------------------------------------------------------------------- |
+| EBNF            | `railroad-ebnf-beta` | Extended Backus–Naur Form (W3C and ISO 14977 styles)                             |
+| ABNF            | `railroad-abnf-beta` | Augmented Backus–Naur Form (RFC 5234)                                            |
+| PEG             | `railroad-peg-beta`  | Parsing Expression Grammar                                                       |
+| IR (primitives) | `railroad-beta`      | Mermaid's railroad intermediate representation, written as explicit constructors |
 
 ```mermaid-example
-railroad-beta
+railroad-ebnf-beta
 title "Digit Definition"
 
 digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
 ```
 
-## Syntax
+## Common Structure
 
-Railroad diagrams use EBNF (Extended Backus-Naur Form) notation to define grammar rules. Mermaid supports both W3C and ISO 14977 EBNF notation styles.
+All four diagram types share the same outer structure:
 
-### Basic Structure
+- Start with the diagram-type keyword on the first line (for example `railroad-ebnf-beta`).
+- Optionally add a `title` followed by a string.
+- Optionally add `accTitle:` and `accDescr:` for accessibility metadata.
+- Define one grammar rule per statement; each rule ends with a semicolon (`;`).
 
-- Start with `railroad-beta` keyword to begin the diagram
-- Optionally add a `title` followed by a quoted string
-- Define grammar rules using the format: `rule_name = definition ;`
-- Each rule must end with a semicolon (`;`)
+The rule assignment operator and the operators used inside a definition depend on the notation, and are described per type below.
 
-### EBNF Notation
+## EBNF (`railroad-ebnf-beta`)
 
-#### Terminals and Non-terminals
+EBNF (Extended Backus-Naur Form) is the most common notation. Mermaid supports both W3C and ISO 14977 EBNF styles. Rules are written as `rule_name = definition ;` (the `::=` assignment operator is also accepted).
 
-Terminals are literal strings enclosed in quotes:
+### Terminals and Non-terminals
 
-- `"text"` - double quotes
-- `'text'` - single quotes
+Terminals are literal strings enclosed in quotes; non-terminals are identifiers that reference other rules:
 
-Non-terminals are identifiers that reference other rules:
-
-- `identifier` - references another rule
+- `"text"` or `'text'` - terminal (literal string)
+- `identifier` - non-terminal (rule reference)
 
 ```mermaid-example
-railroad-beta
+railroad-ebnf-beta
 letter = "a" | "b" | "c" ;
 identifier = letter ;
 ```
 
-#### Sequence (Concatenation)
+### Sequence (Concatenation)
 
 Elements appearing one after another define a sequence:
 
@@ -51,20 +56,20 @@ Elements appearing one after another define a sequence:
 - ISO 14977 notation: `A , B , C`
 
 ```mermaid-example
-railroad-beta
+railroad-ebnf-beta
 greeting = "Hello" " " "World" ;
 ```
 
-#### Choice (Alternation)
+### Choice (Alternation)
 
 The pipe symbol (`|`) indicates alternatives:
 
 ```mermaid-example
-railroad-beta
+railroad-ebnf-beta
 sign = "+" | "-" ;
 ```
 
-#### Optional Elements
+### Optional Elements
 
 Optional elements can appear zero or one time:
 
@@ -72,7 +77,7 @@ Optional elements can appear zero or one time:
 - ISO 14977 notation: `[ A ]`
 
 ```mermaid-example
-railroad-beta
+railroad-ebnf-beta
 title "Optional Sign"
 
 sign = "+" | "-" ;
@@ -80,7 +85,7 @@ number = sign? digit+ ;
 digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
 ```
 
-#### Repetition
+### Repetition
 
 Zero or more repetitions:
 
@@ -92,7 +97,7 @@ One or more repetitions:
 - W3C notation: `A+`
 
 ```mermaid-example
-railroad-beta
+railroad-ebnf-beta
 title "Identifier with Repetition"
 
 identifier = letter ( letter | digit | "_" )* ;
@@ -100,56 +105,55 @@ letter = "a" | "b" | "c" | "d" | "e" ;
 digit = "0" | "1" | "2" ;
 ```
 
-#### Grouping
+### Grouping
 
 Parentheses group elements together:
 
-- `( A B )`
-
 ```mermaid-example
-railroad-beta
+railroad-ebnf-beta
 expression = term ( ( "+" | "-" ) term )* ;
 term = "number" ;
 ```
 
-#### Comments
+### Comments
 
-Comments can be added using either style:
+Comments can be added using either style and are ignored during parsing:
 
 - W3C notation: `/* comment */`
 - ISO 14977 notation: `(* comment *)`
 
-Comments are ignored during parsing and do not appear in the rendered diagram.
-
-#### Special Sequences
+### Special Sequences
 
 Special sequences (ISO 14977 only) describe elements that cannot be easily expressed in EBNF:
 
 - `? description ?`
 
-#### Exception
+### Exception
 
 The minus operator excludes certain alternatives:
 
 - `A - B` (match A but not B)
 
-## Examples
+### EBNF Notation Reference
 
-### Simple Number Grammar
+| Feature         | W3C Notation         | ISO 14977 Notation   | Description      |
+| --------------- | -------------------- | -------------------- | ---------------- |
+| Terminal        | `"text"` or `'text'` | `"text"` or `'text'` | Literal string   |
+| Non-terminal    | `identifier`         | `identifier`         | Rule reference   |
+| Sequence        | `A B`                | `A , B`              | Concatenation    |
+| Choice          | `A \| B`             | `A \| B`             | Alternative      |
+| Optional        | `A?`                 | `[ A ]`              | Zero or one      |
+| Repetition (0+) | `A*`                 | `{ A }`              | Zero or more     |
+| Repetition (1+) | `A+`                 | -                    | One or more      |
+| Grouping        | `( A B )`            | `( A B )`            | Group elements   |
+| Comment         | `/* text */`         | `(* text *)`         | Comment          |
+| Special         | -                    | `? text ?`           | Special sequence |
+| Exception       | `A - B`              | `A - B`              | Exclusion        |
+
+### EBNF Examples
 
 ```mermaid-example
-railroad-beta
-title "Number Grammar"
-
-sign = "+" | "-" ;
-number = sign? digit+ ;
-digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
-```
-
-### Expression Grammar
-
-```mermaid-example
-railroad-beta
+railroad-ebnf-beta
 title "Arithmetic Expression Grammar"
 
 expression = term ( ( "+" | "-" ) term )* ;
@@ -159,10 +163,8 @@ number = digit+ ;
 digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
 ```
 
-### JSON Grammar (Simplified)
-
 ```mermaid-example
-railroad-beta
+railroad-ebnf-beta
 title "JSON Grammar"
 
 json = element ;
@@ -172,20 +174,109 @@ array = "[" [ element ( "," element )* ] "]" ;
 member = string ":" element ;
 ```
 
-### URL Grammar
+## ABNF (`railroad-abnf-beta`)
+
+ABNF (Augmented Backus-Naur Form, [RFC 5234](https://datatracker.ietf.org/doc/html/rfc5234)) is widely used in IETF specifications. Rules are written as `name = definition ;`.
+
+- Alternation uses `/` (instead of `|`): `A / B`
+- Concatenation is whitespace-separated: `A B`
+- Repetition uses a prefix: `*A` (zero or more), `1*A` (one or more), `2*4A` (between 2 and 4), `3A` (exactly 3)
+- Grouping uses parentheses: `( A B )`
+- Optional groups use brackets: `[ A ]`
+- Terminals can be quoted strings (`"text"`) or numeric values (`%x41`, `%d65`, `%b1000001`, including ranges like `%x30-39`)
+- Comments start with `;` and run to the end of the line
+
+```mermaid-example
+railroad-abnf-beta
+title "Email Address"
+
+address = local-part "@" domain ;
+local-part = 1*( ALPHA / DIGIT / "." / "-" ) ;
+domain = label *( "." label ) ;
+label = 1*( ALPHA / DIGIT / "-" ) ;
+```
+
+```mermaid-example
+railroad-abnf-beta
+title "Phone Number"
+
+phone = [ "+" country-code ] subscriber ;
+country-code = 1*DIGIT ;
+subscriber = 1*( DIGIT / "-" / " " ) ;
+```
+
+## PEG (`railroad-peg-beta`)
+
+PEG (Parsing Expression Grammar) describes recursive-descent parsers with ordered choice. Rules are written as `Name <- definition ;`.
+
+- Ordered choice uses `/`: `A / B` (tries `A` first, then `B`)
+- Sequence is whitespace-separated: `A B`
+- Suffix operators: `A?` (optional), `A*` (zero or more), `A+` (one or more)
+- Prefix predicates: `&A` (and-predicate, lookahead), `!A` (not-predicate, negative lookahead)
+- Grouping uses parentheses: `( A B )`
+- `.` matches any single character
+- Terminals are quoted strings (`"text"` or `'text'`)
+- Comments start with `#` and run to the end of the line
+
+```mermaid-example
+railroad-peg-beta
+title "Calculator Grammar"
+
+Expression <- Term (("+" / "-") Term)* ;
+Term <- Factor (("*" / "/") Factor)* ;
+Factor <- Number / "(" Expression ")" ;
+Number <- Digit+ ;
+Digit <- "0" / "1" / "2" / "3" / "4" / "5" / "6" / "7" / "8" / "9" ;
+```
+
+```mermaid-example
+railroad-peg-beta
+title "Identifiers (keywords excluded)"
+
+Identifier <- !Keyword Letter Letter* ;
+Keyword <- "if" / "else" / "while" ;
+Letter <- "a" / "b" / "c" / "_" ;
+```
+
+## IR Primitives (`railroad-beta`)
+
+The `railroad-beta` keyword uses Mermaid's railroad intermediate representation directly. Instead of a grammar notation, each construct is written as an explicit constructor. This gives you direct control over the rendered structure and is useful when you want a layout that does not map cleanly onto a single grammar notation. Rules are written as `rule_name = expression ;`.
+
+| Constructor           | Meaning                       |
+| --------------------- | ----------------------------- |
+| `terminal("text")`    | Terminal (literal string)     |
+| `nonterminal("name")` | Non-terminal (rule reference) |
+| `sequence(a, b, ...)` | Elements in sequence          |
+| `choice(a, b, ...)`   | Alternatives                  |
+| `optional(a)`         | Zero or one                   |
+| `zeroOrMore(a)`       | Zero or more                  |
+| `oneOrMore(a)`        | One or more                   |
+| `special("text")`     | Special sequence              |
 
 ```mermaid-example
 railroad-beta
-title "URL Grammar"
+title Expression Grammar
 
-url = protocol "://" domain path? ;
-protocol = "http" | "https" | "ftp" ;
-domain = label ( "." label )* ;
-label = letter ( letter | digit | "-" )* ;
-path = "/" segment ( "/" segment )* ;
-letter = "a" | "b" | "c" ;
-digit = "0" | "1" | "2" ;
-segment = letter+ ;
+expression = sequence(
+    nonterminal("term"),
+    zeroOrMore(sequence(
+        choice(terminal("+"), terminal("-")),
+        nonterminal("term")
+    ))
+) ;
+term = sequence(
+    nonterminal("factor"),
+    zeroOrMore(sequence(
+        choice(terminal("*"), terminal("/")),
+        nonterminal("factor")
+    ))
+) ;
+factor = choice(
+    nonterminal("number"),
+    sequence(terminal("("), nonterminal("expression"), terminal(")"))
+) ;
+number = oneOrMore(nonterminal("digit")) ;
+digit = choice(terminal("0"), terminal("1"), terminal("2"), terminal("3"), terminal("4"), terminal("5"), terminal("6"), terminal("7"), terminal("8"), terminal("9")) ;
 ```
 
 ## Visual Elements
@@ -207,33 +298,19 @@ Railroad diagrams inherit colors and typography from the active Mermaid theme by
 
 - The hand-drawn look (`look: handDrawn`) is not currently supported for railroad diagrams.
 
-## Notation Reference
-
-| Feature         | W3C Notation         | ISO 14977 Notation   | Description      |
-| --------------- | -------------------- | -------------------- | ---------------- |
-| Terminal        | `"text"` or `'text'` | `"text"` or `'text'` | Literal string   |
-| Non-terminal    | `identifier`         | `identifier`         | Rule reference   |
-| Sequence        | `A B`                | `A , B`              | Concatenation    |
-| Choice          | `A \| B`             | `A \| B`             | Alternative      |
-| Optional        | `A?`                 | `[ A ]`              | Zero or one      |
-| Repetition (0+) | `A*`                 | `{ A }`              | Zero or more     |
-| Repetition (1+) | `A+`                 | -                    | One or more      |
-| Grouping        | `( A B )`            | `( A B )`            | Group elements   |
-| Comment         | `/* text */`         | `(* text *)`         | Comment          |
-| Special         | -                    | `? text ?`           | Special sequence |
-| Exception       | `A - B`              | `A - B`              | Exclusion        |
-
 ## Best Practices
 
 1. Keep rules simple: Break complex rules into smaller, reusable components
 2. Use meaningful names: Choose descriptive names for non-terminals
 3. Add titles: Use the `title` keyword to provide context for the grammar
 4. Group related rules: Define related grammar rules together
-5. Use consistent notation: Stick to either W3C or ISO 14977 notation style throughout your diagram
+5. Use consistent notation: Stick to one notation (and its matching keyword) throughout your diagram
 
 ## References
 
 - [ISO/IEC 14977:1996 - EBNF Standard](https://www.cl.cam.ac.uk/~mgk25/iso-14977.pdf)
 - [W3C EBNF Notation](https://www.w3.org/TR/xml/#sec-notation)
+- [RFC 5234 - Augmented BNF for Syntax Specifications (ABNF)](https://datatracker.ietf.org/doc/html/rfc5234)
+- [Parsing Expression Grammars (Bryan Ford, 2004)](https://bford.info/pub/lang/peg.pdf)
 - [Wikipedia: Extended Backus-Naur Form](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form)
 - [Wikipedia: Syntax Diagram](https://en.wikipedia.org/wiki/Syntax_diagram)

--- a/packages/mermaid/src/docs/syntax/railroad.md
+++ b/packages/mermaid/src/docs/syntax/railroad.md
@@ -7,7 +7,7 @@ Railroad diagrams were first popularized by Niklaus Wirth in his "Pascal User Ma
 Mermaid can render Railroad diagram visualizations from EBNF notation.
 
 ```mermaid-example
-railroad-diagram
+railroad-beta
 title "Digit Definition"
 
 digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
@@ -19,7 +19,7 @@ Railroad diagrams use EBNF (Extended Backus-Naur Form) notation to define gramma
 
 ### Basic Structure
 
-- Start with `railroad-diagram` keyword to begin the diagram
+- Start with `railroad-beta` keyword to begin the diagram
 - Optionally add a `title` followed by a quoted string
 - Define grammar rules using the format: `rule_name = definition ;`
 - Each rule must end with a semicolon (`;`)
@@ -38,7 +38,7 @@ Non-terminals are identifiers that reference other rules:
 - `identifier` - references another rule
 
 ```mermaid-example
-railroad-diagram
+railroad-beta
 letter = "a" | "b" | "c" ;
 identifier = letter ;
 ```
@@ -51,7 +51,7 @@ Elements appearing one after another define a sequence:
 - ISO 14977 notation: `A , B , C`
 
 ```mermaid-example
-railroad-diagram
+railroad-beta
 greeting = "Hello" " " "World" ;
 ```
 
@@ -60,7 +60,7 @@ greeting = "Hello" " " "World" ;
 The pipe symbol (`|`) indicates alternatives:
 
 ```mermaid-example
-railroad-diagram
+railroad-beta
 sign = "+" | "-" ;
 ```
 
@@ -72,7 +72,7 @@ Optional elements can appear zero or one time:
 - ISO 14977 notation: `[ A ]`
 
 ```mermaid-example
-railroad-diagram
+railroad-beta
 title "Optional Sign"
 
 sign = "+" | "-" ;
@@ -92,7 +92,7 @@ One or more repetitions:
 - W3C notation: `A+`
 
 ```mermaid-example
-railroad-diagram
+railroad-beta
 title "Identifier with Repetition"
 
 identifier = letter ( letter | digit | "_" )* ;
@@ -107,7 +107,7 @@ Parentheses group elements together:
 - `( A B )`
 
 ```mermaid-example
-railroad-diagram
+railroad-beta
 expression = term ( ( "+" | "-" ) term )* ;
 term = "number" ;
 ```
@@ -138,7 +138,7 @@ The minus operator excludes certain alternatives:
 ### Simple Number Grammar
 
 ```mermaid-example
-railroad-diagram
+railroad-beta
 title "Number Grammar"
 
 sign = "+" | "-" ;
@@ -149,7 +149,7 @@ digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
 ### Expression Grammar
 
 ```mermaid-example
-railroad-diagram
+railroad-beta
 title "Arithmetic Expression Grammar"
 
 expression = term ( ( "+" | "-" ) term )* ;
@@ -162,7 +162,7 @@ digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
 ### JSON Grammar (Simplified)
 
 ```mermaid-example
-railroad-diagram
+railroad-beta
 title "JSON Grammar"
 
 json = element ;
@@ -175,7 +175,7 @@ member = string ":" element ;
 ### URL Grammar
 
 ```mermaid-example
-railroad-diagram
+railroad-beta
 title "URL Grammar"
 
 url = protocol "://" domain path? ;

--- a/packages/mermaid/src/docs/syntax/swimlanes.md
+++ b/packages/mermaid/src/docs/syntax/swimlanes.md
@@ -3,9 +3,7 @@ title: Swimlanes Diagram Syntax
 outline: 'deep'
 ---
 
-# Swimlanes Diagram
-
-> Available since MERMAID_RELEASE_VERSION.
+# Swimlanes Diagram (v<MERMAID_RELEASE_VERSION>+)
 
 ```warning
 This is a new diagram type in Mermaid. Its syntax may evolve in future versions.
@@ -20,7 +18,7 @@ Use swimlane diagrams when the most important question is not only "what happens
 > The rendered examples on this page use the **Neo** look and the **Redux** theme. Out of the box, swimlanes use your configured default look and theme.
 
 ```mermaid-example
-swimlane LR
+swimlane-beta LR
   subgraph Customer
     request[Request service]
     receive[Receive update]
@@ -45,14 +43,14 @@ swimlane LR
 
 ## Syntax
 
-A swimlane diagram starts with the `swimlane` keyword. You can optionally add a direction after the keyword.
+A swimlane diagram starts with the `swimlane-beta` keyword. You can optionally add a direction after the keyword.
 
 ```
-swimlane
+swimlane-beta
 ```
 
 ```
-swimlane LR
+swimlane-beta LR
 ```
 
 The supported directions are:
@@ -72,7 +70,7 @@ If no direction is set, the diagram uses `TB`.
 Use `subgraph` to create a lane. In a swimlane diagram, top-level subgraphs are rendered as swimlanes. A lane ends with `end`.
 
 ```mermaid-example
-swimlane
+swimlane-beta
   subgraph Sales
     lead[Qualify lead]
     quote[Prepare quote]
@@ -82,7 +80,7 @@ swimlane
 You can give a lane an internal id and a display label. This is useful when the label contains spaces or when you want a stable id for styling.
 
 ```mermaid-example
-swimlane LR
+swimlane-beta LR
   subgraph sales [Sales team]
     lead[Qualify lead]
     quote[Prepare quote]
@@ -101,7 +99,7 @@ swimlane LR
 Nodes use flowchart-style shape syntax. The id is written first, and the label is written inside the shape.
 
 ```mermaid-example
-swimlane LR
+swimlane-beta LR
   subgraph Intake
     start([Start])
     task[Do work]
@@ -139,7 +137,7 @@ For the complete shape catalog, icons, images, markdown strings, classes, and st
 Edges also use flowchart-style syntax. They can connect nodes in the same lane or across lanes.
 
 ```mermaid-example
-swimlane LR
+swimlane-beta LR
   subgraph Buyer
     choose[Choose product]
     pay[Pay invoice]
@@ -172,7 +170,7 @@ For the full edge syntax, including multi-directional arrows and minimum link le
 Use `accTitle` and `accDescr` to provide an accessible title and description.
 
 ```mermaid-example
-swimlane LR
+swimlane-beta LR
   accTitle: Support escalation
   accDescr: A request starts with the customer, is triaged by support, and may be escalated to engineering.
 
@@ -198,7 +196,7 @@ swimlane LR
 Choose lanes that answer "who owns this step?" Avoid mixing teams, phases, and statuses in the same diagram unless that distinction is the point of the diagram.
 
 ```mermaid-example
-swimlane LR
+swimlane-beta LR
   subgraph Customer
     submit[Submit order]
     confirm[Confirm delivery]
@@ -222,7 +220,7 @@ swimlane LR
 A cross-lane arrow is where responsibility changes. Label the arrow when the handoff depends on a document, decision, message, or condition.
 
 ```mermaid-example
-swimlane LR
+swimlane-beta LR
   subgraph Applicant
     apply[Submit application]
     sign[Sign agreement]
@@ -249,7 +247,7 @@ swimlane LR
 Split a large process into several diagrams when the lanes or handoffs stop fitting in one view. A useful swimlane diagram is usually readable without tracing every arrow twice.
 
 ```mermaid-example
-swimlane TB
+swimlane-beta TB
   subgraph Intake
     collect[Collect request]
     validate[Validate details]
@@ -275,7 +273,7 @@ swimlane TB
 Use short, meaningful ids for nodes and lanes. The label can change without breaking links, styles, or later references.
 
 ```mermaid-example
-swimlane LR
+swimlane-beta LR
   subgraph ops [Operations]
     intake[Receive request]
     plan[Plan work]
@@ -296,7 +294,7 @@ swimlane LR
 Place a decision node in the lane that owns the decision. Then route the outcomes to the lanes that act on the result.
 
 ```mermaid-example
-swimlane LR
+swimlane-beta LR
   subgraph Support
     classify{Can support solve it?}
     respond[Respond to customer]

--- a/packages/mermaid/src/mermaidAPI.spec.ts
+++ b/packages/mermaid/src/mermaidAPI.spec.ts
@@ -758,7 +758,7 @@ describe('mermaidAPI', () => {
       `);
     });
     it('resolves swimlanes as its own diagram type', async () => {
-      await expect(mermaidAPI.parse('swimlane TD;A-->B;')).resolves.toMatchInlineSnapshot(`
+      await expect(mermaidAPI.parse('swimlane-beta TD;A-->B;')).resolves.toMatchInlineSnapshot(`
         {
           "config": {},
           "diagramType": "swimlane",

--- a/packages/mermaid/src/rendering-util/multi-diagram-id-uniqueness.spec.ts
+++ b/packages/mermaid/src/rendering-util/multi-diagram-id-uniqueness.spec.ts
@@ -98,16 +98,16 @@ radar-beta
   max 100
   min 0`,
 
-  railroad: `railroad-diagram
+  railroad: `railroad-beta
     rule = choice(terminal("a"), terminal("b")) ;`,
 
-  railroadEbnf: `railroad-ebnf
+  railroadEbnf: `railroad-ebnf-beta
     rule = "a" | "b" ;`,
 
-  railroadAbnf: `railroad-abnf
+  railroadAbnf: `railroad-abnf-beta
     rule = "a" / "b" ;`,
 
-  railroadPeg: `railroad-peg
+  railroadPeg: `railroad-peg-beta
     rule <- "a" / "b" ;`,
 
   treemap: `treemap-beta
@@ -172,7 +172,7 @@ union A, B`,
     service db(database)[DB]
     api:R -- L:db`,
 
-  'wardley-beta': `wardley-beta
+  wardley: `wardley-beta
     title Kettle Evolution Pipeline
     size [1100, 800]
 

--- a/packages/parser/src/language/railroad-abnf/railroad-abnf.langium
+++ b/packages/parser/src/language/railroad-abnf/railroad-abnf.langium
@@ -64,7 +64,7 @@ interface AbnfOptionalGroup extends AbnfPrimary {
 }
 
 entry RailroadAbnf returns RailroadAbnf:
-    'railroad-abnf'
+    'railroad-abnf-beta'
     ((title=TITLE | accTitle=ACC_TITLE | accDescr=ACC_DESCR))*
     rules+=AbnfRule*
 ;

--- a/packages/parser/src/language/railroad-abnf/tokenBuilder.ts
+++ b/packages/parser/src/language/railroad-abnf/tokenBuilder.ts
@@ -2,6 +2,6 @@ import { AbstractMermaidTokenBuilder } from '../common/index.js';
 
 export class RailroadAbnfTokenBuilder extends AbstractMermaidTokenBuilder {
   constructor() {
-    super(['railroad-abnf']);
+    super(['railroad-abnf-beta']);
   }
 }

--- a/packages/parser/src/language/railroad-ebnf/railroad-ebnf.langium
+++ b/packages/parser/src/language/railroad-ebnf/railroad-ebnf.langium
@@ -88,7 +88,7 @@ interface EbnfExceptionPostfix extends EbnfPostfix {
 }
 
 entry RailroadEbnf returns RailroadEbnf:
-    'railroad-ebnf'
+    'railroad-ebnf-beta'
     ((title=TITLE | accTitle=ACC_TITLE | accDescr=ACC_DESCR))*
     rules+=EbnfRule*
 ;

--- a/packages/parser/src/language/railroad-ebnf/tokenBuilder.ts
+++ b/packages/parser/src/language/railroad-ebnf/tokenBuilder.ts
@@ -2,6 +2,6 @@ import { AbstractMermaidTokenBuilder } from '../common/index.js';
 
 export class RailroadEbnfTokenBuilder extends AbstractMermaidTokenBuilder {
   constructor() {
-    super(['railroad-ebnf']);
+    super(['railroad-ebnf-beta']);
   }
 }

--- a/packages/parser/src/language/railroad-peg/railroad-peg.langium
+++ b/packages/parser/src/language/railroad-peg/railroad-peg.langium
@@ -62,7 +62,7 @@ interface PegAny extends PegPrimary {
 }
 
 entry RailroadPeg returns RailroadPeg:
-    'railroad-peg'
+    'railroad-peg-beta'
     ((title=TITLE | accTitle=ACC_TITLE | accDescr=ACC_DESCR))*
     rules+=PegRule*
 ;

--- a/packages/parser/src/language/railroad-peg/tokenBuilder.ts
+++ b/packages/parser/src/language/railroad-peg/tokenBuilder.ts
@@ -2,6 +2,6 @@ import { AbstractMermaidTokenBuilder } from '../common/index.js';
 
 export class RailroadPegTokenBuilder extends AbstractMermaidTokenBuilder {
   constructor() {
-    super(['railroad-peg']);
+    super(['railroad-peg-beta']);
   }
 }

--- a/packages/parser/src/language/railroad/railroad.langium
+++ b/packages/parser/src/language/railroad/railroad.langium
@@ -60,7 +60,7 @@ interface RailroadSpecialExpr extends RailroadExpression {
 }
 
 entry Railroad returns Railroad:
-    'railroad-diagram'
+    'railroad-beta'
     ((title=TITLE | accTitle=ACC_TITLE | accDescr=ACC_DESCR))*
     rules+=RailroadRule*
 ;

--- a/packages/parser/src/language/railroad/tokenBuilder.ts
+++ b/packages/parser/src/language/railroad/tokenBuilder.ts
@@ -2,6 +2,6 @@ import { AbstractMermaidTokenBuilder } from '../common/index.js';
 
 export class RailroadTokenBuilder extends AbstractMermaidTokenBuilder {
   public constructor() {
-    super(['railroad', 'railroad-diagram']);
+    super(['railroad-beta']);
   }
 }

--- a/packages/parser/tests/railroad.test.ts
+++ b/packages/parser/tests/railroad.test.ts
@@ -20,7 +20,7 @@ describe('Railroad parser', () => {
   };
 
   it('should parse title and accessibility metadata', () => {
-    const result = parse(`railroad-diagram
+    const result = parse(`railroad-beta
 title Example Grammar
 accTitle: Accessible Railroad
 accDescr: Railroad description
@@ -35,7 +35,7 @@ rule = terminal("a") ;`);
   });
 
   it('should parse IR function expressions', () => {
-    const result = parse(`railroad-diagram
+    const result = parse(`railroad-beta
 rule = sequence(terminal("a"), nonterminal("b")) ;`);
 
     expectNoErrorsOrAlternatives(result);
@@ -50,7 +50,7 @@ rule = sequence(terminal("a"), nonterminal("b")) ;`);
   });
 
   it('should parse choice expressions', () => {
-    const result = parse(`railroad-diagram
+    const result = parse(`railroad-beta
 rule = choice(terminal("a"), terminal("b"), terminal("c")) ;`);
 
     expectNoErrorsOrAlternatives(result);
@@ -62,7 +62,7 @@ rule = choice(terminal("a"), terminal("b"), terminal("c")) ;`);
   });
 
   it('should parse optional, oneOrMore, and zeroOrMore', () => {
-    const result = parse(`railroad-diagram
+    const result = parse(`railroad-beta
 r1 = optional(terminal("a")) ;
 r2 = oneOrMore(terminal("b")) ;
 r3 = zeroOrMore(terminal("c")) ;`);
@@ -75,7 +75,7 @@ r3 = zeroOrMore(terminal("c")) ;`);
   });
 
   it('should parse special expressions', () => {
-    const result = parse(`railroad-diagram
+    const result = parse(`railroad-beta
 rule = special("any character") ;`);
 
     expectNoErrorsOrAlternatives(result);
@@ -87,7 +87,7 @@ rule = special("any character") ;`);
   });
 
   it('should skip C-style block comments', () => {
-    const result = parse(`railroad-diagram
+    const result = parse(`railroad-beta
 /* comment before the first rule */
 rule = terminal("a") ;
 next = nonterminal("rule") ;`);
@@ -102,7 +102,7 @@ next = nonterminal("rule") ;`);
     await expect(
       parseAsync(
         'railroad',
-        `railroad-diagram
+        `railroad-beta
 rule = terminal("a")`
       )
     ).rejects.toBeInstanceOf(MermaidParseError);


### PR DESCRIPTION
## Summary

- Adds `diagram-beta-policy.spec.ts` enforcing that newly registered diagram types must require `-beta` in their syntax (detector accepts `{id}-beta`, rejects `{id}`).
- Defines two frozen allowlists:
  - `NEVER_BETA_DIAGRAMS` — stable diagrams that never had a beta phase.
  - `GRADUATED_DIAGRAMS` — diagrams that left beta but keep an optional `-beta` suffix for backwards compatibility (test asserts the detector accepts both `{id}` and `{id}-beta`).
- `BETA_KEYWORD_OVERRIDES` handles diagrams whose keyword differs from `{id}-beta` (railroad family).
- Aligns the unreleased **railroad** family (`railroad-beta`, `railroad-ebnf-beta`, `railroad-abnf-beta`, `railroad-peg-beta`) and **swimlane** (`swimlane-beta`) diagrams to the `-beta` convention across detectors, Langium grammars + token builders, the shared flowchart JISON keyword, docs, examples, demos, Cypress specs, DDLT fixtures, and unit tests.
- Cleans up wardley's internal id (`wardley-beta` → `wardley`) so it satisfies the policy via the optional-suffix rule.

## Test plan

- [ ] `pnpm vitest run --dir packages/mermaid packages/mermaid/src/diagram-api/diagram-beta-policy.spec.ts`
- [ ] `pnpm vitest run --dir packages/mermaid` (railroad/swimlane/wardley detector, parser, orchestration, uniqueness specs)
- [ ] `pnpm --filter @mermaid-js/parser test` (railroad grammar tests)
- [ ] E2E: railroad + swimlane rendering specs

Made with [Cursor](https://cursor.com)