### PR TITLE
feat(e2e): batch Argos screenshots into folder-wise composite sheets

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,16 @@ on:
       - release/**
   pull_request:
   merge_group:
+  workflow_dispatch:
+    inputs:
+      group_argos_images:
+        description: Composite screenshots into batched sheets before Argos upload
+        type: boolean
+        default: true
+      spec_pattern:
+        description: Cypress spec glob (empty = full suite)
+        type: string
+        default: ''
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -18,6 +28,7 @@ env:
   # For PRs and MergeQueues, the target commit is used, and for push events to non-develop branches, github.event.previous is used if available. Otherwise, 'develop' is used.
   targetHash: >-
     ${{
+      github.event_name == 'workflow_dispatch' && 'develop' ||
       github.event.pull_request.base.sha ||
       github.event.merge_group.base_sha ||
       (
@@ -29,7 +40,18 @@ env:
       github.event.before
     }}
   RUN_VISUAL_TEST: >-
-    ${{ github.repository == 'mermaid-js/mermaid' && (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'renovate/')) }}
+    ${{
+      github.repository == 'mermaid-js/mermaid' && (
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'renovate/'))
+      )
+    }}
+  # Automatic runs always batch; manual runs can upload per-screenshot instead.
+  GROUP_ARGOS_IMAGES: >-
+    ${{
+      github.event_name != 'workflow_dispatch' && 'true' ||
+      (inputs.group_argos_images && 'true' || 'false')
+    }}
 jobs:
   cache:
     runs-on: ubuntu-latest
@@ -92,6 +114,20 @@ jobs:
       - name: Detect e2e scope
         id: scope
         run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            SPEC="${{ github.event.inputs.spec_pattern }}"
+            if [ -n "$SPEC" ]; then
+              echo "spec_pattern=${SPEC}" >> "$GITHUB_OUTPUT"
+              echo "matrix=[1]" >> "$GITHUB_OUTPUT"
+              echo "[detect-scope] Manual run — scoped to: ${SPEC}"
+            else
+              echo "spec_pattern=" >> "$GITHUB_OUTPUT"
+              echo "matrix=[1,2,3,4,5]" >> "$GITHUB_OUTPUT"
+              echo "[detect-scope] Manual run — full suite."
+            fi
+            exit 0
+          fi
+
           # Kill-switch: set the repo variable E2E_SCOPE_BY_DIAGRAM to 'false'
           # to disable scoping.  Scoping is ON by default so that fork PRs
           # (where repository variables are unavailable) still benefit from it.
@@ -248,7 +284,8 @@ jobs:
     if: >-
       ${{
         github.repository == 'mermaid-js/mermaid' &&
-        (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'renovate/')) &&
+        (github.event_name == 'workflow_dispatch' ||
+          (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'renovate/'))) &&
         needs.detect-scope.outputs.spec_pattern != 'SKIP' &&
         !cancelled()
       }}
@@ -276,16 +313,24 @@ jobs:
           path: cypress/screenshots
 
       - name: Build composite sheets
+        if: env.GROUP_ARGOS_IMAGES == 'true'
         run: pnpm run argos:batch
 
-      - name: Upload sheets to Argos
+      - name: Upload grouped sheets to Argos
+        if: env.GROUP_ARGOS_IMAGES == 'true'
         env:
-          ARGOS_TOKEN: ${{ secrets.ARGOS_MERMAID_BATCHED_TOKEN || secrets.ARGOS_TOKEN }}
           GITHUB_TOKEN: ${{ github.token }}
           # Scoped runs captured only some folders; tell Argos this build is a
           # partial set so absent sheets are not treated as deletions.
           ARGOS_SUBSET: ${{ needs.detect-scope.outputs.spec_pattern != '' }}
-        run: npx argos upload cypress/argos-sheets
+        run: npx argos upload cypress/argos-sheets --token "${{ secrets.ARGOS_BATCHED_TOKEN }}"
+
+      - name: Upload individual screenshots to Argos
+        if: env.GROUP_ARGOS_IMAGES != 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          ARGOS_SUBSET: ${{ needs.detect-scope.outputs.spec_pattern != '' }}
+        run: npx argos upload cypress/screenshots --token "${{ secrets.ARGOS_TOKEN }}"
 
   e2e-required:
     if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -254,11 +254,6 @@ jobs:
       }}
     needs: [detect-scope, e2e]
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      # Argos CLI authenticates via GitHub OIDC (or tokenless on fork PRs).
-      id-token: write
-      pull-requests: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -285,7 +280,7 @@ jobs:
 
       - name: Upload sheets to Argos
         env:
-          # PR metadata for Argos checks/comments (OIDC handles auth — no ARGOS_TOKEN).
+          ARGOS_TOKEN: ${{ secrets.ARGOS_MERMAID_BATCHED_TOKEN || secrets.ARGOS_TOKEN }}
           GITHUB_TOKEN: ${{ github.token }}
           # Scoped runs captured only some folders; tell Argos this build is a
           # partial set so absent sheets are not treated as deletions.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -319,18 +319,14 @@ jobs:
       - name: Upload grouped sheets to Argos
         if: env.GROUP_ARGOS_IMAGES == 'true'
         env:
-          GITHUB_TOKEN: ${{ github.token }}
-          # Scoped runs captured only some folders; tell Argos this build is a
-          # partial set so absent sheets are not treated as deletions.
-          ARGOS_SUBSET: ${{ needs.detect-scope.outputs.spec_pattern != '' }}
-        run: npx argos upload cypress/argos-sheets --token "${{ secrets.ARGOS_BATCHED_TOKEN }}"
+          ARGOS_SUBSET: true
+        run: npx argos upload cypress/argos-sheets
 
       - name: Upload individual screenshots to Argos
         if: env.GROUP_ARGOS_IMAGES != 'true'
         env:
-          GITHUB_TOKEN: ${{ github.token }}
-          ARGOS_SUBSET: ${{ needs.detect-scope.outputs.spec_pattern != '' }}
-        run: npx argos upload cypress/screenshots --token "${{ secrets.ARGOS_TOKEN }}"
+          ARGOS_SUBSET: true
+        run: npx argos upload cypress/screenshots
 
   e2e-required:
     if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -214,9 +214,6 @@ jobs:
           # e.g. if this action was run from a fork
           record: ${{ env.RUN_VISUAL_TEST == 'true' && secrets.CYPRESS_RECORD_KEY != '' }}
         env:
-          # For scoped runs (only a subset of specs executed), mark the Argos
-          # build as a "subset build".
-          ARGOS_SUBSET: "${{ needs.detect-scope.outputs.spec_pattern != '' }}"
           CYPRESS_COMMIT: ${{ github.sha }}
           CYPRESS_RECORD_KEY: ${{ env.RUN_VISUAL_TEST == 'true' && secrets.CYPRESS_RECORD_KEY || ''}}
           SPLIT: ${{ strategy.job-total }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -280,7 +280,8 @@ jobs:
 
       - name: Upload sheets to Argos
         env:
-          ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
+          # Token for the Argos "mermaid-batched" project (composite sheets only).
+          ARGOS_TOKEN: ${{ secrets.ARGOS_MERMAID_BATCHED_TOKEN }}
           # Scoped runs captured only some folders; tell Argos this build is a
           # partial set so absent sheets are not treated as deletions.
           ARGOS_SUBSET: ${{ needs.detect-scope.outputs.spec_pattern != '' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -248,7 +248,13 @@ jobs:
   # Batch all per-container screenshots into folder-wise composite sheets and
   # upload them to Argos in a single build. Replaces per-test Argos uploads.
   argos-batch:
-    if: ${{ env.RUN_VISUAL_TEST == 'true' && needs.detect-scope.outputs.spec_pattern != 'SKIP' && !cancelled() }}
+    if: >-
+      ${{
+        github.repository == 'mermaid-js/mermaid' &&
+        (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'renovate/')) &&
+        needs.detect-scope.outputs.spec_pattern != 'SKIP' &&
+        !cancelled()
+      }}
     needs: [detect-scope, e2e]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -254,6 +254,11 @@ jobs:
       }}
     needs: [detect-scope, e2e]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Argos CLI authenticates via GitHub OIDC (or tokenless on fork PRs).
+      id-token: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -280,8 +285,8 @@ jobs:
 
       - name: Upload sheets to Argos
         env:
-          # Token for the Argos "mermaid-batched" project (composite sheets only).
-          ARGOS_TOKEN: ${{ secrets.ARGOS_MERMAID_BATCHED_TOKEN }}
+          # PR metadata for Argos checks/comments (OIDC handles auth — no ARGOS_TOKEN).
+          GITHUB_TOKEN: ${{ github.token }}
           # Scoped runs captured only some folders; tell Argos this build is a
           # partial set so absent sheets are not treated as deletions.
           ARGOS_SUBSET: ${{ needs.detect-scope.outputs.spec_pattern != '' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -217,9 +217,6 @@ jobs:
           # For scoped runs (only a subset of specs executed), mark the Argos
           # build as a "subset build".
           ARGOS_SUBSET: "${{ needs.detect-scope.outputs.spec_pattern != '' }}"
-          ARGOS_PARALLEL: ${{ env.RUN_VISUAL_TEST == 'true' }}
-          ARGOS_PARALLEL_TOTAL: ${{ env.RUN_VISUAL_TEST == 'true' && strategy.job-total || 1 }}
-          ARGOS_PARALLEL_INDEX: ${{ env.RUN_VISUAL_TEST == 'true' && matrix.containers || 1 }}
           CYPRESS_COMMIT: ${{ github.sha }}
           CYPRESS_RECORD_KEY: ${{ env.RUN_VISUAL_TEST == 'true' && secrets.CYPRESS_RECORD_KEY || ''}}
           SPLIT: ${{ strategy.job-total }}
@@ -238,6 +235,53 @@ jobs:
           fail_ci_if_error: false
           verbose: true
           token: 6845cc80-77ee-4e17-85a1-026cd95e0766
+
+      - name: Upload raw screenshots for Argos batching
+        if: ${{ env.RUN_VISUAL_TEST == 'true' && !cancelled() }}
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: argos-screenshots-${{ matrix.containers }}
+          path: cypress/screenshots
+          if-no-files-found: ignore
+          retention-days: 1
+
+  # Batch all per-container screenshots into folder-wise composite sheets and
+  # upload them to Argos in a single build. Replaces per-test Argos uploads.
+  argos-batch:
+    if: ${{ env.RUN_VISUAL_TEST == 'true' && needs.detect-scope.outputs.spec_pattern != 'SKIP' && !cancelled() }}
+    needs: [detect-scope, e2e]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with:
+          node-version-file: '.node-version'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download screenshot artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          pattern: argos-screenshots-*
+          merge-multiple: true
+          path: cypress/screenshots
+
+      - name: Build composite sheets
+        run: pnpm run argos:batch
+
+      - name: Upload sheets to Argos
+        env:
+          ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
+          # Scoped runs captured only some folders; tell Argos this build is a
+          # partial set so absent sheets are not treated as deletions.
+          ARGOS_SUBSET: ${{ needs.detect-scope.outputs.spec_pattern != '' }}
+        run: npx argos upload cypress/argos-sheets
 
   e2e-required:
     if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ Gemfile.lock
 /.vs
 
 cypress/screenshots/
+cypress/argos-sheets/
 cypress/snapshots/
 
 # eslint --cache file

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -30,14 +30,11 @@ export default eyesPlugin(
         config.env.useArgos = process.env.RUN_VISUAL_TEST === 'true';
 
         if (config.env.useArgos) {
+          // Capture only. Screenshots are written to cypress/screenshots and
+          // uploaded later by the `argos-batch` CI job, which composites them
+          // into folder-wise sheets. Subset handling moves to `argos upload`.
           registerArgosTask(on, config, {
-            // Enable upload to Argos only when it runs on CI.
-            uploadToArgos: !!process.env.CI,
-            // Mark as a subset build when only a scoped set of specs ran.
-            // This tells Argos to ignore missing screenshots (they were not
-            // run, not deleted) and prevents the baseline from being replaced
-            // by a partial run. Mirrors the ARGOS_SUBSET env var set in e2e.yml.
-            subset: process.env.ARGOS_SUBSET === 'true',
+            uploadToArgos: false,
           });
         } else {
           addMatchImageSnapshotPlugin(on, config);

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,5 +1,4 @@
 import eyesPlugin from '@applitools/eyes-cypress';
-import { registerArgosTask } from '@argos-ci/cypress/task';
 import coverage from '@cypress/code-coverage/task.js';
 import { defineConfig } from 'cypress';
 import { addMatchImageSnapshotPlugin } from 'cypress-image-snapshot/plugin.js';
@@ -29,14 +28,10 @@ export default eyesPlugin(
         config.env.useAppli = process.env.USE_APPLI ? true : false;
         config.env.useArgos = process.env.RUN_VISUAL_TEST === 'true';
 
-        if (config.env.useArgos) {
-          // Capture only. Screenshots are written to cypress/screenshots and
-          // uploaded later by the `argos-batch` CI job, which composites them
-          // into folder-wise sheets. Subset handling moves to `argos upload`.
-          registerArgosTask(on, config, {
-            uploadToArgos: false,
-          });
-        } else {
+        // Argos capture uses cy.argosScreenshot from @argos-ci/cypress/support (e2e.js).
+        // Do not register registerArgosTask — its after:run hook uploads to Argos.
+        // Raw PNGs batch-upload in the argos-batch CI job instead.
+        if (!config.env.useArgos) {
           addMatchImageSnapshotPlugin(on, config);
         }
         on('task', {

--- a/cypress/ARGOS.md
+++ b/cypress/ARGOS.md
@@ -6,7 +6,18 @@ Per-test screenshots are captured during Cypress runs but **not** uploaded in-ru
 
 1. **Capture** — `cy.argosScreenshot` writes PNGs to `cypress/screenshots/.../argos/` (local only; no `registerArgosTask` / no in-run upload).
 2. **Batch** — `pnpm run argos:batch` groups screenshots by diagram folder, stable-sorts, chunks into fixed-tile sheets, and writes composites + JSON manifests to `cypress/argos-sheets/`.
-3. **Upload** — the `argos-batch` CI job runs `argos upload cypress/argos-sheets` to the **mermaid-batched** Argos project via `ARGOS_MERMAID_BATCHED_TOKEN` (falls back to `ARGOS_TOKEN`). Set `ARGOS_SUBSET=true` for scoped runs.
+3. **Upload** — the `argos-batch` CI job uploads either composite sheets (`group_argos_images: true`, **mermaid-batched** project) or individual screenshots (`group_argos_images: false`, standard **mermaid** project). Automatic runs always batch; manual workflow dispatches can choose.
+
+## Manual CI run
+
+In GitHub Actions → **E2E** → **Run workflow**:
+
+| Input                | Default   | Description                                  |
+| -------------------- | --------- | -------------------------------------------- |
+| `group_argos_images` | `true`    | Batch into composite sheets before upload    |
+| `spec_pattern`       | _(empty)_ | Cypress spec glob; empty runs the full suite |
+
+When `group_argos_images` is `false`, screenshots upload individually via `ARGOS_TOKEN` (`mermaid` project). Batched sheets use `ARGOS_BATCHED_TOKEN` (`mermaid-batched` project).
 
 ## Local workflow
 
@@ -29,6 +40,11 @@ pnpm run argos:batch
 | `ARGOS_SHEET_COLS`      | `3`                    | Grid columns per sheet        |
 | `ARGOS_SHEET_SCALE`     | `2`                    | Output scale (2 = 2× pixels)  |
 
-CI upload targets the **mermaid-batched** Argos project (`ARGOS_MERMAID_BATCHED_TOKEN` GitHub secret, or `ARGOS_TOKEN`).
+CI upload tokens:
+
+| Upload mode    | GitHub secret         | Argos project     |
+| -------------- | --------------------- | ----------------- |
+| Batched sheets | `ARGOS_BATCHED_TOKEN` | `mermaid-batched` |
+| Per-screenshot | `ARGOS_TOKEN`         | `mermaid`         |
 
 Sheets are grouped by diagram folder (the path prefix before the `*.spec.*` directory segment Cypress inserts). Each sheet has a sibling `.json` manifest listing tile names, positions, and source paths for traceability.

--- a/cypress/ARGOS.md
+++ b/cypress/ARGOS.md
@@ -6,9 +6,7 @@ Per-test screenshots are captured during Cypress runs but **not** uploaded in-ru
 
 1. **Capture** — `cy.argosScreenshot` writes PNGs to `cypress/screenshots/.../argos/` (local only; no `registerArgosTask` / no in-run upload).
 2. **Batch** — `pnpm run argos:batch` groups screenshots by diagram folder, stable-sorts, chunks into fixed-tile sheets, and writes composites + JSON manifests to `cypress/argos-sheets/`.
-3. **Upload** — the `argos-batch` CI job runs `argos upload cypress/argos-sheets` to the **mermaid-batched** Argos project. Auth is automatic via GitHub OIDC (`id-token: write`; tokenless fallback on fork PRs). No `ARGOS_TOKEN` secret. Set `ARGOS_SUBSET=true` for scoped runs.
-
-**Argos setup:** enable GitHub OIDC on the mermaid-batched project (Project Settings → Authentication). Do not expose `ARGOS_TOKEN` to this job — it would bypass OIDC.
+3. **Upload** — the `argos-batch` CI job runs `argos upload cypress/argos-sheets` to the **mermaid-batched** Argos project via `ARGOS_MERMAID_BATCHED_TOKEN` (falls back to `ARGOS_TOKEN`). Set `ARGOS_SUBSET=true` for scoped runs.
 
 ## Local workflow
 
@@ -30,6 +28,6 @@ pnpm run argos:batch
 | `ARGOS_TILES_PER_SHEET` | `12`                   | Max tiles per composite sheet |
 | `ARGOS_SHEET_COLS`      | `3`                    | Grid columns per sheet        |
 
-CI upload targets the **mermaid-batched** Argos project with GitHub OIDC/tokenless auth (no repo secret).
+CI upload targets the **mermaid-batched** Argos project (`ARGOS_MERMAID_BATCHED_TOKEN` GitHub secret, or `ARGOS_TOKEN`).
 
 Sheets are grouped by diagram folder (the path prefix before the `*.spec.*` directory segment Cypress inserts). Each sheet has a sibling `.json` manifest listing tile names, positions, and source paths for traceability.

--- a/cypress/ARGOS.md
+++ b/cypress/ARGOS.md
@@ -38,7 +38,7 @@ pnpm run argos:batch
 | `ARGOS_SHEETS_DIR`        | `cypress/argos-sheets` | Output directory                    |
 | `ARGOS_TILES_PER_SHEET`   | `12`                   | Max tiles per composite sheet       |
 | `ARGOS_SHEET_COLS`        | `3`                    | Grid columns per sheet              |
-| `ARGOS_SHEET_SCALE`       | `2`                    | Output scale (2 = 2× pixels)        |
+| `ARGOS_SHEET_SCALE`       | `1`                    | Output scale (1 = native, 2 = 2× pixels) |
 | `ARGOS_TILE_WIDTH`        | `1440`                 | Fixed cell width (Cypress viewport) |
 | `ARGOS_TILE_IMAGE_HEIGHT` | `1024`                 | Fixed image slot height             |
 

--- a/cypress/ARGOS.md
+++ b/cypress/ARGOS.md
@@ -32,13 +32,15 @@ pnpm run argos:batch
 
 ## Configuration
 
-| Env var                 | Default                | Description                   |
-| ----------------------- | ---------------------- | ----------------------------- |
-| `ARGOS_SCREENSHOT_DIR`  | `cypress/screenshots`  | Input directory               |
-| `ARGOS_SHEETS_DIR`      | `cypress/argos-sheets` | Output directory              |
-| `ARGOS_TILES_PER_SHEET` | `12`                   | Max tiles per composite sheet |
-| `ARGOS_SHEET_COLS`      | `3`                    | Grid columns per sheet        |
-| `ARGOS_SHEET_SCALE`     | `2`                    | Output scale (2 = 2× pixels)  |
+| Env var                   | Default                | Description                         |
+| ------------------------- | ---------------------- | ----------------------------------- |
+| `ARGOS_SCREENSHOT_DIR`    | `cypress/screenshots`  | Input directory                     |
+| `ARGOS_SHEETS_DIR`        | `cypress/argos-sheets` | Output directory                    |
+| `ARGOS_TILES_PER_SHEET`   | `12`                   | Max tiles per composite sheet       |
+| `ARGOS_SHEET_COLS`        | `3`                    | Grid columns per sheet              |
+| `ARGOS_SHEET_SCALE`       | `2`                    | Output scale (2 = 2× pixels)        |
+| `ARGOS_TILE_WIDTH`        | `1440`                 | Fixed cell width (Cypress viewport) |
+| `ARGOS_TILE_IMAGE_HEIGHT` | `1024`                 | Fixed image slot height             |
 
 CI upload tokens:
 
@@ -47,4 +49,4 @@ CI upload tokens:
 | Batched sheets | `ARGOS_BATCHED_TOKEN` | `mermaid-batched` |
 | Per-screenshot | `ARGOS_TOKEN`         | `mermaid`         |
 
-Sheets are grouped by diagram folder (the path prefix before the `*.spec.*` directory segment Cypress inserts). Each sheet has a sibling `.json` manifest listing tile names, positions, and source paths for traceability.
+Sheets are grouped by diagram folder (the path prefix before the `*.spec.*` directory segment Cypress inserts). Each cell uses a fixed 1440×1024 image slot (matching the Cypress viewport) so one diagram changing size does not alter grid layout or sibling tiles. Each sheet has a sibling `.json` manifest listing tile names, positions, and source paths for traceability.

--- a/cypress/ARGOS.md
+++ b/cypress/ARGOS.md
@@ -6,7 +6,7 @@ Per-test screenshots are captured during Cypress runs but **not** uploaded in-ru
 
 1. **Capture** — `cy.argosScreenshot` writes PNGs to `cypress/screenshots/.../argos/` (local only; no `registerArgosTask` / no in-run upload).
 2. **Batch** — `pnpm run argos:batch` groups screenshots by diagram folder, stable-sorts, chunks into fixed-tile sheets, and writes composites + JSON manifests to `cypress/argos-sheets/`.
-3. **Upload** — the `argos-batch` CI job runs `argos upload cypress/argos-sheets` (`ARGOS_SUBSET=true` for scoped runs).
+3. **Upload** — the `argos-batch` CI job runs `argos upload cypress/argos-sheets` against the **mermaid-batched** Argos project (`ARGOS_MERMAID_BATCHED_TOKEN`, `ARGOS_SUBSET=true` for scoped runs).
 
 ## Local workflow
 
@@ -27,5 +27,7 @@ pnpm run argos:batch
 | `ARGOS_SHEETS_DIR`      | `cypress/argos-sheets` | Output directory              |
 | `ARGOS_TILES_PER_SHEET` | `12`                   | Max tiles per composite sheet |
 | `ARGOS_SHEET_COLS`      | `3`                    | Grid columns per sheet        |
+
+CI upload uses the **mermaid-batched** Argos project token (`ARGOS_MERMAID_BATCHED_TOKEN` GitHub secret), separate from the per-test `mermaid` project.
 
 Sheets are grouped by diagram folder (the path prefix before the `*.spec.*` directory segment Cypress inserts). Each sheet has a sibling `.json` manifest listing tile names, positions, and source paths for traceability.

--- a/cypress/ARGOS.md
+++ b/cypress/ARGOS.md
@@ -1,0 +1,31 @@
+# Argos visual regression
+
+Per-test screenshots are captured during Cypress runs but **not** uploaded in-run. A dedicated CI job composites them into folder-wise sheets and uploads once to Argos.
+
+## Pipeline
+
+1. **Capture** — `cy.argosScreenshot` writes PNGs to `cypress/screenshots/` with `uploadToArgos: false` (see `cypress.config.ts`).
+2. **Batch** — `pnpm run argos:batch` groups screenshots by diagram folder, stable-sorts, chunks into fixed-tile sheets, and writes composites + JSON manifests to `cypress/argos-sheets/`.
+3. **Upload** — the `argos-batch` CI job runs `argos upload cypress/argos-sheets` (`ARGOS_SUBSET=true` for scoped runs).
+
+## Local workflow
+
+```bash
+# Capture (requires dev server on :9000)
+RUN_VISUAL_TEST=true CYPRESS_useArgos=true \
+  pnpm exec cypress run --spec 'cypress/integration/rendering/treemap/**'
+
+# Composite sheets
+pnpm run argos:batch
+```
+
+## Configuration
+
+| Env var                 | Default                | Description                   |
+| ----------------------- | ---------------------- | ----------------------------- |
+| `ARGOS_SCREENSHOT_DIR`  | `cypress/screenshots`  | Input directory               |
+| `ARGOS_SHEETS_DIR`      | `cypress/argos-sheets` | Output directory              |
+| `ARGOS_TILES_PER_SHEET` | `12`                   | Max tiles per composite sheet |
+| `ARGOS_SHEET_COLS`      | `3`                    | Grid columns per sheet        |
+
+Sheets are grouped by diagram folder (the path prefix before the `*.spec.*` directory segment Cypress inserts). Each sheet has a sibling `.json` manifest listing tile names, positions, and source paths for traceability.

--- a/cypress/ARGOS.md
+++ b/cypress/ARGOS.md
@@ -4,7 +4,7 @@ Per-test screenshots are captured during Cypress runs but **not** uploaded in-ru
 
 ## Pipeline
 
-1. **Capture** — `cy.argosScreenshot` writes PNGs to `cypress/screenshots/` with `uploadToArgos: false` (see `cypress.config.ts`).
+1. **Capture** — `cy.argosScreenshot` writes PNGs to `cypress/screenshots/.../argos/` (local only; no `registerArgosTask` / no in-run upload).
 2. **Batch** — `pnpm run argos:batch` groups screenshots by diagram folder, stable-sorts, chunks into fixed-tile sheets, and writes composites + JSON manifests to `cypress/argos-sheets/`.
 3. **Upload** — the `argos-batch` CI job runs `argos upload cypress/argos-sheets` (`ARGOS_SUBSET=true` for scoped runs).
 

--- a/cypress/ARGOS.md
+++ b/cypress/ARGOS.md
@@ -6,7 +6,9 @@ Per-test screenshots are captured during Cypress runs but **not** uploaded in-ru
 
 1. **Capture** — `cy.argosScreenshot` writes PNGs to `cypress/screenshots/.../argos/` (local only; no `registerArgosTask` / no in-run upload).
 2. **Batch** — `pnpm run argos:batch` groups screenshots by diagram folder, stable-sorts, chunks into fixed-tile sheets, and writes composites + JSON manifests to `cypress/argos-sheets/`.
-3. **Upload** — the `argos-batch` CI job runs `argos upload cypress/argos-sheets` against the **mermaid-batched** Argos project (`ARGOS_MERMAID_BATCHED_TOKEN`, `ARGOS_SUBSET=true` for scoped runs).
+3. **Upload** — the `argos-batch` CI job runs `argos upload cypress/argos-sheets` to the **mermaid-batched** Argos project. Auth is automatic via GitHub OIDC (`id-token: write`; tokenless fallback on fork PRs). No `ARGOS_TOKEN` secret. Set `ARGOS_SUBSET=true` for scoped runs.
+
+**Argos setup:** enable GitHub OIDC on the mermaid-batched project (Project Settings → Authentication). Do not expose `ARGOS_TOKEN` to this job — it would bypass OIDC.
 
 ## Local workflow
 
@@ -28,6 +30,6 @@ pnpm run argos:batch
 | `ARGOS_TILES_PER_SHEET` | `12`                   | Max tiles per composite sheet |
 | `ARGOS_SHEET_COLS`      | `3`                    | Grid columns per sheet        |
 
-CI upload uses the **mermaid-batched** Argos project token (`ARGOS_MERMAID_BATCHED_TOKEN` GitHub secret), separate from the per-test `mermaid` project.
+CI upload targets the **mermaid-batched** Argos project with GitHub OIDC/tokenless auth (no repo secret).
 
 Sheets are grouped by diagram folder (the path prefix before the `*.spec.*` directory segment Cypress inserts). Each sheet has a sibling `.json` manifest listing tile names, positions, and source paths for traceability.

--- a/cypress/ARGOS.md
+++ b/cypress/ARGOS.md
@@ -6,7 +6,7 @@ Per-test screenshots are captured during Cypress runs but **not** uploaded in-ru
 
 1. **Capture** — `cy.argosScreenshot` writes PNGs to `cypress/screenshots/.../argos/` (local only; no `registerArgosTask` / no in-run upload).
 2. **Batch** — `pnpm run argos:batch` groups screenshots by diagram folder, stable-sorts, chunks into fixed-tile sheets, and writes composites + JSON manifests to `cypress/argos-sheets/`.
-3. **Upload** — the `argos-batch` CI job uploads either composite sheets (`group_argos_images: true`, **mermaid-batched** project) or individual screenshots (`group_argos_images: false`, standard **mermaid** project). Automatic runs always batch; manual workflow dispatches can choose.
+3. **Upload** — the `argos-batch` CI job runs `argos upload` with the same GitHub Actions auth as develop (no `ARGOS_TOKEN`; OIDC or tokenless via `@argos-ci/core`). `ARGOS_SUBSET=true` on every upload.
 
 ## Manual CI run
 
@@ -17,7 +17,7 @@ In GitHub Actions → **E2E** → **Run workflow**:
 | `group_argos_images` | `true`    | Batch into composite sheets before upload    |
 | `spec_pattern`       | _(empty)_ | Cypress spec glob; empty runs the full suite |
 
-When `group_argos_images` is `false`, screenshots upload individually via `ARGOS_TOKEN` (`mermaid` project). Batched sheets use `ARGOS_BATCHED_TOKEN` (`mermaid-batched` project).
+When `group_argos_images` is `false`, screenshots upload individually instead of as composite sheets. Both modes use the same Argos project and auth as develop.
 
 ## Local workflow
 
@@ -42,11 +42,6 @@ pnpm run argos:batch
 | `ARGOS_TILE_WIDTH`        | `1440`                 | Fixed cell width (Cypress viewport) |
 | `ARGOS_TILE_IMAGE_HEIGHT` | `1024`                 | Fixed image slot height             |
 
-CI upload tokens:
-
-| Upload mode    | GitHub secret         | Argos project     |
-| -------------- | --------------------- | ----------------- |
-| Batched sheets | `ARGOS_BATCHED_TOKEN` | `mermaid-batched` |
-| Per-screenshot | `ARGOS_TOKEN`         | `mermaid`         |
+CI upload uses GitHub Actions authentication (same as develop’s `registerArgosTask` path — no repo secret required). Every upload sets `ARGOS_SUBSET=true`.
 
 Sheets are grouped by diagram folder (the path prefix before the `*.spec.*` directory segment Cypress inserts). Each cell uses a fixed 1440×1024 image slot (matching the Cypress viewport) so one diagram changing size does not alter grid layout or sibling tiles. Each sheet has a sibling `.json` manifest listing tile names, positions, and source paths for traceability.

--- a/cypress/ARGOS.md
+++ b/cypress/ARGOS.md
@@ -27,6 +27,7 @@ pnpm run argos:batch
 | `ARGOS_SHEETS_DIR`      | `cypress/argos-sheets` | Output directory              |
 | `ARGOS_TILES_PER_SHEET` | `12`                   | Max tiles per composite sheet |
 | `ARGOS_SHEET_COLS`      | `3`                    | Grid columns per sheet        |
+| `ARGOS_SHEET_SCALE`     | `2`                    | Output scale (2 = 2× pixels)  |
 
 CI upload targets the **mermaid-batched** Argos project (`ARGOS_MERMAID_BATCHED_TOKEN` GitHub secret, or `ARGOS_TOKEN`).
 

--- a/cypress/ARGOS.md
+++ b/cypress/ARGOS.md
@@ -32,15 +32,15 @@ pnpm run argos:batch
 
 ## Configuration
 
-| Env var                   | Default                | Description                         |
-| ------------------------- | ---------------------- | ----------------------------------- |
-| `ARGOS_SCREENSHOT_DIR`    | `cypress/screenshots`  | Input directory                     |
-| `ARGOS_SHEETS_DIR`        | `cypress/argos-sheets` | Output directory                    |
-| `ARGOS_TILES_PER_SHEET`   | `12`                   | Max tiles per composite sheet       |
-| `ARGOS_SHEET_COLS`        | `3`                    | Grid columns per sheet              |
+| Env var                   | Default                | Description                              |
+| ------------------------- | ---------------------- | ---------------------------------------- |
+| `ARGOS_SCREENSHOT_DIR`    | `cypress/screenshots`  | Input directory                          |
+| `ARGOS_SHEETS_DIR`        | `cypress/argos-sheets` | Output directory                         |
+| `ARGOS_TILES_PER_SHEET`   | `12`                   | Max tiles per composite sheet            |
+| `ARGOS_SHEET_COLS`        | `3`                    | Grid columns per sheet                   |
 | `ARGOS_SHEET_SCALE`       | `1`                    | Output scale (1 = native, 2 = 2× pixels) |
-| `ARGOS_TILE_WIDTH`        | `1440`                 | Fixed cell width (Cypress viewport) |
-| `ARGOS_TILE_IMAGE_HEIGHT` | `1024`                 | Fixed image slot height             |
+| `ARGOS_TILE_WIDTH`        | `1440`                 | Fixed cell width (Cypress viewport)      |
+| `ARGOS_TILE_IMAGE_HEIGHT` | `1024`                 | Fixed image slot height                  |
 
 CI upload uses GitHub Actions authentication (same as develop’s `registerArgosTask` path — no repo secret required). Every upload sets `ARGOS_SUBSET=true`.
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "e2e:scope:harness": "start-server-and-test dev http://localhost:${MERMAID_PORT}/ e2e:scope:run",
     "e2e:scope:run": "tsx scripts/run-e2e-scoped.ts",
     "e2e:scope:detect": "git diff --name-only ${E2E_BASE_REF:-develop} HEAD | node scripts/e2e-diagram-scope.mjs",
+    "argos:batch": "tsx scripts/argos-batch-sheets.ts",
     "load:env": "dotenv -e .env",
     "test": "pnpm lint && vitest run",
     "test:watch": "vitest --watch",
@@ -82,6 +83,7 @@
   },
   "devDependencies": {
     "@applitools/eyes-cypress": "^3.60.3",
+    "@argos-ci/cli": "^2.5.0",
     "@argos-ci/cypress": "^6.2.12",
     "@changesets/changelog-github": "^0.5.2",
     "@changesets/cli": "^2.29.8",
@@ -151,6 +153,7 @@
     "prettier-plugin-jsdoc": "^1.3.3",
     "rimraf": "^6.0.1",
     "rollup-plugin-visualizer": "^6.0.11",
+    "sharp": "^0.34.4",
     "sirv-cli": "^3.0.1",
     "start-server-and-test": "^2.1.5",
     "tslib": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "devDependencies": {
     "@applitools/eyes-cypress": "^3.60.3",
-    "@argos-ci/cli": "^2.5.0",
+    "@argos-ci/cli": "^5.0.5",
     "@argos-ci/cypress": "^6.2.12",
     "@changesets/changelog-github": "^0.5.2",
     "@changesets/cli": "^2.29.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^3.60.3
         version: 3.60.3(encoding@0.1.13)(typescript@5.8.3)(webdriver@7.31.1(typescript@5.8.3))
       '@argos-ci/cli':
-        specifier: ^2.5.0
-        version: 2.5.10
+        specifier: ^5.0.5
+        version: 5.0.5
       '@argos-ci/cypress':
         specifier: ^6.2.12
         version: 6.2.12(cypress@14.5.4)
@@ -853,26 +853,26 @@ packages:
     resolution: {integrity: sha512-BG6g+AZABKN8W2syzfPWKhPxxrAB9Wjp2iNS11R4IskHDV6T41+qeQDpT88GOq6eUZ64Sjzoh/nXG+9EpNxtfw==}
     engines: {node: '>=20.0.0'}
 
-  '@argos-ci/api-client@0.8.2':
-    resolution: {integrity: sha512-+b0qq5SSrLcI3NvUdNxsTSb8UkRPF2q8jJKlSHUJEyuMktIliWS2yuzLZYnbjTs7Zw654oRpc15cePwVcCG5jg==}
-    engines: {node: '>=18.0.0'}
+  '@argos-ci/api-client@0.22.0':
+    resolution: {integrity: sha512-CzMDTZXT6+0fvtfdwUwu4NIzyS0zhEJoGd/0m/zSFIK+kXvWIJyIl/eZqyGRr5+B6OPFR1cRtOI9pX5w3u4i8A==}
+    engines: {node: '>=22.0.0'}
 
   '@argos-ci/browser@5.1.2':
     resolution: {integrity: sha512-eQqtM54Vh83++Dac5+7ml4YXKW/KnUHRQWjTZ+VGeXfOJdjnZa4JjfVL6fnFG6CKrXjCK5dd9gcZRmbVpbt8rA==}
     engines: {node: '>=20.0.0'}
 
-  '@argos-ci/cli@2.5.10':
-    resolution: {integrity: sha512-xOiZKSHgE4KNEuj4kQEbKmPBqSa030uEtoZurluIjpUkETq/hTfM73kA3fL4mjCT/TPzD5a8fzmJ4GofbcjQnA==}
-    engines: {node: '>=18.0.0'}
+  '@argos-ci/cli@5.0.5':
+    resolution: {integrity: sha512-ZeAmYjwSmQadW2yP6QyFP5Wj4LaV0xuN0VN8OYDNYJRbMC6LHDMNlkbbftMNq77o5oTjYBf9hdvR1ZupSe0+pw==}
+    engines: {node: '>=22.0.0'}
     hasBin: true
-
-  '@argos-ci/core@3.2.3':
-    resolution: {integrity: sha512-5xr7h4PsQntAb5KJ6U+QnI5pcEEfHei3pclb0rCUM4Qzg1aTJMSvntlrjCCC89BQqfhz8PlxkrPlA8zJktNvaw==}
-    engines: {node: '>=18.0.0'}
 
   '@argos-ci/core@5.1.1':
     resolution: {integrity: sha512-RI5pYb5wmWUoXzWefNCjKSqGA3BroUB2ac9awlYV3McJjSAW8nCGJUt2Eds90Shkp+i4S6KbMLnLG56slhTCsg==}
     engines: {node: '>=20.0.0'}
+
+  '@argos-ci/core@6.1.1':
+    resolution: {integrity: sha512-8W8GYhnMAaxr3HKydsCmLN21PSExEMI+iBerzEoFXRlKgFilCg3HssVBxLKCXrhh/IBPYyQnspgRll5n9QsNeQ==}
+    engines: {node: '>=22.0.0'}
 
   '@argos-ci/cypress@6.2.12':
     resolution: {integrity: sha512-5/9tNusCeIrWwgYdZ2odSGRce0pNJviGKADtjQ5KKyqOv8KSThga32boqhIje5xq/cn60Oz9aLjte8bTR3olyg==}
@@ -880,13 +880,13 @@ packages:
     peerDependencies:
       cypress: '>=12 <16'
 
-  '@argos-ci/util@2.3.3':
-    resolution: {integrity: sha512-XgpHGGgj3QAGXWwiM4aOP61AzFT1KfLXExbUoCzsj8VXCe8FjqnuFojefbsiQUWWmDx6LoYZYIvoN6xKuTFCeA==}
-    engines: {node: '>=18.0.0'}
-
   '@argos-ci/util@3.2.0':
     resolution: {integrity: sha512-/Bn0qCH8VsdPv5WB9TUEf3oTgsIqsTMUEjPVDopHLzKK+j7nQYGOF3MnN7VhBow82BXeStBfJCS3UiZ6cgxRlw==}
     engines: {node: '>=20.0.0'}
+
+  '@argos-ci/util@4.0.0':
+    resolution: {integrity: sha512-2yrJr81OVpa2TkvSjzGZlGv6SVqZcxF62AVk6M79aZ7nXkwWFg3tjA8awbFwn2mODI67gkP5FarAD29bzx3P3w==}
+    engines: {node: '>=22.0.0'}
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -2593,22 +2593,10 @@ packages:
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
     engines: {node: '>=18'}
 
-  '@img/sharp-darwin-arm64@0.33.5':
-    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [darwin]
-
   '@img/sharp-darwin-arm64@0.34.5':
     resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-darwin-x64@0.33.5':
-    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
     os: [darwin]
 
   '@img/sharp-darwin-x64@0.34.5':
@@ -2617,19 +2605,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-arm64@1.0.4':
-    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@img/sharp-libvips-darwin-arm64@1.2.4':
     resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@img/sharp-libvips-darwin-x64@1.0.4':
-    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
-    cpu: [x64]
     os: [darwin]
 
   '@img/sharp-libvips-darwin-x64@1.2.4':
@@ -2637,21 +2615,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.0.4':
-    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-arm@1.0.5':
-    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
-    cpu: [arm]
     os: [linux]
     libc: [glibc]
 
@@ -2673,21 +2639,9 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-s390x@1.0.4':
-    resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-x64@1.0.4':
-    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
-    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -2697,21 +2651,9 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
-    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
-    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
-    cpu: [x64]
     os: [linux]
     libc: [musl]
 
@@ -2721,24 +2663,10 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linux-arm64@0.33.5':
-    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-arm@0.33.5':
-    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm]
     os: [linux]
     libc: [glibc]
 
@@ -2763,24 +2691,10 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-s390x@0.33.5':
-    resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-x64@0.33.5':
-    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -2791,24 +2705,10 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linuxmusl-arm64@0.33.5':
-    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-linuxmusl-x64@0.33.5':
-    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
     os: [linux]
     libc: [musl]
 
@@ -2818,11 +2718,6 @@ packages:
     cpu: [x64]
     os: [linux]
     libc: [musl]
-
-  '@img/sharp-wasm32@0.33.5':
-    resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [wasm32]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -2835,22 +2730,10 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.33.5':
-    resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [ia32]
-    os: [win32]
-
   '@img/sharp-win32-ia32@0.34.5':
     resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
-    os: [win32]
-
-  '@img/sharp-win32-x64@0.33.5':
-    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
     os: [win32]
 
   '@img/sharp-win32-x64@0.34.5':
@@ -5076,6 +4959,10 @@ packages:
     resolution: {integrity: sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==}
     engines: {node: '>=18.20'}
 
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -5307,9 +5194,9 @@ packages:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
 
-  cli-spinners@2.9.2:
-    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
-    engines: {node: '>=6'}
+  cli-spinners@3.4.0:
+    resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
+    engines: {node: '>=18.20'}
 
   cli-table3@0.6.1:
     resolution: {integrity: sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==}
@@ -5376,16 +5263,9 @@ packages:
     resolution: {integrity: sha512-9vEt7gE16EW7Eu7pvZnR0abW9z6ufzhXxGXZEVU9IqPdlsUiMwJeJfRtq0zePUmnbHGT9zajca7mX8zgoayo4A==}
     engines: {node: '>=12.20'}
 
-  color-string@1.9.1:
-    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
-
   color-string@2.1.4:
     resolution: {integrity: sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==}
     engines: {node: '>=18'}
-
-  color@4.2.3:
-    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
-    engines: {node: '>=12.5.0'}
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
@@ -5409,16 +5289,16 @@ packages:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
-  commander@13.1.0:
-    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
-    engines: {node: '>=18'}
-
   commander@14.0.1:
     resolution: {integrity: sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==}
     engines: {node: '>=20'}
 
   commander@14.0.2:
     resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
+    engines: {node: '>=20'}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
   commander@2.20.3:
@@ -5967,6 +5847,14 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
   default-gateway@6.0.3:
     resolution: {integrity: sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==}
     engines: {node: '>= 10'}
@@ -5989,6 +5877,10 @@ packages:
   define-lazy-prop@2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
 
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
@@ -7320,9 +7212,6 @@ packages:
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
-  is-arrayish@0.3.4:
-    resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
-
   is-async-function@2.1.1:
     resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
     engines: {node: '>= 0.4'}
@@ -7367,6 +7256,11 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -7403,6 +7297,15 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  is-in-ssh@1.0.0:
+    resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
+    engines: {node: '>=20'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+
   is-installed-globally@0.4.0:
     resolution: {integrity: sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==}
     engines: {node: '>=10'}
@@ -7425,6 +7328,10 @@ packages:
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
+
+  is-network-error@1.3.2:
+    resolution: {integrity: sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==}
+    engines: {node: '>=16'}
 
   is-npm@6.1.0:
     resolution: {integrity: sha512-O2z4/kNgyjhQwVR1Wpkbfc19JIhggF97NZNCpWTnjH7kVcZMUrnut9XSN7txI7VdyIYk5ZatOq3zvSuWpU8hoA==}
@@ -7515,10 +7422,6 @@ packages:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
 
-  is-unicode-supported@1.3.0:
-    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
-    engines: {node: '>=12'}
-
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
@@ -7550,6 +7453,10 @@ packages:
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
 
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -8095,8 +8002,8 @@ packages:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
 
-  log-symbols@6.0.0:
-    resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
+  log-symbols@7.0.1:
+    resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
     engines: {node: '>=18'}
 
   log-update@4.0.0:
@@ -8713,26 +8620,33 @@ packages:
   oniguruma-to-es@3.1.1:
     resolution: {integrity: sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==}
 
+  open@11.0.0:
+    resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
+    engines: {node: '>=20'}
+
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
-  openapi-fetch@0.13.5:
-    resolution: {integrity: sha512-AQK8T9GSKFREFlN1DBXTYsLjs7YV2tZcJ7zUWxbjMoQmj8dDSFRrzhLCbHPZWA1TMV3vACqfCxLEZcwf2wxV6Q==}
-
   openapi-fetch@0.15.2:
     resolution: {integrity: sha512-rdYTzUmSsJevmNqg7fwUVGuKc2Gfb9h6ph74EVPkPfIGJaZTfqdIbJahtbJ3qg1LKinln30hqZniLnKpH0RJBg==}
 
+  openapi-fetch@0.17.0:
+    resolution: {integrity: sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==}
+
   openapi-typescript-helpers@0.0.15:
     resolution: {integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==}
+
+  openapi-typescript-helpers@0.1.0:
+    resolution: {integrity: sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
-  ora@8.2.0:
-    resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
-    engines: {node: '>=18'}
+  ora@9.4.0:
+    resolution: {integrity: sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==}
+    engines: {node: '>=20'}
 
   ospath@1.2.2:
     resolution: {integrity: sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==}
@@ -8820,6 +8734,10 @@ packages:
   p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
     engines: {node: '>=8'}
+
+  p-retry@8.0.0:
+    resolution: {integrity: sha512-kFVqH1HxOHp8LupNsOys7bSV09VYTRLxarH/mokO4Rqhk6wGi70E0jh4VzvVGXfEVNggHoHLAMWsQqHyU1Ey9A==}
+    engines: {node: '>=22'}
 
   p-timeout@5.1.0:
     resolution: {integrity: sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==}
@@ -9119,6 +9037,10 @@ packages:
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
+
+  powershell-utils@0.1.0:
+    resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
+    engines: {node: '>=20'}
 
   preact@10.27.2:
     resolution: {integrity: sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==}
@@ -9540,6 +9462,10 @@ packages:
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -9694,10 +9620,6 @@ packages:
     resolution: {integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==}
     engines: {node: '>=8'}
 
-  sharp@0.33.5:
-    resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -9764,9 +9686,6 @@ packages:
 
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
-
-  simple-swizzle@0.2.4:
-    resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
 
   sirv-cli@3.0.1:
     resolution: {integrity: sha512-ICXaF2u6IQhLZ0EXF6nqUF4YODfSQSt+mGykt4qqO5rY+oIiwdg7B8w2PVDBJlQulaS2a3J8666CUoDoAuCGvg==}
@@ -9928,8 +9847,8 @@ packages:
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
-  stdin-discarder@0.2.2:
-    resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
+  stdin-discarder@0.3.2:
+    resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
     engines: {node: '>=18'}
 
   stop-iteration-iterator@1.1.0:
@@ -11113,6 +11032,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  wsl-utils@0.3.1:
+    resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
+    engines: {node: '>=20'}
+
   xdg-basedir@5.1.0:
     resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
     engines: {node: '>=12'}
@@ -11188,6 +11111,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -11636,34 +11563,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@argos-ci/api-client@0.8.2':
+  '@argos-ci/api-client@0.22.0':
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
-      openapi-fetch: 0.13.5
+      openapi-fetch: 0.17.0
+      p-retry: 8.0.0
     transitivePeerDependencies:
       - supports-color
 
   '@argos-ci/browser@5.1.2': {}
 
-  '@argos-ci/cli@2.5.10':
+  '@argos-ci/cli@5.0.5':
     dependencies:
-      '@argos-ci/core': 3.2.3
-      commander: 13.1.0
-      ora: 8.2.0
+      '@argos-ci/api-client': 0.22.0
+      '@argos-ci/core': 6.1.1
+      commander: 14.0.3
+      open: 11.0.0
+      ora: 9.4.0
       update-notifier: 7.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@argos-ci/core@3.2.3':
-    dependencies:
-      '@argos-ci/api-client': 0.8.2
-      '@argos-ci/util': 2.3.3
-      axios: 1.16.0(debug@4.4.3)
-      convict: 6.2.5
-      debug: 4.4.3(supports-color@8.1.1)
-      fast-glob: 3.3.3
-      sharp: 0.33.5
-      tmp: 0.2.5
     transitivePeerDependencies:
       - supports-color
 
@@ -11671,6 +11588,19 @@ snapshots:
     dependencies:
       '@argos-ci/api-client': 0.16.0
       '@argos-ci/util': 3.2.0
+      convict: 6.2.5
+      debug: 4.4.3(supports-color@8.1.1)
+      fast-glob: 3.3.3
+      mime-types: 3.0.2
+      sharp: 0.34.5
+      tmp: 0.2.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@argos-ci/core@6.1.1':
+    dependencies:
+      '@argos-ci/api-client': 0.22.0
+      '@argos-ci/util': 4.0.0
       convict: 6.2.5
       debug: 4.4.3(supports-color@8.1.1)
       fast-glob: 3.3.3
@@ -11690,9 +11620,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@argos-ci/util@2.3.3': {}
-
   '@argos-ci/util@3.2.0': {}
+
+  '@argos-ci/util@4.0.0': {}
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -13551,19 +13481,9 @@ snapshots:
 
   '@img/colour@1.0.0': {}
 
-  '@img/sharp-darwin-arm64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.0.4
-    optional: true
-
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-darwin-x64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.0.4
     optional: true
 
   '@img/sharp-darwin-x64@0.34.5':
@@ -13571,25 +13491,13 @@ snapshots:
       '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.0.4':
-    optional: true
-
   '@img/sharp-libvips-darwin-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-darwin-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-darwin-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.0.4':
-    optional: true
-
   '@img/sharp-libvips-linux-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm@1.0.5':
     optional: true
 
   '@img/sharp-libvips-linux-arm@1.2.4':
@@ -13601,43 +13509,21 @@ snapshots:
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.0.4':
-    optional: true
-
   '@img/sharp-libvips-linux-s390x@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
-    optional: true
-
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     optional: true
 
-  '@img/sharp-linux-arm64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.0.4
-    optional: true
-
   '@img/sharp-linux-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-arm@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.0.5
     optional: true
 
   '@img/sharp-linux-arm@0.34.5':
@@ -13655,19 +13541,9 @@ snapshots:
       '@img/sharp-libvips-linux-riscv64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-s390x@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.0.4
-    optional: true
-
   '@img/sharp-linux-s390x@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-s390x': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-x64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.0.4
     optional: true
 
   '@img/sharp-linux-x64@0.34.5':
@@ -13675,29 +13551,14 @@ snapshots:
       '@img/sharp-libvips-linux-x64': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
-    optional: true
-
   '@img/sharp-linuxmusl-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.33.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
-    optional: true
-
   '@img/sharp-linuxmusl-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-wasm32@0.33.5':
-    dependencies:
-      '@emnapi/runtime': 1.10.0
     optional: true
 
   '@img/sharp-wasm32@0.34.5':
@@ -13708,13 +13569,7 @@ snapshots:
   '@img/sharp-win32-arm64@0.34.5':
     optional: true
 
-  '@img/sharp-win32-ia32@0.33.5':
-    optional: true
-
   '@img/sharp-win32-ia32@0.34.5':
-    optional: true
-
-  '@img/sharp-win32-x64@0.33.5':
     optional: true
 
   '@img/sharp-win32-x64@0.34.5':
@@ -16336,6 +16191,10 @@ snapshots:
 
   builtin-modules@5.0.0: {}
 
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
@@ -16559,7 +16418,7 @@ snapshots:
     dependencies:
       restore-cursor: 5.1.0
 
-  cli-spinners@2.9.2: {}
+  cli-spinners@3.4.0: {}
 
   cli-table3@0.6.1:
     dependencies:
@@ -16634,19 +16493,9 @@ snapshots:
 
   color-name@2.0.2: {}
 
-  color-string@1.9.1:
-    dependencies:
-      color-name: 1.1.4
-      simple-swizzle: 0.2.4
-
   color-string@2.1.4:
     dependencies:
       color-name: 2.0.2
-
-  color@4.2.3:
-    dependencies:
-      color-convert: 2.0.1
-      color-string: 1.9.1
 
   colorette@2.0.20: {}
 
@@ -16663,11 +16512,11 @@ snapshots:
 
   commander@12.1.0: {}
 
-  commander@13.1.0: {}
-
   commander@14.0.1: {}
 
   commander@14.0.2: {}
+
+  commander@14.0.3: {}
 
   commander@2.20.3: {}
 
@@ -17329,6 +17178,13 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
   default-gateway@6.0.3:
     dependencies:
       execa: 5.1.1
@@ -17351,6 +17207,8 @@ snapshots:
       gopd: 1.2.0
 
   define-lazy-prop@2.0.0: {}
+
+  define-lazy-prop@3.0.0: {}
 
   define-properties@1.2.1:
     dependencies:
@@ -18983,8 +18841,6 @@ snapshots:
 
   is-arrayish@0.2.1: {}
 
-  is-arrayish@0.3.4: {}
-
   is-async-function@2.1.1:
     dependencies:
       async-function: 1.0.0
@@ -19031,6 +18887,8 @@ snapshots:
 
   is-docker@2.2.1: {}
 
+  is-docker@3.0.0: {}
+
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.1:
@@ -19061,6 +18919,12 @@ snapshots:
 
   is-in-ci@1.0.0: {}
 
+  is-in-ssh@1.0.0: {}
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
+
   is-installed-globally@0.4.0:
     dependencies:
       global-dirs: 3.0.1
@@ -19078,6 +18942,8 @@ snapshots:
   is-module@1.0.0: {}
 
   is-negative-zero@2.0.3: {}
+
+  is-network-error@1.3.2: {}
 
   is-npm@6.1.0: {}
 
@@ -19148,8 +19014,6 @@ snapshots:
 
   is-unicode-supported@0.1.0: {}
 
-  is-unicode-supported@1.3.0: {}
-
   is-unicode-supported@2.1.0: {}
 
   is-url-superb@4.0.0: {}
@@ -19172,6 +19036,10 @@ snapshots:
   is-wsl@2.2.0:
     dependencies:
       is-docker: 2.2.1
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
 
   isarray@1.0.0: {}
 
@@ -19954,10 +19822,10 @@ snapshots:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
 
-  log-symbols@6.0.0:
+  log-symbols@7.0.1:
     dependencies:
-      chalk: 5.6.2
-      is-unicode-supported: 1.3.0
+      is-unicode-supported: 2.1.0
+      yoctocolors: 2.1.2
 
   log-update@4.0.0:
     dependencies:
@@ -20763,21 +20631,32 @@ snapshots:
       regex: 6.0.1
       regex-recursion: 6.0.2
 
+  open@11.0.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-in-ssh: 1.0.0
+      is-inside-container: 1.0.0
+      powershell-utils: 0.1.0
+      wsl-utils: 0.3.1
+
   open@8.4.2:
     dependencies:
       define-lazy-prop: 2.0.0
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openapi-fetch@0.13.5:
-    dependencies:
-      openapi-typescript-helpers: 0.0.15
-
   openapi-fetch@0.15.2:
     dependencies:
       openapi-typescript-helpers: 0.0.15
 
+  openapi-fetch@0.17.0:
+    dependencies:
+      openapi-typescript-helpers: 0.1.0
+
   openapi-typescript-helpers@0.0.15: {}
+
+  openapi-typescript-helpers@0.1.0: {}
 
   optionator@0.9.4:
     dependencies:
@@ -20788,17 +20667,16 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
-  ora@8.2.0:
+  ora@9.4.0:
     dependencies:
       chalk: 5.6.2
       cli-cursor: 5.0.0
-      cli-spinners: 2.9.2
+      cli-spinners: 3.4.0
       is-interactive: 2.0.0
       is-unicode-supported: 2.1.0
-      log-symbols: 6.0.0
-      stdin-discarder: 0.2.2
-      string-width: 7.2.0
-      strip-ansi: 7.1.2
+      log-symbols: 7.0.1
+      stdin-discarder: 0.3.2
+      string-width: 8.1.0
 
   ospath@1.2.2: {}
 
@@ -20901,6 +20779,10 @@ snapshots:
     dependencies:
       '@types/retry': 0.12.0
       retry: 0.13.1
+
+  p-retry@8.0.0:
+    dependencies:
+      is-network-error: 1.3.2
 
   p-timeout@5.1.0: {}
 
@@ -21189,6 +21071,8 @@ snapshots:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  powershell-utils@0.1.0: {}
 
   preact@10.27.2: {}
 
@@ -21677,6 +21561,8 @@ snapshots:
 
   rrweb-cssom@0.8.0: {}
 
+  run-applescript@7.1.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -21872,32 +21758,6 @@ snapshots:
     dependencies:
       kind-of: 6.0.3
 
-  sharp@0.33.5:
-    dependencies:
-      color: 4.2.3
-      detect-libc: 2.1.2
-      semver: 7.7.3
-    optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.33.5
-      '@img/sharp-darwin-x64': 0.33.5
-      '@img/sharp-libvips-darwin-arm64': 1.0.4
-      '@img/sharp-libvips-darwin-x64': 1.0.4
-      '@img/sharp-libvips-linux-arm': 1.0.5
-      '@img/sharp-libvips-linux-arm64': 1.0.4
-      '@img/sharp-libvips-linux-s390x': 1.0.4
-      '@img/sharp-libvips-linux-x64': 1.0.4
-      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
-      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
-      '@img/sharp-linux-arm': 0.33.5
-      '@img/sharp-linux-arm64': 0.33.5
-      '@img/sharp-linux-s390x': 0.33.5
-      '@img/sharp-linux-x64': 0.33.5
-      '@img/sharp-linuxmusl-arm64': 0.33.5
-      '@img/sharp-linuxmusl-x64': 0.33.5
-      '@img/sharp-wasm32': 0.33.5
-      '@img/sharp-win32-ia32': 0.33.5
-      '@img/sharp-win32-x64': 0.33.5
-
   sharp@0.34.5:
     dependencies:
       '@img/colour': 1.0.0
@@ -22002,10 +21862,6 @@ snapshots:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
-
-  simple-swizzle@0.2.4:
-    dependencies:
-      is-arrayish: 0.3.4
 
   sirv-cli@3.0.1:
     dependencies:
@@ -22201,7 +22057,7 @@ snapshots:
 
   std-env@3.9.0: {}
 
-  stdin-discarder@0.2.2: {}
+  stdin-discarder@0.3.2: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -23758,6 +23614,11 @@ snapshots:
 
   ws@8.18.3: {}
 
+  wsl-utils@0.3.1:
+    dependencies:
+      is-wsl: 3.1.1
+      powershell-utils: 0.1.0
+
   xdg-basedir@5.1.0: {}
 
   xml-name-validator@5.0.0: {}
@@ -23832,5 +23693,7 @@ snapshots:
       fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
+
+  yoctocolors@2.1.2: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@applitools/eyes-cypress':
         specifier: ^3.60.3
         version: 3.60.3(encoding@0.1.13)(typescript@5.8.3)(webdriver@7.31.1(typescript@5.8.3))
+      '@argos-ci/cli':
+        specifier: ^2.5.0
+        version: 2.5.10
       '@argos-ci/cypress':
         specifier: ^6.2.12
         version: 6.2.12(cypress@14.5.4)
@@ -228,6 +231,9 @@ importers:
       rollup-plugin-visualizer:
         specifier: ^6.0.11
         version: 6.0.11(rollup@4.60.1)
+      sharp:
+        specifier: ^0.34.4
+        version: 0.34.5
       sirv-cli:
         specifier: ^3.0.1
         version: 3.0.1
@@ -847,9 +853,22 @@ packages:
     resolution: {integrity: sha512-BG6g+AZABKN8W2syzfPWKhPxxrAB9Wjp2iNS11R4IskHDV6T41+qeQDpT88GOq6eUZ64Sjzoh/nXG+9EpNxtfw==}
     engines: {node: '>=20.0.0'}
 
+  '@argos-ci/api-client@0.8.2':
+    resolution: {integrity: sha512-+b0qq5SSrLcI3NvUdNxsTSb8UkRPF2q8jJKlSHUJEyuMktIliWS2yuzLZYnbjTs7Zw654oRpc15cePwVcCG5jg==}
+    engines: {node: '>=18.0.0'}
+
   '@argos-ci/browser@5.1.2':
     resolution: {integrity: sha512-eQqtM54Vh83++Dac5+7ml4YXKW/KnUHRQWjTZ+VGeXfOJdjnZa4JjfVL6fnFG6CKrXjCK5dd9gcZRmbVpbt8rA==}
     engines: {node: '>=20.0.0'}
+
+  '@argos-ci/cli@2.5.10':
+    resolution: {integrity: sha512-xOiZKSHgE4KNEuj4kQEbKmPBqSa030uEtoZurluIjpUkETq/hTfM73kA3fL4mjCT/TPzD5a8fzmJ4GofbcjQnA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  '@argos-ci/core@3.2.3':
+    resolution: {integrity: sha512-5xr7h4PsQntAb5KJ6U+QnI5pcEEfHei3pclb0rCUM4Qzg1aTJMSvntlrjCCC89BQqfhz8PlxkrPlA8zJktNvaw==}
+    engines: {node: '>=18.0.0'}
 
   '@argos-ci/core@5.1.1':
     resolution: {integrity: sha512-RI5pYb5wmWUoXzWefNCjKSqGA3BroUB2ac9awlYV3McJjSAW8nCGJUt2Eds90Shkp+i4S6KbMLnLG56slhTCsg==}
@@ -860,6 +879,10 @@ packages:
     engines: {node: '>=20.0.0'}
     peerDependencies:
       cypress: '>=12 <16'
+
+  '@argos-ci/util@2.3.3':
+    resolution: {integrity: sha512-XgpHGGgj3QAGXWwiM4aOP61AzFT1KfLXExbUoCzsj8VXCe8FjqnuFojefbsiQUWWmDx6LoYZYIvoN6xKuTFCeA==}
+    engines: {node: '>=18.0.0'}
 
   '@argos-ci/util@3.2.0':
     resolution: {integrity: sha512-/Bn0qCH8VsdPv5WB9TUEf3oTgsIqsTMUEjPVDopHLzKK+j7nQYGOF3MnN7VhBow82BXeStBfJCS3UiZ6cgxRlw==}
@@ -2570,10 +2593,22 @@ packages:
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
     engines: {node: '>=18'}
 
+  '@img/sharp-darwin-arm64@0.33.5':
+    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-darwin-arm64@0.34.5':
     resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.33.5':
+    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
     os: [darwin]
 
   '@img/sharp-darwin-x64@0.34.5':
@@ -2582,9 +2617,19 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-libvips-darwin-arm64@1.2.4':
     resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
     cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
+    cpu: [x64]
     os: [darwin]
 
   '@img/sharp-libvips-darwin-x64@1.2.4':
@@ -2592,9 +2637,21 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
+    cpu: [arm]
     os: [linux]
     libc: [glibc]
 
@@ -2616,9 +2673,21 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-s390x@1.0.4':
+    resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
+    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
+    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -2628,9 +2697,21 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
+    cpu: [x64]
     os: [linux]
     libc: [musl]
 
@@ -2640,10 +2721,24 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@img/sharp-linux-arm64@0.33.5':
+    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.33.5':
+    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
     os: [linux]
     libc: [glibc]
 
@@ -2668,10 +2763,24 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-s390x@0.33.5':
+    resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.33.5':
+    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -2682,10 +2791,24 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
     os: [linux]
     libc: [musl]
 
@@ -2695,6 +2818,11 @@ packages:
     cpu: [x64]
     os: [linux]
     libc: [musl]
+
+  '@img/sharp-wasm32@0.33.5':
+    resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -2707,10 +2835,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@img/sharp-win32-ia32@0.33.5':
+    resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@img/sharp-win32-ia32@0.34.5':
     resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.33.5':
+    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
     os: [win32]
 
   '@img/sharp-win32-x64@0.34.5':
@@ -3137,6 +3277,18 @@ packages:
 
   '@plausible-analytics/tracker@0.4.5':
     resolution: {integrity: sha512-6BfAGejXY+YA3Cw6LYT2Zpn4hTxDtPQAawFsYUsQCOg78wIS5C4deAGXTfJffa5VleMWITv5lpJ/EYuQBl1tPA==}
+
+  '@pnpm/config.env-replace@1.1.0':
+    resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
+    engines: {node: '>=12.22.0'}
+
+  '@pnpm/network.ca-file@1.0.2':
+    resolution: {integrity: sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==}
+    engines: {node: '>=12.22.0'}
+
+  '@pnpm/npm-conf@3.0.3':
+    resolution: {integrity: sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==}
+    engines: {node: '>=12'}
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -4723,6 +4875,9 @@ packages:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
 
+  atomically@2.1.1:
+    resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -4865,6 +5020,10 @@ packages:
     resolution: {integrity: sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==}
     engines: {node: '>=10'}
 
+  boxen@8.0.1:
+    resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
+    engines: {node: '>=18'}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -4972,6 +5131,10 @@ packages:
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
+
+  camelcase@8.0.0:
+    resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
+    engines: {node: '>=16'}
 
   caniuse-lite@1.0.30001741:
     resolution: {integrity: sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==}
@@ -5132,6 +5295,10 @@ packages:
     resolution: {integrity: sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==}
     engines: {node: '>=6'}
 
+  cli-boxes@3.0.0:
+    resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
+    engines: {node: '>=10'}
+
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
     engines: {node: '>=8'}
@@ -5139,6 +5306,10 @@ packages:
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
+
+  cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
 
   cli-table3@0.6.1:
     resolution: {integrity: sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==}
@@ -5205,9 +5376,16 @@ packages:
     resolution: {integrity: sha512-9vEt7gE16EW7Eu7pvZnR0abW9z6ufzhXxGXZEVU9IqPdlsUiMwJeJfRtq0zePUmnbHGT9zajca7mX8zgoayo4A==}
     engines: {node: '>=12.20'}
 
+  color-string@1.9.1:
+    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
+
   color-string@2.1.4:
     resolution: {integrity: sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==}
     engines: {node: '>=18'}
+
+  color@4.2.3:
+    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
+    engines: {node: '>=12.5.0'}
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
@@ -5229,6 +5407,10 @@ packages:
 
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
 
   commander@14.0.1:
@@ -5299,6 +5481,13 @@ packages:
 
   confbox@0.2.2:
     resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
+
+  config-chain@1.1.13:
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
+
+  configstore@7.1.0:
+    resolution: {integrity: sha512-N4oog6YJWbR9kGyXvS7jEykLDXIE2C0ILYqNBZBp9iwiJpoCBWYsuAdW6PPFn6w06jjnC+3JstVvWHO4cZqvRg==}
+    engines: {node: '>=18'}
 
   connect-history-api-fallback@2.0.0:
     resolution: {integrity: sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==}
@@ -5934,6 +6123,10 @@ packages:
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
+  dot-prop@9.0.0:
+    resolution: {integrity: sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==}
+    engines: {node: '>=18'}
+
   dotenv-cli@11.0.0:
     resolution: {integrity: sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww==}
     hasBin: true
@@ -6125,6 +6318,10 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-goat@4.0.0:
+    resolution: {integrity: sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==}
+    engines: {node: '>=12'}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -6834,6 +7031,9 @@ packages:
     resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
     engines: {node: '>=10.19.0'}
 
+  graceful-fs@4.2.10:
+    resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -7120,6 +7320,9 @@ packages:
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
+  is-arrayish@0.3.4:
+    resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
+
   is-async-function@2.1.1:
     resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
     engines: {node: '>= 0.4'}
@@ -7195,9 +7398,22 @@ packages:
   is-hexadecimal@1.0.4:
     resolution: {integrity: sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==}
 
+  is-in-ci@1.0.0:
+    resolution: {integrity: sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   is-installed-globally@0.4.0:
     resolution: {integrity: sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==}
     engines: {node: '>=10'}
+
+  is-installed-globally@1.0.0:
+    resolution: {integrity: sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==}
+    engines: {node: '>=18'}
+
+  is-interactive@2.0.0:
+    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
+    engines: {node: '>=12'}
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
@@ -7209,6 +7425,10 @@ packages:
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
+
+  is-npm@6.1.0:
+    resolution: {integrity: sha512-O2z4/kNgyjhQwVR1Wpkbfc19JIhggF97NZNCpWTnjH7kVcZMUrnut9XSN7txI7VdyIYk5ZatOq3zvSuWpU8hoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
@@ -7225,6 +7445,10 @@ packages:
   is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
+
+  is-path-inside@4.0.0:
+    resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
+    engines: {node: '>=12'}
 
   is-plain-obj@3.0.0:
     resolution: {integrity: sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==}
@@ -7290,6 +7514,14 @@ packages:
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
+
+  is-unicode-supported@1.3.0:
+    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
+    engines: {node: '>=12'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
 
   is-url-superb@4.0.0:
     resolution: {integrity: sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==}
@@ -7705,6 +7937,10 @@ packages:
     resolution: {integrity: sha512-X/u76z4JtDVq10u1JA5UQfatPxgPaVDMYTrgHyiTpGN2z4TMEJkIHsoSBBSg9SWZEIXTKsi9kHgiQ9o3Y/4yog==}
     engines: {node: '>=12'}
 
+  ky@1.14.3:
+    resolution: {integrity: sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==}
+    engines: {node: '>=18'}
+
   langium-cli@4.2.1:
     resolution: {integrity: sha512-npo1fSoP/wUf4cxUcKUYph48+jHFPEjeLQJ3pQ1UnA4QRuz8JpOxWsLHB/fdmViZSnI0mb98f06Wo7PKecqoUw==}
     engines: {node: '>=20.10.0', npm: '>=10.2.3'}
@@ -7716,6 +7952,10 @@ packages:
   langium@4.2.4:
     resolution: {integrity: sha512-J0M9BkTOZ9Izee2YL0eXkUKFdWhrmTYYVLgiZTz6Z3KvK03ooM+vjVrfphKcdGVPWmM2cFYtDnNyIsIIZPrHNA==}
     engines: {node: '>=20.10.0', npm: '>=10.2.3'}
+
+  latest-version@9.0.0:
+    resolution: {integrity: sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA==}
+    engines: {node: '>=18'}
 
   launch-editor@2.11.1:
     resolution: {integrity: sha512-SEET7oNfgSaB6Ym0jufAdCeo3meJVeCaaDyzRygy0xsp2BFKCprcfHljTq4QkzTLUxEKkFK6OK4811YM2oSrRg==}
@@ -7854,6 +8094,10 @@ packages:
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
+
+  log-symbols@6.0.0:
+    resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
+    engines: {node: '>=18'}
 
   log-update@4.0.0:
     resolution: {integrity: sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==}
@@ -8473,6 +8717,9 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
+  openapi-fetch@0.13.5:
+    resolution: {integrity: sha512-AQK8T9GSKFREFlN1DBXTYsLjs7YV2tZcJ7zUWxbjMoQmj8dDSFRrzhLCbHPZWA1TMV3vACqfCxLEZcwf2wxV6Q==}
+
   openapi-fetch@0.15.2:
     resolution: {integrity: sha512-rdYTzUmSsJevmNqg7fwUVGuKc2Gfb9h6ph74EVPkPfIGJaZTfqdIbJahtbJ3qg1LKinln30hqZniLnKpH0RJBg==}
 
@@ -8482,6 +8729,10 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  ora@8.2.0:
+    resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
+    engines: {node: '>=18'}
 
   ospath@1.2.2:
     resolution: {integrity: sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==}
@@ -8584,6 +8835,10 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  package-json@10.0.1:
+    resolution: {integrity: sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==}
+    engines: {node: '>=18'}
 
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
@@ -8934,6 +9189,9 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  proto-list@1.2.4:
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -8960,6 +9218,10 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pupa@3.3.0:
+    resolution: {integrity: sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA==}
+    engines: {node: '>=12.20'}
 
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
@@ -9096,6 +9358,14 @@ packages:
   regexpu-core@6.4.0:
     resolution: {integrity: sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==}
     engines: {node: '>=4'}
+
+  registry-auth-token@5.1.1:
+    resolution: {integrity: sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==}
+    engines: {node: '>=14'}
+
+  registry-url@6.0.1:
+    resolution: {integrity: sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==}
+    engines: {node: '>=12'}
 
   regjsgen@0.8.0:
     resolution: {integrity: sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==}
@@ -9424,6 +9694,10 @@ packages:
     resolution: {integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==}
     engines: {node: '>=8'}
 
+  sharp@0.33.5:
+    resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -9490,6 +9764,9 @@ packages:
 
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  simple-swizzle@0.2.4:
+    resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
 
   sirv-cli@3.0.1:
     resolution: {integrity: sha512-ICXaF2u6IQhLZ0EXF6nqUF4YODfSQSt+mGykt4qqO5rY+oIiwdg7B8w2PVDBJlQulaS2a3J8666CUoDoAuCGvg==}
@@ -9651,6 +9928,10 @@ packages:
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
+  stdin-discarder@0.2.2:
+    resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
+    engines: {node: '>=18'}
+
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
@@ -9757,6 +10038,12 @@ packages:
 
   strip-literal@3.0.0:
     resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
+
+  stubborn-fs@2.0.0:
+    resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
+
+  stubborn-utils@1.0.2:
+    resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
 
   style-mod@4.1.3:
     resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
@@ -10317,6 +10604,10 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
+  update-notifier@7.3.1:
+    resolution: {integrity: sha512-+dwUY4L35XFYEzE+OAL3sarJdUioVovq+8f7lcIJ7wnmnYQV5UD1Y/lcwaMSyaQ6Bj3JMj1XSTjZbNLHn/19yA==}
+    engines: {node: '>=18'}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -10672,6 +10963,9 @@ packages:
   whatwg-url@7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
 
+  when-exit@2.1.5:
+    resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -10708,6 +11002,10 @@ packages:
   widest-line@3.1.0:
     resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==}
     engines: {node: '>=8'}
+
+  widest-line@5.0.0:
+    resolution: {integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==}
+    engines: {node: '>=18'}
 
   wildcard@2.0.1:
     resolution: {integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==}
@@ -11338,7 +11636,36 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@argos-ci/api-client@0.8.2':
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      openapi-fetch: 0.13.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@argos-ci/browser@5.1.2': {}
+
+  '@argos-ci/cli@2.5.10':
+    dependencies:
+      '@argos-ci/core': 3.2.3
+      commander: 13.1.0
+      ora: 8.2.0
+      update-notifier: 7.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@argos-ci/core@3.2.3':
+    dependencies:
+      '@argos-ci/api-client': 0.8.2
+      '@argos-ci/util': 2.3.3
+      axios: 1.16.0(debug@4.4.3)
+      convict: 6.2.5
+      debug: 4.4.3(supports-color@8.1.1)
+      fast-glob: 3.3.3
+      sharp: 0.33.5
+      tmp: 0.2.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@argos-ci/core@5.1.1':
     dependencies:
@@ -11362,6 +11689,8 @@ snapshots:
       cypress-wait-until: 3.0.2
     transitivePeerDependencies:
       - supports-color
+
+  '@argos-ci/util@2.3.3': {}
 
   '@argos-ci/util@3.2.0': {}
 
@@ -13222,9 +13551,19 @@ snapshots:
 
   '@img/colour@1.0.0': {}
 
+  '@img/sharp-darwin-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+    optional: true
+
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.0.4
     optional: true
 
   '@img/sharp-darwin-x64@0.34.5':
@@ -13232,13 +13571,25 @@ snapshots:
       '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    optional: true
+
   '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-darwin-x64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    optional: true
+
   '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
     optional: true
 
   '@img/sharp-libvips-linux-arm@1.2.4':
@@ -13250,21 +13601,43 @@ snapshots:
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-s390x@1.0.4':
+    optional: true
+
   '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     optional: true
 
+  '@img/sharp-linux-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+    optional: true
+
   '@img/sharp-linux-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.0.5
     optional: true
 
   '@img/sharp-linux-arm@0.34.5':
@@ -13282,9 +13655,19 @@ snapshots:
       '@img/sharp-libvips-linux-riscv64': 1.2.4
     optional: true
 
+  '@img/sharp-linux-s390x@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.0.4
+    optional: true
+
   '@img/sharp-linux-s390x@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.0.4
     optional: true
 
   '@img/sharp-linux-x64@0.34.5':
@@ -13292,14 +13675,29 @@ snapshots:
       '@img/sharp-libvips-linux-x64': 1.2.4
     optional: true
 
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+    optional: true
+
   '@img/sharp-linuxmusl-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
     optional: true
 
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+    optional: true
+
   '@img/sharp-linuxmusl-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.33.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
     optional: true
 
   '@img/sharp-wasm32@0.34.5':
@@ -13310,7 +13708,13 @@ snapshots:
   '@img/sharp-win32-arm64@0.34.5':
     optional: true
 
+  '@img/sharp-win32-ia32@0.33.5':
+    optional: true
+
   '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.33.5':
     optional: true
 
   '@img/sharp-win32-x64@0.34.5':
@@ -13784,6 +14188,18 @@ snapshots:
   '@pkgr/core@0.2.9': {}
 
   '@plausible-analytics/tracker@0.4.5': {}
+
+  '@pnpm/config.env-replace@1.1.0': {}
+
+  '@pnpm/network.ca-file@1.0.2':
+    dependencies:
+      graceful-fs: 4.2.10
+
+  '@pnpm/npm-conf@3.0.3':
+    dependencies:
+      '@pnpm/config.env-replace': 1.1.0
+      '@pnpm/network.ca-file': 1.0.2
+      config-chain: 1.1.13
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -15637,6 +16053,11 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
+  atomically@2.1.1:
+    dependencies:
+      stubborn-fs: 2.0.0
+      when-exit: 2.1.5
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -15840,6 +16261,17 @@ snapshots:
       widest-line: 3.1.0
       wrap-ansi: 7.0.0
 
+  boxen@8.0.1:
+    dependencies:
+      ansi-align: 3.0.1
+      camelcase: 8.0.0
+      chalk: 5.6.2
+      cli-boxes: 3.0.0
+      string-width: 7.2.0
+      type-fest: 4.41.0
+      widest-line: 5.0.0
+      wrap-ansi: 9.0.2
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -15955,6 +16387,8 @@ snapshots:
   camelcase@5.3.1: {}
 
   camelcase@6.3.0: {}
+
+  camelcase@8.0.0: {}
 
   caniuse-lite@1.0.30001741: {}
 
@@ -16115,6 +16549,8 @@ snapshots:
 
   cli-boxes@2.2.1: {}
 
+  cli-boxes@3.0.0: {}
+
   cli-cursor@3.1.0:
     dependencies:
       restore-cursor: 3.1.0
@@ -16122,6 +16558,8 @@ snapshots:
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
+
+  cli-spinners@2.9.2: {}
 
   cli-table3@0.6.1:
     dependencies:
@@ -16196,9 +16634,19 @@ snapshots:
 
   color-name@2.0.2: {}
 
+  color-string@1.9.1:
+    dependencies:
+      color-name: 1.1.4
+      simple-swizzle: 0.2.4
+
   color-string@2.1.4:
     dependencies:
       color-name: 2.0.2
+
+  color@4.2.3:
+    dependencies:
+      color-convert: 2.0.1
+      color-string: 1.9.1
 
   colorette@2.0.20: {}
 
@@ -16214,6 +16662,8 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   commander@12.1.0: {}
+
+  commander@13.1.0: {}
 
   commander@14.0.1: {}
 
@@ -16275,6 +16725,18 @@ snapshots:
   confbox@0.1.8: {}
 
   confbox@0.2.2: {}
+
+  config-chain@1.1.13:
+    dependencies:
+      ini: 1.3.8
+      proto-list: 1.2.4
+
+  configstore@7.1.0:
+    dependencies:
+      atomically: 2.1.1
+      dot-prop: 9.0.0
+      graceful-fs: 4.2.11
+      xdg-basedir: 5.1.0
 
   connect-history-api-fallback@2.0.0: {}
 
@@ -17027,6 +17489,10 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
+  dot-prop@9.0.0:
+    dependencies:
+      type-fest: 4.41.0
+
   dotenv-cli@11.0.0:
     dependencies:
       cross-spawn: 7.0.6
@@ -17318,6 +17784,8 @@ snapshots:
       '@esbuild/win32-x64': 0.27.7
 
   escalade@3.2.0: {}
+
+  escape-goat@4.0.0: {}
 
   escape-html@1.0.3: {}
 
@@ -18229,6 +18697,8 @@ snapshots:
       p-cancelable: 2.1.1
       responselike: 2.0.1
 
+  graceful-fs@4.2.10: {}
+
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
@@ -18513,6 +18983,8 @@ snapshots:
 
   is-arrayish@0.2.1: {}
 
+  is-arrayish@0.3.4: {}
+
   is-async-function@2.1.1:
     dependencies:
       async-function: 1.0.0
@@ -18587,16 +19059,27 @@ snapshots:
 
   is-hexadecimal@1.0.4: {}
 
+  is-in-ci@1.0.0: {}
+
   is-installed-globally@0.4.0:
     dependencies:
       global-dirs: 3.0.1
       is-path-inside: 3.0.3
+
+  is-installed-globally@1.0.0:
+    dependencies:
+      global-directory: 4.0.1
+      is-path-inside: 4.0.0
+
+  is-interactive@2.0.0: {}
 
   is-map@2.0.3: {}
 
   is-module@1.0.0: {}
 
   is-negative-zero@2.0.3: {}
+
+  is-npm@6.1.0: {}
 
   is-number-object@1.1.1:
     dependencies:
@@ -18608,6 +19091,8 @@ snapshots:
   is-obj@1.0.1: {}
 
   is-path-inside@3.0.3: {}
+
+  is-path-inside@4.0.0: {}
 
   is-plain-obj@3.0.0: {}
 
@@ -18662,6 +19147,10 @@ snapshots:
   is-typedarray@1.0.0: {}
 
   is-unicode-supported@0.1.0: {}
+
+  is-unicode-supported@1.3.0: {}
+
+  is-unicode-supported@2.1.0: {}
 
   is-url-superb@4.0.0: {}
 
@@ -19284,6 +19773,8 @@ snapshots:
 
   ky@0.30.0: {}
 
+  ky@1.14.3: {}
+
   langium-cli@4.2.1:
     dependencies:
       chalk: 5.6.2
@@ -19310,6 +19801,10 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-languageserver-types: 3.17.5
       vscode-uri: 3.1.0
+
+  latest-version@9.0.0:
+    dependencies:
+      package-json: 10.0.1
 
   launch-editor@2.11.1:
     dependencies:
@@ -19458,6 +19953,11 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
+
+  log-symbols@6.0.0:
+    dependencies:
+      chalk: 5.6.2
+      is-unicode-supported: 1.3.0
 
   log-update@4.0.0:
     dependencies:
@@ -20269,6 +20769,10 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
+  openapi-fetch@0.13.5:
+    dependencies:
+      openapi-typescript-helpers: 0.0.15
+
   openapi-fetch@0.15.2:
     dependencies:
       openapi-typescript-helpers: 0.0.15
@@ -20283,6 +20787,18 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  ora@8.2.0:
+    dependencies:
+      chalk: 5.6.2
+      cli-cursor: 5.0.0
+      cli-spinners: 2.9.2
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 6.0.0
+      stdin-discarder: 0.2.2
+      string-width: 7.2.0
+      strip-ansi: 7.1.2
 
   ospath@1.2.2: {}
 
@@ -20398,6 +20914,13 @@ snapshots:
       release-zalgo: 1.0.0
 
   package-json-from-dist@1.0.1: {}
+
+  package-json@10.0.1:
+    dependencies:
+      ky: 1.14.3
+      registry-auth-token: 5.1.1
+      registry-url: 6.0.1
+      semver: 7.7.3
 
   package-manager-detector@0.2.11:
     dependencies:
@@ -20747,6 +21270,8 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  proto-list@1.2.4: {}
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -20768,6 +21293,10 @@ snapshots:
   punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
+
+  pupa@3.3.0:
+    dependencies:
+      escape-goat: 4.0.0
 
   pure-rand@7.0.1: {}
 
@@ -20926,6 +21455,14 @@ snapshots:
       regjsparser: 0.13.1
       unicode-match-property-ecmascript: 2.0.0
       unicode-match-property-value-ecmascript: 2.2.1
+
+  registry-auth-token@5.1.1:
+    dependencies:
+      '@pnpm/npm-conf': 3.0.3
+
+  registry-url@6.0.1:
+    dependencies:
+      rc: 1.2.8
 
   regjsgen@0.8.0: {}
 
@@ -21335,6 +21872,32 @@ snapshots:
     dependencies:
       kind-of: 6.0.3
 
+  sharp@0.33.5:
+    dependencies:
+      color: 4.2.3
+      detect-libc: 2.1.2
+      semver: 7.7.3
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.33.5
+      '@img/sharp-darwin-x64': 0.33.5
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+      '@img/sharp-libvips-darwin-x64': 1.0.4
+      '@img/sharp-libvips-linux-arm': 1.0.5
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+      '@img/sharp-libvips-linux-s390x': 1.0.4
+      '@img/sharp-libvips-linux-x64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+      '@img/sharp-linux-arm': 0.33.5
+      '@img/sharp-linux-arm64': 0.33.5
+      '@img/sharp-linux-s390x': 0.33.5
+      '@img/sharp-linux-x64': 0.33.5
+      '@img/sharp-linuxmusl-arm64': 0.33.5
+      '@img/sharp-linuxmusl-x64': 0.33.5
+      '@img/sharp-wasm32': 0.33.5
+      '@img/sharp-win32-ia32': 0.33.5
+      '@img/sharp-win32-x64': 0.33.5
+
   sharp@0.34.5:
     dependencies:
       '@img/colour': 1.0.0
@@ -21439,6 +22002,10 @@ snapshots:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
+
+  simple-swizzle@0.2.4:
+    dependencies:
+      is-arrayish: 0.3.4
 
   sirv-cli@3.0.1:
     dependencies:
@@ -21634,6 +22201,8 @@ snapshots:
 
   std-env@3.9.0: {}
 
+  stdin-discarder@0.2.2: {}
+
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -21762,6 +22331,12 @@ snapshots:
   strip-literal@3.0.0:
     dependencies:
       js-tokens: 9.0.1
+
+  stubborn-fs@2.0.0:
+    dependencies:
+      stubborn-utils: 1.0.2
+
+  stubborn-utils@1.0.2: {}
 
   style-mod@4.1.3: {}
 
@@ -22370,6 +22945,19 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  update-notifier@7.3.1:
+    dependencies:
+      boxen: 8.0.1
+      chalk: 5.6.2
+      configstore: 7.1.0
+      is-in-ci: 1.0.0
+      is-installed-globally: 1.0.0
+      is-npm: 6.1.0
+      latest-version: 9.0.0
+      pupa: 3.3.0
+      semver: 7.7.3
+      xdg-basedir: 5.1.0
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -22945,6 +23533,8 @@ snapshots:
       tr46: 1.0.1
       webidl-conversions: 4.0.2
 
+  when-exit@2.1.5: {}
+
   which-boxed-primitive@1.1.1:
     dependencies:
       is-bigint: 1.1.0
@@ -23004,6 +23594,10 @@ snapshots:
   widest-line@3.1.0:
     dependencies:
       string-width: 4.2.3
+
+  widest-line@5.0.0:
+    dependencies:
+      string-width: 7.2.0
 
   wildcard@2.0.1: {}
 

--- a/scripts/argos-batch-sheets.spec.ts
+++ b/scripts/argos-batch-sheets.spec.ts
@@ -1,0 +1,144 @@
+import { afterAll, beforeAll, describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import sharp from 'sharp';
+import {
+  deriveGroupKey,
+  planSheets,
+  collectScreenshots,
+  composeSheet,
+} from './argos-batch-sheets.ts';
+
+const FC = 'rendering/flowchart';
+const CLS = 'rendering/class';
+
+describe('deriveGroupKey', () => {
+  it('returns the folder before the *.spec.js directory segment', () => {
+    expect(deriveGroupKey('rendering/flowchart/flowchart-v2.spec.js/Some Test.png')).toBe(FC);
+  });
+  it('handles .spec.ts specs', () => {
+    expect(deriveGroupKey('rendering/treemap/treemap.spec.ts/A.png')).toBe('rendering/treemap');
+  });
+  it('groups every spec file in a folder under the same key', () => {
+    expect(deriveGroupKey('rendering/flowchart/flowchart.spec.js/x.png')).toBe(FC);
+    expect(deriveGroupKey('rendering/flowchart/flowchart-elk.spec.js/y.png')).toBe(FC);
+  });
+});
+
+describe('planSheets', () => {
+  const paths = [
+    `${FC}/flowchart-v2.spec.js/b.png`,
+    `${FC}/flowchart.spec.js/a.png`,
+    `${CLS}/classDiagram-v3.spec.js/c.png`,
+  ];
+
+  it('isolates diagrams into separate groups and sheets', () => {
+    const sheets = planSheets(paths, { tilesPerSheet: 12, cols: 3 });
+    const groups = sheets.map((s) => s.group);
+    expect(groups).toContain(FC);
+    expect(groups).toContain(CLS);
+    // No sheet mixes two diagrams.
+    for (const s of sheets) {
+      expect(s.tiles.every((t) => deriveGroupKey(t.source) === s.group)).toBe(true);
+    }
+  });
+
+  it('is deterministic regardless of input order', () => {
+    const a = planSheets(paths, { tilesPerSheet: 12, cols: 3 });
+    const b = planSheets([...paths].reverse(), { tilesPerSheet: 12, cols: 3 });
+    expect(a).toStrictEqual(b);
+  });
+
+  it('chunks a folder into fixed-size sheets', () => {
+    const many = Array.from(
+      { length: 13 },
+      (_, i) => `${FC}/flowchart.spec.js/t${String(i).padStart(2, '0')}.png`
+    );
+    const sheets = planSheets(many, { tilesPerSheet: 12, cols: 3 });
+    expect(sheets).toHaveLength(2);
+    expect(sheets[0].tiles).toHaveLength(12);
+    expect(sheets[1].tiles).toHaveLength(1);
+    expect(sheets[0].output).toBe(`${FC}/flowchart-001.png`);
+    expect(sheets[1].output).toBe(`${FC}/flowchart-002.png`);
+  });
+
+  it('assigns row/col by column count', () => {
+    const four = ['a', 'b', 'c', 'd'].map((n) => `${FC}/flowchart.spec.js/${n}.png`);
+    const [sheet] = planSheets(four, { tilesPerSheet: 12, cols: 3 });
+    expect(sheet.tiles.map((t) => [t.row, t.col])).toStrictEqual([
+      [0, 0],
+      [0, 1],
+      [0, 2],
+      [1, 0],
+    ]);
+  });
+
+  it('adding a test to one diagram leaves other diagrams’ sheets byte-identical', () => {
+    const before = planSheets(paths, { tilesPerSheet: 12, cols: 3 });
+    const after = planSheets([...paths, `${FC}/flowchart.spec.js/aa.png`], {
+      tilesPerSheet: 12,
+      cols: 3,
+    });
+    const clsBefore = before.filter((s) => s.group === CLS);
+    const clsAfter = after.filter((s) => s.group === CLS);
+    expect(clsAfter).toStrictEqual(clsBefore);
+  });
+});
+
+describe('compositor', () => {
+  let dir: string;
+
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'argos-batch-'));
+    const specDir = join(dir, 'rendering/flowchart/flowchart.spec.js');
+    await mkdir(specDir, { recursive: true });
+    // Three differently-sized solid PNGs.
+    const tiles = [
+      { name: 'a.png', w: 20, h: 10, c: { r: 255, g: 0, b: 0, alpha: 1 } },
+      { name: 'b.png', w: 10, h: 30, c: { r: 0, g: 255, b: 0, alpha: 1 } },
+      { name: 'c.png', w: 40, h: 15, c: { r: 0, g: 0, b: 255, alpha: 1 } },
+    ];
+    for (const t of tiles) {
+      const buf = await sharp({
+        create: { width: t.w, height: t.h, channels: 4, background: t.c },
+      })
+        .png()
+        .toBuffer();
+      await writeFile(join(specDir, t.name), buf);
+    }
+  });
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('collectScreenshots returns sorted relative png paths', async () => {
+    const paths = await collectScreenshots(dir);
+    expect(paths).toStrictEqual([
+      'rendering/flowchart/flowchart.spec.js/a.png',
+      'rendering/flowchart/flowchart.spec.js/b.png',
+      'rendering/flowchart/flowchart.spec.js/c.png',
+    ]);
+  });
+
+  it('composes a fixed-cell grid sized to the largest tile', async () => {
+    const paths = await collectScreenshots(dir);
+    const [plan] = planSheets(paths, { tilesPerSheet: 12, cols: 3 });
+    const { buffer, manifest } = await composeSheet(plan, { inputDir: dir });
+    const meta = await sharp(buffer).metadata();
+    // cellWidth = max(20,10,40)=40, cellHeight=max(10,30,15)=30, cols=3, rows=1
+    expect(meta.width).toBe(120);
+    expect(meta.height).toBe(30);
+    expect(manifest.grid).toStrictEqual({ cols: 3, rows: 1, cellWidth: 40, cellHeight: 30 });
+    expect(manifest.tiles[0]).toMatchObject({ name: 'a', row: 0, col: 0 });
+  });
+
+  it('produces byte-identical output on re-run (determinism)', async () => {
+    const paths = await collectScreenshots(dir);
+    const [plan] = planSheets(paths, { tilesPerSheet: 12, cols: 3 });
+    const first = await composeSheet(plan, { inputDir: dir });
+    const second = await composeSheet(plan, { inputDir: dir });
+    expect(first.buffer.equals(second.buffer)).toBe(true);
+  });
+});

--- a/scripts/argos-batch-sheets.spec.ts
+++ b/scripts/argos-batch-sheets.spec.ts
@@ -8,6 +8,8 @@ import {
   planSheets,
   collectScreenshots,
   composeSheet,
+  formatTileTitle,
+  LABEL_HEIGHT,
 } from './argos-batch-sheets.ts';
 
 const FC = 'rendering/flowchart';
@@ -86,6 +88,14 @@ describe('planSheets', () => {
   });
 });
 
+describe('formatTileTitle', () => {
+  it('restores spaces from hyphenated Cypress screenshot names', () => {
+    expect(formatTileTitle('1-should-render-a-basic-treemap')).toBe(
+      '1 should render a basic treemap'
+    );
+  });
+});
+
 describe('compositor', () => {
   let dir: string;
 
@@ -122,16 +132,35 @@ describe('compositor', () => {
     ]);
   });
 
-  it('composes a fixed-cell grid sized to the largest tile', async () => {
+  it('composes a fixed-cell grid sized to the largest tile with title labels', async () => {
     const paths = await collectScreenshots(dir);
     const [plan] = planSheets(paths, { tilesPerSheet: 12, cols: 3 });
     const { buffer, manifest } = await composeSheet(plan, { inputDir: dir });
     const meta = await sharp(buffer).metadata();
-    // cellWidth = max(20,10,40)=40, cellHeight=max(10,30,15)=30, cols=3, rows=1
+    // cellWidth = max(20,10,40)=40, imageHeight=max(10,30,15)=30, label=24
     expect(meta.width).toBe(120);
-    expect(meta.height).toBe(30);
-    expect(manifest.grid).toStrictEqual({ cols: 3, rows: 1, cellWidth: 40, cellHeight: 30 });
-    expect(manifest.tiles[0]).toMatchObject({ name: 'a', row: 0, col: 0 });
+    expect(meta.height).toBe(30 + LABEL_HEIGHT);
+    expect(manifest.grid).toStrictEqual({
+      cols: 3,
+      rows: 1,
+      cellWidth: 40,
+      cellHeight: 30 + LABEL_HEIGHT,
+      imageHeight: 30,
+      labelHeight: LABEL_HEIGHT,
+      scale: 1,
+    });
+    expect(manifest.tiles[0]).toMatchObject({ name: 'a', title: 'a', row: 0, col: 0 });
+  });
+
+  it('scales output dimensions when scale > 1', async () => {
+    const paths = await collectScreenshots(dir);
+    const [plan] = planSheets(paths, { tilesPerSheet: 12, cols: 3 });
+    const { buffer, manifest } = await composeSheet(plan, { inputDir: dir, scale: 2 });
+    const meta = await sharp(buffer).metadata();
+    expect(meta.width).toBe(240);
+    expect(meta.height).toBe((30 + LABEL_HEIGHT) * 2);
+    expect(manifest.grid.scale).toBe(2);
+    expect(manifest.grid.cellWidth).toBe(80);
   });
 
   it('produces byte-identical output on re-run (determinism)', async () => {

--- a/scripts/argos-batch-sheets.spec.ts
+++ b/scripts/argos-batch-sheets.spec.ts
@@ -10,7 +10,12 @@ import {
   composeSheet,
   formatTileTitle,
   LABEL_HEIGHT,
+  DEFAULT_TILE_WIDTH,
+  DEFAULT_TILE_IMAGE_HEIGHT,
 } from './argos-batch-sheets.ts';
+
+const SLOT_WIDTH = 40;
+const SLOT_HEIGHT = 30;
 
 const FC = 'rendering/flowchart';
 const CLS = 'rendering/class';
@@ -132,42 +137,74 @@ describe('compositor', () => {
     ]);
   });
 
-  it('composes a fixed-cell grid sized to the largest tile with title labels', async () => {
+  it('composes a fixed viewport cell grid with title labels', async () => {
     const paths = await collectScreenshots(dir);
     const [plan] = planSheets(paths, { tilesPerSheet: 12, cols: 3 });
-    const { buffer, manifest } = await composeSheet(plan, { inputDir: dir });
+    const slot = { tileWidth: SLOT_WIDTH, tileImageHeight: SLOT_HEIGHT };
+    const { buffer, manifest } = await composeSheet(plan, { inputDir: dir, ...slot });
     const meta = await sharp(buffer).metadata();
-    // cellWidth = max(20,10,40)=40, imageHeight=max(10,30,15)=30, label=24
-    expect(meta.width).toBe(120);
-    expect(meta.height).toBe(30 + LABEL_HEIGHT);
+    expect(meta.width).toBe(SLOT_WIDTH * 3);
+    expect(meta.height).toBe(SLOT_HEIGHT + LABEL_HEIGHT);
     expect(manifest.grid).toStrictEqual({
       cols: 3,
       rows: 1,
-      cellWidth: 40,
-      cellHeight: 30 + LABEL_HEIGHT,
-      imageHeight: 30,
+      cellWidth: SLOT_WIDTH,
+      cellHeight: SLOT_HEIGHT + LABEL_HEIGHT,
+      imageHeight: SLOT_HEIGHT,
       labelHeight: LABEL_HEIGHT,
       scale: 1,
     });
     expect(manifest.tiles[0]).toMatchObject({ name: 'a', title: 'a', row: 0, col: 0 });
   });
 
+  it('keeps grid dimensions when tile screenshot sizes differ', async () => {
+    const specDir = join(dir, 'rendering/flowchart/flowchart.spec.js');
+    const huge = await sharp({
+      create: { width: 200, height: 150, channels: 4, background: { r: 0, g: 0, b: 0, alpha: 1 } },
+    })
+      .png()
+      .toBuffer();
+    await writeFile(join(specDir, 'huge.png'), huge);
+
+    const slot = { tileWidth: SLOT_WIDTH, tileImageHeight: SLOT_HEIGHT };
+    const [smallPlan] = planSheets(['rendering/flowchart/flowchart.spec.js/a.png'], {
+      tilesPerSheet: 12,
+      cols: 3,
+    });
+    const [hugePlan] = planSheets(['rendering/flowchart/flowchart.spec.js/huge.png'], {
+      tilesPerSheet: 12,
+      cols: 3,
+    });
+
+    const small = await composeSheet(smallPlan, { inputDir: dir, ...slot });
+    const withHuge = await composeSheet(hugePlan, { inputDir: dir, ...slot });
+
+    expect(withHuge.manifest.grid).toStrictEqual(small.manifest.grid);
+  });
+
+  it('defaults to the Cypress viewport slot size', () => {
+    expect(DEFAULT_TILE_WIDTH).toBe(1440);
+    expect(DEFAULT_TILE_IMAGE_HEIGHT).toBe(1024);
+  });
+
   it('scales output dimensions when scale > 1', async () => {
-    const paths = await collectScreenshots(dir);
+    const paths = (await collectScreenshots(dir)).filter((p) => !p.endsWith('huge.png'));
     const [plan] = planSheets(paths, { tilesPerSheet: 12, cols: 3 });
-    const { buffer, manifest } = await composeSheet(plan, { inputDir: dir, scale: 2 });
+    const slot = { tileWidth: SLOT_WIDTH, tileImageHeight: SLOT_HEIGHT, scale: 2 as const };
+    const { buffer, manifest } = await composeSheet(plan, { inputDir: dir, ...slot });
     const meta = await sharp(buffer).metadata();
-    expect(meta.width).toBe(240);
-    expect(meta.height).toBe((30 + LABEL_HEIGHT) * 2);
+    expect(meta.width).toBe(SLOT_WIDTH * 3 * 2);
+    expect(meta.height).toBe((SLOT_HEIGHT + LABEL_HEIGHT) * 2);
     expect(manifest.grid.scale).toBe(2);
-    expect(manifest.grid.cellWidth).toBe(80);
+    expect(manifest.grid.cellWidth).toBe(SLOT_WIDTH * 2);
   });
 
   it('produces byte-identical output on re-run (determinism)', async () => {
-    const paths = await collectScreenshots(dir);
+    const paths = (await collectScreenshots(dir)).filter((p) => !p.endsWith('huge.png'));
     const [plan] = planSheets(paths, { tilesPerSheet: 12, cols: 3 });
-    const first = await composeSheet(plan, { inputDir: dir });
-    const second = await composeSheet(plan, { inputDir: dir });
+    const slot = { tileWidth: SLOT_WIDTH, tileImageHeight: SLOT_HEIGHT };
+    const first = await composeSheet(plan, { inputDir: dir, ...slot });
+    const second = await composeSheet(plan, { inputDir: dir, ...slot });
     expect(first.buffer.equals(second.buffer)).toBe(true);
   });
 });

--- a/scripts/argos-batch-sheets.ts
+++ b/scripts/argos-batch-sheets.ts
@@ -287,7 +287,6 @@ export async function composeSheet(
       sharp(join(inputDir, t.source))
         .resize(cellWidth, imageHeight, {
           fit: 'inside',
-          withoutEnlargement: true,
           kernel: sharp.kernel.lanczos3,
         })
         .png({ compressionLevel: 9 })
@@ -309,14 +308,14 @@ export async function composeSheet(
 
   const composites = plan.tiles.flatMap((t, i) => [
     {
-      input: tileBuffers[i],
+      input: labelBuffers[i],
       left: t.col * cellWidth,
       top: t.row * cellHeight,
     },
     {
-      input: labelBuffers[i],
+      input: tileBuffers[i],
       left: t.col * cellWidth,
-      top: t.row * cellHeight + imageHeight,
+      top: t.row * cellHeight + labelHeight,
     },
   ]);
 

--- a/scripts/argos-batch-sheets.ts
+++ b/scripts/argos-batch-sheets.ts
@@ -30,6 +30,12 @@ const GRID_LINE_WIDTH = 1;
 const GRID_LINE_COLOR = '#cccccc';
 /** Default output scale for composite sheets (1 = native pixel dimensions). */
 export const DEFAULT_SHEET_SCALE = 1;
