### PR TITLE
fix(c4): keep named attributes that land in earlier positional slots

### DIFF
--- a/.changeset/c4-named-attrs-fix.md
+++ b/.changeset/c4-named-attrs-fix.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix(c4): named attributes such as `$tags`, `$link` and `$sprite` are no longer clobbered to undefined when they arrive in an earlier positional slot of Person/System/Container/Component/Boundary/Rel statements.

--- a/packages/mermaid/src/diagrams/c4/c4Db.ts
+++ b/packages/mermaid/src/diagrams/c4/c4Db.ts
@@ -111,19 +111,19 @@ export const addRel = function (
   if (typeof sprite === 'object') {
     const [key, value] = Object.entries(sprite)[0];
     rel[key] = value;
-  } else {
+  } else if (sprite !== undefined) {
     rel.sprite = sprite;
   }
   if (typeof tags === 'object') {
     const [key, value] = Object.entries(tags)[0];
     rel[key] = value;
-  } else {
+  } else if (tags !== undefined) {
     rel.tags = tags;
   }
   if (typeof link === 'object') {
     const [key, value] = Object.entries(link)[0];
     rel[key] = value;
-  } else {
+  } else if (link !== undefined) {
     rel.link = link;
   }
   rel.wrap = autoWrap();
@@ -174,19 +174,19 @@ export const addPersonOrSystem = function (
   if (typeof sprite === 'object') {
     const [key, value] = Object.entries(sprite)[0];
     personOrSystem[key] = value;
-  } else {
+  } else if (sprite !== undefined) {
     personOrSystem.sprite = sprite;
   }
   if (typeof tags === 'object') {
     const [key, value] = Object.entries(tags)[0];
     personOrSystem[key] = value;
-  } else {
+  } else if (tags !== undefined) {
     personOrSystem.tags = tags;
   }
   if (typeof link === 'object') {
     const [key, value] = Object.entries(link)[0];
     personOrSystem[key] = value;
-  } else {
+  } else if (link !== undefined) {
     personOrSystem.link = link;
   }
   personOrSystem.typeC4Shape = { text: typeC4Shape };
@@ -251,19 +251,19 @@ export const addContainer = function (
   if (typeof sprite === 'object') {
     const [key, value] = Object.entries(sprite)[0];
     container[key] = value;
-  } else {
+  } else if (sprite !== undefined) {
     container.sprite = sprite;
   }
   if (typeof tags === 'object') {
     const [key, value] = Object.entries(tags)[0];
     container[key] = value;
-  } else {
+  } else if (tags !== undefined) {
     container.tags = tags;
   }
   if (typeof link === 'object') {
     const [key, value] = Object.entries(link)[0];
     container[key] = value;
-  } else {
+  } else if (link !== undefined) {
     container.link = link;
   }
   container.wrap = autoWrap();
@@ -328,19 +328,19 @@ export const addComponent = function (
   if (typeof sprite === 'object') {
     const [key, value] = Object.entries(sprite)[0];
     component[key] = value;
-  } else {
+  } else if (sprite !== undefined) {
     component.sprite = sprite;
   }
   if (typeof tags === 'object') {
     const [key, value] = Object.entries(tags)[0];
     component[key] = value;
-  } else {
+  } else if (tags !== undefined) {
     component.tags = tags;
   }
   if (typeof link === 'object') {
     const [key, value] = Object.entries(link)[0];
     component[key] = value;
-  } else {
+  } else if (link !== undefined) {
     component.link = link;
   }
   component.wrap = autoWrap();
@@ -393,13 +393,13 @@ export const addPersonOrSystemBoundary = function (
   if (typeof tags === 'object') {
     const [key, value] = Object.entries(tags)[0];
     boundary[key] = value;
-  } else {
+  } else if (tags !== undefined) {
     boundary.tags = tags;
   }
   if (typeof link === 'object') {
     const [key, value] = Object.entries(link)[0];
     boundary[key] = value;
-  } else {
+  } else if (link !== undefined) {
     boundary.link = link;
   }
   boundary.parentBoundary = currentBoundaryParse;
@@ -455,13 +455,13 @@ export const addContainerBoundary = function (
   if (typeof tags === 'object') {
     const [key, value] = Object.entries(tags)[0];
     boundary[key] = value;
-  } else {
+  } else if (tags !== undefined) {
     boundary.tags = tags;
   }
   if (typeof link === 'object') {
     const [key, value] = Object.entries(link)[0];
     boundary[key] = value;
-  } else {
+  } else if (link !== undefined) {
     boundary.link = link;
   }
   boundary.parentBoundary = currentBoundaryParse;
@@ -531,13 +531,13 @@ export const addDeploymentNode = function (
   if (typeof tags === 'object') {
     const [key, value] = Object.entries(tags)[0];
     boundary[key] = value;
-  } else {
+  } else if (tags !== undefined) {
     boundary.tags = tags;
   }
   if (typeof link === 'object') {
     const [key, value] = Object.entries(link)[0];
     boundary[key] = value;
-  } else {
+  } else if (link !== undefined) {
     boundary.link = link;
   }
   boundary.nodeType = nodeType;

--- a/packages/mermaid/src/diagrams/c4/c4Db.ts
+++ b/packages/mermaid/src/diagrams/c4/c4Db.ts
@@ -15,6 +15,29 @@ import type { C4Boundary, C4Rel, C4Shape } from './c4Types.js';
  */
 type ParserAttribute = string | Record<string, string>;
 
+/**
+ * Apply optional C4 attributes to `bag` from the parser.
+ *
+ * Values may arrive as a raw positional value or a single `{ key: value }` named
+ * override; `undefined` is skipped so an earlier-set value is not clobbered.
+ */
+const assignAttributes = <Bag extends C4Shape | C4Boundary | C4Rel>(
+  bag: Bag,
+  attrs: Record<string, ParserAttribute | undefined>
+): void => {
+  for (const [field, value] of Object.entries(attrs)) {
+    if (value === undefined) {
+      continue;
+    }
+    if (typeof value === 'object') {
+      const [key, val] = Object.entries(value)[0];
+      bag[key] = val;
+    } else {
+      bag[field] = value;
+    }
+  }
+};
+
 const createGlobalBoundary = (): C4Boundary =>
   ({
     alias: 'global',
@@ -108,24 +131,7 @@ export const addRel = function (
     }
   }
 
-  if (typeof sprite === 'object') {
-    const [key, value] = Object.entries(sprite)[0];
-    rel[key] = value;
-  } else if (sprite !== undefined) {
-    rel.sprite = sprite;
-  }
-  if (typeof tags === 'object') {
-    const [key, value] = Object.entries(tags)[0];
-    rel[key] = value;
-  } else if (tags !== undefined) {
-    rel.tags = tags;
-  }
-  if (typeof link === 'object') {
-    const [key, value] = Object.entries(link)[0];
-    rel[key] = value;
-  } else if (link !== undefined) {
-    rel.link = link;
-  }
+  assignAttributes(rel, { sprite, tags, link });
   rel.wrap = autoWrap();
 };
 
@@ -171,24 +177,7 @@ export const addPersonOrSystem = function (
     }
   }
 
-  if (typeof sprite === 'object') {
-    const [key, value] = Object.entries(sprite)[0];
-    personOrSystem[key] = value;
-  } else if (sprite !== undefined) {
-    personOrSystem.sprite = sprite;
-  }
-  if (typeof tags === 'object') {
-    const [key, value] = Object.entries(tags)[0];
-    personOrSystem[key] = value;
-  } else if (tags !== undefined) {
-    personOrSystem.tags = tags;
-  }
-  if (typeof link === 'object') {
-    const [key, value] = Object.entries(link)[0];
-    personOrSystem[key] = value;
-  } else if (link !== undefined) {
-    personOrSystem.link = link;
-  }
+  assignAttributes(personOrSystem, { sprite, tags, link });
   personOrSystem.typeC4Shape = { text: typeC4Shape };
   personOrSystem.parentBoundary = currentBoundaryParse;
   personOrSystem.wrap = autoWrap();
@@ -248,24 +237,7 @@ export const addContainer = function (
     }
   }
 
-  if (typeof sprite === 'object') {
-    const [key, value] = Object.entries(sprite)[0];
-    container[key] = value;
-  } else if (sprite !== undefined) {
-    container.sprite = sprite;
-  }
-  if (typeof tags === 'object') {
-    const [key, value] = Object.entries(tags)[0];
-    container[key] = value;
-  } else if (tags !== undefined) {
-    container.tags = tags;
-  }
-  if (typeof link === 'object') {
-    const [key, value] = Object.entries(link)[0];
-    container[key] = value;
-  } else if (link !== undefined) {
-    container.link = link;
-  }
+  assignAttributes(container, { sprite, tags, link });
   container.wrap = autoWrap();
   container.typeC4Shape = { text: typeC4Shape };
   container.parentBoundary = currentBoundaryParse;
@@ -325,24 +297,7 @@ export const addComponent = function (
     }
   }
 
-  if (typeof sprite === 'object') {
-    const [key, value] = Object.entries(sprite)[0];
-    component[key] = value;
-  } else if (sprite !== undefined) {
-    component.sprite = sprite;
-  }
-  if (typeof tags === 'object') {
-    const [key, value] = Object.entries(tags)[0];
-    component[key] = value;
-  } else if (tags !== undefined) {
-    component.tags = tags;
-  }
-  if (typeof link === 'object') {
-    const [key, value] = Object.entries(link)[0];
-    component[key] = value;
-  } else if (link !== undefined) {
-    component.link = link;
-  }
+  assignAttributes(component, { sprite, tags, link });
   component.wrap = autoWrap();
   component.typeC4Shape = { text: typeC4Shape };
   component.parentBoundary = currentBoundaryParse;
@@ -390,18 +345,7 @@ export const addPersonOrSystemBoundary = function (
     }
   }
 
-  if (typeof tags === 'object') {
-    const [key, value] = Object.entries(tags)[0];
-    boundary[key] = value;
-  } else if (tags !== undefined) {
-    boundary.tags = tags;
-  }
-  if (typeof link === 'object') {
-    const [key, value] = Object.entries(link)[0];
-    boundary[key] = value;
-  } else if (link !== undefined) {
-    boundary.link = link;
-  }
+  assignAttributes(boundary, { tags, link });
   boundary.parentBoundary = currentBoundaryParse;
   boundary.wrap = autoWrap();
 
@@ -452,18 +396,7 @@ export const addContainerBoundary = function (
     }
   }
 
-  if (typeof tags === 'object') {
-    const [key, value] = Object.entries(tags)[0];
-    boundary[key] = value;
-  } else if (tags !== undefined) {
-    boundary.tags = tags;
-  }
-  if (typeof link === 'object') {
-    const [key, value] = Object.entries(link)[0];
-    boundary[key] = value;
-  } else if (link !== undefined) {
-    boundary.link = link;
-  }
+  assignAttributes(boundary, { tags, link });
   boundary.parentBoundary = currentBoundaryParse;
   boundary.wrap = autoWrap();
 
@@ -528,18 +461,7 @@ export const addDeploymentNode = function (
     }
   }
 
-  if (typeof tags === 'object') {
-    const [key, value] = Object.entries(tags)[0];
-    boundary[key] = value;
-  } else if (tags !== undefined) {
-    boundary.tags = tags;
-  }
-  if (typeof link === 'object') {
-    const [key, value] = Object.entries(link)[0];
-    boundary[key] = value;
-  } else if (link !== undefined) {
-    boundary.link = link;
-  }
+  assignAttributes(boundary, { tags, link });
   boundary.nodeType = nodeType;
   boundary.parentBoundary = currentBoundaryParse;
   boundary.wrap = autoWrap();

--- a/packages/mermaid/src/diagrams/c4/parser/c4Person.spec.ts
+++ b/packages/mermaid/src/diagrams/c4/parser/c4Person.spec.ts
@@ -109,4 +109,15 @@ Person(customerA, $tags="tag1,tag2")`);
       },
     });
   });
+
+  it('should keep named attributes that land in an earlier positional slot', function () {
+    c4.parser.parse(`C4Context
+Person(customerA, "Banking Customer A", "A customer.", $tags="v1.0+internal", $link="https://example.com")`);
+
+    expect(c4.parser.yy.getC4ShapeArray()[0]).toMatchObject({
+      alias: 'customerA',
+      tags: 'v1.0+internal',
+      link: 'https://example.com',
+    });
+  });
 });


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fixes a C4 db bug: a named attribute (`$tags="..."`, `$link="..."`, `$sprite="..."`) that the parser delivers as a `{ key: value }` object in an earlier positional slot was stored correctly, then **clobbered back to `undefined`** by the unconditional assignment for that slot's own (now-undefined) positional.

Resolves #7846

Example that silently dropped its tags/link before this fix:

```
C4Context
  Person(customerA, "Banking Customer A", "A customer.", $tags="v1.0+internal", $link="https://example.com")
```

## :straight_ruler: Design Decisions

Two commits, separated for easy review:

1. **fix** - the minimal, mechanical change: guard each `sprite`/`tags`/`link` assignment so an undefined positional no longer overwrites a value already set via a named override. Trivially verifiable as correct; includes the regression test (`c4Person.spec.ts`).
2. **refactor** - those object-or-value blocks were copy-pasted across all seven `add*` functions (the duplication is what allowed the bug). Replace them with a single `assignAttributes()` helper that centralises the "named override or raw positional, skip undefined" logic. No behaviour change.

The `{text}`-wrapped `label`/`techn`/`descr` blocks (which set defaults and were never buggy) are intentionally left untouched to keep this focused.

Full disclosure: prepared with assistance from Claude Code; reviewed and tested by a human.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. (Bugfix - no doc change needed.)
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset.
