### PR TITLE
feat(c4): migrate C4 element shapes to the unified shapes

### DIFF
--- a/.changeset/c4-unified-shapes.md
+++ b/.changeset/c4-unified-shapes.md
@@ -1,0 +1,5 @@
+---
+'mermaid': minor
+---
+
+feat(c4): render C4 elements through the unified shape system, using the new person shape

--- a/.changeset/person-shape.md
+++ b/.changeset/person-shape.md
@@ -1,0 +1,5 @@
+---
+'mermaid': minor
+---
+
+feat: add `person` shape (circular head above a rounded body), usable in flowcharts via `A@{ shape: person }`

--- a/.cspell/mermaid-terms.txt
+++ b/.cspell/mermaid-terms.txt
@@ -42,6 +42,7 @@ sandboxed
 sentencepiece
 siebling
 statediagram
+Structurizr
 substate
 treeview
 unfixable

--- a/cypress/integration/rendering/c4/c4-characterization.spec.js
+++ b/cypress/integration/rendering/c4/c4-characterization.spec.js
@@ -250,10 +250,10 @@ describe('C4 characterization', () => {
       );
     });
 
-    it('CHAR.update-element-shape should accept the $shape override (ignored by renderer)', () => {
+    it('CHAR.update-element-shape should apply the $shape="cylinder" override ($shape="folder" not yet supported)', () => {
       imgSnapshotTest(
         `C4Container
-        title UpdateElementStyle shape override (ignored by renderer)
+        title UpdateElementStyle shape override (folder not yet supported)
         Container(a, "Default", "Tech", "no override")
         Container(b, "As Folder", "Tech", "shape override")
         Container(c, "As Cylinder", "Tech", "shape override")
@@ -262,7 +262,10 @@ describe('C4 characterization', () => {
         `,
         {}
       );
-      cy.get('rect').should('have.length', 3);
+      // the cylinder renders as a path; the folder override falls back to the plain box
+      // (scoped to .node to exclude unrelated defs/marker paths)
+      cy.get('.node path').should('have.length', 1);
+      cy.get('.node > rect').should('have.length', 2);
     });
 
     it('CHAR.update-rel-style should apply UpdateRelStyle offsets and colors', () => {
@@ -331,29 +334,28 @@ describe('C4 characterization', () => {
         `,
         {}
       );
-      cy.get('rect').should('have.length', 2);
+      // both containers fall back to the plain box; a sprite implementation must break this
       cy.get('image').should('not.exist');
       cy.get('svg svg').should('not.exist');
+      cy.get('.node > rect').should('have.length', 2);
     });
 
-    it('CHAR.descr-wrapping should not wrap long descriptions (wrap is currently a no-op, see #7949)', () => {
+    it('CHAR.descr-wrapping should wrap long descriptions as SVG text (the wrap-config bug in #7949 is unrelated)', () => {
       imgSnapshotTest(
         `C4Context
-        title Description wrapping (currently a no-op)
+        title Description wrapping
         Person(p, "Person", "A customer of the bank with personal bank accounts and a long description that should wrap across multiple lines")
         System(s, "System", "Allows customers to view information about their bank accounts and make payments")
         Rel(p, s, "Uses")
         `,
-        {}
+        { wrap: true }
       );
-      cy.contains(
-        'tspan',
-        'A customer of the bank with personal bank accounts and a long description that should wrap across multiple lines'
-      ).should('exist');
-      cy.contains(
-        'tspan',
-        'Allows customers to view information about their bank accounts and make payments'
-      ).should('exist');
+      cy.get('.node foreignObject').should('not.exist');
+      cy.get('.node .c4-descr').should('have.length', 2);
+      // wrapping produces multiple tspan lines within the description section
+      cy.get('.node .c4-descr').first().find('tspan.text-outer-tspan').should('have.length.gt', 1);
+      // textContent joins wrapped lines without spaces, so assert within one line
+      cy.get('.node .c4-descr tspan.text-outer-tspan').first().should('contain.text', 'A customer');
     });
   });
 });

--- a/cypress/integration/rendering/c4/c4.spec.js
+++ b/cypress/integration/rendering/c4/c4.spec.js
@@ -138,4 +138,26 @@ describe('C4 diagram', () => {
       {}
     );
   });
+  it('C4.7 should apply per-element font config (personFontFamily, personFontSize)', () => {
+    imgSnapshotTest(
+      [
+        { fontFamily: 'courier', fontSize: 14 },
+        { fontFamily: 'serif', fontSize: 24 },
+      ].map(
+        ({ fontFamily, fontSize }) => `---
+title: personFontFamily=${fontFamily} personFontSize=${fontSize}
+config:
+  c4:
+    personFontFamily: ${fontFamily}
+    personFontSize: ${fontSize}
+---
+C4Context
+      Person(customerA, "Banking Customer A", "A customer of the bank.")
+      System(SystemAA, "Internet Banking System", "Allows customers to view information.")
+      Rel(customerA, SystemAA, "Uses")
+      `
+      ),
+      {}
+    );
+  });
 });

--- a/cypress/integration/rendering/c4/c4.spec.js
+++ b/cypress/integration/rendering/c4/c4.spec.js
@@ -160,4 +160,21 @@ C4Context
       {}
     );
   });
+  it('C4.8 should wrap element text at c4.width when the root wrap config is enabled', () => {
+    imgSnapshotTest(
+      [216, 4000].map(
+        (width) => `---
+title: wrap at c4.width=${width}
+config:
+  wrap: true
+  c4:
+    width: ${width}
+---
+C4Context
+      System(s, "System", "A long description that wraps at the default width and stays on one line when the width is large")
+      `
+      ),
+      {}
+    );
+  });
 });

--- a/cypress/integration/rendering/newShapes.spec.ts
+++ b/cypress/integration/rendering/newShapes.spec.ts
@@ -48,7 +48,8 @@ const newShapesSet5 = [
   'brace-r',
 ] as const;
 
-const newShapesSet6 = ['brace-r', 'braces'] as const;
+const newShapesSet6 = ['brace-r', 'braces', 'person'] as const;
+
 // Aggregate all shape sets into a single array
 const newShapesSets = [
   newShapesSet1,

--- a/docs/config/setup/mermaid/interfaces/LayoutData.md
+++ b/docs/config/setup/mermaid/interfaces/LayoutData.md
@@ -10,7 +10,7 @@
 
 # Interface: LayoutData
 
-Defined in: [packages/mermaid/src/rendering-util/types.ts:211](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L211)
+Defined in: [packages/mermaid/src/rendering-util/types.ts:213](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L213)
 
 ## Indexable
 
@@ -22,7 +22,7 @@ Defined in: [packages/mermaid/src/rendering-util/types.ts:211](https://github.co
 
 > **config**: [`MermaidConfig`](MermaidConfig.md)
 
-Defined in: [packages/mermaid/src/rendering-util/types.ts:214](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L214)
+Defined in: [packages/mermaid/src/rendering-util/types.ts:216](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L216)
 
 ---
 
@@ -30,7 +30,7 @@ Defined in: [packages/mermaid/src/rendering-util/types.ts:214](https://github.co
 
 > `optional` **diagramId**: `string`
 
-Defined in: [packages/mermaid/src/rendering-util/types.ts:215](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L215)
+Defined in: [packages/mermaid/src/rendering-util/types.ts:217](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L217)
 
 ---
 
@@ -38,7 +38,7 @@ Defined in: [packages/mermaid/src/rendering-util/types.ts:215](https://github.co
 
 > **edges**: `Edge`\[]
 
-Defined in: [packages/mermaid/src/rendering-util/types.ts:213](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L213)
+Defined in: [packages/mermaid/src/rendering-util/types.ts:215](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L215)
 
 ---
 
@@ -46,4 +46,4 @@ Defined in: [packages/mermaid/src/rendering-util/types.ts:213](https://github.co
 
 > **nodes**: `Node`\[]
 
-Defined in: [packages/mermaid/src/rendering-util/types.ts:212](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L212)
+Defined in: [packages/mermaid/src/rendering-util/types.ts:214](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L214)

--- a/docs/syntax/c4.md
+++ b/docs/syntax/c4.md
@@ -210,6 +210,19 @@ UpdateRelStyle(customerA, bankA, $offsetY="60")
 
 ```
 
+## Element text wrapping
+
+Element text (name, type and description) stays on one line by default; the element sizes itself to the longest line. Set the root `wrap` config value to wrap text to the element width instead, which is set by the [`c4.width`](/config/schema-docs/config-defs-c4-diagram-config.html#width) config value:
+
+```yaml
+---
+config:
+  wrap: true
+  c4:
+    width: 216
+---
+```
+
 ## C4 System Context Diagram (C4Context)
 
 ```mermaid-example

--- a/docs/syntax/flowchart.md
+++ b/docs/syntax/flowchart.md
@@ -322,56 +322,57 @@ This syntax creates a node A as a rectangle. It renders in the same way as `A["A
 
 Below is a comprehensive list of the newly introduced shapes and their corresponding semantic meanings, short names, and aliases:
 
-| **Semantic Name**                 | **Shape Name**         | **Short Name** | **Description**                | **Alias Supported**                                              |
-| --------------------------------- | ---------------------- | -------------- | ------------------------------ | ---------------------------------------------------------------- |
-| Bang                              | Bang                   | `bang`         | Bang                           | `bang`                                                           |
-| Card                              | Notched Rectangle      | `notch-rect`   | Represents a card              | `card`, `notched-rectangle`                                      |
-| Cloud                             | Cloud                  | `cloud`        | cloud                          | `cloud`                                                          |
-| Collate                           | Hourglass              | `hourglass`    | Represents a collate operation | `collate`, `hourglass`                                           |
-| Com Link                          | Lightning Bolt         | `bolt`         | Communication link             | `com-link`, `lightning-bolt`                                     |
-| Comment                           | Curly Brace            | `brace`        | Adds a comment                 | `brace-l`, `comment`                                             |
-| Comment Right                     | Curly Brace            | `brace-r`      | Adds a comment                 |                                                                  |
-| Comment with braces on both sides | Curly Braces           | `braces`       | Adds a comment                 |                                                                  |
-| Data Input/Output                 | Lean Right             | `lean-r`       | Represents input or output     | `in-out`, `lean-right`                                           |
-| Data Input/Output                 | Lean Left              | `lean-l`       | Represents output or input     | `lean-left`, `out-in`                                            |
-| Data Store                        | Data Store             | `datastore`    | Data flow diagram data store   | `data-store`                                                     |
-| Database                          | Cylinder               | `cyl`          | Database storage               | `cylinder`, `database`, `db`                                     |
-| Decision                          | Diamond                | `diam`         | Decision-making step           | `decision`, `diamond`, `question`                                |
-| Delay                             | Half-Rounded Rectangle | `delay`        | Represents a delay             | `half-rounded-rectangle`                                         |
-| Direct Access Storage             | Horizontal Cylinder    | `h-cyl`        | Direct access storage          | `das`, `horizontal-cylinder`                                     |
-| Disk Storage                      | Lined Cylinder         | `lin-cyl`      | Disk storage                   | `disk`, `lined-cylinder`                                         |
-| Display                           | Curved Trapezoid       | `curv-trap`    | Represents a display           | `curved-trapezoid`, `display`                                    |
-| Divided Process                   | Divided Rectangle      | `div-rect`     | Divided process shape          | `div-proc`, `divided-process`, `divided-rectangle`               |
-| Document                          | Document               | `doc`          | Represents a document          | `doc`, `document`                                                |
-| Event                             | Rounded Rectangle      | `rounded`      | Represents an event            | `event`                                                          |
-| Extract                           | Triangle               | `tri`          | Extraction process             | `extract`, `triangle`                                            |
-| Fork/Join                         | Filled Rectangle       | `fork`         | Fork or join in process flow   | `join`                                                           |
-| Internal Storage                  | Window Pane            | `win-pane`     | Internal storage               | `internal-storage`, `window-pane`                                |
-| Junction                          | Filled Circle          | `f-circ`       | Junction point                 | `filled-circle`, `junction`                                      |
-| Lined Document                    | Lined Document         | `lin-doc`      | Lined document                 | `lined-document`                                                 |
-| Lined/Shaded Process              | Lined Rectangle        | `lin-rect`     | Lined process shape            | `lin-proc`, `lined-process`, `lined-rectangle`, `shaded-process` |
-| Loop Limit                        | Trapezoidal Pentagon   | `notch-pent`   | Loop limit step                | `loop-limit`, `notched-pentagon`                                 |
-| Manual File                       | Flipped Triangle       | `flip-tri`     | Manual file operation          | `flipped-triangle`, `manual-file`                                |
-| Manual Input                      | Sloped Rectangle       | `sl-rect`      | Manual input step              | `manual-input`, `sloped-rectangle`                               |
-| Manual Operation                  | Trapezoid Base Top     | `trap-t`       | Represents a manual task       | `inv-trapezoid`, `manual`, `trapezoid-top`                       |
-| Multi-Document                    | Stacked Document       | `docs`         | Multiple documents             | `documents`, `st-doc`, `stacked-document`                        |
-| Multi-Process                     | Stacked Rectangle      | `st-rect`      | Multiple processes             | `processes`, `procs`, `stacked-rectangle`                        |
-| Odd                               | Odd                    | `odd`          | Odd shape                      |                                                                  |
-| Paper Tape                        | Flag                   | `flag`         | Paper tape                     | `paper-tape`                                                     |
-| Prepare Conditional               | Hexagon                | `hex`          | Preparation or condition step  | `hexagon`, `prepare`                                             |
-| Priority Action                   | Trapezoid Base Bottom  | `trap-b`       | Priority action                | `priority`, `trapezoid`, `trapezoid-bottom`                      |
-| Process                           | Rectangle              | `rect`         | Standard process shape         | `proc`, `process`, `rectangle`                                   |
-| Start                             | Circle                 | `circle`       | Starting point                 | `circ`                                                           |
-| Start                             | Small Circle           | `sm-circ`      | Small starting point           | `small-circle`, `start`                                          |
-| Stop                              | Double Circle          | `dbl-circ`     | Represents a stop point        | `double-circle`                                                  |
-| Stop                              | Framed Circle          | `fr-circ`      | Stop point                     | `framed-circle`, `stop`                                          |
-| Stored Data                       | Bow Tie Rectangle      | `bow-rect`     | Stored data                    | `bow-tie-rectangle`, `stored-data`                               |
-| Subprocess                        | Framed Rectangle       | `fr-rect`      | Subprocess                     | `framed-rectangle`, `subproc`, `subprocess`, `subroutine`        |
-| Summary                           | Crossed Circle         | `cross-circ`   | Summary                        | `crossed-circle`, `summary`                                      |
-| Tagged Document                   | Tagged Document        | `tag-doc`      | Tagged document                | `tag-doc`, `tagged-document`                                     |
-| Tagged Process                    | Tagged Rectangle       | `tag-rect`     | Tagged process                 | `tag-proc`, `tagged-process`, `tagged-rectangle`                 |
-| Terminal Point                    | Stadium                | `stadium`      | Terminal point                 | `pill`, `terminal`                                               |
-| Text Block                        | Text Block             | `text`         | Text block                     |                                                                  |
+| **Semantic Name**                 | **Shape Name**         | **Short Name** | **Description**                             | **Alias Supported**                                              |
+| --------------------------------- | ---------------------- | -------------- | ------------------------------------------- | ---------------------------------------------------------------- |
+| Bang                              | Bang                   | `bang`         | Bang                                        | `bang`                                                           |
+| Card                              | Notched Rectangle      | `notch-rect`   | Represents a card                           | `card`, `notched-rectangle`                                      |
+| Cloud                             | Cloud                  | `cloud`        | cloud                                       | `cloud`                                                          |
+| Collate                           | Hourglass              | `hourglass`    | Represents a collate operation              | `collate`, `hourglass`                                           |
+| Com Link                          | Lightning Bolt         | `bolt`         | Communication link                          | `com-link`, `lightning-bolt`                                     |
+| Comment                           | Curly Brace            | `brace`        | Adds a comment                              | `brace-l`, `comment`                                             |
+| Comment Right                     | Curly Brace            | `brace-r`      | Adds a comment                              |                                                                  |
+| Comment with braces on both sides | Curly Braces           | `braces`       | Adds a comment                              |                                                                  |
+| Data Input/Output                 | Lean Right             | `lean-r`       | Represents input or output                  | `in-out`, `lean-right`                                           |
+| Data Input/Output                 | Lean Left              | `lean-l`       | Represents output or input                  | `lean-left`, `out-in`                                            |
+| Data Store                        | Data Store             | `datastore`    | Data flow diagram data store                | `data-store`                                                     |
+| Database                          | Cylinder               | `cyl`          | Database storage                            | `cylinder`, `database`, `db`                                     |
+| Decision                          | Diamond                | `diam`         | Decision-making step                        | `decision`, `diamond`, `question`                                |
+| Delay                             | Half-Rounded Rectangle | `delay`        | Represents a delay                          | `half-rounded-rectangle`                                         |
+| Direct Access Storage             | Horizontal Cylinder    | `h-cyl`        | Direct access storage                       | `das`, `horizontal-cylinder`                                     |
+| Disk Storage                      | Lined Cylinder         | `lin-cyl`      | Disk storage                                | `disk`, `lined-cylinder`                                         |
+| Display                           | Curved Trapezoid       | `curv-trap`    | Represents a display                        | `curved-trapezoid`, `display`                                    |
+| Divided Process                   | Divided Rectangle      | `div-rect`     | Divided process shape                       | `div-proc`, `divided-process`, `divided-rectangle`               |
+| Document                          | Document               | `doc`          | Represents a document                       | `doc`, `document`                                                |
+| Event                             | Rounded Rectangle      | `rounded`      | Represents an event                         | `event`                                                          |
+| Extract                           | Triangle               | `tri`          | Extraction process                          | `extract`, `triangle`                                            |
+| Fork/Join                         | Filled Rectangle       | `fork`         | Fork or join in process flow                | `join`                                                           |
+| Internal Storage                  | Window Pane            | `win-pane`     | Internal storage                            | `internal-storage`, `window-pane`                                |
+| Junction                          | Filled Circle          | `f-circ`       | Junction point                              | `filled-circle`, `junction`                                      |
+| Lined Document                    | Lined Document         | `lin-doc`      | Lined document                              | `lined-document`                                                 |
+| Lined/Shaded Process              | Lined Rectangle        | `lin-rect`     | Lined process shape                         | `lin-proc`, `lined-process`, `lined-rectangle`, `shaded-process` |
+| Loop Limit                        | Trapezoidal Pentagon   | `notch-pent`   | Loop limit step                             | `loop-limit`, `notched-pentagon`                                 |
+| Manual File                       | Flipped Triangle       | `flip-tri`     | Manual file operation                       | `flipped-triangle`, `manual-file`                                |
+| Manual Input                      | Sloped Rectangle       | `sl-rect`      | Manual input step                           | `manual-input`, `sloped-rectangle`                               |
+| Manual Operation                  | Trapezoid Base Top     | `trap-t`       | Represents a manual task                    | `inv-trapezoid`, `manual`, `trapezoid-top`                       |
+| Multi-Document                    | Stacked Document       | `docs`         | Multiple documents                          | `documents`, `st-doc`, `stacked-document`                        |
+| Multi-Process                     | Stacked Rectangle      | `st-rect`      | Multiple processes                          | `processes`, `procs`, `stacked-rectangle`                        |
+| Odd                               | Odd                    | `odd`          | Odd shape                                   |                                                                  |
+| Paper Tape                        | Flag                   | `flag`         | Paper tape                                  | `paper-tape`                                                     |
+| Person                            | Person                 | `person`       | Person (circular head above a rounded body) |                                                                  |
+| Prepare Conditional               | Hexagon                | `hex`          | Preparation or condition step               | `hexagon`, `prepare`                                             |
+| Priority Action                   | Trapezoid Base Bottom  | `trap-b`       | Priority action                             | `priority`, `trapezoid`, `trapezoid-bottom`                      |
+| Process                           | Rectangle              | `rect`         | Standard process shape                      | `proc`, `process`, `rectangle`                                   |
+| Start                             | Circle                 | `circle`       | Starting point                              | `circ`                                                           |
+| Start                             | Small Circle           | `sm-circ`      | Small starting point                        | `small-circle`, `start`                                          |
+| Stop                              | Double Circle          | `dbl-circ`     | Represents a stop point                     | `double-circle`                                                  |
+| Stop                              | Framed Circle          | `fr-circ`      | Stop point                                  | `framed-circle`, `stop`                                          |
+| Stored Data                       | Bow Tie Rectangle      | `bow-rect`     | Stored data                                 | `bow-tie-rectangle`, `stored-data`                               |
+| Subprocess                        | Framed Rectangle       | `fr-rect`      | Subprocess                                  | `framed-rectangle`, `subproc`, `subprocess`, `subroutine`        |
+| Summary                           | Crossed Circle         | `cross-circ`   | Summary                                     | `crossed-circle`, `summary`                                      |
+| Tagged Document                   | Tagged Document        | `tag-doc`      | Tagged document                             | `tag-doc`, `tagged-document`                                     |
+| Tagged Process                    | Tagged Rectangle       | `tag-rect`     | Tagged process                              | `tag-proc`, `tagged-process`, `tagged-rectangle`                 |
+| Terminal Point                    | Stadium                | `stadium`      | Terminal point                              | `pill`, `terminal`                                               |
+| Text Block                        | Text Block             | `text`         | Text block                                  |                                                                  |
 
 ### Example Flowchart with New Shapes
 

--- a/packages/mermaid/scripts/docs.spec.ts
+++ b/packages/mermaid/scripts/docs.spec.ts
@@ -175,56 +175,57 @@ This Markdown should be kept.
   describe('buildShapeDoc', () => {
     it('should build shapesTable based on the shapeDefs', () => {
       expect(buildShapeDoc()).toMatchInlineSnapshot(`
-        "| **Semantic Name**                 | **Shape Name**         | **Short Name** | **Description**                | **Alias Supported**                                              |
-        | --------------------------------- | ---------------------- | -------------- | ------------------------------ | ---------------------------------------------------------------- |
-        | Bang                              | Bang                   | \`bang\`         | Bang                           | \`bang\`                                                           |
-        | Card                              | Notched Rectangle      | \`notch-rect\`   | Represents a card              | \`card\`, \`notched-rectangle\`                                      |
-        | Cloud                             | Cloud                  | \`cloud\`        | cloud                          | \`cloud\`                                                          |
-        | Collate                           | Hourglass              | \`hourglass\`    | Represents a collate operation | \`collate\`, \`hourglass\`                                           |
-        | Com Link                          | Lightning Bolt         | \`bolt\`         | Communication link             | \`com-link\`, \`lightning-bolt\`                                     |
-        | Comment                           | Curly Brace            | \`brace\`        | Adds a comment                 | \`brace-l\`, \`comment\`                                             |
-        | Comment Right                     | Curly Brace            | \`brace-r\`      | Adds a comment                 |                                                                  |
-        | Comment with braces on both sides | Curly Braces           | \`braces\`       | Adds a comment                 |                                                                  |
-        | Data Input/Output                 | Lean Right             | \`lean-r\`       | Represents input or output     | \`in-out\`, \`lean-right\`                                           |
-        | Data Input/Output                 | Lean Left              | \`lean-l\`       | Represents output or input     | \`lean-left\`, \`out-in\`                                            |
-        | Data Store                        | Data Store             | \`datastore\`    | Data flow diagram data store   | \`data-store\`                                                     |
-        | Database                          | Cylinder               | \`cyl\`          | Database storage               | \`cylinder\`, \`database\`, \`db\`                                     |
-        | Decision                          | Diamond                | \`diam\`         | Decision-making step           | \`decision\`, \`diamond\`, \`question\`                                |
-        | Delay                             | Half-Rounded Rectangle | \`delay\`        | Represents a delay             | \`half-rounded-rectangle\`                                         |
-        | Direct Access Storage             | Horizontal Cylinder    | \`h-cyl\`        | Direct access storage          | \`das\`, \`horizontal-cylinder\`                                     |
-        | Disk Storage                      | Lined Cylinder         | \`lin-cyl\`      | Disk storage                   | \`disk\`, \`lined-cylinder\`                                         |
-        | Display                           | Curved Trapezoid       | \`curv-trap\`    | Represents a display           | \`curved-trapezoid\`, \`display\`                                    |
-        | Divided Process                   | Divided Rectangle      | \`div-rect\`     | Divided process shape          | \`div-proc\`, \`divided-process\`, \`divided-rectangle\`               |
-        | Document                          | Document               | \`doc\`          | Represents a document          | \`doc\`, \`document\`                                                |
-        | Event                             | Rounded Rectangle      | \`rounded\`      | Represents an event            | \`event\`                                                          |
-        | Extract                           | Triangle               | \`tri\`          | Extraction process             | \`extract\`, \`triangle\`                                            |
-        | Fork/Join                         | Filled Rectangle       | \`fork\`         | Fork or join in process flow   | \`join\`                                                           |
-        | Internal Storage                  | Window Pane            | \`win-pane\`     | Internal storage               | \`internal-storage\`, \`window-pane\`                                |
-        | Junction                          | Filled Circle          | \`f-circ\`       | Junction point                 | \`filled-circle\`, \`junction\`                                      |
-        | Lined Document                    | Lined Document         | \`lin-doc\`      | Lined document                 | \`lined-document\`                                                 |
-        | Lined/Shaded Process              | Lined Rectangle        | \`lin-rect\`     | Lined process shape            | \`lin-proc\`, \`lined-process\`, \`lined-rectangle\`, \`shaded-process\` |
-        | Loop Limit                        | Trapezoidal Pentagon   | \`notch-pent\`   | Loop limit step                | \`loop-limit\`, \`notched-pentagon\`                                 |
-        | Manual File                       | Flipped Triangle       | \`flip-tri\`     | Manual file operation          | \`flipped-triangle\`, \`manual-file\`                                |
-        | Manual Input                      | Sloped Rectangle       | \`sl-rect\`      | Manual input step              | \`manual-input\`, \`sloped-rectangle\`                               |
-        | Manual Operation                  | Trapezoid Base Top     | \`trap-t\`       | Represents a manual task       | \`inv-trapezoid\`, \`manual\`, \`trapezoid-top\`                       |
-        | Multi-Document                    | Stacked Document       | \`docs\`         | Multiple documents             | \`documents\`, \`st-doc\`, \`stacked-document\`                        |
-        | Multi-Process                     | Stacked Rectangle      | \`st-rect\`      | Multiple processes             | \`processes\`, \`procs\`, \`stacked-rectangle\`                        |
-        | Odd                               | Odd                    | \`odd\`          | Odd shape                      |                                                                  |
-        | Paper Tape                        | Flag                   | \`flag\`         | Paper tape                     | \`paper-tape\`                                                     |
-        | Prepare Conditional               | Hexagon                | \`hex\`          | Preparation or condition step  | \`hexagon\`, \`prepare\`                                             |
-        | Priority Action                   | Trapezoid Base Bottom  | \`trap-b\`       | Priority action                | \`priority\`, \`trapezoid\`, \`trapezoid-bottom\`                      |
-        | Process                           | Rectangle              | \`rect\`         | Standard process shape         | \`proc\`, \`process\`, \`rectangle\`                                   |
-        | Start                             | Circle                 | \`circle\`       | Starting point                 | \`circ\`                                                           |
-        | Start                             | Small Circle           | \`sm-circ\`      | Small starting point           | \`small-circle\`, \`start\`                                          |
-        | Stop                              | Double Circle          | \`dbl-circ\`     | Represents a stop point        | \`double-circle\`                                                  |
-        | Stop                              | Framed Circle          | \`fr-circ\`      | Stop point                     | \`framed-circle\`, \`stop\`                                          |
-        | Stored Data                       | Bow Tie Rectangle      | \`bow-rect\`     | Stored data                    | \`bow-tie-rectangle\`, \`stored-data\`                               |
-        | Subprocess                        | Framed Rectangle       | \`fr-rect\`      | Subprocess                     | \`framed-rectangle\`, \`subproc\`, \`subprocess\`, \`subroutine\`        |
-        | Summary                           | Crossed Circle         | \`cross-circ\`   | Summary                        | \`crossed-circle\`, \`summary\`                                      |
-        | Tagged Document                   | Tagged Document        | \`tag-doc\`      | Tagged document                | \`tag-doc\`, \`tagged-document\`                                     |
-        | Tagged Process                    | Tagged Rectangle       | \`tag-rect\`     | Tagged process                 | \`tag-proc\`, \`tagged-process\`, \`tagged-rectangle\`                 |
-        | Terminal Point                    | Stadium                | \`stadium\`      | Terminal point                 | \`pill\`, \`terminal\`                                               |
-        | Text Block                        | Text Block             | \`text\`         | Text block                     |                                                                  |
+        "| **Semantic Name**                 | **Shape Name**         | **Short Name** | **Description**                             | **Alias Supported**                                              |
+        | --------------------------------- | ---------------------- | -------------- | ------------------------------------------- | ---------------------------------------------------------------- |
+        | Bang                              | Bang                   | \`bang\`         | Bang                                        | \`bang\`                                                           |
+        | Card                              | Notched Rectangle      | \`notch-rect\`   | Represents a card                           | \`card\`, \`notched-rectangle\`                                      |
+        | Cloud                             | Cloud                  | \`cloud\`        | cloud                                       | \`cloud\`                                                          |
+        | Collate                           | Hourglass              | \`hourglass\`    | Represents a collate operation              | \`collate\`, \`hourglass\`                                           |
+        | Com Link                          | Lightning Bolt         | \`bolt\`         | Communication link                          | \`com-link\`, \`lightning-bolt\`                                     |
+        | Comment                           | Curly Brace            | \`brace\`        | Adds a comment                              | \`brace-l\`, \`comment\`                                             |
+        | Comment Right                     | Curly Brace            | \`brace-r\`      | Adds a comment                              |                                                                  |
+        | Comment with braces on both sides | Curly Braces           | \`braces\`       | Adds a comment                              |                                                                  |
+        | Data Input/Output                 | Lean Right             | \`lean-r\`       | Represents input or output                  | \`in-out\`, \`lean-right\`                                           |
+        | Data Input/Output                 | Lean Left              | \`lean-l\`       | Represents output or input                  | \`lean-left\`, \`out-in\`                                            |
+        | Data Store                        | Data Store             | \`datastore\`    | Data flow diagram data store                | \`data-store\`                                                     |
+        | Database                          | Cylinder               | \`cyl\`          | Database storage                            | \`cylinder\`, \`database\`, \`db\`                                     |
+        | Decision                          | Diamond                | \`diam\`         | Decision-making step                        | \`decision\`, \`diamond\`, \`question\`                                |
+        | Delay                             | Half-Rounded Rectangle | \`delay\`        | Represents a delay                          | \`half-rounded-rectangle\`                                         |
+        | Direct Access Storage             | Horizontal Cylinder    | \`h-cyl\`        | Direct access storage                       | \`das\`, \`horizontal-cylinder\`                                     |
+        | Disk Storage                      | Lined Cylinder         | \`lin-cyl\`      | Disk storage                                | \`disk\`, \`lined-cylinder\`                                         |
+        | Display                           | Curved Trapezoid       | \`curv-trap\`    | Represents a display                        | \`curved-trapezoid\`, \`display\`                                    |
+        | Divided Process                   | Divided Rectangle      | \`div-rect\`     | Divided process shape                       | \`div-proc\`, \`divided-process\`, \`divided-rectangle\`               |
+        | Document                          | Document               | \`doc\`          | Represents a document                       | \`doc\`, \`document\`                                                |
+        | Event                             | Rounded Rectangle      | \`rounded\`      | Represents an event                         | \`event\`                                                          |
+        | Extract                           | Triangle               | \`tri\`          | Extraction process                          | \`extract\`, \`triangle\`                                            |
+        | Fork/Join                         | Filled Rectangle       | \`fork\`         | Fork or join in process flow                | \`join\`                                                           |
+        | Internal Storage                  | Window Pane            | \`win-pane\`     | Internal storage                            | \`internal-storage\`, \`window-pane\`                                |
+        | Junction                          | Filled Circle          | \`f-circ\`       | Junction point                              | \`filled-circle\`, \`junction\`                                      |
+        | Lined Document                    | Lined Document         | \`lin-doc\`      | Lined document                              | \`lined-document\`                                                 |
+        | Lined/Shaded Process              | Lined Rectangle        | \`lin-rect\`     | Lined process shape                         | \`lin-proc\`, \`lined-process\`, \`lined-rectangle\`, \`shaded-process\` |
+        | Loop Limit                        | Trapezoidal Pentagon   | \`notch-pent\`   | Loop limit step                             | \`loop-limit\`, \`notched-pentagon\`                                 |
+        | Manual File                       | Flipped Triangle       | \`flip-tri\`     | Manual file operation                       | \`flipped-triangle\`, \`manual-file\`                                |
+        | Manual Input                      | Sloped Rectangle       | \`sl-rect\`      | Manual input step                           | \`manual-input\`, \`sloped-rectangle\`                               |
+        | Manual Operation                  | Trapezoid Base Top     | \`trap-t\`       | Represents a manual task                    | \`inv-trapezoid\`, \`manual\`, \`trapezoid-top\`                       |
+        | Multi-Document                    | Stacked Document       | \`docs\`         | Multiple documents                          | \`documents\`, \`st-doc\`, \`stacked-document\`                        |
+        | Multi-Process                     | Stacked Rectangle      | \`st-rect\`      | Multiple processes                          | \`processes\`, \`procs\`, \`stacked-rectangle\`                        |
+        | Odd                               | Odd                    | \`odd\`          | Odd shape                                   |                                                                  |
+        | Paper Tape                        | Flag                   | \`flag\`         | Paper tape                                  | \`paper-tape\`                                                     |
+        | Person                            | Person                 | \`person\`       | Person (circular head above a rounded body) |                                                                  |
+        | Prepare Conditional               | Hexagon                | \`hex\`          | Preparation or condition step               | \`hexagon\`, \`prepare\`                                             |
+        | Priority Action                   | Trapezoid Base Bottom  | \`trap-b\`       | Priority action                             | \`priority\`, \`trapezoid\`, \`trapezoid-bottom\`                      |
+        | Process                           | Rectangle              | \`rect\`         | Standard process shape                      | \`proc\`, \`process\`, \`rectangle\`                                   |
+        | Start                             | Circle                 | \`circle\`       | Starting point                              | \`circ\`                                                           |
+        | Start                             | Small Circle           | \`sm-circ\`      | Small starting point                        | \`small-circle\`, \`start\`                                          |
+        | Stop                              | Double Circle          | \`dbl-circ\`     | Represents a stop point                     | \`double-circle\`                                                  |
+        | Stop                              | Framed Circle          | \`fr-circ\`      | Stop point                                  | \`framed-circle\`, \`stop\`                                          |
+        | Stored Data                       | Bow Tie Rectangle      | \`bow-rect\`     | Stored data                                 | \`bow-tie-rectangle\`, \`stored-data\`                               |
+        | Subprocess                        | Framed Rectangle       | \`fr-rect\`      | Subprocess                                  | \`framed-rectangle\`, \`subproc\`, \`subprocess\`, \`subroutine\`        |
+        | Summary                           | Crossed Circle         | \`cross-circ\`   | Summary                                     | \`crossed-circle\`, \`summary\`                                      |
+        | Tagged Document                   | Tagged Document        | \`tag-doc\`      | Tagged document                             | \`tag-doc\`, \`tagged-document\`                                     |
+        | Tagged Process                    | Tagged Rectangle       | \`tag-rect\`     | Tagged process                              | \`tag-proc\`, \`tagged-process\`, \`tagged-rectangle\`                 |
+        | Terminal Point                    | Stadium                | \`stadium\`      | Terminal point                              | \`pill\`, \`terminal\`                                               |
+        | Text Block                        | Text Block             | \`text\`         | Text block                                  |                                                                  |
         "
       `);
     });

--- a/packages/mermaid/src/diagrams/c4/c4Renderer.ts
+++ b/packages/mermaid/src/diagrams/c4/c4Renderer.ts
@@ -309,6 +309,9 @@ export const drawC4ShapeArray = async function (
     c4Shapes.map(async (c4Shape) => {
       const node = buildC4Node(c4Shape, conf, conf.c4ShapePadding, look, conf.width);
       node.domId = `${diagramId}-${node.id}`;
+      // Needed to properly calculate the intersection points.
+      node.x = c4Shape.x + c4Shape.width / 2;
+      node.y = c4Shape.y + c4Shape.height / 2;
       // Appending before the await keeps the shapes' stacking order deterministic.
       const positioned = diagram
         .append('g')
@@ -317,6 +320,7 @@ export const drawC4ShapeArray = async function (
           `translate(${c4Shape.x + c4Shape.width / 2}, ${c4Shape.y + c4Shape.height / 2})`
         );
       await shapeHandlerFor(node)(positioned, node, renderOptions);
+      c4Shape.intersect = node.intersect;
     })
   );
 
@@ -333,88 +337,17 @@ class Point {
   }
 }
 
-/* * *
+/*
  * Get the intersection of the line between the center point of a rectangle and a point outside the rectangle.
- * Algorithm idea.
- * Using a point outside the rectangle as the coordinate origin, the graph is divided into four quadrants, and each quadrant is divided into two cases, with separate treatment on the coordinate axes
- * 1. The case of coordinate axes.
- * 1. The case of the negative x-axis
- * 2. The case of the positive x-axis
- * 3. The case of the positive y-axis
- * 4. The negative y-axis case
- * 2. Quadrant cases.
- * 2.1. first quadrant: the case where the line intersects the left side of the rectangle; the case where it intersects the lower side of the rectangle
- * 2.2. second quadrant: the case where the line intersects the right side of the rectangle; the case where it intersects the lower edge of the rectangle
- * 2.3. third quadrant: the case where the line intersects the right side of the rectangle; the case where it intersects the upper edge of the rectangle
- * 2.4. fourth quadrant: the case where the line intersects the left side of the rectangle; the case where it intersects the upper side of the rectangle
- *
  */
 const getIntersectPoint = function (fromNode: C4Shape, endPoint: Point): Point | null {
-  const x1 = fromNode.x;
-
-  const y1 = fromNode.y;
-
-  const x2 = endPoint.x;
-
-  const y2 = endPoint.y;
-
-  const fromCenterX = x1 + fromNode.width / 2;
-
-  const fromCenterY = y1 + fromNode.height / 2;
-
-  const dx = Math.abs(x1 - x2);
-
-  const dy = Math.abs(y1 - y2);
-
-  const tanDYX = dy / dx;
-
-  const fromDYX = fromNode.height / fromNode.width;
-
-  let returnPoint: Point | null = null;
-
-  if (y1 == y2 && x1 < x2) {
-    returnPoint = new Point(x1 + fromNode.width, fromCenterY);
-  } else if (y1 == y2 && x1 > x2) {
-    returnPoint = new Point(x1, fromCenterY);
-  } else if (x1 == x2 && y1 < y2) {
-    returnPoint = new Point(fromCenterX, y1 + fromNode.height);
-  } else if (x1 == x2 && y1 > y2) {
-    returnPoint = new Point(fromCenterX, y1);
+  if (!fromNode.intersect) {
+    throw new Error(
+      `C4 shape "${fromNode.alias}" has no intersect function. Please report this to https://github.com/mermaid-js/mermaid/issues`
+    );
   }
-
-  if (x1 > x2 && y1 < y2) {
-    if (fromDYX >= tanDYX) {
-      returnPoint = new Point(x1, fromCenterY + (tanDYX * fromNode.width) / 2);
-    } else {
-      returnPoint = new Point(
-        fromCenterX - ((dx / dy) * fromNode.height) / 2,
-        y1 + fromNode.height
-      );
-    }
-  } else if (x1 < x2 && y1 < y2) {
-    //
-    if (fromDYX >= tanDYX) {
-      returnPoint = new Point(x1 + fromNode.width, fromCenterY + (tanDYX * fromNode.width) / 2);
-    } else {
-      returnPoint = new Point(
-        fromCenterX + ((dx / dy) * fromNode.height) / 2,
-        y1 + fromNode.height
-      );
-    }
-  } else if (x1 < x2 && y1 > y2) {
-    if (fromDYX >= tanDYX) {
-      returnPoint = new Point(x1 + fromNode.width, fromCenterY - (tanDYX * fromNode.width) / 2);
-    } else {
-      returnPoint = new Point(fromCenterX + ((fromNode.height / 2) * dx) / dy, y1);
-    }
-  } else if (x1 > x2 && y1 > y2) {
-    if (fromDYX >= tanDYX) {
-      returnPoint = new Point(x1, fromCenterY - (fromNode.width / 2) * tanDYX);
-    } else {
-      returnPoint = new Point(fromCenterX - ((fromNode.height / 2) * dx) / dy, y1);
-    }
-  }
-  return returnPoint;
+  const { x, y } = fromNode.intersect(endPoint);
+  return new Point(x, y);
 };
 
 const getIntersectPoints = function (fromNode: C4Shape, endNode: C4Shape) {

--- a/packages/mermaid/src/diagrams/c4/c4Renderer.ts
+++ b/packages/mermaid/src/diagrams/c4/c4Renderer.ts
@@ -15,6 +15,8 @@ import type { C4DiagramConfig } from '../../config.type.js';
 import type { SVG } from '../../diagram-api/types.js';
 import type { TextDimensionConfig } from '../../types.js';
 import type { C4Boundary, C4DrawConfig, C4Font, C4Rel, C4Shape, C4Text } from './c4Types.js';
+import { shapes } from '../../rendering-util/rendering-elements/shapes.js';
+import { buildC4Node } from './c4ShapeAdapter.js';
 
 type C4DB = typeof c4Db;
 
@@ -173,14 +175,6 @@ export const setConf = function (cnf?: C4SetConfigParam) {
   }
 };
 
-const c4ShapeFont = (cnf: C4DrawConfig, typeC4Shape: string): C4Font => {
-  return {
-    fontFamily: cnf[typeC4Shape + 'FontFamily'] as string,
-    fontSize: cnf[typeC4Shape + 'FontSize'] as number,
-    fontWeight: cnf[typeC4Shape + 'FontWeight'] as string | number,
-  };
-};
-
 const boundaryFont = (cnf: C4DrawConfig): C4Font => {
   return {
     fontFamily: cnf.boundaryFontFamily,
@@ -263,128 +257,68 @@ export const drawBoundary = function (diagram: SVG, boundary: C4Boundary, bounds
   svgDraw.drawBoundary(diagram, boundary, conf);
 };
 
-export const drawC4ShapeArray = function (
+export const drawC4ShapeArray = async function (
   currentBounds: Bounds,
   diagram: SVG,
   c4ShapeArray: C4Shape[],
   c4ShapeKeys: string[]
 ) {
-  // Upper Y is relative point
-  let Y = 0;
-  // Draw the c4ShapeArray
-  for (const c4ShapeKey of c4ShapeKeys) {
-    Y = 0;
-    // `c4ShapeKeys` are the (numeric string) indices of `c4ShapeArray`.
-    const c4Shape = c4ShapeArray[Number(c4ShapeKey)];
+  const mermaidConfig = getConfig();
+  const look = mermaidConfig.look ?? 'classic';
+  const renderOptions = { config: mermaidConfig };
+  // Namespace the shape DOM ids with the diagram id so two diagrams on one page don't
+  // collide (the unified shapes use node.domId for the element id).
+  const diagramId = diagram.attr('id') ?? '';
 
-    // calc c4 shape type width and height
+  // `c4ShapeKeys` are the (numeric string) indices of `c4ShapeArray`.
+  const c4Shapes = c4ShapeKeys.map((key) => c4ShapeArray[Number(key)]);
 
-    const c4ShapeTypeConf = c4ShapeFont(conf, c4Shape.typeC4Shape.text);
-    c4ShapeTypeConf.fontSize = c4ShapeTypeConf.fontSize - 2;
-    c4Shape.typeC4Shape.width = calculateTextWidth(
-      '«' + c4Shape.typeC4Shape.text + '»',
-      c4ShapeTypeConf as TextDimensionConfig
-    );
-    c4Shape.typeC4Shape.height = c4ShapeTypeConf.fontSize + 2;
-    c4Shape.typeC4Shape.Y = conf.c4ShapePadding;
-    Y = c4Shape.typeC4Shape.Y + c4Shape.typeC4Shape.height - 4;
-
-    // set image width and height c4Shape.x + c4Shape.width / 2 - 24, c4Shape.y + 28
-    // let imageWidth = 0,
-    //   imageHeight = 0,
-    //   imageY = 0;
-    //
-    c4Shape.image = { width: 0, height: 0, Y: 0 };
-    switch (c4Shape.typeC4Shape.text) {
-      case 'person':
-      case 'external_person':
-        c4Shape.image.width = 48;
-        c4Shape.image.height = 48;
-        c4Shape.image.Y = Y;
-        Y = c4Shape.image.Y + c4Shape.image.height;
-        break;
+  const shapeHandlerFor = (node: ReturnType<typeof buildC4Node>) => {
+    const handler = node.shape ? shapes[node.shape] : undefined;
+    if (!handler) {
+      throw new Error(`C4: no shape handler for "${node.shape}"`);
     }
-    if (c4Shape.sprite) {
-      c4Shape.image.width = 48;
-      c4Shape.image.height = 48;
-      c4Shape.image.Y = Y;
-      Y = c4Shape.image.Y + c4Shape.image.height;
-    }
+    return handler;
+  };
 
-    // Y = conf.c4ShapePadding + c4Shape.image.height;
+  // Pass 1 (measure): render each shape, read its self-sized dimensions onto the legacy
+  // c4Shape, then discard the rendering. The shape is drawn again in pass 2 directly at its
+  // final position, so its label (and any composited sub-element) lays out under the final
+  // transform - drawing at the origin and translating afterwards leaves composited layers
+  // (e.g. anything with opacity) painting at the stale origin.
+  await Promise.all(
+    c4Shapes.map(async (c4Shape) => {
+      const node = buildC4Node(c4Shape, conf, conf.c4ShapePadding, look, conf.width);
+      node.domId = `${diagramId}-${node.id}`;
+      const measured = await shapeHandlerFor(node)(diagram, node, renderOptions);
+      c4Shape.width = node.width ?? conf.width;
+      c4Shape.height = node.height ?? conf.height;
+      c4Shape.margin = conf.c4ShapeMargin;
+      measured.remove();
+    })
+  );
 
-    const c4ShapeTextWrap = c4Shape.wrap && conf.wrap;
-    const textLimitWidth = conf.width - conf.c4ShapePadding * 2;
-
-    const c4ShapeLabelConf = c4ShapeFont(conf, c4Shape.typeC4Shape.text);
-    c4ShapeLabelConf.fontSize = c4ShapeLabelConf.fontSize + 2;
-    c4ShapeLabelConf.fontWeight = 'bold';
-    const label = calcC4ShapeTextWH(
-      'label',
-      c4Shape,
-      c4ShapeTextWrap,
-      c4ShapeLabelConf,
-      textLimitWidth
-    );
-    label.Y = Y + 8;
-    Y = label.Y + label.height;
-
-    if (c4Shape.type && c4Shape.type.text !== '') {
-      c4Shape.type.text = '[' + c4Shape.type.text + ']';
-      const c4ShapeTypeConf = c4ShapeFont(conf, c4Shape.typeC4Shape.text);
-      const type = calcC4ShapeTextWH(
-        'type',
-        c4Shape,
-        c4ShapeTextWrap,
-        c4ShapeTypeConf,
-        textLimitWidth
-      );
-      type.Y = Y + 5;
-      Y = type.Y + type.height;
-    } else if (c4Shape.techn && c4Shape.techn.text !== '') {
-      c4Shape.techn.text = '[' + c4Shape.techn.text + ']';
-      const c4ShapeTechnConf = c4ShapeFont(conf, c4Shape.techn.text);
-      const techn = calcC4ShapeTextWH(
-        'techn',
-        c4Shape,
-        c4ShapeTextWrap,
-        c4ShapeTechnConf,
-        textLimitWidth
-      );
-      techn.Y = Y + 5;
-      Y = techn.Y + techn.height;
-    }
-
-    let rectHeight = Y;
-    let rectWidth = label.width;
-
-    if (c4Shape.descr && c4Shape.descr.text !== '') {
-      const c4ShapeDescrConf = c4ShapeFont(conf, c4Shape.typeC4Shape.text);
-      const descr = calcC4ShapeTextWH(
-        'descr',
-        c4Shape,
-        c4ShapeTextWrap,
-        c4ShapeDescrConf,
-        textLimitWidth
-      );
-      descr.Y = Y + 20;
-      Y = descr.Y + descr.height;
-
-      rectWidth = Math.max(label.width, descr.width);
-      rectHeight = Y - descr.textLines * 5;
-    }
-
-    rectWidth = rectWidth + conf.c4ShapePadding;
-    // let rectHeight =
-
-    c4Shape.width = Math.max(c4Shape.width || conf.width, rectWidth, conf.width);
-    c4Shape.height = Math.max(c4Shape.height || conf.height, rectHeight, conf.height);
-    c4Shape.margin = c4Shape.margin || conf.c4ShapeMargin;
-
+  // Position with the legacy grid.
+  for (const c4Shape of c4Shapes) {
     currentBounds.insert(c4Shape);
-
-    svgDraw.drawC4Shape(diagram, c4Shape, conf);
   }
+
+  // Pass 2 (draw): render each shape into a group already translated to its grid position
+  // (unified shapes are centred at the origin; legacy x/y is the top-left corner).
+  await Promise.all(
+    c4Shapes.map(async (c4Shape) => {
+      const node = buildC4Node(c4Shape, conf, conf.c4ShapePadding, look, conf.width);
+      node.domId = `${diagramId}-${node.id}`;
+      // Appending before the await keeps the shapes' stacking order deterministic.
+      const positioned = diagram
+        .append('g')
+        .attr(
+          'transform',
+          `translate(${c4Shape.x + c4Shape.width / 2}, ${c4Shape.y + c4Shape.height / 2})`
+        );
+      await shapeHandlerFor(node)(positioned, node, renderOptions);
+    })
+  );
 
   currentBounds.bumpLastMargin(conf.c4ShapeMargin);
 };
@@ -541,7 +475,7 @@ export const drawRels = function (
   svgDraw.drawRels(diagram, rels, conf, diagramId);
 };
 
-function drawInsideBoundary(
+async function drawInsideBoundary(
   diagram: SVG,
   parentBoundaryAlias: string,
   parentBounds: Bounds,
@@ -631,7 +565,7 @@ function drawInsideBoundary(
     const currentPersonOrSystemKeys = db.getC4ShapeKeys(currentBoundary.alias);
 
     if (currentPersonOrSystemKeys.length > 0) {
-      drawC4ShapeArray(
+      await drawC4ShapeArray(
         currentBounds,
         diagram,
         currentPersonOrSystemArray,
@@ -643,7 +577,7 @@ function drawInsideBoundary(
 
     if (nextCurrentBoundaries.length > 0) {
       // draw boundary inside currentBoundary
-      drawInsideBoundary(
+      await drawInsideBoundary(
         diagram,
         parentBoundaryAlias,
         currentBounds,
@@ -671,7 +605,7 @@ function drawInsideBoundary(
 /**
  * Draws a sequenceDiagram in the tag with id: id based on the graph definition in text.
  */
-export const draw = function (_text: string, id: string, _version: string, diagObj: Diagram) {
+export const draw = async function (_text: string, id: string, _version: string, diagObj: Diagram) {
   conf = getRequiredConfig('c4') as C4DrawConfig;
   const securityLevel = getConfig().securityLevel;
   // Handle root and Document for when rendering in sandbox mode
@@ -709,7 +643,7 @@ export const draw = function (_text: string, id: string, _version: string, diagO
   const currentBoundaries = db.getBoundaries('');
   // switch (c4type) {
   //   case 'C4Context':
-  drawInsideBoundary(diagram, '', screenBounds, currentBoundaries, diagObj);
+  await drawInsideBoundary(diagram, '', screenBounds, currentBoundaries, diagObj);
   //     break;
   // }
 

--- a/packages/mermaid/src/diagrams/c4/c4ShapeAdapter.ts
+++ b/packages/mermaid/src/diagrams/c4/c4ShapeAdapter.ts
@@ -1,0 +1,197 @@
+import type { C4DiagramConfig } from '../../config.type.js';
+import type { ShapeID } from '../../rendering-util/rendering-elements/shapes.js';
+import type { NonClusterNode } from '../../rendering-util/types.js';
+
+/**
+ * Builds a unified-renderer {@link Node} from a legacy C4 shape so the legacy
+ * renderer can draw elements through the shared unified shapes (the first
+ * "migrate shapes" step of the C4 renderer migration). Layout still comes from
+ * the legacy grid; only the drawing is delegated to the unified shapes.
+ */
+
+interface C4Text {
+  text: string;
+}
+
+/** The subset of a legacy C4 shape the adapter reads. */
+export interface C4ShapeLike {
+  alias: string;
+  label: C4Text;
+  typeC4Shape: C4Text;
+  techn?: C4Text;
+  descr?: C4Text;
+  bgColor?: string;
+  fontColor?: string;
+  borderColor?: string;
+  shape?: string;
+  sprite?: string;
+  tags?: string;
+}
+
+const QUEUE_SHAPES = new Set([
+  'system_queue',
+  'external_system_queue',
+  'container_queue',
+  'external_container_queue',
+  'component_queue',
+  'external_component_queue',
+]);
+
+const DB_SHAPES = new Set([
+  'system_db',
+  'external_system_db',
+  'container_db',
+  'external_container_db',
+  'component_db',
+  'external_component_db',
+]);
+
+// Structurizr-style shape keywords accepted via $shape, $sprite or $tags.
+const SHAPE_KEYWORDS: Record<string, ShapeID> = {
+  person: 'person',
+  box: 'rounded',
+  rounded: 'rounded',
+  cylinder: 'cylinder',
+  database: 'cylinder',
+  db: 'cylinder',
+  queue: 'h-cyl',
+  pipe: 'h-cyl',
+  component: 'fr-rect',
+};
+
+const keywordShape = (value: string | undefined): ShapeID | undefined =>
+  value ? SHAPE_KEYWORDS[value.toLowerCase()] : undefined;
+
+/**
+ * Resolves the render shape for a C4 element: explicit $shape/$sprite first,
+ * then a recognised $tags token, then the element type.
+ */
+export const resolveNodeShape = (shape: C4ShapeLike): ShapeID => {
+  const explicit = keywordShape(shape.shape) ?? keywordShape(shape.sprite);
+  if (explicit) {
+    return explicit;
+  }
+  if (shape.tags) {
+    for (const tag of shape.tags.split(',')) {
+      const tagged = keywordShape(tag.trim());
+      if (tagged) {
+        return tagged;
+      }
+    }
+  }
+  const typeC4Shape = shape.typeC4Shape.text;
+  if (typeC4Shape === 'person' || typeC4Shape === 'external_person') {
+    return 'person';
+  }
+  if (DB_SHAPES.has(typeC4Shape)) {
+    return 'cylinder';
+  }
+  if (QUEUE_SHAPES.has(typeC4Shape)) {
+    return 'h-cyl';
+  }
+  return 'rounded';
+};
+
+const STEREOTYPE_NAMES: Record<string, string> = {
+  person: 'Person',
+  system: 'Software System',
+  container: 'Container',
+  component: 'Component',
+};
+
+// Structurizr-style stereotype, e.g. `Software System` for system / system_db / external_system.
+const stereotypeLabel = (typeC4Shape: string): string => {
+  const base = typeC4Shape.replace(/^external_/, '').replace(/_(db|queue)$/, '');
+  return STEREOTYPE_NAMES[base] ?? base.replace(/_/g, ' ');
+};
+
+const isExternal = (typeC4Shape: string): boolean => typeC4Shape.startsWith('external_');
+
+// Structurizr-style type line, e.g. `[Container: Node.js]`.
+const stereotypeText = (shape: C4ShapeLike): string => {
+  const stereotype = stereotypeLabel(shape.typeC4Shape.text);
+  return shape.techn?.text ? `[${stereotype}: ${shape.techn.text}]` : `[${stereotype}]`;
+};
+
+/** The C4 element types, internal and external, that carry per-type config. */
+export const C4_ELEMENT_TYPES = (
+  [
+    'person',
+    'system',
+    'system_db',
+    'system_queue',
+    'container',
+    'container_db',
+    'container_queue',
+    'component',
+    'component_db',
+    'component_queue',
+  ] as const
+).flatMap((type) => [type, `external_${type}`] as const);
+
+const C4_ELEMENT_TYPE_SET = new Set<string>(C4_ELEMENT_TYPES);
+
+const isC4ElementType = (value: string): value is (typeof C4_ELEMENT_TYPES)[number] =>
+  C4_ELEMENT_TYPE_SET.has(value);
+
+/**
+ * Element colours: the per-element `<type>_bg_color`/`<type>_border_color` config
+ * palette drives the fill and border, with white text. An explicit per-element
+ * colour (UpdateElementStyle: $bgColor/$borderColor/$fontColor) overrides it.
+ */
+const elementCssStyles = (shape: C4ShapeLike, config: C4DiagramConfig): string[] => {
+  const elementType = shape.typeC4Shape.text;
+  const fill = shape.bgColor ?? (isC4ElementType(elementType) && config[`${elementType}_bg_color`]);
+  const stroke =
+    shape.borderColor ?? (isC4ElementType(elementType) && config[`${elementType}_border_color`]);
+  const styles: string[] = [];
+  if (fill) {
+    styles.push(`fill:${fill}`);
+  }
+  if (stroke) {
+    styles.push(`stroke:${stroke}`);
+  }
+  styles.push(`color:${shape.fontColor ?? '#FFFFFF'}`);
+  return styles;
+};
+
+/**
+ * Converts a legacy C4 shape into a unified-renderer Node. `config` is the c4
+ * diagram config, whose `<type>_bg_color`/`<type>_border_color` palette drives the fill and border.
+ * `elementWidth` is the target shape width (`c4.width`); the label helper
+ * derives its own text-wrapping width from it.
+ */
+export const buildC4Node = (
+  shape: C4ShapeLike,
+  config: C4DiagramConfig,
+  padding: number,
+  look: string,
+  elementWidth: number
+): NonClusterNode => {
+  const typeC4Shape = shape.typeC4Shape.text;
+  const cssClasses = ['c4-shape', `c4-${typeC4Shape}`];
+  if (isExternal(typeC4Shape)) {
+    cssClasses.push('c4-external');
+  }
+  const nodeShape = resolveNodeShape(shape);
+  const cssStyles = elementCssStyles(shape, config);
+  if (nodeShape === 'rounded' || nodeShape === 'fr-rect') {
+    // Inline so it wins over the shape's default corner radius.
+    cssStyles.push('rx:12px', 'ry:12px');
+  }
+  return {
+    id: shape.alias,
+    label: shape.label.text,
+    stereotype: stereotypeText(shape),
+    description: shape.descr?.text ? [shape.descr.text] : undefined,
+    labelType: 'string',
+    isGroup: false,
+    shape: nodeShape,
+    cssClasses: cssClasses.join(' '),
+    cssStyles,
+    padding,
+    look,
+    useHtmlLabels: false,
+    width: elementWidth,
+  };
+};

--- a/packages/mermaid/src/diagrams/c4/c4Types.ts
+++ b/packages/mermaid/src/diagrams/c4/c4Types.ts
@@ -55,6 +55,8 @@ export interface C4Shape {
   height: number;
   margin: number;
   image: C4Image;
+  /* Should be set by the shape renderer */
+  intersect?: (point: C4Point) => C4Point;
 }
 
 export interface C4Boundary {

--- a/packages/mermaid/src/diagrams/c4/styles.js
+++ b/packages/mermaid/src/diagrams/c4/styles.js
@@ -1,7 +1,69 @@
+import { getConfig } from '../../diagram-api/diagramAPI.js';
+import { C4_ELEMENT_TYPES } from './c4ShapeAdapter.js';
+
+// Per-element-type font rules from the c4 config (personFontFamily and friends).
+// Built through the CSSOM so config values are parsed as CSS values: a value
+// that does not fit the property's grammar (e.g. one smuggling extra
+// declarations) is dropped whole instead of landing in the stylesheet.
+const elementFontStyles = () => {
+  const c4 = getConfig().c4 ?? {};
+  const sheet = new CSSStyleSheet();
+  for (const type of C4_ELEMENT_TYPES) {
+    const rule =
+      sheet.cssRules[sheet.insertRule(`.c4-shape.c4-${type} .label {}`, sheet.cssRules.length)];
+    const fontFamily = c4[`${type}FontFamily`];
+    const fontSize = c4[`${type}FontSize`];
+    const fontWeight = c4[`${type}FontWeight`];
+    if (fontFamily) {
+      rule.style.setProperty('font-family', fontFamily);
+    }
+    if (fontSize) {
+      rule.style.setProperty(
+        'font-size',
+        typeof fontSize === 'number' ? `${fontSize}px` : fontSize
+      );
+    }
+    if (fontWeight) {
+      rule.style.setProperty('font-weight', String(fontWeight));
+    }
+  }
+  return [...sheet.cssRules]
+    .filter((rule) => rule.style.length > 0)
+    .map((rule) => `  ${rule.cssText}`)
+    .join('\n');
+};
+
 const getStyles = (options) =>
   `.person {
     stroke: ${options.personBorder};
     fill: ${options.personBkg};
+  }
+${elementFontStyles()}
+
+  /* The element font colour is set inline per element (default white); the
+     label text takes it via currentColor. */
+  .c4-shape .label,
+  .c4-shape .label text {
+    color: inherit;
+    fill: currentColor;
+  }
+  /* Structurizr typography: bold name, smaller stereotype/type and description lines. */
+  .c4-shape .label .c4-name {
+    font-weight: bold;
+  }
+  .c4-shape .label .c4-type {
+    font-size: 0.75em;
+  }
+  .c4-shape .label .c4-descr {
+    font-size: 0.82em;
+  }
+  .c4-shape .basic,
+  .c4-shape rect,
+  .c4-shape path,
+  .c4-shape circle,
+  .c4-shape ellipse,
+  .c4-shape line {
+    stroke-width: 2px;
   }
 `;
 

--- a/packages/mermaid/src/diagrams/c4/svgDraw.ts
+++ b/packages/mermaid/src/diagrams/c4/svgDraw.ts
@@ -1,11 +1,10 @@
 import common from '../common/common.js';
 import * as svgDrawCommon from '../common/svgDrawCommon.js';
-import { sanitizeUrl } from '@braintree/sanitize-url';
 import type { BaseType, Selection } from 'd3';
 import type { SVG, SVGGroup } from '../../diagram-api/types.js';
 import type { D3Selection } from '../../types.js';
 import type { RectData } from '../common/commonTypes.js';
-import type { C4Boundary, C4DrawConfig, C4Font, C4Rel, C4Shape } from './c4Types.js';
+import type { C4Boundary, C4DrawConfig, C4Font, C4Rel } from './c4Types.js';
 
 type TextAttrs = Record<string, string | number>;
 
@@ -22,23 +21,6 @@ type DrawTextFunction = <T extends SVGElement>(
 
 export const drawRect = function (elem: SVG | SVGGroup, rectData: RectData) {
   return svgDrawCommon.drawRect(elem, rectData);
-};
-
-export const drawImage = function <T extends SVGElement>(
-  elem: D3Selection<T>,
-  width: number,
-  height: number,
-  x: number,
-  y: number,
-  link: string
-) {
-  const imageElem = elem.append('image');
-  imageElem.attr('width', width);
-  imageElem.attr('height', height);
-  imageElem.attr('x', x);
-  imageElem.attr('y', y);
-  const sanitizedLink = link.startsWith('data:image/png;base64') ? link : sanitizeUrl(link);
-  imageElem.attr('xlink:href', sanitizedLink);
 };
 
 export const drawRels = (elem: SVG, rels: C4Rel[], conf: C4DrawConfig, diagramId: string) => {
@@ -228,215 +210,6 @@ const drawBoundary = function (elem: SVG, boundary: C4Boundary, conf: C4DrawConf
   }
 };
 
-export const drawC4Shape = function (elem: SVG, c4Shape: C4Shape, conf: C4DrawConfig) {
-  const fillColor = c4Shape.bgColor
-    ? c4Shape.bgColor
-    : (conf[c4Shape.typeC4Shape.text + '_bg_color'] as string);
-  const strokeColor = c4Shape.borderColor
-    ? c4Shape.borderColor
-    : (conf[c4Shape.typeC4Shape.text + '_border_color'] as string);
-  const fontColor = c4Shape.fontColor ? c4Shape.fontColor : '#FFFFFF';
-
-  let personImg =
-    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAIAAADYYG7QAAACD0lEQVR4Xu2YoU4EMRCGT+4j8Ai8AhaH4QHgAUjQuFMECUgMIUgwJAgMhgQsAYUiJCiQIBBY+EITsjfTdme6V24v4c8vyGbb+ZjOtN0bNcvjQXmkH83WvYBWto6PLm6v7p7uH1/w2fXD+PBycX1Pv2l3IdDm/vn7x+dXQiAubRzoURa7gRZWd0iGRIiJbOnhnfYBQZNJjNbuyY2eJG8fkDE3bbG4ep6MHUAsgYxmE3nVs6VsBWJSGccsOlFPmLIViMzLOB7pCVO2AtHJMohH7Fh6zqitQK7m0rJvAVYgGcEpe//PLdDz65sM4pF9N7ICcXDKIB5Nv6j7tD0NoSdM2QrU9Gg0ewE1LqBhHR3BBdvj2vapnidjHxD/q6vd7Pvhr31AwcY8eXMTXAKECZZJFXuEq27aLgQK5uLMohCenGGuGewOxSjBvYBqeG6B+Nqiblggdjnc+ZXDy+FNFpFzw76O3UBAROuXh6FoiAcf5g9eTvUgzy0nWg6I8cXHRUpg5bOVBCo+KDpFajOf23GgPme7RSQ+lacIENUgJ6gg1k6HjgOlqnLqip4tEuhv0hNEMXUD0clyXE3p6pZA0S2nnvTlXwLJEZWlb7cTQH1+USgTN4VhAenm/wea1OCAOmqo6fE1WCb9WSKBah+rbUWPWAmE2Rvk0ApiB45eOyNAzU8xcTvj8KvkKEoOaIYeHNA3ZuygAvFMUO0AAAAASUVORK5CYII=';
-  switch (c4Shape.typeC4Shape.text) {
-    case 'person':
-      personImg =
-        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAIAAADYYG7QAAACD0lEQVR4Xu2YoU4EMRCGT+4j8Ai8AhaH4QHgAUjQuFMECUgMIUgwJAgMhgQsAYUiJCiQIBBY+EITsjfTdme6V24v4c8vyGbb+ZjOtN0bNcvjQXmkH83WvYBWto6PLm6v7p7uH1/w2fXD+PBycX1Pv2l3IdDm/vn7x+dXQiAubRzoURa7gRZWd0iGRIiJbOnhnfYBQZNJjNbuyY2eJG8fkDE3bbG4ep6MHUAsgYxmE3nVs6VsBWJSGccsOlFPmLIViMzLOB7pCVO2AtHJMohH7Fh6zqitQK7m0rJvAVYgGcEpe//PLdDz65sM4pF9N7ICcXDKIB5Nv6j7tD0NoSdM2QrU9Gg0ewE1LqBhHR3BBdvj2vapnidjHxD/q6vd7Pvhr31AwcY8eXMTXAKECZZJFXuEq27aLgQK5uLMohCenGGuGewOxSjBvYBqeG6B+Nqiblggdjnc+ZXDy+FNFpFzw76O3UBAROuXh6FoiAcf5g9eTvUgzy0nWg6I8cXHRUpg5bOVBCo+KDpFajOf23GgPme7RSQ+lacIENUgJ6gg1k6HjgOlqnLqip4tEuhv0hNEMXUD0clyXE3p6pZA0S2nnvTlXwLJEZWlb7cTQH1+USgTN4VhAenm/wea1OCAOmqo6fE1WCb9WSKBah+rbUWPWAmE2Rvk0ApiB45eOyNAzU8xcTvj8KvkKEoOaIYeHNA3ZuygAvFMUO0AAAAASUVORK5CYII=';
-      break;
-    case 'external_person':
-      personImg =
-        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAIAAADYYG7QAAAB6ElEQVR4Xu2YLY+EMBCG9+dWr0aj0Wg0Go1Go0+j8Xdv2uTCvv1gpt0ebHKPuhDaeW4605Z9mJvx4AdXUyTUdd08z+u6flmWZRnHsWkafk9DptAwDPu+f0eAYtu2PEaGWuj5fCIZrBAC2eLBAnRCsEkkxmeaJp7iDJ2QMDdHsLg8SxKFEJaAo8lAXnmuOFIhTMpxxKATebo4UiFknuNo4OniSIXQyRxEA3YsnjGCVEjVXD7yLUAqxBGUyPv/Y4W2beMgGuS7kVQIBycH0fD+oi5pezQETxdHKmQKGk1eQEYldK+jw5GxPfZ9z7Mk0Qnhf1W1m3w//EUn5BDmSZsbR44QQLBEqrBHqOrmSKaQAxdnLArCrxZcM7A7ZKs4ioRq8LFC+NpC3WCBJsvpVw5edm9iEXFuyNfxXAgSwfrFQ1c0iNda8AdejvUgnktOtJQQxmcfFzGglc5WVCj7oDgFqU18boeFSs52CUh8LE8BIVQDT1ABrB0HtgSEYlX5doJnCwv9TXocKCaKbnwhdDKPq4lf3SwU3HLq4V/+WYhHVMa/3b4IlfyikAduCkcBc7mQ3/z/Qq/cTuikhkzB12Ae/mcJC9U+Vo8Ej1gWAtgbeGgFsAMHr50BIWOLCbezvhpBFUdY6EJuJ/QDW0XoMX60zZ0AAAAASUVORK5CYII=';
-      break;
-  }
-
-  const c4ShapeElem = elem.append('g');
-  c4ShapeElem.attr('class', 'person-man');
-
-  // <rect fill="#08427B" height="119.2188" rx="2.5" ry="2.5" stroke="#073B6F" stroke-width="0.5" width="110" x="120" y="7"/>
-  // draw rect of c4Shape
-  const rect = svgDrawCommon.getNoteRect();
-
-  switch (c4Shape.typeC4Shape.text) {
-    case 'person':
-    case 'external_person':
-    case 'system':
-    case 'external_system':
-    case 'container':
-    case 'external_container':
-    case 'component':
-    case 'external_component':
-      rect.x = c4Shape.x;
-      rect.y = c4Shape.y;
-      rect.fill = fillColor;
-      rect.width = c4Shape.width;
-      rect.height = c4Shape.height;
-      rect.stroke = strokeColor;
-      rect.rx = 2.5;
-      rect.ry = 2.5;
-      rect.attrs = { 'stroke-width': 0.5 };
-      drawRect(c4ShapeElem, rect);
-      break;
-    case 'system_db':
-    case 'external_system_db':
-    case 'container_db':
-    case 'external_container_db':
-    case 'component_db':
-    case 'external_component_db':
-      c4ShapeElem
-        .append('path')
-        .attr('fill', fillColor)
-        .attr('stroke-width', '0.5')
-        .attr('stroke', strokeColor)
-        .attr(
-          'd',
-          'Mstartx,startyc0,-10 half,-10 half,-10c0,0 half,0 half,10l0,heightc0,10 -half,10 -half,10c0,0 -half,0 -half,-10l0,-height'
-            .replaceAll('startx', c4Shape.x as unknown as string)
-            .replaceAll('starty', c4Shape.y as unknown as string)
-            .replaceAll('half', (c4Shape.width / 2) as unknown as string)
-            .replaceAll('height', c4Shape.height as unknown as string)
-        );
-      c4ShapeElem
-        .append('path')
-        .attr('fill', 'none')
-        .attr('stroke-width', '0.5')
-        .attr('stroke', strokeColor)
-        .attr(
-          'd',
-          'Mstartx,startyc0,10 half,10 half,10c0,0 half,0 half,-10'
-            .replaceAll('startx', c4Shape.x as unknown as string)
-            .replaceAll('starty', c4Shape.y as unknown as string)
-            .replaceAll('half', (c4Shape.width / 2) as unknown as string)
-        );
-      break;
-    case 'system_queue':
-    case 'external_system_queue':
-    case 'container_queue':
-    case 'external_container_queue':
-    case 'component_queue':
-    case 'external_component_queue':
-      c4ShapeElem
-        .append('path')
-        .attr('fill', fillColor)
-        .attr('stroke-width', '0.5')
-        .attr('stroke', strokeColor)
-        .attr(
-          'd',
-          'Mstartx,startylwidth,0c5,0 5,half 5,halfc0,0 0,half -5,halfl-width,0c-5,0 -5,-half -5,-halfc0,0 0,-half 5,-half'
-            .replaceAll('startx', c4Shape.x as unknown as string)
-            .replaceAll('starty', c4Shape.y as unknown as string)
-            .replaceAll('width', c4Shape.width as unknown as string)
-            .replaceAll('half', (c4Shape.height / 2) as unknown as string)
-        );
-      c4ShapeElem
-        .append('path')
-        .attr('fill', 'none')
-        .attr('stroke-width', '0.5')
-        .attr('stroke', strokeColor)
-        .attr(
-          'd',
-          'Mstartx,startyc-5,0 -5,half -5,halfc0,half 5,half 5,half'
-            .replaceAll('startx', (c4Shape.x + c4Shape.width) as unknown as string)
-            .replaceAll('starty', c4Shape.y as unknown as string)
-            .replaceAll('half', (c4Shape.height / 2) as unknown as string)
-        );
-      break;
-  }
-
-  // draw type of c4Shape
-  const c4ShapeFontConf = getC4ShapeFont(conf, c4Shape.typeC4Shape.text);
-  // The type text was measured by the renderer before drawing.
-  const typeC4ShapeWidth = c4Shape.typeC4Shape.width!;
-  c4ShapeElem
-    .append('text')
-    .attr('fill', fontColor)
-    .attr('font-family', c4ShapeFontConf.fontFamily)
-    .attr('font-size', c4ShapeFontConf.fontSize - 2)
-    .attr('font-style', 'italic')
-    .attr('lengthAdjust', 'spacing')
-    .attr('textLength', typeC4ShapeWidth)
-    .attr('x', c4Shape.x + c4Shape.width / 2 - typeC4ShapeWidth / 2)
-    .attr('y', c4Shape.y + c4Shape.typeC4Shape.Y!)
-    .text('<<' + c4Shape.typeC4Shape.text + '>>');
-
-  // draw image/sprite
-  switch (c4Shape.typeC4Shape.text) {
-    case 'person':
-    case 'external_person':
-      drawImage(
-        c4ShapeElem,
-        48,
-        48,
-        c4Shape.x + c4Shape.width / 2 - 24,
-        c4Shape.y + c4Shape.image.Y,
-        personImg
-      );
-      break;
-  }
-
-  // draw label
-  let textFontConf = (conf[c4Shape.typeC4Shape.text + 'Font'] as () => C4Font)();
-  textFontConf.fontWeight = 'bold';
-  textFontConf.fontSize = textFontConf.fontSize + 2;
-  textFontConf.fontColor = fontColor;
-  _drawTextCandidateFunc(conf)(
-    c4Shape.label.text,
-    c4ShapeElem,
-    c4Shape.x,
-    c4Shape.y + c4Shape.label.Y!,
-    c4Shape.width,
-    c4Shape.height,
-    { fill: fontColor },
-    textFontConf
-  );
-
-  // draw techn/type
-  textFontConf = (conf[c4Shape.typeC4Shape.text + 'Font'] as () => C4Font)();
-  textFontConf.fontColor = fontColor;
-
-  if (c4Shape.techn && c4Shape.techn?.text !== '') {
-    _drawTextCandidateFunc(conf)(
-      c4Shape.techn.text,
-      c4ShapeElem,
-      c4Shape.x,
-      c4Shape.y + c4Shape.techn.Y!,
-      c4Shape.width,
-      c4Shape.height,
-      { fill: fontColor, 'font-style': 'italic' },
-      textFontConf
-    );
-  } else if (c4Shape.type && c4Shape.type.text !== '') {
-    _drawTextCandidateFunc(conf)(
-      c4Shape.type.text,
-      c4ShapeElem,
-      c4Shape.x,
-      c4Shape.y + c4Shape.type.Y!,
-      c4Shape.width,
-      c4Shape.height,
-      { fill: fontColor, 'font-style': 'italic' },
-      textFontConf
-    );
-  }
-
-  // draw descr
-  if (c4Shape.descr && c4Shape.descr.text !== '') {
-    textFontConf = conf.personFont();
-    textFontConf.fontColor = fontColor;
-    _drawTextCandidateFunc(conf)(
-      c4Shape.descr.text,
-      c4ShapeElem,
-      c4Shape.x,
-      c4Shape.y + c4Shape.descr.Y!,
-      c4Shape.width,
-      c4Shape.height,
-      { fill: fontColor },
-      textFontConf
-    );
-  }
-
-  return c4Shape.height;
-};
-
 export const insertDatabaseIcon = function (elem: SVG, id: string) {
   elem
     .append('defs')
@@ -566,14 +339,6 @@ export const insertArrowCrossHead = function (elem: SVG, id: string) {
   // this is actual shape for arrowhead
 };
 
-const getC4ShapeFont = (cnf: C4DrawConfig, typeC4Shape: string): C4Font => {
-  return {
-    fontFamily: cnf[typeC4Shape + 'FontFamily'] as string,
-    fontSize: cnf[typeC4Shape + 'FontSize'] as number,
-    fontWeight: cnf[typeC4Shape + 'FontWeight'] as string | number,
-  };
-};
-
 const _drawTextCandidateFunc = (function () {
   function byText<T extends SVGElement>(
     content: string,
@@ -683,9 +448,7 @@ const _drawTextCandidateFunc = (function () {
 export default {
   drawRect,
   drawBoundary,
-  drawC4Shape,
   drawRels,
-  drawImage,
   insertArrowHead,
   insertArrowEnd,
   insertArrowFilledHead,

--- a/packages/mermaid/src/docs/syntax/c4.md
+++ b/packages/mermaid/src/docs/syntax/c4.md
@@ -154,6 +154,19 @@ UpdateRelStyle(customerA, bankA, $offsetY="60")
 
 ```
 
+## Element text wrapping
+
+Element text (name, type and description) stays on one line by default; the element sizes itself to the longest line. Set the root `wrap` config value to wrap text to the element width instead, which is set by the [`c4.width`](/config/schema-docs/config-defs-c4-diagram-config.html#width) config value:
+
+```yaml
+---
+config:
+  wrap: true
+  c4:
+    width: 216
+---
+```
+
 ## C4 System Context Diagram (C4Context)
 
 ```mermaid-example

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes.ts
@@ -14,6 +14,7 @@ import { curlyBraceLeft } from './shapes/curlyBraceLeft.js';
 import { curlyBraceRight } from './shapes/curlyBraceRight.js';
 import { curlyBraces } from './shapes/curlyBraces.js';
 import { curvedTrapezoid } from './shapes/curvedTrapezoid.js';
+import { person } from './shapes/person.js';
 import { cylinder } from './shapes/cylinder.js';
 import { datastore } from './shapes/datastore.js';
 import { dividedRectangle } from './shapes/dividedRect.js';
@@ -142,6 +143,13 @@ export const shapesDefs = [
     description: 'Data flow diagram data store',
     aliases: ['data-store'],
     handler: datastore,
+  },
+  {
+    semanticName: 'Person',
+    name: 'Person',
+    shortName: 'person',
+    description: 'Person (circular head above a rounded body)',
+    handler: person,
   },
   {
     semanticName: 'Start',

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/c4LabelHelper.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/c4LabelHelper.ts
@@ -1,0 +1,95 @@
+import { select } from 'd3';
+import { createText } from '../../createText.js';
+import type { Node } from '../../types.js';
+import { getConfig } from '../../../diagram-api/diagramAPI.js';
+import { sanitizeText } from '../../../diagrams/common/common.js';
+import { decodeEntities, handleUndefinedAttr } from '../../../utils.js';
+import type { D3Selection } from '../../../types.js';
+
+const SECTION_GAP = 3;
+const MIN_WRAP_WIDTH = 32;
+
+/**
+ * Renders a stacked multi-section node label (name, stereotype, description
+ * lines) as pure SVG text, one `createText` call per section so each section
+ * can be styled through its own CSS class.
+ *
+ * Drop-in for `labelHelper` on nodes carrying a `stereotype`: same element
+ * structure and return contract. The wrap width is a soft limit - an
+ * unbreakable word may exceed it, and the calling shape self-sizes from the
+ * returned bounds.
+ */
+export const c4LabelHelper = async <T extends SVGGraphicsElement>(
+  parent: D3Selection<T>,
+  node: Node,
+  classes?: string
+) => {
+  const config = getConfig();
+
+  const shapeSvg = parent
+    .insert('g')
+    .attr('class', classes ?? 'node default')
+    .attr('id', node.domId || node.id);
+
+  const labelEl = shapeSvg
+    .insert('g')
+    .attr('class', 'label')
+    .attr('style', handleUndefinedAttr(node.labelStyle));
+
+  const name = typeof node.label === 'string' ? node.label : (node.label?.[0] ?? '');
+  const sections = [
+    { text: name, cssClass: 'c4-name' },
+    { text: node.stereotype, cssClass: 'c4-type' },
+    ...(node.description ?? []).map((line) => ({ text: line, cssClass: 'c4-descr' })),
+  ].filter((section) => section.text);
+
+  const wrapWidth = node.width
+    ? Math.max(node.width - 2 * (node.padding ?? 0), MIN_WRAP_WIDTH)
+    : (getConfig().flowchart?.wrappingWidth ?? 200);
+  // Wrapping is opt-in via the root `wrap` config, matching the legacy C4
+  // renderer; the (currently ignored) c4.wrap option is tracked in #7949.
+  const width = config.wrap ? wrapWidth : Number.POSITIVE_INFINITY;
+
+  const rendered = await Promise.all(
+    sections.map(async (section) => {
+      // Appending before the first await pins the section order in the DOM.
+      const sectionEl = labelEl.append('g').attr('class', section.cssClass);
+      const textEl = await createText(
+        sectionEl,
+        sanitizeText(decodeEntities(section.text ?? ''), config),
+        {
+          useHtmlLabels: false,
+          markdown: false,
+          isNode: true,
+          width,
+          style: node.labelStyle,
+        },
+        config
+      );
+      // Center each wrapped line within the section; the outer tspan elements sit at x=0.
+      select(textEl).selectAll('tspan.text-outer-tspan').attr('text-anchor', 'middle');
+      // Without markdown every word is "normal"; drop the presentation attributes so
+      // font weight and style from CSS (section classes, per-element config) inherit.
+      select(textEl)
+        .selectAll('tspan.text-inner-tspan')
+        .attr('font-weight', null)
+        .attr('font-style', null);
+      return { el: sectionEl, box: sectionEl.node()!.getBBox() };
+    })
+  );
+
+  const totalWidth = Math.max(...rendered.map(({ box }) => box.width), 0);
+  let y = 0;
+  for (const { el, box } of rendered) {
+    el.attr('transform', `translate(${totalWidth / 2 - box.x - box.width / 2}, ${y - box.y})`);
+    y += box.height + SECTION_GAP;
+  }
+  const totalHeight = rendered.length > 0 ? y - SECTION_GAP : 0;
+
+  labelEl.insert('rect', ':first-child');
+  labelEl.attr('transform', `translate(${-totalWidth / 2}, ${-totalHeight / 2})`);
+
+  const bbox = labelEl.node()!.getBBox();
+  const halfPadding = (node.padding ?? 0) / 2;
+  return { shapeSvg, bbox, halfPadding, label: labelEl };
+};

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/cylinder.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/cylinder.ts
@@ -82,10 +82,10 @@ export async function cylinder<T extends SVGGraphicsElement>(parent: D3Selection
 
   const { shapeSvg, bbox, label } = await labelHelper(parent, node, getNodeClasses(node));
 
-  const w = (node.width ? node.width : bbox.width) + labelPaddingY;
+  const w = Math.max(node.width ?? 0, bbox.width) + labelPaddingY;
   const rx = w / 2;
   const ry = rx / (2.5 + w / 50);
-  const h = (node.height ? node.height : bbox.height) + labelPaddingX + ry;
+  const h = Math.max(node.height ?? 0, bbox.height) + labelPaddingX + ry;
 
   let cylinder: D3Selection<SVGPathElement> | D3Selection<SVGGElement>;
   const { cssStyles } = node;

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/cylinder.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/cylinder.ts
@@ -62,16 +62,18 @@ export async function cylinder<T extends SVGGraphicsElement>(parent: D3Selection
   const labelPaddingX = node.look === 'neo' ? 24 : nodePadding;
   const labelPaddingY = node.look === 'neo' ? 24 : nodePadding;
 
-  if (node.width || node.height) {
-    const originalWidth = node.width ?? 0;
-    node.width = (node.width ?? 0) - labelPaddingY;
+  const originalWidth = node.width ?? 0;
+  if (node.width) {
+    node.width = node.width - labelPaddingY;
     if (node.width < MIN_WIDTH) {
       node.width = MIN_WIDTH;
     }
+  }
 
+  if (node.height) {
     const rx = originalWidth / 2;
     const ry = rx / (2.5 + originalWidth / 50);
-    node.height = (node.height ?? 0) - labelPaddingX - ry * 3;
+    node.height = node.height - labelPaddingX - ry * 3;
 
     if (node.height < MIN_HEIGHT) {
       node.height = MIN_HEIGHT;

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/person.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/person.ts
@@ -1,0 +1,132 @@
+import { labelHelper, updateNodeBounds, getNodeClasses, generateCirclePoints } from './util.js';
+import intersect from '../intersect/index.js';
+import type { Node } from '../../types.js';
+import { styles2String, userNodeOverrides } from './handDrawnShapeStyles.js';
+import rough from 'roughjs';
+import { createRoundedRectPathD } from './roundedRectPath.js';
+import type { D3Selection } from '../../../types.js';
+
+/**
+ * Person shape: a circular head above a rounded-rectangle body, as used for
+ * people/actors in C4 model notation.
+ */
+export async function person<T extends SVGGraphicsElement>(parent: D3Selection<T>, node: Node) {
+  const { labelStyles, nodeStyles } = styles2String(node);
+  node.labelStyle = labelStyles;
+
+  const { shapeSvg, bbox, label } = await labelHelper(parent, node, getNodeClasses(node));
+
+  const padding = node.padding ?? 20;
+  const w = Math.max(bbox.width + padding * 2, node.width ?? 0, 100);
+  // Proportions taken from the c4model.com person: head radius 0.23x the body
+  // width, overlapping the body by 0.27x the head radius, body corners 0.177x
+  // the width. The head is clamped so a body widened by a long unwrapped
+  // label keeps a person-sized head.
+  const headRadius = Math.min(Math.max(w * 0.23, 16), 56);
+  const overlap = headRadius * 0.27;
+  const bodyHeight = Math.max(
+    bbox.height + padding * 2,
+    node.height ? node.height - (2 * headRadius - overlap) : 0
+  );
+  const bodyRadius = Math.min(w * 0.177, bodyHeight * 0.45);
+  const totalHeight = bodyHeight + 2 * headRadius - overlap;
+  const top = -totalHeight / 2;
+  const bodyTop = top + 2 * headRadius - overlap;
+
+  const group = shapeSvg.insert('g', ':first-child').attr('class', 'basic label-container');
+  const { cssStyles } = node;
+
+  if (node.look === 'handDrawn') {
+    // @ts-expect-error -- Passing a D3.Selection seems to work for some reason
+    const rc = rough.svg(shapeSvg);
+    const options = userNodeOverrides(node, {});
+    const body = rc.path(
+      createRoundedRectPathD(-w / 2, bodyTop, w, bodyHeight, bodyRadius),
+      options
+    );
+    const head = rc.circle(0, top + headRadius, headRadius * 2, options);
+
+    // Body first, then the head drawn on top so the full circle stays visible.
+    group.insert(() => head, ':first-child');
+    group.insert(() => body, ':first-child');
+    if (cssStyles) {
+      group.attr('style', cssStyles);
+    }
+  } else {
+    // Body first, then the head drawn on top so the full circle stays visible.
+    group
+      .append('rect')
+      .attr('x', -w / 2)
+      .attr('y', bodyTop)
+      .attr('width', w)
+      .attr('height', bodyHeight)
+      .attr('rx', bodyRadius)
+      .attr('ry', bodyRadius)
+      .attr('style', nodeStyles);
+
+    group
+      .append('circle')
+      .attr('cx', 0)
+      .attr('cy', top + headRadius)
+      .attr('r', headRadius)
+      .attr('style', nodeStyles);
+  }
+
+  updateNodeBounds(node, group);
+
+  const bodyCenterY = bodyTop + bodyHeight / 2;
+  label.attr(
+    'transform',
+    `translate(${-(bbox.width / 2) - (bbox.x - (bbox.left ?? 0))}, ${bodyCenterY - bbox.height / 2 - (bbox.y - (bbox.top ?? 0))})`
+  );
+
+  // Edge intersection outline: the head's exposed arc joined to the body's
+  // rounded-rectangle outline, so arrows meet the person silhouette rather than
+  // its bounding box.
+  const headCenterY = top + headRadius;
+  const phiRightDeg =
+    (Math.asin(Math.min(1, (bodyTop - headCenterY) / headRadius)) * 180) / Math.PI;
+  const HEAD_SEGMENTS = 24;
+  const headArc = generateCirclePoints(
+    0,
+    -headCenterY,
+    headRadius,
+    HEAD_SEGMENTS,
+    180 + phiRightDeg,
+    -phiRightDeg
+  );
+  const outline = [
+    ...headArc,
+    ...generateCirclePoints(-(-w / 2 + bodyRadius), -(bodyTop + bodyRadius), bodyRadius, 12, 90, 0),
+    ...generateCirclePoints(
+      -(-w / 2 + bodyRadius),
+      -(totalHeight / 2 - bodyRadius),
+      bodyRadius,
+      12,
+      360,
+      270
+    ),
+    ...generateCirclePoints(
+      -(w / 2 - bodyRadius),
+      -(totalHeight / 2 - bodyRadius),
+      bodyRadius,
+      12,
+      270,
+      180
+    ),
+    ...generateCirclePoints(
+      -(w / 2 - bodyRadius),
+      -(bodyTop + bodyRadius),
+      bodyRadius,
+      12,
+      180,
+      90
+    ),
+  ];
+
+  node.intersect = function (point) {
+    return intersect.polygon(node, outline, point);
+  };
+
+  return shapeSvg;
+}

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/tiltedCylinder.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/tiltedCylinder.ts
@@ -62,17 +62,19 @@ export async function tiltedCylinder<T extends SVGGraphicsElement>(
   node.labelStyle = labelStyles;
   const nodePadding = node.padding ?? 0;
   const labelPadding = node.look === 'neo' ? 12 : nodePadding / 2;
-  if (node.width || node.height) {
-    const originalHeight = node.height ?? 0;
-    node.height = (node.height ?? 0) - labelPadding;
+  const originalHeight = node.height ?? 0;
+  if (node.height) {
+    node.height = node.height - labelPadding;
     if (node.height < MIN_HEIGHT) {
       node.height = MIN_HEIGHT;
     }
+  }
+
+  if (node.width) {
     const ry = originalHeight / 2;
     // based on this height, width is calculated
     const rx = ry / (2.5 + originalHeight / 50);
-
-    node.width = (node.width ?? 0) - labelPadding - rx * 3;
+    node.width = node.width - labelPadding - rx * 3;
     if (node.width < MIN_WIDTH) {
       node.width = MIN_WIDTH;
     }

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/tiltedCylinder.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/tiltedCylinder.ts
@@ -81,10 +81,10 @@ export async function tiltedCylinder<T extends SVGGraphicsElement>(
   }
   const { shapeSvg, bbox, label } = await labelHelper(parent, node, getNodeClasses(node));
 
-  const h = (node.height ? node.height : bbox.height) + labelPadding;
+  const h = Math.max(node.height ?? 0, bbox.height) + labelPadding;
   const ry = h / 2;
   const rx = ry / (2.5 + h / 50);
-  const w = (node.width ? node.width : bbox.width) + rx + labelPadding;
+  const w = Math.max(node.width ?? 0, bbox.width) + rx + labelPadding;
   const { cssStyles } = node;
 
   let cylinder: D3Selection<SVGGElement> | D3Selection<SVGPathElement>;

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/util.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/util.ts
@@ -8,12 +8,17 @@ import { decodeEntities, handleUndefinedAttr } from '../../../utils.js';
 import type { D3Selection, Point } from '../../../types.js';
 import { configureLabelImages } from './labelImageUtils.js';
 import { profiler } from '../../../profiler.js';
+import { c4LabelHelper } from './c4LabelHelper.js';
 
 export const labelHelper = async <T extends SVGGraphicsElement>(
   parent: D3Selection<T>,
   node: Node,
   _classes?: string
 ) => {
+  // Nodes carrying a stereotype render a stacked multi-section SVG label.
+  if (node.stereotype !== undefined) {
+    return c4LabelHelper(parent, node, _classes);
+  }
   let cssClasses;
   const useHtmlLabels = node.useHtmlLabels || evaluate(getConfig()?.htmlLabels);
   if (!_classes) {

--- a/packages/mermaid/src/rendering-util/types.ts
+++ b/packages/mermaid/src/rendering-util/types.ts
@@ -15,6 +15,8 @@ interface BaseNode {
   id: string;
   label?: string;
   description?: string[];
+  /** Stereotype line rendered between label and description in multi-section labels, e.g. `[Container: Node.js]`. */
+  stereotype?: string;
   parentId?: string;
   position?: string; // Keep, this is for notes 'left of', 'right of', etc. Move into nodeNode
   cssStyles?: string[]; // Renamed from `styles` to `cssStyles`


### PR DESCRIPTION
## What this is

The first slice of an **in-place migration** of the C4 renderer onto mermaid's unified shapes - no opt-in flag, drawn directly (the approach @aloisklink asked for). The plan (characterization suite -> shapes -> edges -> layout) is tracked in #7849; the characterization baseline is #7876 (merged).

## This slice: migrate element shapes

The legacy C4 renderer's bespoke element drawing (`svgDraw.drawC4Shape`) is replaced with the unified shapes via a small `c4ShapeAdapter`:

- `Person`/`Person_Ext` -> the general `person` shape (promoted from a C4-only shape so flowcharts can use it too, with a hand-drawn variant and a proper outline `node.intersect`)
- `*Db` -> the shared `cylinder`, `*Queue` -> the shared `h-cyl` (tilted cylinder) - reusing the existing shapes (per review) after a per-axis sizing fix, rather than adding C4-only copies
- everything else -> `rounded`; `external_*` keeps the same shape with an `external` style

Element labels render as **pure SVG text sections** (`c4LabelHelper`, no HTML `foreignObject`, so SVG/PDF export works), with bold name + `[type]` stereotype + description. Wrapping is **opt-in via the root `wrap` config** (off by default, matching the legacy renderer). Per-element font config (`personFontFamily` etc.) is preserved via scoped CSS rules built through the CSSOM.

**Colours are unchanged from today:** `<type>_bg_color` fills, `<type>_border_color` strokes, `UpdateElementStyle` ($bgColor/$borderColor/$fontColor) overrides win. The c4model.com outline redesign that an earlier version of this PR bundled in has been **split out to #7991**, so this slice stays a config-safe, minimal-diff shape migration.

The legacy **layout** (`Bounds` grid), **relationships** and **boundaries** are untouched - they are the next slices (edges = #7883, then layout). The now-dead `svgDraw.drawC4Shape` and its private helpers are removed.

## How to see it

There's no flag, so the existing C4 cypress baselines render through the unified shapes and **Argos shows exactly what changed** per element. With colours preserved, that diff is now the shape geometry only (rounded corners, self-sizing), not a colour change.

## Review

Addresses @aloisklink's three review rounds: SVG-text labels, shared cylinder/queue reuse, `person` promotion, CSSOM font config, opt-in wrapping, `Promise.all` rendering, palette typing, person head clamp + outline intersect, preserved colours, and svgDraw dead-code removal. A `minor` changeset is included. Reviewable by commit.

Made with assistance from Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Migrates C4 element rendering to Mermaid’s unified shapes by introducing a `c4ShapeAdapter` that converts legacy Structurizr C4 “shape-like” inputs into unified `NonClusterNode` definitions, preserving the existing legacy grid layout, relationships, boundaries, and edge rendering.
- Refactors `c4Renderer` into an async, handler-based two-pass pipeline: `drawC4ShapeArray` now renders once to measure (pass 1), records the resulting dimensions, clears the temporary output, then renders again at the final grid-aligned translated positions (pass 2). The top-level `draw` and `drawInsideBoundary` are also converted to `async` and await completion before relation/marker drawing and SVG sizing.
- Adds C4-specific visuals and label behavior:
  - Introduces a unified `person` shape handler and reuses shared shape variants for database/queue elements (cylinder variants), while other elements use rounded shapes.
  - Implements pure-SVG stacked C4 labels via `c4LabelHelper` (no HTML `foreignObject`), with description/name/type wrapping controlled by `c4.width` and enabled only when the root `wrap` configuration is set.
  - Preserves per-element font configuration by generating scoped per-type label font rules through dynamic CSS generation (CSSOM `insertRule`) in `c4/styles.js`, and routing boundary label typography through a dedicated boundary font helper.
- Cleans up legacy/unsupported overrides (e.g., unsupported `$shape`/`$sprite` folder/bucket/terminal/browser-style overrides), removing sprite artifacts while keeping relationship/boundary rendering unchanged.
- Updates release notes and docs to reflect the unified-shape C4 rendering changes (SVG text labels, shared C4 person/database/queue shapes, and `c4.width`-driven wrapping).

## Testing

- Updated Cypress characterization tests in `c4-characterization.spec.js` to assert the new SVG-only rendering behavior for element shape/sprite overrides and SVG description wrapping.
- Added Cypress snapshot coverage in `c4.spec.js` for:
  - Multiple `personFontFamily`/`personFontSize` combinations
  - Wrapping behavior changes driven by varying `c4.width` (with `wrap: true`)
- Expanded rendering snapshot matrix coverage in `newShapes.spec.ts` to include the new `person` shape.
- Updated shape documentation snapshot expectations (`packages/mermaid/scripts/docs.spec.ts`) and the flowchart “complete list of new shapes” documentation to reflect the expanded/updated unified shape catalog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