+/** Default sheets composited concurrently (bounded so memory stays sane). */
+export const DEFAULT_SHEET_CONCURRENCY = 4;
+/** zlib level for the final written sheet — uploaded then discarded, so size barely matters. */
+const SHEET_PNG_COMPRESSION = 3;
+/** Transient buffers are re-decoded during composite; skip zlib effort entirely. */
+const INTERMEDIATE_PNG_COMPRESSION = 0;
 
 function scaled(value: number, scale: number): number {
   return Math.round(value * scale);
@@ -105,18 +111,6 @@ function createLabelSvg(
   return Buffer.from(svg);
 }
 
-async function createLabelBuffer(
-  title: string,
-  width: number,
-  height: number,
-  fontSize: number,
-  padding: number
-): Promise<Buffer> {
-  return sharp(createLabelSvg(title, width, height, fontSize, padding))
-    .png({ compressionLevel: 9 })
-    .toBuffer();
-}
-
 function createGridLinesSvg(
   width: number,
   height: number,
@@ -161,8 +155,29 @@ async function createGridLinesBuffer(
   lineWidth: number
 ): Promise<Buffer> {
   return sharp(createGridLinesSvg(width, height, cols, rows, cellWidth, cellHeight, lineWidth))
-    .png({ compressionLevel: 9 })
+    .png({ compressionLevel: INTERMEDIATE_PNG_COMPRESSION })
     .toBuffer();
+}
+
+// Grid lines depend only on dimensions, which repeat across same-shape sheets
+// (every full sheet shares them). Rasterize once per shape and reuse.
+const gridBufferCache = new Map<string, Promise<Buffer>>();
+function getGridBuffer(
+  width: number,
+  height: number,
+  cols: number,
+  rows: number,
+  cellWidth: number,
+  cellHeight: number,
+  lineWidth: number
+): Promise<Buffer> {
+  const key = `${width}:${height}:${cols}:${rows}:${cellWidth}:${cellHeight}:${lineWidth}`;
+  let buffer = gridBufferCache.get(key);
+  if (!buffer) {
+    buffer = createGridLinesBuffer(width, height, cols, rows, cellWidth, cellHeight, lineWidth);
+    gridBufferCache.set(key, buffer);
+  }
+  return buffer;
 }
 
 export interface PlanSheetsOptions {
@@ -187,6 +202,7 @@ export interface WriteSheetsOptions {
   scale?: number;
   tileWidth?: number;
   tileImageHeight?: number;
+  concurrency?: number;
 }
 
 /** Maps a screenshot path to its diagram folder (prefix before the `*.spec.*` segment). */
@@ -289,26 +305,22 @@ export async function composeSheet(
           fit: 'inside',
           kernel: sharp.kernel.lanczos3,
         })
-        .png({ compressionLevel: 9 })
+        .png({ compressionLevel: INTERMEDIATE_PNG_COMPRESSION })
         .toBuffer()
     )
   );
 
