### PR TITLE
feat(er): allow omitted attribute types

### DIFF
--- a/.changeset/er-omitted-attribute-types.md
+++ b/.changeset/er-omitted-attribute-types.md
@@ -1,0 +1,9 @@
+---
+'mermaid': minor
+---
+
+feat(er): allow ER attributes without data types
+
+ER diagrams can now define attributes as names only, including keys and comments, and may use `_` as an explicit omitted type marker. When an entity has no typed attributes, the renderer omits the type column instead of rendering an empty column.
+
+Closes mermaid-js/mermaid#5563

--- a/cypress/integration/rendering/er/erDiagram.spec.js
+++ b/cypress/integration/rendering/er/erDiagram.spec.js
@@ -200,6 +200,42 @@ describe('Entity Relationship Diagram', () => {
     );
   });
 
+  it('should render entities with omitted attribute types without a type column', () => {
+    imgSnapshotTest(
+      `
+    erDiagram
+        PRIVATE_FINANCIAL_INSTITUTION {
+          registrationNumber PK
+          displayName "Preferred customer name"
+          status
+        }
+      `,
+      { logLevel: 1 },
+      false,
+      ($svg) => {
+        expect($svg.find('.attribute-type')).to.have.length(0);
+      }
+    );
+  });
+
+  it('should render entities with explicit omitted attribute type markers', () => {
+    imgSnapshotTest(
+      `
+    erDiagram
+        CAR {
+          _ registrationNumber PK
+          _ make
+          _ model
+        }
+      `,
+      { logLevel: 1 },
+      false,
+      ($svg) => {
+        expect($svg.find('.attribute-type')).to.have.length(0);
+      }
+    );
+  });
+
   it('should render entities with attributes that begin with asterisk', () => {
     imgSnapshotTest(
       `

--- a/docs/syntax/entityRelationshipDiagram.md
+++ b/docs/syntax/entityRelationshipDiagram.md
@@ -247,6 +247,42 @@ erDiagram
 
 The `type` values must begin with an alphabetic character and may contain digits, hyphens, underscores, parentheses and square brackets. The `name` values follow a similar format to `type`, but may start with an asterisk as another option to indicate an attribute is a primary key. Other than that, there are no restrictions, and there is no implicit set of valid data types.
 
+#### Omitted attribute types (v\<MERMAID_RELEASE_VERSION>+)
+
+Attribute `type` values may be omitted when a diagram only needs logical attribute names without data types. If no attributes on an entity have a type, the type column is not rendered. An underscore (`_`) may also be used as an explicit omitted type marker.
+
+```mermaid-example
+erDiagram
+    CAR {
+        registrationNumber PK
+        make
+        model
+    }
+    PERSON {
+        driversLicense PK "The license #"
+        firstName "Only 99 characters are allowed"
+        lastName
+        phone UK
+        age
+    }
+```
+
+```mermaid
+erDiagram
+    CAR {
+        registrationNumber PK
+        make
+        model
+    }
+    PERSON {
+        driversLicense PK "The license #"
+        firstName "Only 99 characters are allowed"
+        lastName
+        phone UK
+        age
+    }
+```
+
 #### Optional attribute types (v\<MERMAID_RELEASE_VERSION>+)
 
 Attribute `type` values may end with `?` to indicate an optional or nullable type.

--- a/packages/mermaid/src/diagrams/er/erDb.ts
+++ b/packages/mermaid/src/diagrams/er/erDb.ts
@@ -98,6 +98,9 @@ export class ErDB implements DiagramDB {
     // Process attribs in reverse order due to effect of recursive construction (last attribute is first)
     let i;
     for (i = attribs.length - 1; i >= 0; i--) {
+      if (!attribs[i].type) {
+        attribs[i].type = '';
+      }
       if (!attribs[i].keys) {
         attribs[i].keys = [];
       }

--- a/packages/mermaid/src/diagrams/er/erRenderer.js
+++ b/packages/mermaid/src/diagrams/er/erRenderer.js
@@ -48,6 +48,7 @@ const drawAttributes = (groupNode, entityTextNode, attributes) => {
   const attrFontSize = conf.fontSize * 0.85;
   const labelBBox = entityTextNode.node().getBBox();
   const attributeNodes = []; // Intermediate storage for attribute nodes created so that we can do a second pass
+  let hasAttributeType = false;
   let hasKeyType = false;
   let hasComment = false;
   let maxTypeWidth = 0;
@@ -59,11 +60,19 @@ const drawAttributes = (groupNode, entityTextNode, attributes) => {
 
   // Check to see if any of the attributes has a key or a comment
   attributes.forEach((item) => {
-    if (item.attributeKeyTypeList !== undefined && item.attributeKeyTypeList.length > 0) {
+    const attributeType = item.attributeType ?? item.type ?? '';
+    const attributeKeyTypeList = item.attributeKeyTypeList ?? item.keys;
+    const attributeComment = item.attributeComment ?? item.comment;
+
+    if (attributeType.trim().length > 0) {
+      hasAttributeType = true;
+    }
+
+    if (attributeKeyTypeList !== undefined && attributeKeyTypeList.length > 0) {
       hasKeyType = true;
     }
 
-    if (item.attributeComment !== undefined) {
+    if (attributeComment !== undefined && attributeComment.length > 0) {
       hasComment = true;
     }
   });
@@ -72,20 +81,29 @@ const drawAttributes = (groupNode, entityTextNode, attributes) => {
     const attrPrefix = `${entityTextNode.node().id}-attr-${attrNum}`;
     let nodeHeight = 0;
 
-    const attributeType = parseGenericTypes(item.attributeType);
+    const attributeType = parseGenericTypes(item.attributeType ?? item.type ?? '');
+    const attributeName = item.attributeName ?? item.name;
+    const attributeKeyTypeList = item.attributeKeyTypeList ?? item.keys;
+    const attributeComment = item.attributeComment ?? item.comment;
+    let typeNode;
+    let typeBBox = { width: 0, height: 0 };
 
-    // Add a text node for the attribute type
-    const typeNode = groupNode
-      .append('text')
-      .classed('er entityLabel', true)
-      .attr('id', `${attrPrefix}-type`)
-      .attr('x', 0)
-      .attr('y', 0)
-      .style('dominant-baseline', 'middle')
-      .style('text-anchor', 'left')
-      .style('font-family', getConfig().fontFamily)
-      .style('font-size', attrFontSize + 'px')
-      .text(attributeType);
+    if (hasAttributeType) {
+      // Add a text node for the attribute type
+      typeNode = groupNode
+        .append('text')
+        .classed('er entityLabel', true)
+        .attr('id', `${attrPrefix}-type`)
+        .attr('x', 0)
+        .attr('y', 0)
+        .style('dominant-baseline', 'middle')
+        .style('text-anchor', 'left')
+        .style('font-family', getConfig().fontFamily)
+        .style('font-size', attrFontSize + 'px')
+        .text(attributeType);
+      typeBBox = typeNode.node().getBBox();
+      maxTypeWidth = Math.max(maxTypeWidth, typeBBox.width);
+    }
 
     // Add a text node for the attribute name
     const nameNode = groupNode
@@ -98,22 +116,22 @@ const drawAttributes = (groupNode, entityTextNode, attributes) => {
       .style('text-anchor', 'left')
       .style('font-family', getConfig().fontFamily)
       .style('font-size', attrFontSize + 'px')
-      .text(item.attributeName);
+      .text(attributeName);
 
     const attributeNode = {};
-    attributeNode.tn = typeNode;
+    if (typeNode) {
+      attributeNode.tn = typeNode;
+    }
     attributeNode.nn = nameNode;
 
-    const typeBBox = typeNode.node().getBBox();
     const nameBBox = nameNode.node().getBBox();
-    maxTypeWidth = Math.max(maxTypeWidth, typeBBox.width);
     maxNameWidth = Math.max(maxNameWidth, nameBBox.width);
 
     nodeHeight = Math.max(typeBBox.height, nameBBox.height);
 
     if (hasKeyType) {
       const keyTypeNodeText =
-        item.attributeKeyTypeList !== undefined ? item.attributeKeyTypeList.join(',') : '';
+        attributeKeyTypeList !== undefined ? attributeKeyTypeList.join(',') : '';
 
       const keyTypeNode = groupNode
         .append('text')
@@ -144,7 +162,7 @@ const drawAttributes = (groupNode, entityTextNode, attributes) => {
         .style('text-anchor', 'left')
         .style('font-family', getConfig().fontFamily)
         .style('font-size', attrFontSize + 'px')
-        .text(item.attributeComment || '');
+        .text(attributeComment || '');
 
       attributeNode.cn = commentNode;
       const commentNodeBBox = commentNode.node().getBBox();
@@ -159,7 +177,7 @@ const drawAttributes = (groupNode, entityTextNode, attributes) => {
     attrNum += 1;
   });
 
-  let widthPaddingFactor = 4;
+  let widthPaddingFactor = hasAttributeType ? 4 : 2;
   if (hasKeyType) {
     widthPaddingFactor += 2;
   }
@@ -205,20 +223,24 @@ const drawAttributes = (groupNode, entityTextNode, attributes) => {
       // Calculate the alignment y coordinate for the type/name of the attribute
       const alignY = heightOffset + heightPadding + attributeNode.height / 2;
 
-      // Position the type attribute
-      attributeNode.tn.attr('transform', 'translate(' + widthPadding + ',' + alignY + ')');
+      let nameXOffset = 0;
 
-      // TODO Handle spareWidth in attr('width')
-      // Insert a rectangle for the type
-      const typeRect = groupNode
-        .insert('rect', '#' + attributeNode.tn.node().id)
-        .classed(`er ${attribStyle}`, true)
-        .attr('x', 0)
-        .attr('y', heightOffset)
-        .attr('width', maxTypeWidth + widthPadding * 2 + spareColumnWidth)
-        .attr('height', attributeNode.height + heightPadding * 2);
+      if (hasAttributeType) {
+        // Position the type attribute
+        attributeNode.tn.attr('transform', 'translate(' + widthPadding + ',' + alignY + ')');
 
-      const nameXOffset = parseFloat(typeRect.attr('x')) + parseFloat(typeRect.attr('width'));
+        // TODO Handle spareWidth in attr('width')
+        // Insert a rectangle for the type
+        const typeRect = groupNode
+          .insert('rect', '#' + attributeNode.tn.node().id)
+          .classed(`er ${attribStyle}`, true)
+          .attr('x', 0)
+          .attr('y', heightOffset)
+          .attr('width', maxTypeWidth + widthPadding * 2 + spareColumnWidth)
+          .attr('height', attributeNode.height + heightPadding * 2);
+
+        nameXOffset = parseFloat(typeRect.attr('x')) + parseFloat(typeRect.attr('width'));
+      }
 
       // Position the name attribute
       attributeNode.nn.attr(

--- a/packages/mermaid/src/diagrams/er/parser/erDiagram.jison
+++ b/packages/mermaid/src/diagrams/er/parser/erDiagram.jison
@@ -31,7 +31,7 @@ accDescr\s*"{"\s*                                { this.begin("acc_descr_multili
 ","                             return 'COMMA';
 ":::"                           return 'STYLE_SEPARATOR';
 ":"                             return 'COLON';
-<block>\s+                      /* skip whitespace in block */
+<block>[ \t\r]+                 /* skip whitespace in block */
 <block>\b((?:PK)|(?:FK)|(?:UK))\b      return 'ATTRIBUTE_KEY'
 <block>([^\s]*)[~].*[~]([^\s]*)        return 'ATTRIBUTE_WORD';
 <block>([\*A-Za-z_\u00C0-\uFFFF][A-Za-z0-9\-\_\[\]\(\)\.,\u00C0-\uFFFF\*]*)  return 'ATTRIBUTE_WORD';
@@ -39,7 +39,7 @@ accDescr\s*"{"\s*                                { this.begin("acc_descr_multili
 <block_bq>[^`]+                 return 'ATTRIBUTE_WORD';
 <block_bq>[`]                   { this.popState(); }
 <block>\"[^"]*\"                return 'COMMENT';
-<block>[\n]+                    /* nothing */
+<block>[\n]+                    return 'NEWLINE';
 <block>"}"                      { this.popState(); return 'BLOCK_STOP'; }
 <block>.                        return yytext[0];
 "["                             return 'SQS';
@@ -164,8 +164,6 @@ statement
           yy.setClass([$1], $3);
           $$ = [$1];
       }
-    | entityName BLOCK_START BLOCK_STOP { yy.addEntity($1); $$ = [$1]; }
-    | entityName STYLE_SEPARATOR idList BLOCK_START BLOCK_STOP { yy.addEntity($1); yy.setClass([$1], $3); $$ = [$1]; }
     | entityName { yy.addEntity($1); $$ = [$1]; }
     | entityName STYLE_SEPARATOR idList { yy.addEntity($1); yy.setClass([$1], $3); $$ = [$1]; }
     | entityName SQS entityName SQE BLOCK_START attributes BLOCK_STOP
@@ -181,8 +179,6 @@ statement
           yy.setClass([$1], $6);
           $$ = [$1];
       }
-    | entityName SQS entityName SQE BLOCK_START BLOCK_STOP { yy.addEntity($1, $3); $$ = [$1]; }
-    | entityName SQS entityName SQE STYLE_SEPARATOR idList BLOCK_START BLOCK_STOP { yy.addEntity($1, $3); yy.setClass([$1], $6); $$ = [$1]; }
     | entityName SQS entityName SQE { yy.addEntity($1, $3); }
     | entityName SQS entityName SQE STYLE_SEPARATOR idList { yy.addEntity($1, $3); yy.setClass([$1], $6); }
     | title title_value  { $$=$2.trim();yy.setAccTitle($$); }
@@ -272,25 +268,60 @@ entityName
     ;
 
 attributes
+    : optionalNewLines { $$ = []; }
+    | optionalNewLines attributeRows { $$ = $2; }
+    ;
+
+optionalNewLines
+    : /* empty */ { $$ = []; }
+    | optionalNewLines NEWLINE { $$ = $1; }
+    ;
+
+attributeRows
     : attribute { $$ = [$1]; }
-    | attribute attributes { $2.push($1); $$=$2; }
+    | attributeRows NEWLINE attribute { $1.unshift($3); $$ = $1; }
+    | attributeRows NEWLINE { $$ = $1; }
     ;
 
 attribute
-    : attributeType attributeName { $$ = { type: $1, name: $2 }; }
-    | attributeType attributeName attributeKeyTypeList { $$ = { type: $1, name: $2, keys: $3 }; }
-    | attributeType attributeName attributeComment { $$ = { type: $1, name: $2, comment: $3 }; }
-    | attributeType attributeName attributeKeyTypeList attributeComment { $$ = { type: $1, name: $2, keys: $3, comment: $4 }; }
+    : attributeWordList
+      {
+        var words = $1;
+        $$ = words.length === 1
+          ? { type: '', name: words[0] }
+          : { type: words[0] === '_' ? '' : words.slice(0, -1).join(' '), name: words[words.length - 1] };
+      }
+    | attributeWordList attributeKeyTypeList
+      {
+        var words = $1;
+        $$ = words.length === 1
+          ? { type: '', name: words[0], keys: $2 }
+          : { type: words[0] === '_' ? '' : words.slice(0, -1).join(' '), name: words[words.length - 1], keys: $2 };
+      }
+    | attributeWordList attributeComment
+      {
+        var words = $1;
+        $$ = words.length === 1
+          ? { type: '', name: words[0], comment: $2 }
+          : { type: words[0] === '_' ? '' : words.slice(0, -1).join(' '), name: words[words.length - 1], comment: $2 };
+      }
+    | attributeWordList attributeKeyTypeList attributeComment
+      {
+        var words = $1;
+        $$ = words.length === 1
+          ? { type: '', name: words[0], keys: $2, comment: $3 }
+          : { type: words[0] === '_' ? '' : words.slice(0, -1).join(' '), name: words[words.length - 1], keys: $2, comment: $3 };
+      }
     ;
 
+attributeWordList
+    : attributeWord { $$ = [$1]; }
+    | attributeWordList attributeWord { $1.push($2); $$ = $1; }
+    ;
 
-attributeType
+attributeWord
     : ATTRIBUTE_WORD { $$=$1; }
     | ATTRIBUTE_WORD '?' { $$=$1 + $2; }
-    ;
-
-attributeName
-    : ATTRIBUTE_WORD { $$=$1; }
     ;
 
 attributeKeyTypeList

--- a/packages/mermaid/src/diagrams/er/parser/erDiagram.jison
+++ b/packages/mermaid/src/diagrams/er/parser/erDiagram.jison
@@ -39,7 +39,7 @@ accDescr\s*"{"\s*                                { this.begin("acc_descr_multili
 <block_bq>[^`]+                 return 'ATTRIBUTE_WORD';
 <block_bq>[`]                   { this.popState(); }
 <block>\"[^"]*\"                return 'COMMENT';
-<block>[\n]+                    return 'NEWLINE';
+<block>[\n]+                    /* attribute rows are newline-separated in block mode */ return 'NEWLINE';
 <block>"}"                      { this.popState(); return 'BLOCK_STOP'; }
 <block>.                        return yytext[0];
 "["                             return 'SQS';

--- a/packages/mermaid/src/diagrams/er/parser/erDiagram.spec.js
+++ b/packages/mermaid/src/diagrams/er/parser/erDiagram.spec.js
@@ -305,6 +305,69 @@ describe('when parsing ER diagram it...', function () {
       expect(entities.get(entity).attributes[0].keys).toEqual(['UK']);
       expect(entities.get(entity).attributes[0].comment).toBe('optional display name');
     });
+
+    it('should allow attributes without types', function () {
+      const entity = 'PERSON';
+      const attribute1 = 'firstName';
+      const attribute2 = 'lastName';
+      const attribute3 = 'age';
+
+      erDiagram.parser.parse(
+        `erDiagram\n${entity} {\n${attribute1}\n${attribute2}\n${attribute3}\n}`
+      );
+      const entities = erDb.getEntities();
+
+      expect(entities.size).toBe(1);
+      expect(entities.get(entity).attributes.length).toBe(3);
+      expect(entities.get(entity).attributes[0].type).toBe('');
+      expect(entities.get(entity).attributes[0].name).toBe('firstName');
+      expect(entities.get(entity).attributes[1].type).toBe('');
+      expect(entities.get(entity).attributes[1].name).toBe('lastName');
+      expect(entities.get(entity).attributes[2].type).toBe('');
+      expect(entities.get(entity).attributes[2].name).toBe('age');
+    });
+
+    it('should allow attributes without types to have keys and comments', function () {
+      const entity = 'PERSON';
+      const attribute1 = 'driversLicense PK "The license #"';
+      const attribute2 = 'firstName "Only 99 characters are allowed"';
+      const attribute3 = 'phone UK';
+
+      erDiagram.parser.parse(
+        `erDiagram\n${entity} {\n${attribute1}\n${attribute2}\n${attribute3}\n}`
+      );
+      const entities = erDb.getEntities();
+
+      expect(entities.size).toBe(1);
+      expect(entities.get(entity).attributes.length).toBe(3);
+      expect(entities.get(entity).attributes[0].type).toBe('');
+      expect(entities.get(entity).attributes[0].name).toBe('driversLicense');
+      expect(entities.get(entity).attributes[0].keys).toEqual(['PK']);
+      expect(entities.get(entity).attributes[0].comment).toBe('The license #');
+      expect(entities.get(entity).attributes[1].type).toBe('');
+      expect(entities.get(entity).attributes[1].name).toBe('firstName');
+      expect(entities.get(entity).attributes[1].comment).toBe('Only 99 characters are allowed');
+      expect(entities.get(entity).attributes[2].type).toBe('');
+      expect(entities.get(entity).attributes[2].name).toBe('phone');
+      expect(entities.get(entity).attributes[2].keys).toEqual(['UK']);
+    });
+
+    it('should allow an underscore to explicitly omit an attribute type', function () {
+      const entity = 'CAR';
+      const attribute1 = '_ registrationNumber PK';
+      const attribute2 = '_ make';
+
+      erDiagram.parser.parse(`erDiagram\n${entity} {\n${attribute1}\n${attribute2}\n}`);
+      const entities = erDb.getEntities();
+
+      expect(entities.size).toBe(1);
+      expect(entities.get(entity).attributes.length).toBe(2);
+      expect(entities.get(entity).attributes[0].type).toBe('');
+      expect(entities.get(entity).attributes[0].name).toBe('registrationNumber');
+      expect(entities.get(entity).attributes[0].keys).toEqual(['PK']);
+      expect(entities.get(entity).attributes[1].type).toBe('');
+      expect(entities.get(entity).attributes[1].name).toBe('make');
+    });
   });
 
   it('should allow an entity with a single attribute to be defined', function () {

--- a/packages/mermaid/src/docs/syntax/entityRelationshipDiagram.md
+++ b/packages/mermaid/src/docs/syntax/entityRelationshipDiagram.md
@@ -173,6 +173,26 @@ erDiagram
 
 The `type` values must begin with an alphabetic character and may contain digits, hyphens, underscores, parentheses and square brackets. The `name` values follow a similar format to `type`, but may start with an asterisk as another option to indicate an attribute is a primary key. Other than that, there are no restrictions, and there is no implicit set of valid data types.
 
+#### Omitted attribute types (v<MERMAID_RELEASE_VERSION>+)
+
+Attribute `type` values may be omitted when a diagram only needs logical attribute names without data types. If no attributes on an entity have a type, the type column is not rendered. An underscore (`_`) may also be used as an explicit omitted type marker.
+
+```mermaid-example
+erDiagram
+    CAR {
+        registrationNumber PK
+        make
+        model
+    }
+    PERSON {
+        driversLicense PK "The license #"
+        firstName "Only 99 characters are allowed"
+        lastName
+        phone UK
+        age
+    }
+```
+
 #### Optional attribute types (v<MERMAID_RELEASE_VERSION>+)
 
 Attribute `type` values may end with `?` to indicate an optional or nullable type.

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/erBox.spec.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/erBox.spec.ts
@@ -1,0 +1,23 @@
+import { hasNonEmptyAttributeType } from './erBox.js';
+
+describe('erBox', () => {
+  describe('hasNonEmptyAttributeType', () => {
+    it('returns false when no attribute has a type', () => {
+      expect(
+        hasNonEmptyAttributeType([
+          { type: '', name: 'firstName', keys: [], comment: '' },
+          { type: '', name: 'lastName', keys: [], comment: '' },
+        ])
+      ).toBe(false);
+    });
+
+    it('returns true when any attribute has a type', () => {
+      expect(
+        hasNonEmptyAttributeType([
+          { type: '', name: 'firstName', keys: [], comment: '' },
+          { type: 'string', name: 'lastName', keys: [], comment: '' },
+        ])
+      ).toBe(true);
+    });
+  });
+});

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/erBox.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/erBox.ts
@@ -176,7 +176,9 @@ export async function erBox<T extends SVGGraphicsElement>(parent: D3Selection<T>
   ) {
     const difference =
       nameBBox.width + PADDING * 2 - (maxTypeWidth + maxNameWidth + maxKeysWidth + maxCommentWidth);
-    maxTypeWidth += difference / totalWidthSections;
+    if (typePresent) {
+      maxTypeWidth += difference / totalWidthSections;
+    }
     maxNameWidth += difference / totalWidthSections;
     if (maxKeysWidth > 0) {
       maxKeysWidth += difference / totalWidthSections;

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/erBox.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/erBox.ts
@@ -16,6 +16,10 @@ import type { D3Selection } from '../../../types.js';
 const COLOR_THEMES = new Set(['redux-color', 'redux-dark-color']);
 const REDUX_THEMES = new Set(['redux', 'redux-dark', 'redux-color', 'redux-dark-color']);
 
+export function hasNonEmptyAttributeType(attributes: EntityNode['attributes']) {
+  return attributes.some((attribute) => (attribute.type ?? '').trim().length > 0);
+}
+
 export async function erBox<T extends SVGGraphicsElement>(parent: D3Selection<T>, node: Node) {
   // Treat node as entityNode for certain entityNode checks
   const entityNode = node as unknown as EntityNode;
@@ -104,19 +108,16 @@ export async function erBox<T extends SVGGraphicsElement>(parent: D3Selection<T>
   let maxNameWidth = 0;
   let maxKeysWidth = 0;
   let maxCommentWidth = 0;
+  const typePresent = hasNonEmptyAttributeType(entityNode.attributes);
   let keysPresent = true;
   let commentPresent = true;
   for (const attribute of entityNode.attributes) {
-    const typeBBox = await addText(
-      shapeSvg,
-      attribute.type,
-      config,
-      0,
-      yOffset,
-      ['attribute-type'],
-      labelStyles
-    );
-    maxTypeWidth = Math.max(maxTypeWidth, typeBBox.width + PADDING);
+    const typeBBox = typePresent
+      ? await addText(shapeSvg, attribute.type, config, 0, yOffset, ['attribute-type'], labelStyles)
+      : { width: 0, height: 0 };
+    if (typePresent) {
+      maxTypeWidth = Math.max(maxTypeWidth, typeBBox.width + PADDING);
+    }
     const nameBBox = await addText(
       shapeSvg,
       attribute.name,
@@ -154,7 +155,7 @@ export async function erBox<T extends SVGGraphicsElement>(parent: D3Selection<T>
     rows.push({ yOffset, rowHeight });
     yOffset += rowHeight;
   }
-  let totalWidthSections = 4;
+  let totalWidthSections = typePresent ? 4 : 3;
 
   if (maxKeysWidth <= PADDING) {
     keysPresent = false;
@@ -277,12 +278,20 @@ export async function erBox<T extends SVGGraphicsElement>(parent: D3Selection<T>
   );
   shapeSvg.insert(() => roughLine).attr('class', 'divider');
   // First line
-  points = lineToPolygon(maxTypeWidth + x, nameBBox.height + y, maxTypeWidth + x, h + y, thickness);
-  roughLine = rc.polygon(
-    points.map((p) => [p.x, p.y]),
-    options
-  );
-  shapeSvg.insert(() => roughLine).attr('class', 'divider');
+  if (typePresent) {
+    points = lineToPolygon(
+      maxTypeWidth + x,
+      nameBBox.height + y,
+      maxTypeWidth + x,
+      h + y,
+      thickness
+    );
+    roughLine = rc.polygon(
+      points.map((p) => [p.x, p.y]),
+      options
+    );
+    shapeSvg.insert(() => roughLine).attr('class', 'divider');
+  }
   // Second line
   if (keysPresent) {
     const xCoord = maxTypeWidth + maxNameWidth + x;


### PR DESCRIPTION
## Summary
- Allow ER entity attributes to be written as names without data types, including keys and comments.
- Support `_` as an explicit omitted type marker for attributes.
- Hide the ER attribute type column and divider when an entity has no typed attributes.
- Document the omitted type syntax and add parser/render helper coverage.

Closes mermaid-js/mermaid#5563

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run packages/mermaid/src/diagrams/er packages/mermaid/src/rendering-util/rendering-elements/shapes/erBox.spec.ts`
- `pnpm lint:jison`
- `pnpm exec prettier --check .changeset/er-omitted-attribute-types.md docs/syntax/entityRelationshipDiagram.md packages/mermaid/src/docs/syntax/entityRelationshipDiagram.md packages/mermaid/src/diagrams/er/erDb.ts packages/mermaid/src/diagrams/er/erRenderer.js packages/mermaid/src/diagrams/er/parser/erDiagram.spec.js packages/mermaid/src/rendering-util/rendering-elements/shapes/erBox.ts packages/mermaid/src/rendering-util/rendering-elements/shapes/erBox.spec.ts`
- `pnpm exec eslint packages/mermaid/src/diagrams/er/erDb.ts packages/mermaid/src/diagrams/er/erRenderer.js packages/mermaid/src/diagrams/er/parser/erDiagram.spec.js packages/mermaid/src/rendering-util/rendering-elements/shapes/erBox.ts packages/mermaid/src/rendering-util/rendering-elements/shapes/erBox.spec.ts`
- `pnpm exec tsc -p packages/mermaid/tsconfig.json --noEmit`