### PR TITLE
refactor(c4): adopt C4 TypeScript conversion from #7829

### DIFF
--- a/.changeset/c4-typescript-conversion.md
+++ b/.changeset/c4-typescript-conversion.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+chore: convert the C4 diagram implementation (c4Db, c4Renderer, svgDraw, parser specs) to TypeScript and add shared getRequiredConfig/getDiagramRoot helpers. No behavior change.

--- a/packages/mermaid/src/diagram-api/requiredConfig.ts
+++ b/packages/mermaid/src/diagram-api/requiredConfig.ts
@@ -1,0 +1,18 @@
+import type { MermaidConfig } from '../config.type.js';
+import { getConfig } from './diagramAPI.js';
+
+/**
+ * Returns a diagram section of the current (site + user) config with all
+ * fields typed as present.
+ *
+ * `getConfig()` always merges the full `defaultConfig` (generated from the
+ * config JSON schema, where every field has a default) under any user
+ * overrides, so every field of every diagram section is guaranteed to be
+ * defined at runtime even though the `MermaidConfig` input type marks them
+ * optional. This helper centralizes that invariant so renderers don't need
+ * non-null assertions on every config access.
+ */
+export const getRequiredConfig = <K extends keyof MermaidConfig>(
+  section: K
+): Required<NonNullable<MermaidConfig[K]>> =>
+  getConfig()[section] as Required<NonNullable<MermaidConfig[K]>>;

--- a/packages/mermaid/src/diagrams/c4/c4Db.ts
+++ b/packages/mermaid/src/diagrams/c4/c4Db.ts
@@ -1,4 +1,5 @@
 import { getConfig } from '../../diagram-api/diagramAPI.js';