-  const labelBuffers = await Promise.all(
-    plan.tiles.map((t) =>
-      createLabelBuffer(
+  // Label SVGs are composited directly; sharp rasterizes them in the sheet
+  // pipeline, avoiding a per-tile PNG encode + decode round-trip.
+  const composites = plan.tiles.flatMap((t, i) => [
+    {
+      input: createLabelSvg(
         formatTileTitle(t.name),
         cellWidth,
         labelHeight,
         labelFontSize,
         labelPadding
-      )
-    )
-  );
-
-  const composites = plan.tiles.flatMap((t, i) => [
-    {
-      input: labelBuffers[i],
+      ),
       left: t.col * cellWidth,
       top: t.row * cellHeight,
     },
@@ -321,7 +333,7 @@ export async function composeSheet(
 
   const sheetWidth = cellWidth * cols;
   const sheetHeight = cellHeight * rows;
-  const gridBuffer = await createGridLinesBuffer(
+  const gridBuffer = await getGridBuffer(
     sheetWidth,
     sheetHeight,
     cols,
@@ -335,7 +347,7 @@ export async function composeSheet(
     create: { width: sheetWidth, height: sheetHeight, channels: 4, background },
   })
     .composite([...composites, { input: gridBuffer, left: 0, top: 0 }])
-    .png({ compressionLevel: 9 })
+    .png({ compressionLevel: SHEET_PNG_COMPRESSION })
     .toBuffer();
 
   const manifest: SheetManifest = {
@@ -365,7 +377,8 @@ export async function composeSheet(
 
 /** Writes composite PNGs and sibling `.json` manifests under outDir. */
 export async function writeSheets(plans: Sheet[], options: WriteSheetsOptions): Promise<void> {
-  for (const plan of plans) {
+  const concurrency = Math.max(1, options.concurrency ?? DEFAULT_SHEET_CONCURRENCY);
+  const writeOne = async (plan: Sheet): Promise<void> => {
     const { buffer, manifest } = await composeSheet(plan, {
       inputDir: options.inputDir,
       scale: options.scale,
@@ -376,6 +389,9 @@ export async function writeSheets(plans: Sheet[], options: WriteSheetsOptions): 
     await mkdir(dirname(sheetPath), { recursive: true });
     await writeFile(sheetPath, buffer);
     await writeFile(sheetPath.replace(/\.png$/, '.json'), JSON.stringify(manifest, null, 2) + '\n');
+  };
+  for (let start = 0; start < plans.length; start += concurrency) {
+    await Promise.all(plans.slice(start, start + concurrency).map(writeOne));
   }
 }
 
@@ -387,10 +403,11 @@ async function main(): Promise<void> {
   const scale = Number(process.env.ARGOS_SHEET_SCALE ?? DEFAULT_SHEET_SCALE);
   const tileWidth = Number(process.env.ARGOS_TILE_WIDTH ?? DEFAULT_TILE_WIDTH);
   const tileImageHeight = Number(process.env.ARGOS_TILE_IMAGE_HEIGHT ?? DEFAULT_TILE_IMAGE_HEIGHT);
+  const concurrency = Number(process.env.ARGOS_SHEET_CONCURRENCY ?? DEFAULT_SHEET_CONCURRENCY);
 
   const relPaths = await collectScreenshots(inputDir);
   const plans = planSheets(relPaths, { tilesPerSheet, cols });
-  await writeSheets(plans, { inputDir, outDir, scale, tileWidth, tileImageHeight });
+  await writeSheets(plans, { inputDir, outDir, scale, tileWidth, tileImageHeight, concurrency });
   process.stdout.write(
     `[argos-batch] ${relPaths.length} screenshots → ${plans.length} sheets in ${outDir}\n`
   );

--- a/scripts/argos-batch-sheets.ts
+++ b/scripts/argos-batch-sheets.ts
@@ -7,7 +7,7 @@
  * CLI usage:
  *   pnpm run argos:batch
  *   ARGOS_SCREENSHOT_DIR=cypress/screenshots ARGOS_SHEETS_DIR=cypress/argos-sheets
- *     ARGOS_TILES_PER_SHEET=12 ARGOS_SHEET_COLS=3 pnpm run argos:batch
+ *     ARGOS_TILES_PER_SHEET=12 ARGOS_SHEET_COLS=3 ARGOS_SHEET_SCALE=2 pnpm run argos:batch
  */
 
 import { readdir, mkdir, writeFile } from 'node:fs/promises';
@@ -18,12 +18,32 @@ import sharp from 'sharp';
 // Matches a Cypress spec-file path segment: foo.spec.js / foo.spec.ts / .cjs / .mts
 const SPEC_SEGMENT_RE = /\.spec\.[cm]?[jt]s$/;
 
-export interface Tile {
-  index: number;
-  row: number;
-  col: number;
-  name: string;
-  source: string;
+/** Fixed label band under each screenshot tile (deterministic grid sizing). */
+export const LABEL_HEIGHT = 24;
+const LABEL_FONT_SIZE = 11;
+const LABEL_PADDING = 4;
+const GRID_LINE_WIDTH = 1;
+const GRID_LINE_COLOR = '#cccccc';
+/** Default output scale for composite sheets (2 = 2× pixel dimensions). */
+export const DEFAULT_SHEET_SCALE = 2;
+
+function scaled(value: number, scale: number): number {
+  return Math.round(value * scale);
+}
+
+export interface SheetManifest {
+  sheet: string;
+  group: string;
+  grid: {
+    cols: number;
+    rows: number;
+    cellWidth: number;
+    cellHeight: number;
+    imageHeight: number;
+    labelHeight: number;
+    scale: number;
+  };
+  tiles: (Tile & { title: string })[];
 }
 
 export interface Sheet {
@@ -34,11 +54,111 @@ export interface Sheet {
   tiles: Tile[];
 }
 
-export interface SheetManifest {
-  sheet: string;
-  group: string;
-  grid: { cols: number; rows: number; cellWidth: number; cellHeight: number };
-  tiles: Tile[];
+export interface Tile {
+  index: number;
+  row: number;
+  col: number;
+  name: string;
+  source: string;
+}
+
+/** Cypress screenshot names use hyphens instead of spaces; restore for display. */
+export function formatTileTitle(name: string): string {
+  return name.replace(/-/g, ' ');
+}
+
+function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function truncateTitle(title: string, maxWidth: number, fontSize: number, padding: number): string {
+  const maxChars = Math.floor((maxWidth - padding * 2) / (fontSize * 0.55));
+  if (title.length <= maxChars) {
+    return title;
+  }
+  return `${title.slice(0, Math.max(0, maxChars - 1))}…`;
+}
+
+function createLabelSvg(
+  title: string,
+  width: number,
+  height: number,
+  fontSize: number,
+  padding: number
+): Buffer {
+  const text = escapeXml(truncateTitle(title, width, fontSize, padding));
+  const baseline = fontSize + padding;
+  const svg = [
+    `<svg width="${width}" height="${height}" xmlns="http://www.w3.org/2000/svg">`,
+    `<rect width="100%" height="100%" fill="#ffffff"/>`,
+    `<text x="${padding}" y="${baseline}" font-family="sans-serif" font-size="${fontSize}" fill="#333333">${text}</text>`,
+    `</svg>`,
+  ].join('');
+  return Buffer.from(svg);
+}
+
+async function createLabelBuffer(
+  title: string,
+  width: number,
+  height: number,
+  fontSize: number,
+  padding: number
+): Promise<Buffer> {
+  return sharp(createLabelSvg(title, width, height, fontSize, padding))
+    .png({ compressionLevel: 9 })
+    .toBuffer();
+}
+
+function createGridLinesSvg(
+  width: number,
+  height: number,
+  cols: number,
+  rows: number,
+  cellWidth: number,
+  cellHeight: number,
+  lineWidth: number
+): Buffer {
+  const lines: string[] = [];
+  for (let c = 1; c < cols; c++) {
+    const x = c * cellWidth;
+    lines.push(
+      `<line x1="${x}" y1="0" x2="${x}" y2="${height}" stroke="${GRID_LINE_COLOR}" stroke-width="${lineWidth}"/>`
+    );
+  }
+  for (let r = 1; r < rows; r++) {
+    const y = r * cellHeight;
+    lines.push(
+      `<line x1="0" y1="${y}" x2="${width}" y2="${y}" stroke="${GRID_LINE_COLOR}" stroke-width="${lineWidth}"/>`
+    );
+  }
+  const inset = lineWidth / 2;
+  lines.push(
+    `<rect x="${inset}" y="${inset}" width="${width - lineWidth}" height="${height - lineWidth}" fill="none" stroke="${GRID_LINE_COLOR}" stroke-width="${lineWidth}"/>`
+  );
+  const svg = [
+    `<svg width="${width}" height="${height}" xmlns="http://www.w3.org/2000/svg">`,
+    ...lines,
+    `</svg>`,
+  ].join('');
+  return Buffer.from(svg);
+}
+
+async function createGridLinesBuffer(
+  width: number,
+  height: number,
+  cols: number,
+  rows: number,
+  cellWidth: number,
+  cellHeight: number,
+  lineWidth: number
+): Promise<Buffer> {
+  return sharp(createGridLinesSvg(width, height, cols, rows, cellWidth, cellHeight, lineWidth))
+    .png({ compressionLevel: 9 })
+    .toBuffer();
 }
 
 export interface PlanSheetsOptions {
@@ -49,11 +169,14 @@ export interface PlanSheetsOptions {
 export interface ComposeSheetOptions {
   inputDir: string;
   background?: { r: number; g: number; b: number; alpha: number };
+  /** Output scale factor (1 = native screenshot size, 2 = 2× pixels). */
+  scale?: number;
 }
 
 export interface WriteSheetsOptions {
   inputDir: string;
   outDir: string;
+  scale?: number;
 }
 
 /** Maps a screenshot path to its diagram folder (prefix before the `*.spec.*` segment). */
@@ -135,6 +258,7 @@ export async function composeSheet(
 ): Promise<{ buffer: Buffer; manifest: SheetManifest }> {
   const { inputDir } = options;
   const background = options.background ?? { r: 255, g: 255, b: 255, alpha: 1 };
+  const scale = options.scale ?? 1;
   const { cols } = plan;
 
   const dims = await Promise.all(
@@ -143,33 +267,91 @@ export async function composeSheet(
       return { width: meta.width ?? 0, height: meta.height ?? 0 };
     })
   );
-  const cellWidth = Math.max(...dims.map((d) => d.width));
-  const cellHeight = Math.max(...dims.map((d) => d.height));
+  const baseCellWidth = Math.max(...dims.map((d) => d.width));
+  const baseImageHeight = Math.max(...dims.map((d) => d.height));
+  const cellWidth = scaled(baseCellWidth, scale);
+  const imageHeight = scaled(baseImageHeight, scale);
+  const labelHeight = scaled(LABEL_HEIGHT, scale);
+  const cellHeight = imageHeight + labelHeight;
+  const labelFontSize = scaled(LABEL_FONT_SIZE, scale);
+  const labelPadding = scaled(LABEL_PADDING, scale);
+  const gridLineWidth = scaled(GRID_LINE_WIDTH, scale);
   const rows = Math.max(...plan.tiles.map((t) => t.row)) + 1;
 
-  const composites = plan.tiles.map((t) => ({
-    input: join(inputDir, t.source),
-    left: t.col * cellWidth,
-    top: t.row * cellHeight,
-  }));
+  const tileBuffers = await Promise.all(
+    plan.tiles.map((t, i) =>
+      sharp(join(inputDir, t.source))
+        .resize(scaled(dims[i].width, scale), scaled(dims[i].height, scale), {
+          kernel: sharp.kernel.lanczos3,
+        })
+        .png({ compressionLevel: 9 })
+        .toBuffer()
+    )
+  );
+
+  const labelBuffers = await Promise.all(
+    plan.tiles.map((t) =>
+      createLabelBuffer(
+        formatTileTitle(t.name),
+        cellWidth,
+        labelHeight,
+        labelFontSize,
+        labelPadding
+      )
+    )
+  );
+
+  const composites = plan.tiles.flatMap((t, i) => [
+    {
+      input: tileBuffers[i],
+      left: t.col * cellWidth,
+      top: t.row * cellHeight,
+    },
+    {
+      input: labelBuffers[i],
+      left: t.col * cellWidth,
+      top: t.row * cellHeight + imageHeight,
+    },
+  ]);
+
+  const sheetWidth = cellWidth * cols;
+  const sheetHeight = cellHeight * rows;
+  const gridBuffer = await createGridLinesBuffer(
+    sheetWidth,
+    sheetHeight,
+    cols,
+    rows,
+    cellWidth,
+    cellHeight,
+    gridLineWidth
+  );
 
   const buffer = await sharp({
-    create: { width: cellWidth * cols, height: cellHeight * rows, channels: 4, background },
+    create: { width: sheetWidth, height: sheetHeight, channels: 4, background },
   })
-    .composite(composites)
+    .composite([...composites, { input: gridBuffer, left: 0, top: 0 }])
     .png({ compressionLevel: 9 })
     .toBuffer();
 
   const manifest: SheetManifest = {
     sheet: plan.output,
     group: plan.group,
-    grid: { cols, rows, cellWidth, cellHeight },
+    grid: {
+      cols,
+      rows,
+      cellWidth,
+      cellHeight,
+      imageHeight,
+      labelHeight,
+      scale,
+    },
     tiles: plan.tiles.map((t) => ({
       index: t.index,
       row: t.row,
       col: t.col,
       name: t.name,
       source: t.source,
+      title: formatTileTitle(t.name),
     })),
   };
 
@@ -179,7 +361,10 @@ export async function composeSheet(
 /** Writes composite PNGs and sibling `.json` manifests under outDir. */
 export async function writeSheets(plans: Sheet[], options: WriteSheetsOptions): Promise<void> {
   for (const plan of plans) {
-    const { buffer, manifest } = await composeSheet(plan, { inputDir: options.inputDir });
+    const { buffer, manifest } = await composeSheet(plan, {
+      inputDir: options.inputDir,
+      scale: options.scale,
+    });
     const sheetPath = join(options.outDir, plan.output);
     await mkdir(dirname(sheetPath), { recursive: true });
     await writeFile(sheetPath, buffer);
@@ -192,10 +377,11 @@ async function main(): Promise<void> {
   const outDir = process.env.ARGOS_SHEETS_DIR ?? 'cypress/argos-sheets';
   const tilesPerSheet = Number(process.env.ARGOS_TILES_PER_SHEET ?? 12);
   const cols = Number(process.env.ARGOS_SHEET_COLS ?? 3);
+  const scale = Number(process.env.ARGOS_SHEET_SCALE ?? DEFAULT_SHEET_SCALE);
 
   const relPaths = await collectScreenshots(inputDir);
   const plans = planSheets(relPaths, { tilesPerSheet, cols });
-  await writeSheets(plans, { inputDir, outDir });
+  await writeSheets(plans, { inputDir, outDir, scale });
   process.stdout.write(
     `[argos-batch] ${relPaths.length} screenshots → ${plans.length} sheets in ${outDir}\n`
   );

--- a/scripts/argos-batch-sheets.ts
+++ b/scripts/argos-batch-sheets.ts
@@ -1,0 +1,206 @@
+/**
+ * Batches per-test Cypress screenshots into composite "sheets" for Argos,
+ * grouping by diagram folder so a new test in one diagram never alters another
+ * diagram's sheets. Pure planning is separated from sharp-backed compositing so
+ * the grouping/ordering rules can be unit-tested without images.
+ *
+ * CLI usage:
+ *   pnpm run argos:batch
+ *   ARGOS_SCREENSHOT_DIR=cypress/screenshots ARGOS_SHEETS_DIR=cypress/argos-sheets
+ *     ARGOS_TILES_PER_SHEET=12 ARGOS_SHEET_COLS=3 pnpm run argos:batch
+ */
+
+import { readdir, mkdir, writeFile } from 'node:fs/promises';
+import { join, dirname, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import sharp from 'sharp';
+
+// Matches a Cypress spec-file path segment: foo.spec.js / foo.spec.ts / .cjs / .mts
+const SPEC_SEGMENT_RE = /\.spec\.[cm]?[jt]s$/;
+
+export interface Tile {
+  index: number;
+  row: number;
+  col: number;
+  name: string;
+  source: string;
+}
+
+export interface Sheet {
+  group: string;
+  index: number;
+  output: string;
+  cols: number;
+  tiles: Tile[];
+}
+
+export interface SheetManifest {
+  sheet: string;
+  group: string;
+  grid: { cols: number; rows: number; cellWidth: number; cellHeight: number };
+  tiles: Tile[];
+}
+
+export interface PlanSheetsOptions {
+  tilesPerSheet?: number;
+  cols?: number;
+}
+
+export interface ComposeSheetOptions {
+  inputDir: string;
+  background?: { r: number; g: number; b: number; alpha: number };
+}
+
+export interface WriteSheetsOptions {
+  inputDir: string;
+  outDir: string;
+}
+
+/** Maps a screenshot path to its diagram folder (prefix before the `*.spec.*` segment). */
+export function deriveGroupKey(relPath: string): string {
+  const parts = relPath.split('/');
+  const specIdx = parts.findIndex((p) => SPEC_SEGMENT_RE.test(p));
+  if (specIdx > 0) {
+    return parts.slice(0, specIdx).join('/');
+  }
+  if (specIdx === 0) {
+    return parts[0].replace(SPEC_SEGMENT_RE, '');
+  }
+  return parts.slice(0, -1).join('/') || 'root';
+}
+
+/** Groups, stable-sorts, and chunks screenshots into fixed-size grid sheets. */
+export function planSheets(relPaths: string[], options: PlanSheetsOptions = {}): Sheet[] {
+  const tilesPerSheet = options.tilesPerSheet ?? 12;
+  const cols = options.cols ?? 3;
+
+  const groups = new Map<string, string[]>();
+  for (const p of relPaths) {
+    const key = deriveGroupKey(p);
+    const bucket = groups.get(key);
+    if (bucket) {
+      bucket.push(p);
+    } else {
+      groups.set(key, [p]);
+    }
+  }
+
+  const sheets: Sheet[] = [];
+  for (const key of [...groups.keys()].sort()) {
+    const tiles = [...(groups.get(key) ?? [])].sort();
+    const basename = key.split('/').pop() ?? 'sheet';
+    for (let start = 0; start < tiles.length; start += tilesPerSheet) {
+      const chunk = tiles.slice(start, start + tilesPerSheet);
+      const index = start / tilesPerSheet;
+      const output = `${key}/${basename}-${String(index + 1).padStart(3, '0')}.png`;
+      sheets.push({
+        group: key,
+        index,
+        output,
+        cols,
+        tiles: chunk.map((source, i) => ({
+          index: i,
+          row: Math.floor(i / cols),
+          col: i % cols,
+          name:
+            source
+              .split('/')
+              .pop()
+              ?.replace(/\.png$/, '') ?? '',
+          source,
+        })),
+      });
+    }
+  }
+  return sheets;
+}
+
+/** Recursively collects PNG paths under `dir`, relative with forward slashes, sorted. */
+export async function collectScreenshots(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { recursive: true, withFileTypes: true });
+  return entries
+    .filter((e) => e.isFile() && e.name.endsWith('.png'))
+    .map((e) =>
+      relative(dir, join(e.parentPath ?? e.path, e.name))
+        .split(sep)
+        .join('/')
+    )
+    .sort();
+}
+
+/** Composites one sheet into a deterministic PNG plus a tile manifest. */
+export async function composeSheet(
+  plan: Sheet,
+  options: ComposeSheetOptions
+): Promise<{ buffer: Buffer; manifest: SheetManifest }> {
+  const { inputDir } = options;
+  const background = options.background ?? { r: 255, g: 255, b: 255, alpha: 1 };
+  const { cols } = plan;
+
+  const dims = await Promise.all(
+    plan.tiles.map(async (t) => {
+      const meta = await sharp(join(inputDir, t.source)).metadata();
+      return { width: meta.width ?? 0, height: meta.height ?? 0 };
+    })
+  );
+  const cellWidth = Math.max(...dims.map((d) => d.width));
+  const cellHeight = Math.max(...dims.map((d) => d.height));
+  const rows = Math.max(...plan.tiles.map((t) => t.row)) + 1;
+
+  const composites = plan.tiles.map((t) => ({
+    input: join(inputDir, t.source),
+    left: t.col * cellWidth,
+    top: t.row * cellHeight,
+  }));
+
+  const buffer = await sharp({
+    create: { width: cellWidth * cols, height: cellHeight * rows, channels: 4, background },
+  })
+    .composite(composites)
+    .png({ compressionLevel: 9 })
+    .toBuffer();
+
+  const manifest: SheetManifest = {
+    sheet: plan.output,
+    group: plan.group,
+    grid: { cols, rows, cellWidth, cellHeight },
+    tiles: plan.tiles.map((t) => ({
+      index: t.index,
+      row: t.row,
+      col: t.col,
+      name: t.name,
+      source: t.source,
+    })),
+  };
+
+  return { buffer, manifest };
+}
+
+/** Writes composite PNGs and sibling `.json` manifests under outDir. */
+export async function writeSheets(plans: Sheet[], options: WriteSheetsOptions): Promise<void> {
+  for (const plan of plans) {
+    const { buffer, manifest } = await composeSheet(plan, { inputDir: options.inputDir });
+    const sheetPath = join(options.outDir, plan.output);
+    await mkdir(dirname(sheetPath), { recursive: true });
+    await writeFile(sheetPath, buffer);
+    await writeFile(sheetPath.replace(/\.png$/, '.json'), JSON.stringify(manifest, null, 2) + '\n');
+  }
+}
+
+async function main(): Promise<void> {
+  const inputDir = process.env.ARGOS_SCREENSHOT_DIR ?? 'cypress/screenshots';
+  const outDir = process.env.ARGOS_SHEETS_DIR ?? 'cypress/argos-sheets';
+  const tilesPerSheet = Number(process.env.ARGOS_TILES_PER_SHEET ?? 12);
+  const cols = Number(process.env.ARGOS_SHEET_COLS ?? 3);
+
+  const relPaths = await collectScreenshots(inputDir);
+  const plans = planSheets(relPaths, { tilesPerSheet, cols });
+  await writeSheets(plans, { inputDir, outDir });
+  process.stdout.write(
+    `[argos-batch] ${relPaths.length} screenshots → ${plans.length} sheets in ${outDir}\n`
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  void main();
+}

--- a/scripts/argos-batch-sheets.ts
+++ b/scripts/argos-batch-sheets.ts
@@ -28,8 +28,8 @@ const LABEL_FONT_SIZE = 11;
 const LABEL_PADDING = 4;
 const GRID_LINE_WIDTH = 1;
 const GRID_LINE_COLOR = '#cccccc';
-/** Default output scale for composite sheets (2 = 2× pixel dimensions). */
-export const DEFAULT_SHEET_SCALE = 2;
+/** Default output scale for composite sheets (1 = native pixel dimensions). */
+export const DEFAULT_SHEET_SCALE = 1;
 
 function scaled(value: number, scale: number): number {
   return Math.round(value * scale);

--- a/scripts/argos-batch-sheets.ts
+++ b/scripts/argos-batch-sheets.ts
@@ -7,7 +7,8 @@
  * CLI usage:
  *   pnpm run argos:batch
  *   ARGOS_SCREENSHOT_DIR=cypress/screenshots ARGOS_SHEETS_DIR=cypress/argos-sheets
- *     ARGOS_TILES_PER_SHEET=12 ARGOS_SHEET_COLS=3 ARGOS_SHEET_SCALE=2 pnpm run argos:batch
+ *     ARGOS_TILES_PER_SHEET=12 ARGOS_SHEET_COLS=3 ARGOS_SHEET_SCALE=2
+ *     ARGOS_TILE_WIDTH=1440 ARGOS_TILE_IMAGE_HEIGHT=1024 pnpm run argos:batch
  */
 
 import { readdir, mkdir, writeFile } from 'node:fs/promises';
@@ -20,6 +21,9 @@ const SPEC_SEGMENT_RE = /\.spec\.[cm]?[jt]s$/;
 
 /** Fixed label band under each screenshot tile (deterministic grid sizing). */
 export const LABEL_HEIGHT = 24;
+/** Matches cypress.config.ts viewport — every cell uses this slot, not max(tile). */
+export const DEFAULT_TILE_WIDTH = 1440;
+export const DEFAULT_TILE_IMAGE_HEIGHT = 1024;
 const LABEL_FONT_SIZE = 11;
 const LABEL_PADDING = 4;
 const GRID_LINE_WIDTH = 1;
@@ -171,12 +175,18 @@ export interface ComposeSheetOptions {
   background?: { r: number; g: number; b: number; alpha: number };
   /** Output scale factor (1 = native screenshot size, 2 = 2× pixels). */
   scale?: number;
+  /** Fixed image slot width in pixels before scale (default: Cypress viewport width). */
+  tileWidth?: number;
+  /** Fixed image slot height in pixels before scale (default: Cypress viewport height). */
+  tileImageHeight?: number;
 }
 
 export interface WriteSheetsOptions {
   inputDir: string;
   outDir: string;
   scale?: number;
+  tileWidth?: number;
+  tileImageHeight?: number;
 }
 
 /** Maps a screenshot path to its diagram folder (prefix before the `*.spec.*` segment). */
@@ -258,17 +268,11 @@ export async function composeSheet(
 ): Promise<{ buffer: Buffer; manifest: SheetManifest }> {
   const { inputDir } = options;
   const background = options.background ?? { r: 255, g: 255, b: 255, alpha: 1 };
-  const scale = options.scale ?? 1;
   const { cols } = plan;
 
-  const dims = await Promise.all(
-    plan.tiles.map(async (t) => {
-      const meta = await sharp(join(inputDir, t.source)).metadata();
-      return { width: meta.width ?? 0, height: meta.height ?? 0 };
-    })
-  );
-  const baseCellWidth = Math.max(...dims.map((d) => d.width));
-  const baseImageHeight = Math.max(...dims.map((d) => d.height));
+  const scale = options.scale ?? 1;
+  const baseCellWidth = options.tileWidth ?? DEFAULT_TILE_WIDTH;
+  const baseImageHeight = options.tileImageHeight ?? DEFAULT_TILE_IMAGE_HEIGHT;
   const cellWidth = scaled(baseCellWidth, scale);
   const imageHeight = scaled(baseImageHeight, scale);
   const labelHeight = scaled(LABEL_HEIGHT, scale);
@@ -279,9 +283,11 @@ export async function composeSheet(
   const rows = Math.max(...plan.tiles.map((t) => t.row)) + 1;
 
   const tileBuffers = await Promise.all(
-    plan.tiles.map((t, i) =>
+    plan.tiles.map((t) =>
       sharp(join(inputDir, t.source))
-        .resize(scaled(dims[i].width, scale), scaled(dims[i].height, scale), {
+        .resize(cellWidth, imageHeight, {
+          fit: 'inside',
+          withoutEnlargement: true,
           kernel: sharp.kernel.lanczos3,
         })
         .png({ compressionLevel: 9 })
@@ -364,6 +370,8 @@ export async function writeSheets(plans: Sheet[], options: WriteSheetsOptions): 
     const { buffer, manifest } = await composeSheet(plan, {
       inputDir: options.inputDir,
       scale: options.scale,
+      tileWidth: options.tileWidth,
+      tileImageHeight: options.tileImageHeight,
     });
     const sheetPath = join(options.outDir, plan.output);
     await mkdir(dirname(sheetPath), { recursive: true });
@@ -378,10 +386,12 @@ async function main(): Promise<void> {
   const tilesPerSheet = Number(process.env.ARGOS_TILES_PER_SHEET ?? 12);
   const cols = Number(process.env.ARGOS_SHEET_COLS ?? 3);
   const scale = Number(process.env.ARGOS_SHEET_SCALE ?? DEFAULT_SHEET_SCALE);
+  const tileWidth = Number(process.env.ARGOS_TILE_WIDTH ?? DEFAULT_TILE_WIDTH);
+  const tileImageHeight = Number(process.env.ARGOS_TILE_IMAGE_HEIGHT ?? DEFAULT_TILE_IMAGE_HEIGHT);
 
   const relPaths = await collectScreenshots(inputDir);
   const plans = planSheets(relPaths, { tilesPerSheet, cols });
-  await writeSheets(plans, { inputDir, outDir, scale });
+  await writeSheets(plans, { inputDir, outDir, scale, tileWidth, tileImageHeight });
   process.stdout.write(
     `[argos-batch] ${relPaths.length} screenshots → ${plans.length} sheets in ${outDir}\n`
   );


### PR DESCRIPTION
## Summary

- Capture per-test Argos screenshots during Cypress with `uploadToArgos: false`; no in-run uploads.
- Add `scripts/argos-batch-sheets.ts` — deterministic planner + sharp compositor that groups screenshots by diagram folder, chunks into fixed-tile sheets, and writes PNG + JSON manifests.
- Add `argos-batch` CI job: download per-container screenshot artifacts, run `pnpm run argos:batch`, single `argos upload`. Drops `ARGOS_PARALLEL*` env vars.

Reduces ~1,574 per-build Argos uploads to ~150–200 composite sheets without changing test count or coverage.

## Test plan

- [x] `pnpm vitest run scripts/argos-batch-sheets.spec.ts` — 11/11 pass (planner, compositor, determinism)
- [ ] CI `e2e` job uploads `argos-screenshots-*` artifacts when `RUN_VISUAL_TEST=true`
- [ ] CI `argos-batch` job composites and uploads to Argos successfully
- [ ] Scoped runs set `ARGOS_SUBSET=true` so absent sheets aren't treated as deletions
- [ ] Fork/local `cypress-image-snapshot` path unchanged when `RUN_VISUAL_TEST` is unset


Made with [Cursor](https://cursor.com)