### PR TITLE
fix(block): allow classdefs to update text color

### DIFF
--- a/.changeset/kind-dogs-crash.md
+++ b/.changeset/kind-dogs-crash.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix(block): allow classdefs to update text color

--- a/cypress/integration/rendering/block/block.spec.js
+++ b/cypress/integration/rendering/block/block.spec.js
@@ -200,9 +200,9 @@ describe('Block diagram', () => {
   it('BL14: should style statements and class statements', () => {
     imgSnapshotTest(
       `block
-    A
+    A["My text here"]
     B
-    classDef blue fill:#66f,stroke:#333,stroke-width:2px;
+    classDef blue fill:#66f,stroke:#333,stroke-width:2px,color:#ff6;
     class A blue
     style B fill:#f9F,stroke:#333,stroke-width:4px
       `,

--- a/packages/mermaid/src/diagrams/block/styles.ts
+++ b/packages/mermaid/src/diagrams/block/styles.ts
@@ -38,13 +38,13 @@ const getStyles = (options: BlockChartStyleOptions) =>
   .cluster-label text {
     fill: ${options.titleColor};
   }
-  .cluster-label span,p {
+  .cluster-label span {
     color: ${options.titleColor};
   }
 
 
 
-  .label text,span,p {
+  .label text,span {
     fill: ${options.nodeTextColor || options.textColor};
     color: ${options.nodeTextColor || options.textColor};
   }
@@ -127,7 +127,7 @@ const getStyles = (options: BlockChartStyleOptions) =>
     fill: ${options.titleColor};
   }
 
-  .cluster span,p {
+  .cluster span {
     color: ${options.titleColor};
   }
   /* .cluster div {


### PR DESCRIPTION
## :bookmark_tabs: Summary

Setting a `classDef` changing `color` doesn't change the text colour in block diagrams. Block diagram nodes are rendered like the following:

```svg
<g class="node myCustomClassForMyClassDef">
  <rect class="basic label-container"></rect>
  <g class="label">
    <foreignObject>
      <div>
        <span class="nodeLabel">
          <p> My text here </p>
        </span>
      </div>
    </foreignObject>
  </g>
</g>
```

However, the CSS selectors in the theme contain stuff like `.label span,p`. I'm pretty sure the author meant
`.label span, .label p`, since there are multiple rules for `p`, which means the `classDef` never does anything.

Copies the fix for flowcharts from
406c0d869 (Add support for custom cssStyle and compiledStyles for custom classDefs for flowchart, 2024-06-18) into block diagrams, which removes those extra `p` rules, since they don't do anything.

Fixes: https://github.com/mermaid-js/mermaid/issues/7833

## :straight_ruler: Design Decisions

For:

```
block
  columns 6
  SilverNode:6
  nui :2
  NeonRAW["NeonRAW\nRawSpeed, LibRaw, Own"] :3
  NeonEXIF :1
  vgrenderer["vg-renderer"] :2
  JRS["Job & Resource System"] :3
  space:1
  bgfx :3
  Halide["Halide Runtime"] :2 space
  SDL3 :2 GPU["CUDA / Metal / Vulkan / OpenCL "] :3 space
  OS :5

classDef att fill:#521,stroke-width:2px,color:#fff
class NeonRAW att
class JRS att
class Halide att
```

### Current

`color:#fff` in `classDef att fill:#521,stroke-width:2px,color:#fff` does nothing.

<img width="1208" height="584" alt="image" src="https://github.com/user-attachments/assets/b61599ca-f851-4025-9ebc-e064e3dd8f0e" />

### Proposed

<img width="1208" height="584" alt="image" src="https://github.com/user-attachments/assets/81394d74-9d4a-48c4-9b95-0a3a98f3fe84" />

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
