### PR TITLE
docs(sequence): document supported box color formats

### DIFF
--- a/docs/syntax/sequenceDiagram.md
+++ b/docs/syntax/sequenceDiagram.md
@@ -341,6 +341,9 @@ And fixing diagram code does not get rid of this error and rendering of all othe
 
 The actor(s) can be grouped in vertical boxes. You can define a color (if not, it will be transparent) and/or a descriptive label using the following notation:
 
+> **Note**
+> For colored boxes, the color value must be placed **before** the optional description.
+
 ```
 box Aqua Group Description
 ... actors ...
@@ -354,7 +357,16 @@ end
 box rgba(33,66,99,0.5)
 ... actors ...
 end
+box hsl(10, 40%, 90%)
+... actors ...
+end
+box hsla(10, 40%, 90%, 0.5)
+... actors ...
+end
 ```
+
+> **Warning**
+> **Hex colors** (e.g., `#ff0000`) are currently **not supported** as the `#` character is interpreted as comment syntax.
 
 > **Note**
 > If your group name is a color you can force the color to be transparent:

--- a/packages/mermaid/src/docs/syntax/sequenceDiagram.md
+++ b/packages/mermaid/src/docs/syntax/sequenceDiagram.md
@@ -213,6 +213,10 @@ And fixing diagram code does not get rid of this error and rendering of all othe
 
 The actor(s) can be grouped in vertical boxes. You can define a color (if not, it will be transparent) and/or a descriptive label using the following notation:
 
+```note
+For colored boxes, the color value must be placed **before** the optional description.
+```
+
 ```
 box Aqua Group Description
 ... actors ...
@@ -226,6 +230,16 @@ end
 box rgba(33,66,99,0.5)
 ... actors ...
 end
+box hsl(10, 40%, 90%)
+... actors ...
+end
+box hsla(10, 40%, 90%, 0.5)
+... actors ...
+end
+```
+
+```warning
+**Hex colors** (e.g., `#ff0000`) are currently **not supported** as the `#` character is interpreted as comment syntax.
 ```
 
 ```note


### PR DESCRIPTION
## :bookmark_tabs: Summary

Updates the Sequence Diagram "Grouping / Box" documentation to clarify supported color formats and usage.

Partially addresses #7668

**Changes**

- Added a note clarifying that color values must appear before the optional box description.
- Added HSL (hsl()) and HSLA (hsla()) examples to the documented box color formats.
- Added a warning explaining that hex colors (for example #ff0000) are currently not supported because # is interpreted as comment syntax.
- Preserved the existing documentation behavior and wording while improving clarity around box color configuration.

**Why**

The current documentation does not fully describe all supported box color formats and leaves some syntax details ambiguous. These updates help users understand which color formats are supported and avoid common mistakes when styling sequence diagram grouping boxes.

## :straight_ruler: Design Decisions

This PR focuses only on documentation updates for existing sequence diagram box color behavior. No code changes were made.

### :clipboard: Tasks

Make sure you

- [X] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.s (not applicable – documentation only)
- [X] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
