### PR TITLE
fix: support ::: class operator with @{ } shape data syntax in flowcharts

### DIFF
--- a/.changeset/fix-flowchart-shapedata-class-separator.md
+++ b/.changeset/fix-flowchart-shapedata-class-separator.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: allow applying a class with the `:::` operator on flowchart nodes that use the `@{ ... }` shape data syntax (e.g. `n1@{ shape: rect }:::myClass`)

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow-node-data.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow-node-data.spec.js
@@ -62,6 +62,69 @@ describe('when parsing directions', function () {
     expect(data4Layout.nodes[0].label).toEqual('D');
     expect(data4Layout.nodes[1].label).toEqual('E');
   });
+  it('should be possible to apply a class to a node with shape data using :::', function () {
+    const res = flow.parser.parse(`flowchart TD
+      classDef customClazz fill:#bbf,stroke:#f66,stroke-width:2px
+      n1@{ shape: rect, label: "Rectangle" }:::customClazz`);
+
+    const data4Layout = flow.parser.yy.getData();
+    expect(data4Layout.nodes.length).toBe(1);
+    expect(data4Layout.nodes[0].shape).toEqual('rect');
+    expect(data4Layout.nodes[0].label).toEqual('Rectangle');
+
+    const vertices = flow.parser.yy.getVertices();
+    expect(vertices.get('n1').classes).toContain('customClazz');
+  });
+  it('should be possible to apply a class to a node with shape data and edges using :::', function () {
+    const res = flow.parser.parse(`flowchart TD
+      classDef customClazz fill:#bbf,stroke:#f66,stroke-width:2px
+      n1@{ shape: rect, label: "Rectangle" }:::customClazz --> n2`);
+
+    const data4Layout = flow.parser.yy.getData();
+    expect(data4Layout.nodes.length).toBe(2);
+
+    const vertices = flow.parser.yy.getVertices();
+    expect(vertices.get('n1').classes).toContain('customClazz');
+    expect(vertices.get('n2').classes.length).toBe(0);
+  });
+  it('should be possible to apply a class to a linked target node with shape data using :::', function () {
+    const res = flow.parser.parse(`flowchart TD
+      classDef customClazz fill:#bbf,stroke:#f66,stroke-width:2px
+      n1 --> n2@{ shape: rect, label: "Rectangle" }:::customClazz`);
+
+    const data4Layout = flow.parser.yy.getData();
+    expect(data4Layout.nodes.length).toBe(2);
+    expect(data4Layout.nodes[1].shape).toEqual('rect');
+    expect(data4Layout.nodes[1].label).toEqual('Rectangle');
+
+    const vertices = flow.parser.yy.getVertices();
+    expect(vertices.get('n1').classes.length).toBe(0);
+    expect(vertices.get('n2').classes).toContain('customClazz');
+  });
+  it('should be possible to chain a linked target node with shape data and ::: class', function () {
+    const res = flow.parser.parse(`flowchart TD
+      classDef customClazz fill:#bbf,stroke:#f66,stroke-width:2px
+      n1 --> n2@{ shape: rect, label: "Rectangle" }:::customClazz --> n3`);
+
+    const data4Layout = flow.parser.yy.getData();
+    expect(data4Layout.nodes.length).toBe(3);
+
+    const vertices = flow.parser.yy.getVertices();
+    expect(vertices.get('n2').classes).toContain('customClazz');
+    expect(vertices.get('n3').classes.length).toBe(0);
+  });
+  it('should be possible to apply a class to a node with shape data before an ampersand', function () {
+    const res = flow.parser.parse(`flowchart TD
+      classDef customClazz fill:#bbf,stroke:#f66,stroke-width:2px
+      n1@{ shape: rect, label: "Rectangle" }:::customClazz & n2`);
+
+    const data4Layout = flow.parser.yy.getData();
+    expect(data4Layout.nodes.length).toBe(2);
+
+    const vertices = flow.parser.yy.getVertices();
+    expect(vertices.get('n1').classes).toContain('customClazz');
+    expect(vertices.get('n2').classes.length).toBe(0);
+  });
   it('should handle basic shape data statements with amp and edges 2', function () {
     const res = flow.parser.parse(`flowchart TB
       D@{ shape: rounded } & E@{ shape: rounded } --> F`);

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
@@ -400,13 +400,21 @@ shapeData:
     { $$ = $1; }
     ;
 
-vertexStatement: vertexStatement link node shapeData
+vertexStatement: vertexStatement link node shapeData STYLE_SEPARATOR idString
+        { /* console.warn('vs shapeData STYLE_SEPARATOR idString',$vertexStatement.stmt,$node, $shapeData, $idString);*/ yy.addVertex($node[$node.length-1],undefined,undefined,undefined, undefined,undefined, undefined,$shapeData); yy.setClass($node[$node.length-1],$idString); yy.addLink($vertexStatement.stmt,$node,$link); $$ = { stmt: $node, nodes: $node.concat($vertexStatement.nodes) } }
+    | vertexStatement link node shapeData
         { /* console.warn('vs shapeData',$vertexStatement.stmt,$node, $shapeData);*/ yy.addVertex($node[$node.length-1],undefined,undefined,undefined, undefined,undefined, undefined,$shapeData); yy.addLink($vertexStatement.stmt,$node,$link); $$ = { stmt: $node, nodes: $node.concat($vertexStatement.nodes) } }
     | vertexStatement link node
         { /*console.warn('vs',$vertexStatement.stmt,$node);*/ yy.addLink($vertexStatement.stmt,$node,$link); $$ = { stmt: $node, nodes: $node.concat($vertexStatement.nodes) } }
     |  vertexStatement link node spaceList
         { /* console.warn('vs',$vertexStatement.stmt,$node); */ yy.addLink($vertexStatement.stmt,$node,$link); $$ = { stmt: $node, nodes: $node.concat($vertexStatement.nodes) } }
     |node spaceList { /*console.warn('vertexStatement: node spaceList', $node);*/ $$ = {stmt: $node, nodes:$node }}
+    |node shapeData STYLE_SEPARATOR idString {
+        /*console.warn('vertexStatement: node shapeData STYLE_SEPARATOR idString', $node[0], $shapeData, $idString);*/
+        yy.addVertex($node[$node.length-1],undefined,undefined,undefined, undefined,undefined, undefined,$shapeData);
+        yy.setClass($node[$node.length-1],$idString);
+        $$ = {stmt: $node, nodes:$node, shapeData: $shapeData}
+    }
     |node shapeData {
         /*console.warn('vertexStatement: node shapeData', $node[0], $shapeData);*/
         yy.addVertex($node[$node.length-1],undefined,undefined,undefined, undefined,undefined, undefined,$shapeData);
@@ -417,6 +425,8 @@ vertexStatement: vertexStatement link node shapeData
 
 node: styledVertex
         { /*console.warn('nod', $styledVertex);*/ $$ = [$styledVertex];}
+    | node shapeData STYLE_SEPARATOR idString spaceList AMP spaceList styledVertex
+        {  yy.addVertex($node[$node.length-1],undefined,undefined,undefined, undefined,undefined, undefined,$shapeData); yy.setClass($node[$node.length-1],$idString); $$ = $node.concat($styledVertex); /*console.warn('pip2 styled', $node[0], $styledVertex, $$);*/  }
     | node shapeData spaceList AMP spaceList styledVertex
         {  yy.addVertex($node[$node.length-1],undefined,undefined,undefined, undefined,undefined, undefined,$shapeData); $$ = $node.concat($styledVertex); /*console.warn('pip2', $node[0], $styledVertex, $$);*/  }
     | node spaceList AMP spaceList styledVertex


### PR DESCRIPTION
## Description

Fixes #7826

The new `@{ ... }` shape data syntax did not support the `:::` class operator, while the legacy node syntax did. For example, the following failed to parse:

```mermaid
flowchart TD
    classDef customClazz fill:#bbf,stroke:#f66,stroke-width:2px
    n1@{ shape: rect, label: "Rectangle" }:::customClazz
```

## Changes

- Added grammar productions in `flow.jison` so the `:::class` operator works with `@{ ... }` shape data nodes, covering:
  - statement-start nodes: `n1@{...}:::cls`
  - linked target nodes: `A --> n1@{...}:::cls`
  - chained edges: `A --> n1@{...}:::cls --> B`
  - ampersand-grouped nodes: `A@{...}:::cls & B`
- Added parser unit tests in `flow-node-data.spec.js` asserting the class is actually applied to the right vertices.
- Added a changeset.

## Testing

`pnpm vitest run packages/mermaid/src/diagrams/flowchart/parser` — 967 passed, 3 skipped, no regressions.