+import { getRequiredConfig } from '../../diagram-api/requiredConfig.js';
 import { sanitizeText } from '../common/common.js';
 import {
   setAccTitle,
@@ -6,39 +7,58 @@ import {
   getAccDescription,
   setAccDescription,
 } from '../common/commonDb.js';
+import type { C4Boundary, C4Rel, C4Shape } from './c4Types.js';
 
-let c4ShapeArray = [];
-let boundaryParseStack = [''];
-let currentBoundaryParse = 'global';
-let parentBoundaryParse = '';
-let boundaries = [
-  {
+/**
+ * The parser may pass a plain string or an object with a single
+ * `{ key: value }` entry for most attributes.
+ */
+type ParserAttribute = string | Record<string, string>;
+
+const createGlobalBoundary = (): C4Boundary =>
+  ({
     alias: 'global',
     label: { text: 'global' },
     type: { text: 'global' },
     tags: null,
     link: null,
     parentBoundary: '',
-  },
-];
-let rels = [];
+    // The layout fields are populated later by the renderer.
+  }) as C4Boundary;
+
+let c4ShapeArray: C4Shape[] = [];
+let boundaryParseStack = [''];
+let currentBoundaryParse = 'global';
+let parentBoundaryParse = '';
+let boundaries: C4Boundary[] = [createGlobalBoundary()];
+let rels: C4Rel[] = [];
 let title = '';
-let wrapEnabled = false;
+let wrapEnabled: boolean | undefined = false;
 let c4ShapeInRow = 4;
 let c4BoundaryInRow = 2;
-var c4Type;
+let c4Type: string | undefined;
 
 export const getC4Type = function () {
   return c4Type;
 };
 
-export const setC4Type = function (c4TypeParam) {
-  let sanitizedText = sanitizeText(c4TypeParam, getConfig());
+export const setC4Type = function (c4TypeParam: string) {
+  const sanitizedText = sanitizeText(c4TypeParam, getConfig());
   c4Type = sanitizedText;
 };
 
 //type, from, to, label, ?techn, ?descr, ?sprite, ?tags, $link
-export const addRel = function (type, from, to, label, techn, descr, sprite, tags, link) {
+export const addRel = function (
+  type: string | null | undefined,
+  from: string | null | undefined,
+  to: string | null | undefined,
+  label: string | null | undefined,
+  techn?: ParserAttribute | null,
+  descr?: ParserAttribute | null,
+  sprite?: ParserAttribute,
+  tags?: ParserAttribute,
+  link?: ParserAttribute
+) {
   // Don't allow label nulling
   if (
     type === undefined ||
@@ -53,7 +73,7 @@ export const addRel = function (type, from, to, label, techn, descr, sprite, tag
     return;
   }
 
-  let rel = {};
+  let rel = {} as C4Rel;
   const old = rels.find((rel) => rel.from === from && rel.to === to);
   if (old) {
     rel = old;
@@ -70,7 +90,7 @@ export const addRel = function (type, from, to, label, techn, descr, sprite, tag
     rel.techn = { text: '' };
   } else {
     if (typeof techn === 'object') {
-      let [key, value] = Object.entries(techn)[0];
+      const [key, value] = Object.entries(techn)[0];
       rel[key] = { text: value };
     } else {
       rel.techn = { text: techn };
@@ -81,7 +101,7 @@ export const addRel = function (type, from, to, label, techn, descr, sprite, tag
     rel.descr = { text: '' };
   } else {
     if (typeof descr === 'object') {
-      let [key, value] = Object.entries(descr)[0];
+      const [key, value] = Object.entries(descr)[0];
       rel[key] = { text: value };
     } else {
       rel.descr = { text: descr };
@@ -89,19 +109,19 @@ export const addRel = function (type, from, to, label, techn, descr, sprite, tag
   }
 
   if (typeof sprite === 'object') {
-    let [key, value] = Object.entries(sprite)[0];
+    const [key, value] = Object.entries(sprite)[0];
     rel[key] = value;
   } else {
     rel.sprite = sprite;
   }
   if (typeof tags === 'object') {
-    let [key, value] = Object.entries(tags)[0];
+    const [key, value] = Object.entries(tags)[0];
     rel[key] = value;
   } else {
     rel.tags = tags;
   }
   if (typeof link === 'object') {
-    let [key, value] = Object.entries(link)[0];
+    const [key, value] = Object.entries(link)[0];
     rel[key] = value;
   } else {
     rel.link = link;
@@ -110,13 +130,21 @@ export const addRel = function (type, from, to, label, techn, descr, sprite, tag
 };
 
 //type, alias, label, ?descr, ?sprite, ?tags, $link
-export const addPersonOrSystem = function (typeC4Shape, alias, label, descr, sprite, tags, link) {
+export const addPersonOrSystem = function (
+  typeC4Shape: string,
+  alias: string | null,
+  label: string | null | undefined,
+  descr?: ParserAttribute | null,
+  sprite?: ParserAttribute,
+  tags?: ParserAttribute,
+  link?: ParserAttribute
+) {
   // Don't allow label nulling
   if (alias === null || label === null) {
     return;
   }
 
-  let personOrSystem = {};
+  let personOrSystem = {} as C4Shape;
   const old = c4ShapeArray.find((personOrSystem) => personOrSystem.alias === alias);
   if (old && alias === old.alias) {
     personOrSystem = old;
@@ -136,7 +164,7 @@ export const addPersonOrSystem = function (typeC4Shape, alias, label, descr, spr
     personOrSystem.descr = { text: '' };
   } else {
     if (typeof descr === 'object') {
-      let [key, value] = Object.entries(descr)[0];
+      const [key, value] = Object.entries(descr)[0];
       personOrSystem[key] = { text: value };
     } else {
       personOrSystem.descr = { text: descr };
@@ -144,19 +172,19 @@ export const addPersonOrSystem = function (typeC4Shape, alias, label, descr, spr
   }
 
   if (typeof sprite === 'object') {
-    let [key, value] = Object.entries(sprite)[0];
+    const [key, value] = Object.entries(sprite)[0];
     personOrSystem[key] = value;
   } else {
     personOrSystem.sprite = sprite;
   }
   if (typeof tags === 'object') {
-    let [key, value] = Object.entries(tags)[0];
+    const [key, value] = Object.entries(tags)[0];
     personOrSystem[key] = value;
   } else {
     personOrSystem.tags = tags;
   }
   if (typeof link === 'object') {
-    let [key, value] = Object.entries(link)[0];
+    const [key, value] = Object.entries(link)[0];
     personOrSystem[key] = value;
   } else {
     personOrSystem.link = link;
@@ -167,13 +195,22 @@ export const addPersonOrSystem = function (typeC4Shape, alias, label, descr, spr
 };
 
 //type, alias, label, ?techn, ?descr ?sprite, ?tags, $link
-export const addContainer = function (typeC4Shape, alias, label, techn, descr, sprite, tags, link) {
+export const addContainer = function (
+  typeC4Shape: string,
+  alias: string | null,
+  label: string | null | undefined,
+  techn?: ParserAttribute | null,
+  descr?: ParserAttribute | null,
+  sprite?: ParserAttribute,
+  tags?: ParserAttribute,
+  link?: ParserAttribute
+) {
   // Don't allow label nulling
   if (alias === null || label === null) {
     return;
   }
 
-  let container = {};
+  let container = {} as C4Shape;
   const old = c4ShapeArray.find((container) => container.alias === alias);
   if (old && alias === old.alias) {
     container = old;
@@ -193,7 +230,7 @@ export const addContainer = function (typeC4Shape, alias, label, techn, descr, s
     container.techn = { text: '' };
   } else {
     if (typeof techn === 'object') {
-      let [key, value] = Object.entries(techn)[0];
+      const [key, value] = Object.entries(techn)[0];
       container[key] = { text: value };
     } else {
       container.techn = { text: techn };
@@ -204,7 +241,7 @@ export const addContainer = function (typeC4Shape, alias, label, techn, descr, s
     container.descr = { text: '' };
   } else {
     if (typeof descr === 'object') {
-      let [key, value] = Object.entries(descr)[0];
+      const [key, value] = Object.entries(descr)[0];
       container[key] = { text: value };
     } else {
       container.descr = { text: descr };
@@ -212,19 +249,19 @@ export const addContainer = function (typeC4Shape, alias, label, techn, descr, s
   }
 
   if (typeof sprite === 'object') {
-    let [key, value] = Object.entries(sprite)[0];
+    const [key, value] = Object.entries(sprite)[0];
     container[key] = value;
   } else {
     container.sprite = sprite;
   }
   if (typeof tags === 'object') {
-    let [key, value] = Object.entries(tags)[0];
+    const [key, value] = Object.entries(tags)[0];
     container[key] = value;
   } else {
     container.tags = tags;
   }
   if (typeof link === 'object') {
-    let [key, value] = Object.entries(link)[0];
+    const [key, value] = Object.entries(link)[0];
     container[key] = value;
   } else {
     container.link = link;
@@ -235,13 +272,22 @@ export const addContainer = function (typeC4Shape, alias, label, techn, descr, s
 };
 
 //type, alias, label, ?techn, ?descr ?sprite, ?tags, $link
-export const addComponent = function (typeC4Shape, alias, label, techn, descr, sprite, tags, link) {
+export const addComponent = function (
+  typeC4Shape: string,
+  alias: string | null,
+  label: string | null | undefined,
+  techn?: ParserAttribute | null,
+  descr?: ParserAttribute | null,
+  sprite?: ParserAttribute,
+  tags?: ParserAttribute,
+  link?: ParserAttribute
+) {
   // Don't allow label nulling
   if (alias === null || label === null) {
     return;
   }
 
-  let component = {};
+  let component = {} as C4Shape;
   const old = c4ShapeArray.find((component) => component.alias === alias);
   if (old && alias === old.alias) {
     component = old;
@@ -261,7 +307,7 @@ export const addComponent = function (typeC4Shape, alias, label, techn, descr, s
     component.techn = { text: '' };
   } else {
     if (typeof techn === 'object') {
-      let [key, value] = Object.entries(techn)[0];
+      const [key, value] = Object.entries(techn)[0];
       component[key] = { text: value };
     } else {
       component.techn = { text: techn };
@@ -272,7 +318,7 @@ export const addComponent = function (typeC4Shape, alias, label, techn, descr, s
     component.descr = { text: '' };
   } else {
     if (typeof descr === 'object') {
-      let [key, value] = Object.entries(descr)[0];
+      const [key, value] = Object.entries(descr)[0];
       component[key] = { text: value };
     } else {
       component.descr = { text: descr };
@@ -280,19 +326,19 @@ export const addComponent = function (typeC4Shape, alias, label, techn, descr, s
   }
 
   if (typeof sprite === 'object') {
-    let [key, value] = Object.entries(sprite)[0];
+    const [key, value] = Object.entries(sprite)[0];
     component[key] = value;
   } else {
     component.sprite = sprite;
   }
   if (typeof tags === 'object') {
-    let [key, value] = Object.entries(tags)[0];
+    const [key, value] = Object.entries(tags)[0];
     component[key] = value;
   } else {
     component.tags = tags;
   }
   if (typeof link === 'object') {
-    let [key, value] = Object.entries(link)[0];
+    const [key, value] = Object.entries(link)[0];
     component[key] = value;
   } else {
     component.link = link;
@@ -303,7 +349,13 @@ export const addComponent = function (typeC4Shape, alias, label, techn, descr, s
 };
 
 //alias, label, ?type, ?tags, $link
-export const addPersonOrSystemBoundary = function (alias, label, type, tags, link) {
+export const addPersonOrSystemBoundary = function (
+  alias: string | null,
+  label: string | null | undefined,
+  type?: ParserAttribute | null,
+  tags?: ParserAttribute,
+  link?: ParserAttribute
+) {
   // if (parentBoundary === null) return;
 
   // Don't allow label nulling
@@ -311,7 +363,7 @@ export const addPersonOrSystemBoundary = function (alias, label, type, tags, lin
     return;
   }
 
-  let boundary = {};
+  let boundary = {} as C4Boundary;
   const old = boundaries.find((boundary) => boundary.alias === alias);
   if (old && alias === old.alias) {
     boundary = old;
@@ -331,7 +383,7 @@ export const addPersonOrSystemBoundary = function (alias, label, type, tags, lin
     boundary.type = { text: 'system' };
   } else {
     if (typeof type === 'object') {
-      let [key, value] = Object.entries(type)[0];
+      const [key, value] = Object.entries(type)[0];
       boundary[key] = { text: value };
     } else {
       boundary.type = { text: type };
@@ -339,13 +391,13 @@ export const addPersonOrSystemBoundary = function (alias, label, type, tags, lin
   }
 
   if (typeof tags === 'object') {
-    let [key, value] = Object.entries(tags)[0];
+    const [key, value] = Object.entries(tags)[0];
     boundary[key] = value;
   } else {
     boundary.tags = tags;
   }
   if (typeof link === 'object') {
-    let [key, value] = Object.entries(link)[0];
+    const [key, value] = Object.entries(link)[0];
     boundary[key] = value;
   } else {
     boundary.link = link;
@@ -359,7 +411,13 @@ export const addPersonOrSystemBoundary = function (alias, label, type, tags, lin
 };
 
 //alias, label, ?type, ?tags, $link
-export const addContainerBoundary = function (alias, label, type, tags, link) {
+export const addContainerBoundary = function (
+  alias: string | null,
+  label: string | null | undefined,
+  type?: ParserAttribute | null,
+  tags?: ParserAttribute,
+  link?: ParserAttribute
+) {
   // if (parentBoundary === null) return;
 
   // Don't allow label nulling
@@ -367,7 +425,7 @@ export const addContainerBoundary = function (alias, label, type, tags, link) {
     return;
   }
 
-  let boundary = {};
+  let boundary = {} as C4Boundary;
   const old = boundaries.find((boundary) => boundary.alias === alias);
   if (old && alias === old.alias) {
     boundary = old;
@@ -387,7 +445,7 @@ export const addContainerBoundary = function (alias, label, type, tags, link) {
     boundary.type = { text: 'container' };
   } else {
     if (typeof type === 'object') {
-      let [key, value] = Object.entries(type)[0];
+      const [key, value] = Object.entries(type)[0];
       boundary[key] = { text: value };
     } else {
       boundary.type = { text: type };
@@ -395,13 +453,13 @@ export const addContainerBoundary = function (alias, label, type, tags, link) {
   }
 
   if (typeof tags === 'object') {
-    let [key, value] = Object.entries(tags)[0];
+    const [key, value] = Object.entries(tags)[0];
     boundary[key] = value;
   } else {
     boundary.tags = tags;
   }
   if (typeof link === 'object') {
-    let [key, value] = Object.entries(link)[0];
+    const [key, value] = Object.entries(link)[0];
     boundary[key] = value;
   } else {
     boundary.link = link;
@@ -416,14 +474,14 @@ export const addContainerBoundary = function (alias, label, type, tags, link) {
 
 //alias, label, ?type, ?descr, ?sprite, ?tags, $link
 export const addDeploymentNode = function (
-  nodeType,
-  alias,
-  label,
-  type,
-  descr,
-  sprite,
-  tags,
-  link
+  nodeType: string,
+  alias: string | null,
+  label: string | null | undefined,
+  type?: ParserAttribute | null,
+  descr?: ParserAttribute | null,
+  sprite?: ParserAttribute,
+  tags?: ParserAttribute,
+  link?: ParserAttribute
 ) {
   // if (parentBoundary === null) return;
 
@@ -432,7 +490,7 @@ export const addDeploymentNode = function (
     return;
   }
 
-  let boundary = {};
+  let boundary = {} as C4Boundary;
   const old = boundaries.find((boundary) => boundary.alias === alias);
   if (old && alias === old.alias) {
     boundary = old;
@@ -452,7 +510,7 @@ export const addDeploymentNode = function (
     boundary.type = { text: 'node' };
   } else {
     if (typeof type === 'object') {
-      let [key, value] = Object.entries(type)[0];
+      const [key, value] = Object.entries(type)[0];
       boundary[key] = { text: value };
     } else {
       boundary.type = { text: type };
@@ -463,7 +521,7 @@ export const addDeploymentNode = function (
     boundary.descr = { text: '' };
   } else {
     if (typeof descr === 'object') {
-      let [key, value] = Object.entries(descr)[0];
+      const [key, value] = Object.entries(descr)[0];
       boundary[key] = { text: value };
     } else {
       boundary.descr = { text: descr };
@@ -471,13 +529,13 @@ export const addDeploymentNode = function (
   }
 
   if (typeof tags === 'object') {
-    let [key, value] = Object.entries(tags)[0];
+    const [key, value] = Object.entries(tags)[0];
     boundary[key] = value;
   } else {
     boundary.tags = tags;
   }
   if (typeof link === 'object') {
-    let [key, value] = Object.entries(link)[0];
+    const [key, value] = Object.entries(link)[0];
     boundary[key] = value;
   } else {
     boundary.link = link;
@@ -494,25 +552,27 @@ export const addDeploymentNode = function (
 export const popBoundaryParseStack = function () {
   currentBoundaryParse = parentBoundaryParse;
   boundaryParseStack.pop();
-  parentBoundaryParse = boundaryParseStack.pop();
+  parentBoundaryParse = boundaryParseStack.pop()!;
   boundaryParseStack.push(parentBoundaryParse);
 };
 
 //elementName, ?bgColor, ?fontColor, ?borderColor, ?shadowing, ?shape, ?sprite, ?techn, ?legendText, ?legendSprite
 export const updateElStyle = function (
-  typeC4Shape,
-  elementName,
-  bgColor,
-  fontColor,
-  borderColor,
-  shadowing,
-  shape,
-  sprite,
-  techn,
-  legendText,
-  legendSprite
+  typeC4Shape: string,
+  elementName: string,
+  bgColor?: ParserAttribute | null,
+  fontColor?: ParserAttribute | null,
+  borderColor?: ParserAttribute | null,
+  shadowing?: ParserAttribute | null,
+  shape?: ParserAttribute | null,
+  sprite?: ParserAttribute | null,
+  techn?: ParserAttribute | null,
+  legendText?: ParserAttribute | null,
+  legendSprite?: ParserAttribute | null
 ) {
-  let old = c4ShapeArray.find((element) => element.alias === elementName);
+  let old: C4Shape | C4Boundary | undefined = c4ShapeArray.find(
+    (element) => element.alias === elementName
+  );
   if (old === undefined) {
     old = boundaries.find((element) => element.alias === elementName);
     if (old === undefined) {
@@ -521,7 +581,7 @@ export const updateElStyle = function (
   }
   if (bgColor !== undefined && bgColor !== null) {
     if (typeof bgColor === 'object') {
-      let [key, value] = Object.entries(bgColor)[0];
+      const [key, value] = Object.entries(bgColor)[0];
       old[key] = value;
     } else {
       old.bgColor = bgColor;
@@ -529,7 +589,7 @@ export const updateElStyle = function (
   }
   if (fontColor !== undefined && fontColor !== null) {
     if (typeof fontColor === 'object') {
-      let [key, value] = Object.entries(fontColor)[0];
+      const [key, value] = Object.entries(fontColor)[0];
       old[key] = value;
     } else {
       old.fontColor = fontColor;
@@ -537,7 +597,7 @@ export const updateElStyle = function (
   }
   if (borderColor !== undefined && borderColor !== null) {
     if (typeof borderColor === 'object') {
-      let [key, value] = Object.entries(borderColor)[0];
+      const [key, value] = Object.entries(borderColor)[0];
       old[key] = value;
     } else {
       old.borderColor = borderColor;
@@ -545,7 +605,7 @@ export const updateElStyle = function (
   }
   if (shadowing !== undefined && shadowing !== null) {
     if (typeof shadowing === 'object') {
-      let [key, value] = Object.entries(shadowing)[0];
+      const [key, value] = Object.entries(shadowing)[0];
       old[key] = value;
     } else {
       old.shadowing = shadowing;
@@ -553,7 +613,7 @@ export const updateElStyle = function (
   }
   if (shape !== undefined && shape !== null) {
     if (typeof shape === 'object') {
-      let [key, value] = Object.entries(shape)[0];
+      const [key, value] = Object.entries(shape)[0];
       old[key] = value;
     } else {
       old.shape = shape;
@@ -561,7 +621,7 @@ export const updateElStyle = function (
   }
   if (sprite !== undefined && sprite !== null) {
     if (typeof sprite === 'object') {
-      let [key, value] = Object.entries(sprite)[0];
+      const [key, value] = Object.entries(sprite)[0];
       old[key] = value;
     } else {
       old.sprite = sprite;
@@ -569,15 +629,17 @@ export const updateElStyle = function (
   }
   if (techn !== undefined && techn !== null) {
     if (typeof techn === 'object') {
-      let [key, value] = Object.entries(techn)[0];
+      const [key, value] = Object.entries(techn)[0];
       old[key] = value;
     } else {
-      old.techn = techn;
+      // The parser hands over a plain string here, even though `techn` is a
+      // `{ text: string }` object everywhere else.
+      old.techn = techn as unknown as C4Shape['techn'];
     }
   }
   if (legendText !== undefined && legendText !== null) {
     if (typeof legendText === 'object') {
-      let [key, value] = Object.entries(legendText)[0];
+      const [key, value] = Object.entries(legendText)[0];
       old[key] = value;
     } else {
       old.legendText = legendText;
@@ -585,7 +647,7 @@ export const updateElStyle = function (
   }
   if (legendSprite !== undefined && legendSprite !== null) {
     if (typeof legendSprite === 'object') {
-      let [key, value] = Object.entries(legendSprite)[0];
+      const [key, value] = Object.entries(legendSprite)[0];
       old[key] = value;
     } else {
       old.legendSprite = legendSprite;
@@ -595,13 +657,13 @@ export const updateElStyle = function (
 
 //textColor, lineColor, ?offsetX, ?offsetY
 export const updateRelStyle = function (
-  typeC4Shape,
-  from,
-  to,
-  textColor,
-  lineColor,
-  offsetX,
-  offsetY
+  typeC4Shape: string,
+  from: string,
+  to: string,
+  textColor?: ParserAttribute | null,
+  lineColor?: ParserAttribute | null,
+  offsetX?: ParserAttribute | null,
+  offsetY?: ParserAttribute | null
 ) {
   const old = rels.find((rel) => rel.from === from && rel.to === to);
   if (old === undefined) {
@@ -609,7 +671,7 @@ export const updateRelStyle = function (
   }
   if (textColor !== undefined && textColor !== null) {
     if (typeof textColor === 'object') {
-      let [key, value] = Object.entries(textColor)[0];
+      const [key, value] = Object.entries(textColor)[0];
       old[key] = value;
     } else {
       old.textColor = textColor;
@@ -617,7 +679,7 @@ export const updateRelStyle = function (
   }
   if (lineColor !== undefined && lineColor !== null) {
     if (typeof lineColor === 'object') {
-      let [key, value] = Object.entries(lineColor)[0];
+      const [key, value] = Object.entries(lineColor)[0];
       old[key] = value;
     } else {
       old.lineColor = lineColor;
@@ -625,7 +687,7 @@ export const updateRelStyle = function (
   }
   if (offsetX !== undefined && offsetX !== null) {
     if (typeof offsetX === 'object') {
-      let [key, value] = Object.entries(offsetX)[0];
+      const [key, value] = Object.entries(offsetX)[0];
       old[key] = parseInt(value);
     } else {
       old.offsetX = parseInt(offsetX);
@@ -633,7 +695,7 @@ export const updateRelStyle = function (
   }
   if (offsetY !== undefined && offsetY !== null) {
     if (typeof offsetY === 'object') {
-      let [key, value] = Object.entries(offsetY)[0];
+      const [key, value] = Object.entries(offsetY)[0];
       old[key] = parseInt(value);
     } else {
       old.offsetY = parseInt(offsetY);
@@ -642,7 +704,11 @@ export const updateRelStyle = function (
 };
 
 //?c4ShapeInRow, ?c4BoundaryInRow
-export const updateLayoutConfig = function (typeC4Shape, c4ShapeInRowParam, c4BoundaryInRowParam) {
+export const updateLayoutConfig = function (
+  typeC4Shape: string,
+  c4ShapeInRowParam: ParserAttribute,
+  c4BoundaryInRowParam: ParserAttribute
+) {
   let c4ShapeInRowValue = c4ShapeInRow;
   let c4BoundaryInRowValue = c4BoundaryInRow;
 
@@ -681,7 +747,7 @@ export const getParentBoundaryParse = function () {
   return parentBoundaryParse;
 };
 
-export const getC4ShapeArray = function (parentBoundary) {
+export const getC4ShapeArray = function (parentBoundary?: string | null) {
   if (parentBoundary === undefined || parentBoundary === null) {
     return c4ShapeArray;
   } else {
@@ -690,14 +756,14 @@ export const getC4ShapeArray = function (parentBoundary) {
     });
   }
 };
-export const getC4Shape = function (alias) {
+export const getC4Shape = function (alias: string) {
   return c4ShapeArray.find((personOrSystem) => personOrSystem.alias === alias);
 };
-export const getC4ShapeKeys = function (parentBoundary) {
+export const getC4ShapeKeys = function (parentBoundary?: string | null) {
   return Object.keys(getC4ShapeArray(parentBoundary));
 };
 
-export const getBoundaries = function (parentBoundary) {
+export const getBoundaries = function (parentBoundary?: string | null) {
   if (parentBoundary === undefined || parentBoundary === null) {
     return boundaries;
   } else {
@@ -719,7 +785,7 @@ export const getTitle = function () {
   return title;
 };
 
-export const setWrap = function (wrapSetting) {
+export const setWrap = function (wrapSetting?: boolean) {
   wrapEnabled = wrapSetting;
 };
 
@@ -729,16 +795,7 @@ export const autoWrap = function () {
 
 export const clear = function () {
   c4ShapeArray = [];
-  boundaries = [
-    {
-      alias: 'global',
-      label: { text: 'global' },
-      type: { text: 'global' },
-      tags: null,
-      link: null,
-      parentBoundary: '',
-    },
-  ];
+  boundaries = [createGlobalBoundary()];
   parentBoundaryParse = '';
   currentBoundaryParse = 'global';
   boundaryParseStack = [''];
@@ -788,8 +845,8 @@ export const PLACEMENT = {
   OVER: 2,
 };
 
-export const setTitle = function (txt) {
-  let sanitizedText = sanitizeText(txt, getConfig());
+export const setTitle = function (txt: string) {
+  const sanitizedText = sanitizeText(txt, getConfig());
   title = sanitizedText;
 };
 
@@ -823,7 +880,7 @@ export default {
   getAccTitle,
   getAccDescription,
   setAccDescription,
-  getConfig: () => getConfig().c4,
+  getConfig: () => getRequiredConfig('c4'),
   clear,
   LINETYPE,
   ARROWTYPE,

--- a/packages/mermaid/src/diagrams/c4/c4Renderer.ts
+++ b/packages/mermaid/src/diagrams/c4/c4Renderer.ts
@@ -1,13 +1,48 @@
-import { select } from 'd3';
 import svgDraw from './svgDraw.js';
 import { log } from '../../logger.js';
+// @ts-ignore: JISON doesn't support types
 import { parser } from './parser/c4Diagram.jison';
 import common from '../common/common.js';
 import c4Db from './c4Db.js';
 import { getConfig } from '../../diagram-api/diagramAPI.js';
+import { getRequiredConfig } from '../../diagram-api/requiredConfig.js';
 import assignWithDepth from '../../assignWithDepth.js';
 import { wrapLabel, calculateTextWidth, calculateTextHeight } from '../../utils.js';
+import { getDiagramRoot } from '../../utils/diagramRoot.js';
 import { configureSvgSize } from '../../setupGraphViewbox.js';
+import type { Diagram } from '../../Diagram.js';
+import type { C4DiagramConfig } from '../../config.type.js';
+import type { SVG } from '../../diagram-api/types.js';
+import type { TextDimensionConfig } from '../../types.js';
+import type { C4Boundary, C4DrawConfig, C4Font, C4Rel, C4Shape, C4Text } from './c4Types.js';
+
+type C4DB = typeof c4Db;
+
+/** The config passed to {@link setConf} may carry the global font settings. */
+type C4SetConfigParam = C4DiagramConfig & {
+  fontFamily?: string;
+  fontSize?: string | number;
+  fontWeight?: string | number;
+};
+
+interface BoundsData {
+  startx?: number;
+  stopx?: number;
+  starty?: number;
+  stopy?: number;
+  widthLimit?: number;
+}
+
+interface NextBoundsData {
+  startx?: number;
+  stopx?: number;
+  starty?: number;
+  stopy?: number;
+  cnt: number;
+}
+
+/** A {@link C4Text} after measurement: the layout fields are populated. */
+type MeasuredC4Text = C4Text & { width: number; height: number; textLines: number };
 
 let globalBoundaryMaxX = 0,
   globalBoundaryMaxY = 0;
@@ -17,10 +52,14 @@ let c4BoundaryInRow = 2;
 
 parser.yy = c4Db;
 
-let conf = {};
+let conf = {} as C4DrawConfig;
 
 class Bounds {
-  constructor(diagObj) {
+  name: string;
+  data: BoundsData;
+  nextData: NextBoundsData;
+
+  constructor(diagObj: Diagram) {
     this.name = '';
     this.data = {};
     this.data.startx = undefined;
@@ -29,24 +68,29 @@ class Bounds {
     this.data.stopy = undefined;
     this.data.widthLimit = undefined;
 
-    this.nextData = {};
+    this.nextData = {} as NextBoundsData;
     this.nextData.startx = undefined;
     this.nextData.stopx = undefined;
     this.nextData.starty = undefined;
     this.nextData.stopy = undefined;
     this.nextData.cnt = 0;
 
-    setConf(diagObj.db.getConfig());
+    setConf((diagObj.db as C4DB).getConfig());
   }
 
-  setData(startx, stopx, starty, stopy) {
+  setData(startx: number, stopx: number, starty: number, stopy: number) {
     this.nextData.startx = this.data.startx = startx;
     this.nextData.stopx = this.data.stopx = stopx;
     this.nextData.starty = this.data.starty = starty;
     this.nextData.stopy = this.data.stopy = stopy;
   }
 
-  updateVal(obj, key, val, fun) {
+  updateVal(
+    obj: BoundsData | NextBoundsData,
+    key: 'startx' | 'stopx' | 'starty' | 'stopy',
+    val: number,
+    fun: (a: number, b: number) => number
+  ) {
     if (obj[key] === undefined) {
       obj[key] = val;
     } else {
@@ -54,22 +98,21 @@ class Bounds {
     }
   }
 
-  insert(c4Shape) {
+  insert(c4Shape: C4Shape) {
     this.nextData.cnt = this.nextData.cnt + 1;
+    // `setData()` seeds the bounds before any `insert()` call.
+    const nextStopx = this.nextData.stopx!;
+    const widthLimit = this.data.widthLimit!;
     let _startx =
       this.nextData.startx === this.nextData.stopx
-        ? this.nextData.stopx + c4Shape.margin
-        : this.nextData.stopx + c4Shape.margin * 2;
+        ? nextStopx + c4Shape.margin
+        : nextStopx + c4Shape.margin * 2;
     let _stopx = _startx + c4Shape.width;
-    let _starty = this.nextData.starty + c4Shape.margin * 2;
+    let _starty = this.nextData.starty! + c4Shape.margin * 2;
     let _stopy = _starty + c4Shape.height;
-    if (
-      _startx >= this.data.widthLimit ||
-      _stopx >= this.data.widthLimit ||
-      this.nextData.cnt > c4ShapeInRow
-    ) {
-      _startx = this.nextData.startx + c4Shape.margin + conf.nextLinePaddingX;
-      _starty = this.nextData.stopy + c4Shape.margin * 2;
+    if (_startx >= widthLimit || _stopx >= widthLimit || this.nextData.cnt > c4ShapeInRow) {
+      _startx = this.nextData.startx! + c4Shape.margin + conf.nextLinePaddingX;
+      _starty = this.nextData.stopy! + c4Shape.margin * 2;
 
       this.nextData.stopx = _stopx = _startx + c4Shape.width;
       this.nextData.starty = this.nextData.stopy;
@@ -91,7 +134,7 @@ class Bounds {
     this.updateVal(this.nextData, 'stopy', _stopy, Math.max);
   }
 
-  init(diagObj) {
+  init(diagObj: Diagram) {
     this.name = '';
     this.data = {
       startx: undefined,
@@ -107,121 +150,140 @@ class Bounds {
       stopy: undefined,
       cnt: 0,
     };
-    setConf(diagObj.db.getConfig());
+    setConf((diagObj.db as C4DB).getConfig());
   }
 
-  bumpLastMargin(margin) {
-    this.data.stopx += margin;
-    this.data.stopy += margin;
+  bumpLastMargin(margin: number) {
+    this.data.stopx! += margin;
+    this.data.stopy! += margin;
   }
 }
 
-export const setConf = function (cnf) {
+export const setConf = function (cnf?: C4SetConfigParam) {
   assignWithDepth(conf, cnf);
 
-  if (cnf.fontFamily) {
+  if (cnf?.fontFamily) {
     conf.personFontFamily = conf.systemFontFamily = conf.messageFontFamily = cnf.fontFamily;
   }
-  if (cnf.fontSize) {
+  if (cnf?.fontSize) {
     conf.personFontSize = conf.systemFontSize = conf.messageFontSize = cnf.fontSize;
   }
-  if (cnf.fontWeight) {
+  if (cnf?.fontWeight) {
     conf.personFontWeight = conf.systemFontWeight = conf.messageFontWeight = cnf.fontWeight;
   }
 };
 
-const c4ShapeFont = (cnf, typeC4Shape) => {
+const c4ShapeFont = (cnf: C4DrawConfig, typeC4Shape: string): C4Font => {
   return {
-    fontFamily: cnf[typeC4Shape + 'FontFamily'],
-    fontSize: cnf[typeC4Shape + 'FontSize'],
-    fontWeight: cnf[typeC4Shape + 'FontWeight'],
+    fontFamily: cnf[typeC4Shape + 'FontFamily'] as string,
+    fontSize: cnf[typeC4Shape + 'FontSize'] as number,
+    fontWeight: cnf[typeC4Shape + 'FontWeight'] as string | number,
   };
 };
 
-const boundaryFont = (cnf) => {
+const boundaryFont = (cnf: C4DrawConfig): C4Font => {
   return {
     fontFamily: cnf.boundaryFontFamily,
-    fontSize: cnf.boundaryFontSize,
+    fontSize: cnf.boundaryFontSize as number,
     fontWeight: cnf.boundaryFontWeight,
   };
 };
 
-const messageFont = (cnf) => {
+const messageFont = (cnf: C4DrawConfig): C4Font => {
   return {
     fontFamily: cnf.messageFontFamily,
-    fontSize: cnf.messageFontSize,
+    fontSize: cnf.messageFontSize as number,
     fontWeight: cnf.messageFontWeight,
   };
 };
 
-/**
- * @param textType
- * @param c4Shape
- * @param c4ShapeTextWrap
- * @param textConf
- * @param textLimitWidth
- */
-function calcC4ShapeTextWH(textType, c4Shape, c4ShapeTextWrap, textConf, textLimitWidth) {
-  if (!c4Shape[textType].width) {
+function calcC4ShapeTextWH(
+  textType: 'label' | 'type' | 'techn' | 'descr',
+  c4Shape: C4Shape | C4Boundary | C4Rel,
+  c4ShapeTextWrap: boolean | undefined,
+  textConf: C4Font,
+  textLimitWidth: number
+): MeasuredC4Text {
+  // `textType` is always one of the `C4Text` valued fields of `c4Shape`, and
+  // the layout fields are populated below (or by an earlier measurement).
+  const textElement = c4Shape[textType] as MeasuredC4Text;
+  if (!textElement.width) {
     if (c4ShapeTextWrap) {
-      c4Shape[textType].text = wrapLabel(c4Shape[textType].text, textLimitWidth, textConf);
-      c4Shape[textType].textLines = c4Shape[textType].text.split(common.lineBreakRegex).length;
-      // c4Shape[textType].width = calculateTextWidth(c4Shape[textType].text, textConf);
-      c4Shape[textType].width = textLimitWidth;
-      // c4Shape[textType].height = c4Shape[textType].textLines * textConf.fontSize;
-      c4Shape[textType].height = calculateTextHeight(c4Shape[textType].text, textConf);
+      textElement.text = wrapLabel(
+        textElement.text,
+        textLimitWidth,
+        textConf as Parameters<typeof wrapLabel>[2]
+      );
+      textElement.textLines = textElement.text.split(common.lineBreakRegex).length;
+      // textElement.width = calculateTextWidth(textElement.text, textConf);
+      textElement.width = textLimitWidth;
+      // textElement.height = textElement.textLines * textConf.fontSize;
+      textElement.height = calculateTextHeight(textElement.text, textConf as TextDimensionConfig);
     } else {
-      let lines = c4Shape[textType].text.split(common.lineBreakRegex);
-      c4Shape[textType].textLines = lines.length;
+      const lines = textElement.text.split(common.lineBreakRegex);
+      textElement.textLines = lines.length;
       let lineHeight = 0;
-      c4Shape[textType].height = 0;
-      c4Shape[textType].width = 0;
+      textElement.height = 0;
+      textElement.width = 0;
       for (const line of lines) {
-        c4Shape[textType].width = Math.max(
-          calculateTextWidth(line, textConf),
-          c4Shape[textType].width
+        textElement.width = Math.max(
+          calculateTextWidth(line, textConf as TextDimensionConfig),
+          textElement.width
         );
-        lineHeight = calculateTextHeight(line, textConf);
-        c4Shape[textType].height = c4Shape[textType].height + lineHeight;
+        lineHeight = calculateTextHeight(line, textConf as TextDimensionConfig);
+        textElement.height = textElement.height + lineHeight;
       }
       // c4Shapes[textType].height = c4Shapes[textType].textLines * textConf.fontSize;
     }
   }
+  return textElement;
 }
 
-export const drawBoundary = function (diagram, boundary, bounds) {
-  boundary.x = bounds.data.startx;
-  boundary.y = bounds.data.starty;
-  boundary.width = bounds.data.stopx - bounds.data.startx;
-  boundary.height = bounds.data.stopy - bounds.data.starty;
+export const drawBoundary = function (diagram: SVG, boundary: C4Boundary, bounds: Bounds) {
+  // The bounds are seeded via `setData()` before a boundary is drawn.
+  const startx = bounds.data.startx!;
+  const starty = bounds.data.starty!;
+  boundary.x = startx;
+  boundary.y = starty;
+  boundary.width = bounds.data.stopx! - startx;
+  boundary.height = bounds.data.stopy! - starty;
 
   boundary.label.y = conf.c4ShapeMargin - 35;
 
-  let boundaryTextWrap = boundary.wrap && conf.wrap;
-  let boundaryLabelConf = boundaryFont(conf);
+  const boundaryTextWrap = boundary.wrap && conf.wrap;
+  const boundaryLabelConf = boundaryFont(conf);
   boundaryLabelConf.fontSize = boundaryLabelConf.fontSize + 2;
   boundaryLabelConf.fontWeight = 'bold';
-  let textLimitWidth = calculateTextWidth(boundary.label.text, boundaryLabelConf);
+  const textLimitWidth = calculateTextWidth(
+    boundary.label.text,
+    boundaryLabelConf as TextDimensionConfig
+  );
   calcC4ShapeTextWH('label', boundary, boundaryTextWrap, boundaryLabelConf, textLimitWidth);
 
   svgDraw.drawBoundary(diagram, boundary, conf);
 };
 
-export const drawC4ShapeArray = function (currentBounds, diagram, c4ShapeArray, c4ShapeKeys) {
+export const drawC4ShapeArray = function (
+  currentBounds: Bounds,
+  diagram: SVG,
+  c4ShapeArray: C4Shape[],
+  c4ShapeKeys: string[]
+) {
   // Upper Y is relative point
   let Y = 0;
   // Draw the c4ShapeArray
   for (const c4ShapeKey of c4ShapeKeys) {
     Y = 0;
-    const c4Shape = c4ShapeArray[c4ShapeKey];
+    // `c4ShapeKeys` are the (numeric string) indices of `c4ShapeArray`.
+    const c4Shape = c4ShapeArray[Number(c4ShapeKey)];
 
     // calc c4 shape type width and height
 
-    let c4ShapeTypeConf = c4ShapeFont(conf, c4Shape.typeC4Shape.text);
+    const c4ShapeTypeConf = c4ShapeFont(conf, c4Shape.typeC4Shape.text);
     c4ShapeTypeConf.fontSize = c4ShapeTypeConf.fontSize - 2;
     c4Shape.typeC4Shape.width = calculateTextWidth(
       '«' + c4Shape.typeC4Shape.text + '»',
-      c4ShapeTypeConf
+      c4ShapeTypeConf as TextDimensionConfig
     );
     c4Shape.typeC4Shape.height = c4ShapeTypeConf.fontSize + 2;
     c4Shape.typeC4Shape.Y = conf.c4ShapePadding;
@@ -251,41 +313,65 @@ export const drawC4ShapeArray = function (currentBounds, diagram, c4ShapeArray, 
 
     // Y = conf.c4ShapePadding + c4Shape.image.height;
 
-    let c4ShapeTextWrap = c4Shape.wrap && conf.wrap;
-    let textLimitWidth = conf.width - conf.c4ShapePadding * 2;
+    const c4ShapeTextWrap = c4Shape.wrap && conf.wrap;
+    const textLimitWidth = conf.width - conf.c4ShapePadding * 2;
 
-    let c4ShapeLabelConf = c4ShapeFont(conf, c4Shape.typeC4Shape.text);
+    const c4ShapeLabelConf = c4ShapeFont(conf, c4Shape.typeC4Shape.text);
     c4ShapeLabelConf.fontSize = c4ShapeLabelConf.fontSize + 2;
     c4ShapeLabelConf.fontWeight = 'bold';
-    calcC4ShapeTextWH('label', c4Shape, c4ShapeTextWrap, c4ShapeLabelConf, textLimitWidth);
-    c4Shape.label.Y = Y + 8;
-    Y = c4Shape.label.Y + c4Shape.label.height;
+    const label = calcC4ShapeTextWH(
+      'label',
+      c4Shape,
+      c4ShapeTextWrap,
+      c4ShapeLabelConf,
+      textLimitWidth
+    );
+    label.Y = Y + 8;
+    Y = label.Y + label.height;
 
     if (c4Shape.type && c4Shape.type.text !== '') {
       c4Shape.type.text = '[' + c4Shape.type.text + ']';
-      let c4ShapeTypeConf = c4ShapeFont(conf, c4Shape.typeC4Shape.text);
-      calcC4ShapeTextWH('type', c4Shape, c4ShapeTextWrap, c4ShapeTypeConf, textLimitWidth);
-      c4Shape.type.Y = Y + 5;
-      Y = c4Shape.type.Y + c4Shape.type.height;
+      const c4ShapeTypeConf = c4ShapeFont(conf, c4Shape.typeC4Shape.text);
+      const type = calcC4ShapeTextWH(
+        'type',
+        c4Shape,
+        c4ShapeTextWrap,
+        c4ShapeTypeConf,
+        textLimitWidth
+      );
+      type.Y = Y + 5;
+      Y = type.Y + type.height;
     } else if (c4Shape.techn && c4Shape.techn.text !== '') {
       c4Shape.techn.text = '[' + c4Shape.techn.text + ']';
-      let c4ShapeTechnConf = c4ShapeFont(conf, c4Shape.techn.text);
-      calcC4ShapeTextWH('techn', c4Shape, c4ShapeTextWrap, c4ShapeTechnConf, textLimitWidth);
-      c4Shape.techn.Y = Y + 5;
-      Y = c4Shape.techn.Y + c4Shape.techn.height;
+      const c4ShapeTechnConf = c4ShapeFont(conf, c4Shape.techn.text);
+      const techn = calcC4ShapeTextWH(
+        'techn',
+        c4Shape,
+        c4ShapeTextWrap,
+        c4ShapeTechnConf,
+        textLimitWidth
+      );
+      techn.Y = Y + 5;
+      Y = techn.Y + techn.height;
     }
 
     let rectHeight = Y;
-    let rectWidth = c4Shape.label.width;
+    let rectWidth = label.width;
 
     if (c4Shape.descr && c4Shape.descr.text !== '') {
-      let c4ShapeDescrConf = c4ShapeFont(conf, c4Shape.typeC4Shape.text);
-      calcC4ShapeTextWH('descr', c4Shape, c4ShapeTextWrap, c4ShapeDescrConf, textLimitWidth);
-      c4Shape.descr.Y = Y + 20;
-      Y = c4Shape.descr.Y + c4Shape.descr.height;
+      const c4ShapeDescrConf = c4ShapeFont(conf, c4Shape.typeC4Shape.text);
+      const descr = calcC4ShapeTextWH(
+        'descr',
+        c4Shape,
+        c4ShapeTextWrap,
+        c4ShapeDescrConf,
+        textLimitWidth
+      );
+      descr.Y = Y + 20;
+      Y = descr.Y + descr.height;
 
-      rectWidth = Math.max(c4Shape.label.width, c4Shape.descr.width);
-      rectHeight = Y - c4Shape.descr.textLines * 5;
+      rectWidth = Math.max(label.width, descr.width);
+      rectHeight = Y - descr.textLines * 5;
     }
 
     rectWidth = rectWidth + conf.c4ShapePadding;
@@ -304,7 +390,10 @@ export const drawC4ShapeArray = function (currentBounds, diagram, c4ShapeArray, 
 };
 
 class Point {
-  constructor(x, y) {
+  x: number;
+  y: number;
+
+  constructor(x: number, y: number) {
     this.x = x;
     this.y = y;
   }
@@ -326,28 +415,28 @@ class Point {
  * 2.4. fourth quadrant: the case where the line intersects the left side of the rectangle; the case where it intersects the upper side of the rectangle
  *
  */
-let getIntersectPoint = function (fromNode, endPoint) {
-  let x1 = fromNode.x;
+const getIntersectPoint = function (fromNode: C4Shape, endPoint: Point): Point | null {
+  const x1 = fromNode.x;
 
-  let y1 = fromNode.y;
+  const y1 = fromNode.y;
 
-  let x2 = endPoint.x;
+  const x2 = endPoint.x;
 
-  let y2 = endPoint.y;
+  const y2 = endPoint.y;
 
-  let fromCenterX = x1 + fromNode.width / 2;
+  const fromCenterX = x1 + fromNode.width / 2;
 
-  let fromCenterY = y1 + fromNode.height / 2;
+  const fromCenterY = y1 + fromNode.height / 2;
 
-  let dx = Math.abs(x1 - x2);
+  const dx = Math.abs(x1 - x2);
 
-  let dy = Math.abs(y1 - y2);
+  const dy = Math.abs(y1 - y2);
 
-  let tanDYX = dy / dx;
+  const tanDYX = dy / dx;
 
-  let fromDYX = fromNode.height / fromNode.width;
+  const fromDYX = fromNode.height / fromNode.width;
 
-  let returnPoint = null;
+  let returnPoint: Point | null = null;
 
   if (y1 == y2 && x1 < x2) {
     returnPoint = new Point(x1 + fromNode.width, fromCenterY);
@@ -394,73 +483,81 @@ let getIntersectPoint = function (fromNode, endPoint) {
   return returnPoint;
 };
 
-let getIntersectPoints = function (fromNode, endNode) {
-  let endIntersectPoint = { x: 0, y: 0 };
+const getIntersectPoints = function (fromNode: C4Shape, endNode: C4Shape) {
+  const endIntersectPoint = { x: 0, y: 0 };
   endIntersectPoint.x = endNode.x + endNode.width / 2;
   endIntersectPoint.y = endNode.y + endNode.height / 2;
-  let startPoint = getIntersectPoint(fromNode, endIntersectPoint);
+  const startPoint = getIntersectPoint(fromNode, endIntersectPoint);
 
   endIntersectPoint.x = fromNode.x + fromNode.width / 2;
   endIntersectPoint.y = fromNode.y + fromNode.height / 2;
-  let endPoint = getIntersectPoint(endNode, endIntersectPoint);
+  const endPoint = getIntersectPoint(endNode, endIntersectPoint);
   return { startPoint: startPoint, endPoint: endPoint };
 };
 
-export const drawRels = function (diagram, rels, getC4ShapeObj, diagObj, diagramId) {
+export const drawRels = function (
+  diagram: SVG,
+  rels: C4Rel[],
+  getC4ShapeObj: (alias: string) => C4Shape | undefined,
+  diagObj: Diagram,
+  diagramId: string
+) {
+  const diagramType = (diagObj.db as C4DB).getC4Type();
   let i = 0;
-  for (let rel of rels) {
+  for (const rel of rels) {
     i = i + 1;
-    let relTextWrap = rel.wrap && conf.wrap;
-    let relConf = messageFont(conf);
-    let diagramType = diagObj.db.getC4Type();
+    const relTextWrap = rel.wrap && conf.wrap;
+    const relConf = messageFont(conf);
     if (diagramType === 'C4Dynamic') {
       rel.label.text = i + ': ' + rel.label.text;
     }
-    let textLimitWidth = calculateTextWidth(rel.label.text, relConf);
+    let textLimitWidth = calculateTextWidth(rel.label.text, relConf as TextDimensionConfig);
     calcC4ShapeTextWH('label', rel, relTextWrap, relConf, textLimitWidth);
 
     if (rel.techn && rel.techn.text !== '') {
-      textLimitWidth = calculateTextWidth(rel.techn.text, relConf);
+      textLimitWidth = calculateTextWidth(rel.techn.text, relConf as TextDimensionConfig);
       calcC4ShapeTextWH('techn', rel, relTextWrap, relConf, textLimitWidth);
     }
 
     if (rel.descr && rel.descr.text !== '') {
-      textLimitWidth = calculateTextWidth(rel.descr.text, relConf);
+      textLimitWidth = calculateTextWidth(rel.descr.text, relConf as TextDimensionConfig);
       calcC4ShapeTextWH('descr', rel, relTextWrap, relConf, textLimitWidth);
     }
 
-    let fromNode = getC4ShapeObj(rel.from);
-    let endNode = getC4ShapeObj(rel.to);
-    let points = getIntersectPoints(fromNode, endNode);
+    const fromNode = getC4ShapeObj(rel.from);
+    const endNode = getC4ShapeObj(rel.to);
+    if (!fromNode || !endNode) {
+      throw new Error(`C4 rel "${rel.from}" -> "${rel.to}" references an unknown shape`);
+    }
+    const points = getIntersectPoints(fromNode, endNode);
+    if (!points.startPoint || !points.endPoint) {
+      throw new Error(
+        `Could not calculate intersection points for rel "${rel.from}" -> "${rel.to}"`
+      );
+    }
     rel.startPoint = points.startPoint;
     rel.endPoint = points.endPoint;
   }
   svgDraw.drawRels(diagram, rels, conf, diagramId);
 };
 
-/**
- * @param diagram
- * @param parentBoundaryAlias
- * @param parentBounds
- * @param currentBoundaries
- * @param diagObj
- */
 function drawInsideBoundary(
-  diagram,
-  parentBoundaryAlias,
-  parentBounds,
-  currentBoundaries,
-  diagObj
+  diagram: SVG,
+  parentBoundaryAlias: string,
+  parentBounds: Bounds,
+  currentBoundaries: C4Boundary[],
+  diagObj: Diagram
 ) {
-  let currentBounds = new Bounds(diagObj);
+  const db = diagObj.db as C4DB;
+  const currentBounds = new Bounds(diagObj);
   // Calculate the width limit of the boundary.  label/type 的长度，
   currentBounds.data.widthLimit =
-    parentBounds.data.widthLimit / Math.min(c4BoundaryInRow, currentBoundaries.length);
+    parentBounds.data.widthLimit! / Math.min(c4BoundaryInRow, currentBoundaries.length);
   // Math.min(
   //   conf.width * conf.c4ShapeInRow + conf.c4ShapeMargin * conf.c4ShapeInRow * 2,
   //   parentBounds.data.widthLimit / Math.min(conf.c4BoundaryInRow, currentBoundaries.length)
   // );
-  for (let [i, currentBoundary] of currentBoundaries.entries()) {
+  for (const [i, currentBoundary] of currentBoundaries.entries()) {
     let Y = 0;
     currentBoundary.image = { width: 0, height: 0, Y: 0 };
     if (currentBoundary.sprite) {
@@ -470,68 +567,68 @@ function drawInsideBoundary(
       Y = currentBoundary.image.Y + currentBoundary.image.height;
     }
 
-    let currentBoundaryTextWrap = currentBoundary.wrap && conf.wrap;
+    const currentBoundaryTextWrap = currentBoundary.wrap && conf.wrap;
 
-    let currentBoundaryLabelConf = boundaryFont(conf);
+    const currentBoundaryLabelConf = boundaryFont(conf);
     currentBoundaryLabelConf.fontSize = currentBoundaryLabelConf.fontSize + 2;
     currentBoundaryLabelConf.fontWeight = 'bold';
-    calcC4ShapeTextWH(
+    const label = calcC4ShapeTextWH(
       'label',
       currentBoundary,
       currentBoundaryTextWrap,
       currentBoundaryLabelConf,
       currentBounds.data.widthLimit
     );
-    currentBoundary.label.Y = Y + 8;
-    Y = currentBoundary.label.Y + currentBoundary.label.height;
+    label.Y = Y + 8;
+    Y = label.Y + label.height;
 
     if (currentBoundary.type && currentBoundary.type.text !== '') {
       currentBoundary.type.text = '[' + currentBoundary.type.text + ']';
-      let currentBoundaryTypeConf = boundaryFont(conf);
-      calcC4ShapeTextWH(
+      const currentBoundaryTypeConf = boundaryFont(conf);
+      const type = calcC4ShapeTextWH(
         'type',
         currentBoundary,
         currentBoundaryTextWrap,
         currentBoundaryTypeConf,
         currentBounds.data.widthLimit
       );
-      currentBoundary.type.Y = Y + 5;
-      Y = currentBoundary.type.Y + currentBoundary.type.height;
+      type.Y = Y + 5;
+      Y = type.Y + type.height;
     }
 
     if (currentBoundary.descr && currentBoundary.descr.text !== '') {
-      let currentBoundaryDescrConf = boundaryFont(conf);
+      const currentBoundaryDescrConf = boundaryFont(conf);
       currentBoundaryDescrConf.fontSize = currentBoundaryDescrConf.fontSize - 2;
-      calcC4ShapeTextWH(
+      const descr = calcC4ShapeTextWH(
         'descr',
         currentBoundary,
         currentBoundaryTextWrap,
         currentBoundaryDescrConf,
         currentBounds.data.widthLimit
       );
-      currentBoundary.descr.Y = Y + 20;
-      Y = currentBoundary.descr.Y + currentBoundary.descr.height;
+      descr.Y = Y + 20;
+      Y = descr.Y + descr.height;
     }
 
     if (i == 0 || i % c4BoundaryInRow === 0) {
       // Calculate the drawing start point of the currentBoundaries.
-      let _x = parentBounds.data.startx + conf.diagramMarginX;
-      let _y = parentBounds.data.stopy + conf.diagramMarginY + Y;
+      const _x = parentBounds.data.startx! + conf.diagramMarginX;
+      const _y = parentBounds.data.stopy! + conf.diagramMarginY + Y;
 
       currentBounds.setData(_x, _x, _y, _y);
     } else {
       // Calculate the drawing start point of the currentBoundaries.
-      let _x =
+      const _x =
         currentBounds.data.stopx !== currentBounds.data.startx
-          ? currentBounds.data.stopx + conf.diagramMarginX
-          : currentBounds.data.startx;
-      let _y = currentBounds.data.starty;
+          ? currentBounds.data.stopx! + conf.diagramMarginX
+          : currentBounds.data.startx!;
+      const _y = currentBounds.data.starty!;
 
       currentBounds.setData(_x, _x, _y, _y);
     }
     currentBounds.name = currentBoundary.alias;
-    let currentPersonOrSystemArray = diagObj.db.getC4ShapeArray(currentBoundary.alias);
-    let currentPersonOrSystemKeys = diagObj.db.getC4ShapeKeys(currentBoundary.alias);
+    const currentPersonOrSystemArray = db.getC4ShapeArray(currentBoundary.alias);
+    const currentPersonOrSystemKeys = db.getC4ShapeKeys(currentBoundary.alias);
 
     if (currentPersonOrSystemKeys.length > 0) {
       drawC4ShapeArray(
@@ -542,7 +639,7 @@ function drawInsideBoundary(
       );
     }
     parentBoundaryAlias = currentBoundary.alias;
-    let nextCurrentBoundaries = diagObj.db.getBoundaries(parentBoundaryAlias);
+    const nextCurrentBoundaries = db.getBoundaries(parentBoundaryAlias);
 
     if (nextCurrentBoundaries.length > 0) {
       // draw boundary inside currentBoundary
@@ -559,12 +656,12 @@ function drawInsideBoundary(
       drawBoundary(diagram, currentBoundary, currentBounds);
     }
     parentBounds.data.stopy = Math.max(
-      currentBounds.data.stopy + conf.c4ShapeMargin,
-      parentBounds.data.stopy
+      currentBounds.data.stopy! + conf.c4ShapeMargin,
+      parentBounds.data.stopy!
     );
     parentBounds.data.stopx = Math.max(
-      currentBounds.data.stopx + conf.c4ShapeMargin,
-      parentBounds.data.stopx
+      currentBounds.data.stopx! + conf.c4ShapeMargin,
+      parentBounds.data.stopx!
     );
     globalBoundaryMaxX = Math.max(globalBoundaryMaxX, parentBounds.data.stopx);
     globalBoundaryMaxY = Math.max(globalBoundaryMaxY, parentBounds.data.stopy);
@@ -573,42 +670,29 @@ function drawInsideBoundary(
 
 /**
  * Draws a sequenceDiagram in the tag with id: id based on the graph definition in text.
- *
- * @param {any} _text
- * @param {any} id
- * @param {any} _version
- * @param diagObj
  */
-export const draw = function (_text, id, _version, diagObj) {
-  conf = getConfig().c4;
+export const draw = function (_text: string, id: string, _version: string, diagObj: Diagram) {
+  conf = getRequiredConfig('c4') as C4DrawConfig;
   const securityLevel = getConfig().securityLevel;
   // Handle root and Document for when rendering in sandbox mode
-  let sandboxElement;
-  if (securityLevel === 'sandbox') {
-    sandboxElement = select('#i' + id);
-  }
-  const root =
-    securityLevel === 'sandbox'
-      ? select(sandboxElement.nodes()[0].contentDocument.body)
-      : select('body');
+  const { root } = getDiagramRoot(id, securityLevel);
 
-  let db = diagObj.db;
+  const db = diagObj.db as C4DB;
 
-  diagObj.db.setWrap(conf.wrap);
+  db.setWrap(conf.wrap);
 
   c4ShapeInRow = db.getC4ShapeInRow();
   c4BoundaryInRow = db.getC4BoundaryInRow();
 
   log.debug(`C:${JSON.stringify(conf, null, 2)}`);
 
-  const diagram =
-    securityLevel === 'sandbox' ? root.select(`[id="${id}"]`) : select(`[id="${id}"]`);
+  const diagram: SVG = root.select<SVGSVGElement>(`[id="${id}"]`);
 
   svgDraw.insertComputerIcon(diagram, id);
   svgDraw.insertDatabaseIcon(diagram, id);
   svgDraw.insertClockIcon(diagram, id);
 
-  let screenBounds = new Bounds(diagObj);
+  const screenBounds = new Bounds(diagObj);
 
   screenBounds.setData(
     conf.diagramMarginX,
@@ -621,8 +705,8 @@ export const draw = function (_text, id, _version, diagObj) {
   globalBoundaryMaxX = conf.diagramMarginX;
   globalBoundaryMaxY = conf.diagramMarginY;
 
-  const title = diagObj.db.getTitle();
-  let currentBoundaries = diagObj.db.getBoundaries('');
+  const title = db.getTitle();
+  const currentBoundaries = db.getBoundaries('');
   // switch (c4type) {
   //   case 'C4Context':
   drawInsideBoundary(diagram, '', screenBounds, currentBoundaries, diagObj);
@@ -635,28 +719,31 @@ export const draw = function (_text, id, _version, diagObj) {
   svgDraw.insertArrowCrossHead(diagram, id);
   svgDraw.insertArrowFilledHead(diagram, id);
 
-  drawRels(diagram, diagObj.db.getRels(), diagObj.db.getC4Shape, diagObj, id);
+  drawRels(diagram, db.getRels(), db.getC4Shape, diagObj, id);
 
   screenBounds.data.stopx = globalBoundaryMaxX;
   screenBounds.data.stopy = globalBoundaryMaxY;
 
   const box = screenBounds.data;
+  // `setData()` above seeded the start coordinates.
+  const boxStartx = box.startx!;
+  const boxStarty = box.starty!;
 
   // Make sure the height of the diagram supports long menus.
-  let boxHeight = box.stopy - box.starty;
+  const boxHeight = globalBoundaryMaxY - boxStarty;
 
-  let height = boxHeight + 2 * conf.diagramMarginY;
+  const height = boxHeight + 2 * conf.diagramMarginY;
 
   // Make sure the width of the diagram supports wide menus.
-  let boxWidth = box.stopx - box.startx;
+  const boxWidth = globalBoundaryMaxX - boxStartx;
   const width = boxWidth + 2 * conf.diagramMarginX;
 
   if (title) {
     diagram
       .append('text')
       .text(title)
-      .attr('x', (box.stopx - box.startx) / 2 - 4 * conf.diagramMarginX)
-      .attr('y', box.starty + conf.diagramMarginY);
+      .attr('x', boxWidth / 2 - 4 * conf.diagramMarginX)
+      .attr('y', boxStarty + conf.diagramMarginY);
   }
 
   configureSvgSize(diagram, height, width, conf.useMaxWidth);
@@ -664,7 +751,7 @@ export const draw = function (_text, id, _version, diagObj) {
   const extraVertForTitle = title ? 60 : 0;
   diagram.attr(
     'viewBox',
-    box.startx -
+    boxStartx -
       conf.diagramMarginX +
       ' -' +
       (conf.diagramMarginY + extraVertForTitle) +

--- a/packages/mermaid/src/diagrams/c4/c4Types.ts
+++ b/packages/mermaid/src/diagrams/c4/c4Types.ts
@@ -1,0 +1,139 @@
+import type { C4DiagramConfig } from '../../config.type.js';
+
+/**
+ * A text element of a C4 entity (label, type, description, …).
+ * The layout related fields are populated by the renderer.
+ */
+export interface C4Text {
+  text: string;
+  width?: number;
+  height?: number;
+  Y?: number;
+  /** Number of lines the (possibly wrapped) text spans. */
+  textLines?: number;
+  /** Written (but never read) by the renderer for boundary labels. */
+  y?: number;
+}
+
+export interface C4Image {
+  width: number;
+  height: number;
+  Y: number;
+}
+
+export interface C4Point {
+  x: number;
+  y: number;
+}
+
+export interface C4Shape {
+  /** The parser may set additional keys via `{ key: value }` shaped arguments. */
+  [key: string]: unknown;
+  alias: string;
+  label: C4Text;
+  typeC4Shape: C4Text;
+  parentBoundary: string;
+  wrap?: boolean;
+  descr?: C4Text;
+  techn?: C4Text;
+  type?: C4Text;
+  sprite?: string;
+  tags?: string;
+  link?: string;
+  /* Style fields, set via UpdateElementStyle. */
+  bgColor?: string;
+  fontColor?: string;
+  borderColor?: string;
+  shadowing?: string;
+  shape?: string;
+  legendText?: string;
+  legendSprite?: string;
+  /* Layout fields, populated by the renderer before drawing. */
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  margin: number;
+  image: C4Image;
+}
+
+export interface C4Boundary {
+  /** The parser may set additional keys via `{ key: value }` shaped arguments. */
+  [key: string]: unknown;
+  alias: string;
+  label: C4Text;
+  type: C4Text;
+  tags?: string | null;
+  link?: string | null;
+  parentBoundary: string;
+  wrap?: boolean;
+  descr?: C4Text;
+  techn?: C4Text;
+  nodeType?: string;
+  sprite?: string;
+  /* Style fields, set via UpdateElementStyle. */
+  bgColor?: string;
+  fontColor?: string;
+  borderColor?: string;
+  shadowing?: string;
+  shape?: string;
+  legendText?: string;
+  legendSprite?: string;
+  /* Layout fields, populated by the renderer before drawing. */
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  image: C4Image;
+}
+
+export interface C4Rel {
+  /** The parser may set additional keys via `{ key: value }` shaped arguments. */
+  [key: string]: unknown;
+  type: string;
+  from: string;
+  to: string;
+  label: C4Text;
+  techn: C4Text;
+  descr: C4Text;
+  sprite?: string;
+  tags?: string;
+  link?: string;
+  wrap?: boolean;
+  /* Style fields, set via UpdateRelStyle. */
+  textColor?: string;
+  lineColor?: string;
+  offsetX?: number;
+  offsetY?: number;
+  /* Layout fields, populated by the renderer before drawing. */
+  startPoint: C4Point;
+  endPoint: C4Point;
+}
+
+/**
+ * Font configuration as produced by the `*Font()` helpers of the C4
+ * configuration. The helpers always populate family/size/weight from the
+ * (defaulted) config, so those fields are typed as present.
+ */
+export interface C4Font {
+  fontFamily: string;
+  fontSize: number;
+  fontWeight: string | number;
+  fontColor?: string;
+}
+
+/**
+ * The C4 configuration at render time: all defaults are applied and the
+ * `*Font()` helper functions from the default config are present.
+ * Additional dynamically accessed keys (e.g. `person_bg_color`,
+ * `external_systemFont`) are covered by the `Record<string, unknown>` part.
+ */
+export type C4DrawConfig = Omit<
+  Required<C4DiagramConfig>,
+  'personFont' | 'boundaryFont' | 'messageFont'
+> & {
+  personFont: () => C4Font;
+  boundaryFont: () => C4Font;
+  messageFont: () => C4Font;
+  textPlacement?: string;
+} & Record<string, unknown>;

--- a/packages/mermaid/src/diagrams/c4/parser/c4Boundary.spec.ts
+++ b/packages/mermaid/src/diagrams/c4/parser/c4Boundary.spec.ts
@@ -1,4 +1,5 @@
 import c4Db from '../c4Db.js';
+// @ts-ignore: JISON doesn't support types
 import c4 from './c4Diagram.jison';
 import { setConfig } from '../../../config.js';
 

--- a/packages/mermaid/src/diagrams/c4/parser/c4Component.spec.ts
+++ b/packages/mermaid/src/diagrams/c4/parser/c4Component.spec.ts
@@ -1,4 +1,5 @@
 import c4Db from '../c4Db.js';
+// @ts-ignore: JISON doesn't support types
 import c4 from './c4Diagram.jison';
 import { setConfig } from '../../../config.js';
 

--- a/packages/mermaid/src/diagrams/c4/parser/c4Container.spec.ts
+++ b/packages/mermaid/src/diagrams/c4/parser/c4Container.spec.ts
@@ -1,4 +1,5 @@
 import c4Db from '../c4Db.js';
+// @ts-ignore: JISON doesn't support types
 import c4 from './c4Diagram.jison';
 import { setConfig } from '../../../config.js';
 
@@ -6,16 +7,23 @@ setConfig({
   securityLevel: 'strict',
 });
 
-describe('parsing a C4 Person', function () {
+describe.each([
+  ['Container', 'container'],
+  ['ContainerDb', 'container_db'],
+  ['ContainerQueue', 'container_queue'],
+  ['Container_Ext', 'external_container'],
+  ['ContainerDb_Ext', 'external_container_db'],
+  ['ContainerQueue_Ext', 'external_container_queue'],
+])('parsing a C4 %s', function (macroName, elementName) {
   beforeEach(function () {
     c4.parser.yy = c4Db;
     c4.parser.yy.clear();
   });
 
-  it('should parse a C4 diagram with one Person correctly', function () {
+  it('should parse a C4 diagram with one Container correctly', function () {
     c4.parser.parse(`C4Context
-title System Context diagram for Internet Banking System
-Person(customerA, "Banking Customer A", "A customer of the bank, with personal bank accounts.")`);
+title Container diagram for Internet Banking Container
+${macroName}(ContainerAA, "Internet Banking Container", "Technology", "Allows customers to view information about their bank accounts, and make payments.")`);
 
     const yy = c4.parser.yy;
 
@@ -24,16 +32,22 @@ Person(customerA, "Banking Customer A", "A customer of the bank, with personal b
     const onlyShape = shapes[0];
 
     expect(onlyShape).toEqual({
-      alias: 'customerA',
+      alias: 'ContainerAA',
       descr: {
-        text: 'A customer of the bank, with personal bank accounts.',
+        text: 'Allows customers to view information about their bank accounts, and make payments.',
       },
       label: {
-        text: 'Banking Customer A',
+        text: 'Internet Banking Container',
       },
+      link: undefined,
+      sprite: undefined,
+      tags: undefined,
       parentBoundary: 'global',
       typeC4Shape: {
-        text: 'person',
+        text: elementName,
+      },
+      techn: {
+        text: 'Technology',
       },
       wrap: false,
     });
@@ -41,38 +55,49 @@ Person(customerA, "Banking Customer A", "A customer of the bank, with personal b
 
   it('should parse the alias', function () {
     c4.parser.parse(`C4Context
-Person(customerA, "Banking Customer A")`);
+${macroName}(ContainerAA, "Internet Banking Container")`);
 
     expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
-      alias: 'customerA',
+      alias: 'ContainerAA',
     });
   });
 
   it('should parse the label', function () {
     c4.parser.parse(`C4Context
-Person(customerA, "Banking Customer A")`);
+${macroName}(ContainerAA, "Internet Banking Container")`);
 
     expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
       label: {
-        text: 'Banking Customer A',
+        text: 'Internet Banking Container',
+      },
+    });
+  });
+
+  it('should parse the technology', function () {
+    c4.parser.parse(`C4Context
+${macroName}(ContainerAA, "", "Java")`);
+
+    expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
+      techn: {
+        text: 'Java',
       },
     });
   });
 
   it('should parse the description', function () {
     c4.parser.parse(`C4Context
-Person(customerA, "", "A customer of the bank, with personal bank accounts.")`);
+${macroName}(ContainerAA, "", "", "Allows customers to view information about their bank accounts, and make payments.")`);
 
     expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
       descr: {
-        text: 'A customer of the bank, with personal bank accounts.',
+        text: 'Allows customers to view information about their bank accounts, and make payments.',
       },
     });
   });
 
   it('should parse a sprite', function () {
     c4.parser.parse(`C4Context
-Person(customerA, $sprite="users")`);
+${macroName}(ContainerAA, $sprite="users")`);
 
     expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
       label: {
@@ -85,7 +110,7 @@ Person(customerA, $sprite="users")`);
 
   it('should parse a link', function () {
     c4.parser.parse(`C4Context
-Person(customerA, $link="https://github.com/mermaidjs")`);
+${macroName}(ContainerAA, $link="https://github.com/mermaidjs")`);
 
     expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
       label: {
@@ -98,7 +123,7 @@ Person(customerA, $link="https://github.com/mermaidjs")`);
 
   it('should parse tags', function () {
     c4.parser.parse(`C4Context
-Person(customerA, $tags="tag1,tag2")`);
+${macroName}(ContainerAA, $tags="tag1,tag2")`);
 
     expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
       label: {

--- a/packages/mermaid/src/diagrams/c4/parser/c4Diagram.spec.ts
+++ b/packages/mermaid/src/diagrams/c4/parser/c4Diagram.spec.ts
@@ -1,4 +1,5 @@
 import c4Db from '../c4Db.js';
+// @ts-ignore: JISON doesn't support types
 import c4 from './c4Diagram.jison';
 import { setConfig } from '../../../config.js';
 

--- a/packages/mermaid/src/diagrams/c4/parser/c4Person.spec.ts
+++ b/packages/mermaid/src/diagrams/c4/parser/c4Person.spec.ts
@@ -1,4 +1,5 @@
 import c4Db from '../c4Db.js';
+// @ts-ignore: JISON doesn't support types
 import c4 from './c4Diagram.jison';
 import { setConfig } from '../../../config.js';
 
@@ -6,16 +7,16 @@ setConfig({
   securityLevel: 'strict',
 });
 
-describe('parsing a C4 Person_Ext', function () {
+describe('parsing a C4 Person', function () {
   beforeEach(function () {
     c4.parser.yy = c4Db;
     c4.parser.yy.clear();
   });
 
-  it('should parse a C4 diagram with one Person_Ext correctly', function () {
+  it('should parse a C4 diagram with one Person correctly', function () {
     c4.parser.parse(`C4Context
 title System Context diagram for Internet Banking System
-Person_Ext(customerA, "Banking Customer A", "A customer of the bank, with personal bank accounts.")`);
+Person(customerA, "Banking Customer A", "A customer of the bank, with personal bank accounts.")`);
 
     const yy = c4.parser.yy;
 
@@ -31,14 +32,9 @@ Person_Ext(customerA, "Banking Customer A", "A customer of the bank, with person
       label: {
         text: 'Banking Customer A',
       },
-      // TODO: Why are link, sprite, and tags undefined instead of not appearing at all?
-      //       Compare to Person where they don't show up.
-      link: undefined,
-      sprite: undefined,
-      tags: undefined,
       parentBoundary: 'global',
       typeC4Shape: {
-        text: 'external_person',
+        text: 'person',
       },
       wrap: false,
     });
@@ -46,7 +42,7 @@ Person_Ext(customerA, "Banking Customer A", "A customer of the bank, with person
 
   it('should parse the alias', function () {
     c4.parser.parse(`C4Context
-Person_Ext(customerA, "Banking Customer A")`);
+Person(customerA, "Banking Customer A")`);
 
     expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
       alias: 'customerA',
@@ -55,7 +51,7 @@ Person_Ext(customerA, "Banking Customer A")`);
 
   it('should parse the label', function () {
     c4.parser.parse(`C4Context
-Person_Ext(customerA, "Banking Customer A")`);
+Person(customerA, "Banking Customer A")`);
 
     expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
       label: {
@@ -66,7 +62,7 @@ Person_Ext(customerA, "Banking Customer A")`);
 
   it('should parse the description', function () {
     c4.parser.parse(`C4Context
-Person_Ext(customerA, "", "A customer of the bank, with personal bank accounts.")`);
+Person(customerA, "", "A customer of the bank, with personal bank accounts.")`);
 
     expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
       descr: {
@@ -77,7 +73,7 @@ Person_Ext(customerA, "", "A customer of the bank, with personal bank accounts."
 
   it('should parse a sprite', function () {
     c4.parser.parse(`C4Context
-Person_Ext(customerA, $sprite="users")`);
+Person(customerA, $sprite="users")`);
 
     expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
       label: {
@@ -90,7 +86,7 @@ Person_Ext(customerA, $sprite="users")`);
 
   it('should parse a link', function () {
     c4.parser.parse(`C4Context
-Person_Ext(customerA, $link="https://github.com/mermaidjs")`);
+Person(customerA, $link="https://github.com/mermaidjs")`);
 
     expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
       label: {
@@ -103,7 +99,7 @@ Person_Ext(customerA, $link="https://github.com/mermaidjs")`);
 
   it('should parse tags', function () {
     c4.parser.parse(`C4Context
-Person_Ext(customerA, $tags="tag1,tag2")`);
+Person(customerA, $tags="tag1,tag2")`);
 
     expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
       label: {

--- a/packages/mermaid/src/diagrams/c4/parser/c4PersonExt.spec.ts
+++ b/packages/mermaid/src/diagrams/c4/parser/c4PersonExt.spec.ts
@@ -1,4 +1,5 @@
 import c4Db from '../c4Db.js';
+// @ts-ignore: JISON doesn't support types
 import c4 from './c4Diagram.jison';
 import { setConfig } from '../../../config.js';
 
@@ -6,23 +7,16 @@ setConfig({
   securityLevel: 'strict',
 });
 
-describe.each([
-  ['Container', 'container'],
-  ['ContainerDb', 'container_db'],
-  ['ContainerQueue', 'container_queue'],
-  ['Container_Ext', 'external_container'],
-  ['ContainerDb_Ext', 'external_container_db'],
-  ['ContainerQueue_Ext', 'external_container_queue'],
-])('parsing a C4 %s', function (macroName, elementName) {
+describe('parsing a C4 Person_Ext', function () {
   beforeEach(function () {
     c4.parser.yy = c4Db;
     c4.parser.yy.clear();
   });
 
-  it('should parse a C4 diagram with one Container correctly', function () {
+  it('should parse a C4 diagram with one Person_Ext correctly', function () {
     c4.parser.parse(`C4Context
-title Container diagram for Internet Banking Container
-${macroName}(ContainerAA, "Internet Banking Container", "Technology", "Allows customers to view information about their bank accounts, and make payments.")`);
+title System Context diagram for Internet Banking System
+Person_Ext(customerA, "Banking Customer A", "A customer of the bank, with personal bank accounts.")`);
 
     const yy = c4.parser.yy;
 
@@ -31,22 +25,21 @@ ${macroName}(ContainerAA, "Internet Banking Container", "Technology", "Allows cu
     const onlyShape = shapes[0];
 
     expect(onlyShape).toEqual({
-      alias: 'ContainerAA',
+      alias: 'customerA',
       descr: {
-        text: 'Allows customers to view information about their bank accounts, and make payments.',
+        text: 'A customer of the bank, with personal bank accounts.',
       },
       label: {
-        text: 'Internet Banking Container',
+        text: 'Banking Customer A',
       },
+      // TODO: Why are link, sprite, and tags undefined instead of not appearing at all?
+      //       Compare to Person where they don't show up.
       link: undefined,
       sprite: undefined,
       tags: undefined,
       parentBoundary: 'global',
       typeC4Shape: {
-        text: elementName,
-      },
-      techn: {
-        text: 'Technology',
+        text: 'external_person',
       },
       wrap: false,
     });
@@ -54,49 +47,38 @@ ${macroName}(ContainerAA, "Internet Banking Container", "Technology", "Allows cu
 
   it('should parse the alias', function () {
     c4.parser.parse(`C4Context
-${macroName}(ContainerAA, "Internet Banking Container")`);
+Person_Ext(customerA, "Banking Customer A")`);
 
     expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
-      alias: 'ContainerAA',
+      alias: 'customerA',
     });
   });
 
   it('should parse the label', function () {
     c4.parser.parse(`C4Context
-${macroName}(ContainerAA, "Internet Banking Container")`);
+Person_Ext(customerA, "Banking Customer A")`);
 
     expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
       label: {
-        text: 'Internet Banking Container',
-      },
-    });
-  });
-
-  it('should parse the technology', function () {
-    c4.parser.parse(`C4Context
-${macroName}(ContainerAA, "", "Java")`);
-
-    expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
-      techn: {
-        text: 'Java',
+        text: 'Banking Customer A',
       },
     });
   });
 
   it('should parse the description', function () {
     c4.parser.parse(`C4Context
-${macroName}(ContainerAA, "", "", "Allows customers to view information about their bank accounts, and make payments.")`);
+Person_Ext(customerA, "", "A customer of the bank, with personal bank accounts.")`);
 
     expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
       descr: {
-        text: 'Allows customers to view information about their bank accounts, and make payments.',
+        text: 'A customer of the bank, with personal bank accounts.',
       },
     });
   });
 
   it('should parse a sprite', function () {
     c4.parser.parse(`C4Context
-${macroName}(ContainerAA, $sprite="users")`);
+Person_Ext(customerA, $sprite="users")`);
 
     expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
       label: {
@@ -109,7 +91,7 @@ ${macroName}(ContainerAA, $sprite="users")`);
 
   it('should parse a link', function () {
     c4.parser.parse(`C4Context
-${macroName}(ContainerAA, $link="https://github.com/mermaidjs")`);
+Person_Ext(customerA, $link="https://github.com/mermaidjs")`);
 
     expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
       label: {
@@ -122,7 +104,7 @@ ${macroName}(ContainerAA, $link="https://github.com/mermaidjs")`);
 
   it('should parse tags', function () {
     c4.parser.parse(`C4Context
-${macroName}(ContainerAA, $tags="tag1,tag2")`);
+Person_Ext(customerA, $tags="tag1,tag2")`);
 
     expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
       label: {

--- a/packages/mermaid/src/diagrams/c4/parser/c4System.spec.ts
+++ b/packages/mermaid/src/diagrams/c4/parser/c4System.spec.ts
@@ -1,4 +1,5 @@
 import c4Db from '../c4Db.js';
+// @ts-ignore: JISON doesn't support types
 import c4 from './c4Diagram.jison';
 import { setConfig } from '../../../config.js';
 

--- a/packages/mermaid/src/diagrams/c4/svgDraw.ts
+++ b/packages/mermaid/src/diagrams/c4/svgDraw.ts
@@ -1,33 +1,61 @@
 import common from '../common/common.js';
 import * as svgDrawCommon from '../common/svgDrawCommon.js';
 import { sanitizeUrl } from '@braintree/sanitize-url';
+import type { BaseType, Selection } from 'd3';
+import type { SVG, SVGGroup } from '../../diagram-api/types.js';
+import type { D3Selection } from '../../types.js';
+import type { RectData } from '../common/commonTypes.js';
+import type { C4Boundary, C4DrawConfig, C4Font, C4Rel, C4Shape } from './c4Types.js';
 
-export const drawRect = function (elem, rectData) {
+type TextAttrs = Record<string, string | number>;
+
+type DrawTextFunction = <T extends SVGElement>(
+  content: string,
+  g: D3Selection<T>,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  textAttrs: TextAttrs,
+  conf: C4Font
+) => void;
+
+export const drawRect = function (elem: SVG | SVGGroup, rectData: RectData) {
   return svgDrawCommon.drawRect(elem, rectData);
 };
 
-export const drawImage = function (elem, width, height, x, y, link) {
+export const drawImage = function <T extends SVGElement>(
+  elem: D3Selection<T>,
+  width: number,
+  height: number,
+  x: number,
+  y: number,
+  link: string
+) {
   const imageElem = elem.append('image');
   imageElem.attr('width', width);
   imageElem.attr('height', height);
   imageElem.attr('x', x);
   imageElem.attr('y', y);
-  let sanitizedLink = link.startsWith('data:image/png;base64') ? link : sanitizeUrl(link);
+  const sanitizedLink = link.startsWith('data:image/png;base64') ? link : sanitizeUrl(link);
   imageElem.attr('xlink:href', sanitizedLink);
 };
 
-export const drawRels = (elem, rels, conf, diagramId) => {
+export const drawRels = (elem: SVG, rels: C4Rel[], conf: C4DrawConfig, diagramId: string) => {
   const relsElem = elem.append('g');
   let i = 0;
-  for (let rel of rels) {
-    let textColor = rel.textColor ? rel.textColor : '#444444';
-    let strokeColor = rel.lineColor ? rel.lineColor : '#444444';
-    let offsetX = rel.offsetX ? parseInt(rel.offsetX) : 0;
-    let offsetY = rel.offsetY ? parseInt(rel.offsetY) : 0;
+  for (const rel of rels) {
+    const textColor = rel.textColor ? rel.textColor : '#444444';
+    const strokeColor = rel.lineColor ? rel.lineColor : '#444444';
+    // The parseInt is load-bearing: the JISON grammar passes $key="value" attributes
+    // positionally, so offsets that arrive in the textColor/lineColor parameter slots are
+    // stored by the db as raw strings and must be coerced here before coordinate arithmetic.
+    const offsetX = rel.offsetX ? parseInt(String(rel.offsetX)) : 0;
+    const offsetY = rel.offsetY ? parseInt(String(rel.offsetY)) : 0;
 
-    let url = '';
+    const url = '';
     if (i === 0) {
-      let line = relsElem.append('line');
+      const line = relsElem.append('line');
       line.attr('x1', rel.startPoint.x);
       line.attr('y1', rel.startPoint.y);
       line.attr('x2', rel.endPoint.x);
@@ -44,7 +72,7 @@ export const drawRels = (elem, rels, conf, diagramId) => {
       }
       i = -1;
     } else {
-      let line = relsElem.append('path');
+      const line = relsElem.append('path');
       line
         .attr('fill', 'none')
         .attr('stroke-width', '1')
@@ -52,17 +80,20 @@ export const drawRels = (elem, rels, conf, diagramId) => {
         .attr(
           'd',
           'Mstartx,starty Qcontrolx,controly stopx,stopy '
-            .replaceAll('startx', rel.startPoint.x)
-            .replaceAll('starty', rel.startPoint.y)
+            .replaceAll('startx', rel.startPoint.x as unknown as string)
+            .replaceAll('starty', rel.startPoint.y as unknown as string)
             .replaceAll(
               'controlx',
-              rel.startPoint.x +
+              (rel.startPoint.x +
                 (rel.endPoint.x - rel.startPoint.x) / 2 -
-                (rel.endPoint.x - rel.startPoint.x) / 4
+                (rel.endPoint.x - rel.startPoint.x) / 4) as unknown as string
             )
-            .replaceAll('controly', rel.startPoint.y + (rel.endPoint.y - rel.startPoint.y) / 2)
-            .replaceAll('stopx', rel.endPoint.x)
-            .replaceAll('stopy', rel.endPoint.y)
+            .replaceAll(
+              'controly',
+              (rel.startPoint.y + (rel.endPoint.y - rel.startPoint.y) / 2) as unknown as string
+            )
+            .replaceAll('stopx', rel.endPoint.x as unknown as string)
+            .replaceAll('stopy', rel.endPoint.y as unknown as string)
         );
       if (rel.type !== 'rel_b') {
         line.attr('marker-end', 'url(' + url + '#' + diagramId + '-arrowhead)');
@@ -72,6 +103,8 @@ export const drawRels = (elem, rels, conf, diagramId) => {
       }
     }
 
+    // The label was measured by the renderer before drawing.
+    const labelWidth = rel.label.width!;
     let messageConf = conf.messageFont();
     _drawTextCandidateFunc(conf)(
       rel.label.text,
@@ -82,8 +115,8 @@ export const drawRels = (elem, rels, conf, diagramId) => {
       Math.min(rel.startPoint.y, rel.endPoint.y) +
         Math.abs(rel.endPoint.y - rel.startPoint.y) / 2 +
         offsetY,
-      rel.label.width,
-      rel.label.height,
+      labelWidth,
+      rel.label.height!,
       { fill: textColor },
       messageConf
     );
@@ -98,11 +131,11 @@ export const drawRels = (elem, rels, conf, diagramId) => {
           offsetX,
         Math.min(rel.startPoint.y, rel.endPoint.y) +
           Math.abs(rel.endPoint.y - rel.startPoint.y) / 2 +
-          conf.messageFontSize +
+          (conf.messageFontSize as number) +
           5 +
           offsetY,
-        Math.max(rel.label.width, rel.techn.width),
-        rel.techn.height,
+        Math.max(labelWidth, rel.techn.width!),
+        rel.techn.height!,
         { fill: textColor, 'font-style': 'italic' },
         messageConf
       );
@@ -113,22 +146,25 @@ export const drawRels = (elem, rels, conf, diagramId) => {
 /**
  * Draws a boundary in the diagram
  *
- * @param {any} elem - The diagram we'll draw to.
- * @param {any} boundary - The boundary to draw.
- * @param {any} conf - DrawText implementation discriminator object
+ * @param elem - The diagram we'll draw to.
+ * @param boundary - The boundary to draw.
+ * @param conf - DrawText implementation discriminator object
  */
-const drawBoundary = function (elem, boundary, conf) {
+const drawBoundary = function (elem: SVG, boundary: C4Boundary, conf: C4DrawConfig) {
   const boundaryElem = elem.append('g');
 
-  let fillColor = boundary.bgColor ? boundary.bgColor : 'none';
-  let strokeColor = boundary.borderColor ? boundary.borderColor : '#444444';
-  let fontColor = boundary.fontColor ? boundary.fontColor : 'black';
+  const fillColor = boundary.bgColor ? boundary.bgColor : 'none';
+  const strokeColor = boundary.borderColor ? boundary.borderColor : '#444444';
+  const fontColor = boundary.fontColor ? boundary.fontColor : 'black';
 
-  let attrsValue = { 'stroke-width': 1.0, 'stroke-dasharray': '7.0,7.0' };
+  let attrsValue: Record<string, string | number> = {
+    'stroke-width': 1.0,
+    'stroke-dasharray': '7.0,7.0',
+  };
   if (boundary.nodeType) {
     attrsValue = { 'stroke-width': 1.0 };
   }
-  let rectData = {
+  const rectData: RectData = {
     x: boundary.x,
     y: boundary.y,
     fill: fillColor,
@@ -151,7 +187,7 @@ const drawBoundary = function (elem, boundary, conf) {
     boundary.label.text,
     boundaryElem,
     boundary.x,
-    boundary.y + boundary.label.Y,
+    boundary.y + boundary.label.Y!,
     boundary.width,
     boundary.height,
     { fill: '#444444' },
@@ -166,7 +202,7 @@ const drawBoundary = function (elem, boundary, conf) {
       boundary.type.text,
       boundaryElem,
       boundary.x,
-      boundary.y + boundary.type.Y,
+      boundary.y + boundary.type.Y!,
       boundary.width,
       boundary.height,
       { fill: '#444444' },
@@ -183,7 +219,7 @@ const drawBoundary = function (elem, boundary, conf) {
       boundary.descr.text,
       boundaryElem,
       boundary.x,
-      boundary.y + boundary.descr.Y,
+      boundary.y + boundary.descr.Y!,
       boundary.width,
       boundary.height,
       { fill: '#444444' },
@@ -192,12 +228,14 @@ const drawBoundary = function (elem, boundary, conf) {
   }
 };
 
-export const drawC4Shape = function (elem, c4Shape, conf) {
-  let fillColor = c4Shape.bgColor ? c4Shape.bgColor : conf[c4Shape.typeC4Shape.text + '_bg_color'];
-  let strokeColor = c4Shape.borderColor
+export const drawC4Shape = function (elem: SVG, c4Shape: C4Shape, conf: C4DrawConfig) {
+  const fillColor = c4Shape.bgColor
+    ? c4Shape.bgColor
+    : (conf[c4Shape.typeC4Shape.text + '_bg_color'] as string);
+  const strokeColor = c4Shape.borderColor
     ? c4Shape.borderColor
-    : conf[c4Shape.typeC4Shape.text + '_border_color'];
-  let fontColor = c4Shape.fontColor ? c4Shape.fontColor : '#FFFFFF';
+    : (conf[c4Shape.typeC4Shape.text + '_border_color'] as string);
+  const fontColor = c4Shape.fontColor ? c4Shape.fontColor : '#FFFFFF';
 
   let personImg =
     'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAIAAADYYG7QAAACD0lEQVR4Xu2YoU4EMRCGT+4j8Ai8AhaH4QHgAUjQuFMECUgMIUgwJAgMhgQsAYUiJCiQIBBY+EITsjfTdme6V24v4c8vyGbb+ZjOtN0bNcvjQXmkH83WvYBWto6PLm6v7p7uH1/w2fXD+PBycX1Pv2l3IdDm/vn7x+dXQiAubRzoURa7gRZWd0iGRIiJbOnhnfYBQZNJjNbuyY2eJG8fkDE3bbG4ep6MHUAsgYxmE3nVs6VsBWJSGccsOlFPmLIViMzLOB7pCVO2AtHJMohH7Fh6zqitQK7m0rJvAVYgGcEpe//PLdDz65sM4pF9N7ICcXDKIB5Nv6j7tD0NoSdM2QrU9Gg0ewE1LqBhHR3BBdvj2vapnidjHxD/q6vd7Pvhr31AwcY8eXMTXAKECZZJFXuEq27aLgQK5uLMohCenGGuGewOxSjBvYBqeG6B+Nqiblggdjnc+ZXDy+FNFpFzw76O3UBAROuXh6FoiAcf5g9eTvUgzy0nWg6I8cXHRUpg5bOVBCo+KDpFajOf23GgPme7RSQ+lacIENUgJ6gg1k6HjgOlqnLqip4tEuhv0hNEMXUD0clyXE3p6pZA0S2nnvTlXwLJEZWlb7cTQH1+USgTN4VhAenm/wea1OCAOmqo6fE1WCb9WSKBah+rbUWPWAmE2Rvk0ApiB45eOyNAzU8xcTvj8KvkKEoOaIYeHNA3ZuygAvFMUO0AAAAASUVORK5CYII=';
@@ -253,10 +291,10 @@ export const drawC4Shape = function (elem, c4Shape, conf) {
         .attr(
           'd',
           'Mstartx,startyc0,-10 half,-10 half,-10c0,0 half,0 half,10l0,heightc0,10 -half,10 -half,10c0,0 -half,0 -half,-10l0,-height'
-            .replaceAll('startx', c4Shape.x)
-            .replaceAll('starty', c4Shape.y)
-            .replaceAll('half', c4Shape.width / 2)
-            .replaceAll('height', c4Shape.height)
+            .replaceAll('startx', c4Shape.x as unknown as string)
+            .replaceAll('starty', c4Shape.y as unknown as string)
+            .replaceAll('half', (c4Shape.width / 2) as unknown as string)
+            .replaceAll('height', c4Shape.height as unknown as string)
         );
       c4ShapeElem
         .append('path')
@@ -266,9 +304,9 @@ export const drawC4Shape = function (elem, c4Shape, conf) {
         .attr(
           'd',
           'Mstartx,startyc0,10 half,10 half,10c0,0 half,0 half,-10'
-            .replaceAll('startx', c4Shape.x)
-            .replaceAll('starty', c4Shape.y)
-            .replaceAll('half', c4Shape.width / 2)
+            .replaceAll('startx', c4Shape.x as unknown as string)
+            .replaceAll('starty', c4Shape.y as unknown as string)
+            .replaceAll('half', (c4Shape.width / 2) as unknown as string)
         );
       break;
     case 'system_queue':
@@ -285,10 +323,10 @@ export const drawC4Shape = function (elem, c4Shape, conf) {
         .attr(
           'd',
           'Mstartx,startylwidth,0c5,0 5,half 5,halfc0,0 0,half -5,halfl-width,0c-5,0 -5,-half -5,-halfc0,0 0,-half 5,-half'
-            .replaceAll('startx', c4Shape.x)
-            .replaceAll('starty', c4Shape.y)
-            .replaceAll('width', c4Shape.width)
-            .replaceAll('half', c4Shape.height / 2)
+            .replaceAll('startx', c4Shape.x as unknown as string)
+            .replaceAll('starty', c4Shape.y as unknown as string)
+            .replaceAll('width', c4Shape.width as unknown as string)
+            .replaceAll('half', (c4Shape.height / 2) as unknown as string)
         );
       c4ShapeElem
         .append('path')
@@ -298,15 +336,17 @@ export const drawC4Shape = function (elem, c4Shape, conf) {
         .attr(
           'd',
           'Mstartx,startyc-5,0 -5,half -5,halfc0,half 5,half 5,half'
-            .replaceAll('startx', c4Shape.x + c4Shape.width)
-            .replaceAll('starty', c4Shape.y)
-            .replaceAll('half', c4Shape.height / 2)
+            .replaceAll('startx', (c4Shape.x + c4Shape.width) as unknown as string)
+            .replaceAll('starty', c4Shape.y as unknown as string)
+            .replaceAll('half', (c4Shape.height / 2) as unknown as string)
         );
       break;
   }
 
   // draw type of c4Shape
-  let c4ShapeFontConf = getC4ShapeFont(conf, c4Shape.typeC4Shape.text);
+  const c4ShapeFontConf = getC4ShapeFont(conf, c4Shape.typeC4Shape.text);
+  // The type text was measured by the renderer before drawing.
+  const typeC4ShapeWidth = c4Shape.typeC4Shape.width!;
   c4ShapeElem
     .append('text')
     .attr('fill', fontColor)
@@ -314,9 +354,9 @@ export const drawC4Shape = function (elem, c4Shape, conf) {
     .attr('font-size', c4ShapeFontConf.fontSize - 2)
     .attr('font-style', 'italic')
     .attr('lengthAdjust', 'spacing')
-    .attr('textLength', c4Shape.typeC4Shape.width)
-    .attr('x', c4Shape.x + c4Shape.width / 2 - c4Shape.typeC4Shape.width / 2)
-    .attr('y', c4Shape.y + c4Shape.typeC4Shape.Y)
+    .attr('textLength', typeC4ShapeWidth)
+    .attr('x', c4Shape.x + c4Shape.width / 2 - typeC4ShapeWidth / 2)
+    .attr('y', c4Shape.y + c4Shape.typeC4Shape.Y!)
     .text('<<' + c4Shape.typeC4Shape.text + '>>');
 
   // draw image/sprite
@@ -335,7 +375,7 @@ export const drawC4Shape = function (elem, c4Shape, conf) {
   }
 
   // draw label
-  let textFontConf = conf[c4Shape.typeC4Shape.text + 'Font']();
+  let textFontConf = (conf[c4Shape.typeC4Shape.text + 'Font'] as () => C4Font)();
   textFontConf.fontWeight = 'bold';
   textFontConf.fontSize = textFontConf.fontSize + 2;
   textFontConf.fontColor = fontColor;
@@ -343,7 +383,7 @@ export const drawC4Shape = function (elem, c4Shape, conf) {
     c4Shape.label.text,
     c4ShapeElem,
     c4Shape.x,
-    c4Shape.y + c4Shape.label.Y,
+    c4Shape.y + c4Shape.label.Y!,
     c4Shape.width,
     c4Shape.height,
     { fill: fontColor },
@@ -351,7 +391,7 @@ export const drawC4Shape = function (elem, c4Shape, conf) {
   );
 
   // draw techn/type
-  textFontConf = conf[c4Shape.typeC4Shape.text + 'Font']();
+  textFontConf = (conf[c4Shape.typeC4Shape.text + 'Font'] as () => C4Font)();
   textFontConf.fontColor = fontColor;
 
   if (c4Shape.techn && c4Shape.techn?.text !== '') {
@@ -359,7 +399,7 @@ export const drawC4Shape = function (elem, c4Shape, conf) {
       c4Shape.techn.text,
       c4ShapeElem,
       c4Shape.x,
-      c4Shape.y + c4Shape.techn.Y,
+      c4Shape.y + c4Shape.techn.Y!,
       c4Shape.width,
       c4Shape.height,
       { fill: fontColor, 'font-style': 'italic' },
@@ -370,7 +410,7 @@ export const drawC4Shape = function (elem, c4Shape, conf) {
       c4Shape.type.text,
       c4ShapeElem,
       c4Shape.x,
-      c4Shape.y + c4Shape.type.Y,
+      c4Shape.y + c4Shape.type.Y!,
       c4Shape.width,
       c4Shape.height,
       { fill: fontColor, 'font-style': 'italic' },
@@ -386,7 +426,7 @@ export const drawC4Shape = function (elem, c4Shape, conf) {
       c4Shape.descr.text,
       c4ShapeElem,
       c4Shape.x,
-      c4Shape.y + c4Shape.descr.Y,
+      c4Shape.y + c4Shape.descr.Y!,
       c4Shape.width,
       c4Shape.height,
       { fill: fontColor },
@@ -397,7 +437,7 @@ export const drawC4Shape = function (elem, c4Shape, conf) {
   return c4Shape.height;
 };
 
-export const insertDatabaseIcon = function (elem, id) {
+export const insertDatabaseIcon = function (elem: SVG, id: string) {
   elem
     .append('defs')
     .append('symbol')
@@ -412,7 +452,7 @@ export const insertDatabaseIcon = function (elem, id) {
     );
 };
 
-export const insertComputerIcon = function (elem, id) {
+export const insertComputerIcon = function (elem: SVG, id: string) {
   elem
     .append('defs')
     .append('symbol')
@@ -427,7 +467,7 @@ export const insertComputerIcon = function (elem, id) {
     );
 };
 
-export const insertClockIcon = function (elem, id) {
+export const insertClockIcon = function (elem: SVG, id: string) {
   elem
     .append('defs')
     .append('symbol')
@@ -444,10 +484,8 @@ export const insertClockIcon = function (elem, id) {
 
 /**
  * Setup arrow head and define the marker. The result is appended to the svg.
- *
- * @param elem
  */
-export const insertArrowHead = function (elem, id) {
+export const insertArrowHead = function (elem: SVG, id: string) {
   elem
     .append('defs')
     .append('marker')
@@ -462,7 +500,7 @@ export const insertArrowHead = function (elem, id) {
     .attr('d', 'M 0 0 L 10 5 L 0 10 z'); // this is actual shape for arrowhead
 };
 
-export const insertArrowEnd = function (elem, id) {
+export const insertArrowEnd = function (elem: SVG, id: string) {
   elem
     .append('defs')
     .append('marker')
@@ -479,10 +517,8 @@ export const insertArrowEnd = function (elem, id) {
 
 /**
  * Setup arrow head and define the marker. The result is appended to the svg.
- *
- * @param {any} elem
  */
-export const insertArrowFilledHead = function (elem, id) {
+export const insertArrowFilledHead = function (elem: SVG, id: string) {
   elem
     .append('defs')
     .append('marker')
@@ -498,10 +534,8 @@ export const insertArrowFilledHead = function (elem, id) {
 
 /**
  * Setup arrow head and define the marker. The result is appended to the svg.
- *
- * @param {any} elem
  */
-export const insertArrowCrossHead = function (elem, id) {
+export const insertArrowCrossHead = function (elem: SVG, id: string) {
   const defs = elem.append('defs');
   const marker = defs
     .append('marker')
@@ -532,25 +566,24 @@ export const insertArrowCrossHead = function (elem, id) {
   // this is actual shape for arrowhead
 };
 
-const getC4ShapeFont = (cnf, typeC4Shape) => {
+const getC4ShapeFont = (cnf: C4DrawConfig, typeC4Shape: string): C4Font => {
   return {
-    fontFamily: cnf[typeC4Shape + 'FontFamily'],
-    fontSize: cnf[typeC4Shape + 'FontSize'],
-    fontWeight: cnf[typeC4Shape + 'FontWeight'],
+    fontFamily: cnf[typeC4Shape + 'FontFamily'] as string,
+    fontSize: cnf[typeC4Shape + 'FontSize'] as number,
+    fontWeight: cnf[typeC4Shape + 'FontWeight'] as string | number,
   };
 };
 
 const _drawTextCandidateFunc = (function () {
-  /**
-   * @param {any} content
-   * @param {any} g
-   * @param {any} x
-   * @param {any} y
-   * @param {any} width
-   * @param {any} height
-   * @param {any} textAttrs
-   */
-  function byText(content, g, x, y, width, height, textAttrs) {
+  function byText<T extends SVGElement>(
+    content: string,
+    g: D3Selection<T>,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    textAttrs: TextAttrs
+  ) {
     const text = g
       .append('text')
       .attr('x', x + width / 2)
@@ -560,17 +593,16 @@ const _drawTextCandidateFunc = (function () {
     _setTextAttrs(text, textAttrs);
   }
 
-  /**
-   * @param {any} content
-   * @param {any} g
-   * @param {any} x
-   * @param {any} y
-   * @param {any} width
-   * @param {any} height
-   * @param {any} textAttrs
-   * @param {any} conf
-   */
-  function byTspan(content, g, x, y, width, height, textAttrs, conf) {
+  function byTspan<T extends SVGElement>(
+    content: string,
+    g: D3Selection<T>,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    textAttrs: TextAttrs,
+    conf: C4Font
+  ) {
     const { fontSize, fontFamily, fontWeight } = conf;
 
     const lines = content.split(common.lineBreakRegex);
@@ -597,17 +629,16 @@ const _drawTextCandidateFunc = (function () {
     }
   }
 
-  /**
-   * @param {any} content
-   * @param {any} g
-   * @param {any} x
-   * @param {any} y
-   * @param {any} width
-   * @param {any} height
-   * @param {any} textAttrs
-   * @param {any} conf
-   */
-  function byFo(content, g, x, y, width, height, textAttrs, conf) {
+  function byFo<T extends SVGElement>(
+    content: string,
+    g: D3Selection<T>,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    textAttrs: TextAttrs,
+    conf: C4Font
+  ) {
     const s = g.append('switch');
     const f = s
       .append('foreignObject')
@@ -633,11 +664,10 @@ const _drawTextCandidateFunc = (function () {
     _setTextAttrs(text, textAttrs);
   }
 
-  /**
-   * @param {any} toText
-   * @param {any} fromTextAttrsDict
-   */
-  function _setTextAttrs(toText, fromTextAttrsDict) {
+  function _setTextAttrs<T extends BaseType>(
+    toText: Selection<T, unknown, Element | null, unknown>,
+    fromTextAttrsDict: TextAttrs
+  ) {
     for (const key in fromTextAttrsDict) {
       if (fromTextAttrsDict.hasOwnProperty(key)) {
         toText.attr(key, fromTextAttrsDict[key]);
@@ -645,7 +675,7 @@ const _drawTextCandidateFunc = (function () {
     }
   }
 
-  return function (conf) {
+  return function (conf: C4DrawConfig): DrawTextFunction {
     return conf.textPlacement === 'fo' ? byFo : conf.textPlacement === 'old' ? byText : byTspan;
   };
 })();

--- a/packages/mermaid/src/utils/diagramRoot.ts
+++ b/packages/mermaid/src/utils/diagramRoot.ts
@@ -1,0 +1,27 @@
+import { select } from 'd3';
+import type { D3HtmlSelection } from '../types.js';
+
+export interface DiagramRoot {
+  /** Selection of the body that diagram elements should be queried from. */
+  root: D3HtmlSelection<HTMLElement>;
+  /** Owner document of {@link root} (the iframe document in sandbox mode). */
+  doc: Document;
+}
+
+/**
+ * Resolves the root selection a renderer should draw into, accounting for
+ * `securityLevel: 'sandbox'` where the diagram lives inside an `#i<id>`
+ * iframe. Centralizes the sandbox handling that was previously copy-pasted
+ * (with non-null assertions) into every renderer.
+ */
+export const getDiagramRoot = (id: string, securityLevel?: string): DiagramRoot => {
+  if (securityLevel === 'sandbox') {
+    const sandboxElement = select<HTMLIFrameElement, unknown>('#i' + id);
+    const doc = sandboxElement.node()?.contentDocument;
+    if (!doc) {
+      throw new Error(`Sandbox iframe #i${id} is missing its content document`);
+    }
+    return { root: select(doc.body) as unknown as D3HtmlSelection<HTMLElement>, doc };
+  }
+  return { root: select('body') as unknown as D3HtmlSelection<HTMLElement>, doc: document };
+};


### PR DESCRIPTION
## :bookmark_tabs: Summary

Adopts the **C4 portion of the TypeScript conversion from #7829**, as invited by @sidharthv96 in https://github.com/mermaid-js/mermaid/pull/7829#issuecomment-4686299579.

Scope: `c4Db.js -> c4Db.ts` (with a new `c4Types.ts`), `c4Renderer.js -> c4Renderer.ts`, `svgDraw.js -> svgDraw.ts`, and the seven parser spec files renamed to `.ts`. Also brings along the two small shared helpers the conversion relies on: `getRequiredConfig()` (typed access to fully-defaulted diagram config sections) and `getDiagramRoot()` (centralized `securityLevel: sandbox` handling).

**Zero behavior change** - all 125 existing C4 unit tests pass unchanged, and the legacy renderer output is untouched (same Argos baselines).

## :straight_ruler: Design Decisions

- **`styles.js` is deliberately NOT converted here**: #7842 extends that file substantially, and converting it in both PRs would guarantee a conflict. It can be converted in a small follow-up once #7842 lands.
- Commits are atomic and adopt the work with `Co-authored-by: Sidharth Vinod` trailers: helpers, c4Db, renderer+svgDraw, spec renames, changeset.
- This is item 1 of the PR series for the C4 unified-renderer migration planned in #7673 (first slice: #7842).

Full disclosure: prepared with assistance from Claude Code; all changes reviewed and tested by a human before submission.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests. (Pure refactor - the existing 125-test suite covers it; spec files themselves are part of the conversion.)
- [x] :notebook: have added documentation. (No user-facing change.)
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts.
