### PR TITLE
ci(e2e): seed develop Argos baseline with grouped + individual screenshots

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -324,25 +324,22 @@ jobs:
         if: env.GROUP_ARGOS_IMAGES == 'true'
         run: pnpm run argos:batch
 
-      # Baseline branch (develop): combine the grouped sheets and the individual
+      # Baseline branch (develop): merge the grouped sheets and the individual
       # screenshots into one tree and upload them as a SINGLE Argos build. The CLI
       # uploads one directory and names each screenshot relative to it, so merging
       # preserves both naming schemes — sheet names (<group>/<group>-NNN.png) and
       # individual names (<group>/<spec>.spec.js/<name>.png) never collide and match
       # exactly what grouped PR / manual runs upload. The default build thus becomes
       # a superset baseline both modes can diff against (each marked --subset).
-      - name: Combine sheets and individual screenshots (develop baseline)
+      # No --subset here: a develop push runs the full suite and uploads both
+      # representations, so this is the complete, authoritative baseline.
+      - name: Upload combined baseline to Argos (develop)
         if: env.ARGOS_UPLOAD_BOTH == 'true'
         run: |
           mkdir -p cypress/argos-baseline
           cp -r cypress/argos-sheets/. cypress/argos-baseline/
           cp -r cypress/screenshots/. cypress/argos-baseline/
-
-      # No --subset: a develop push runs the full suite and uploads both
-      # representations, so this is the complete, authoritative baseline.
-      - name: Upload combined baseline to Argos (develop)
-        if: env.ARGOS_UPLOAD_BOTH == 'true'
-        run: npx argos upload cypress/argos-baseline
+          npx argos upload cypress/argos-baseline
 
       # PR / merge-queue / manual grouped runs: upload only the composite sheets.
       - name: Upload grouped sheets to Argos

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,6 +52,12 @@ env:
       github.event_name != 'workflow_dispatch' && 'true' ||
       (inputs.group_argos_images && 'true' || 'false')
     }}
+  # On a push to the baseline branch (develop), upload BOTH the grouped sheets
+  # and the individual per-test screenshots in a single Argos build, so the
+  # default build's baseline is a superset. Scoped grouped PRs and manual
+  # per-screenshot runs then both diff cleanly against it (each marked --subset).
+  ARGOS_UPLOAD_BOTH: >-
+    ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
 jobs:
   cache:
     runs-on: ubuntu-latest
@@ -279,7 +285,9 @@ jobs:
           retention-days: 1
 
   # Batch all per-container screenshots into folder-wise composite sheets and
-  # upload them to Argos in a single build. Replaces per-test Argos uploads.
+  # upload them to Argos in a single build. PR / merge-queue runs upload only the
+  # sheets; a push to develop additionally uploads the individual screenshots so
+  # the baseline is a superset (see ARGOS_UPLOAD_BOTH).
   argos-batch:
     if: >-
       ${{
@@ -316,12 +324,34 @@ jobs:
         if: env.GROUP_ARGOS_IMAGES == 'true'
         run: pnpm run argos:batch
 
+      # Baseline branch (develop): combine the grouped sheets and the individual
+      # screenshots into one tree and upload them as a SINGLE Argos build. The CLI
+      # uploads one directory and names each screenshot relative to it, so merging
+      # preserves both naming schemes — sheet names (<group>/<group>-NNN.png) and
+      # individual names (<group>/<spec>.spec.js/<name>.png) never collide and match
+      # exactly what grouped PR / manual runs upload. The default build thus becomes
+      # a superset baseline both modes can diff against (each marked --subset).
+      - name: Combine sheets and individual screenshots (develop baseline)
+        if: env.ARGOS_UPLOAD_BOTH == 'true'
+        run: |
+          mkdir -p cypress/argos-baseline
+          cp -r cypress/argos-sheets/. cypress/argos-baseline/
+          cp -r cypress/screenshots/. cypress/argos-baseline/
+
+      # No --subset: a develop push runs the full suite and uploads both
+      # representations, so this is the complete, authoritative baseline.
+      - name: Upload combined baseline to Argos (develop)
+        if: env.ARGOS_UPLOAD_BOTH == 'true'
+        run: npx argos upload cypress/argos-baseline
+
+      # PR / merge-queue / manual grouped runs: upload only the composite sheets.
       - name: Upload grouped sheets to Argos
-        if: env.GROUP_ARGOS_IMAGES == 'true'
+        if: env.GROUP_ARGOS_IMAGES == 'true' && env.ARGOS_UPLOAD_BOTH != 'true'
         env:
           ARGOS_SUBSET: true
         run: npx argos upload cypress/argos-sheets
 
+      # Manual per-screenshot runs (workflow_dispatch with group_argos_images=false).
       - name: Upload individual screenshots to Argos
         if: env.GROUP_ARGOS_IMAGES != 'true'
         env:


### PR DESCRIPTION
## Problem

The `argos-batch` job uploads **either** the grouped composite sheets (default) **or** the individual per-test screenshots (manual `workflow_dispatch` with `group_argos_images=false`) — never both. Both modes upload to the same default Argos build name, but develop's baseline only ever contains the grouped sheets. So a manual per-screenshot run has **no matching baseline** to diff against — every screenshot shows up as new.

## Change

On a **push to `develop`**, the job now merges `cypress/argos-sheets` + `cypress/screenshots` into one tree and uploads them as a **single** Argos build. develop's default-build baseline becomes a **superset** containing both representations, so:

- normal grouped PRs (sheets only, `--subset`) diff against the sheet baseline, and
- manual per-screenshot runs (individuals only, `--subset`) diff against the individual baseline.

No PR-side changes are needed — both modes already target the default build name.

### Why a single merged upload (not two `argos upload` calls)

`argos upload` takes one directory and names screenshots relative to it. Two uploads to the same commit + build name **collide** (the second supersedes the first) rather than combining. Merging into one root preserves both naming schemes exactly:

- sheets → `rendering/flowchart/flowchart-001.png`
- individuals → `rendering/flowchart/flowchart-v2.spec.js/<name>.png`

These never collide, and the names match precisely what grouped / manual PR runs upload.

The combined develop upload is **not** marked `--subset` — a develop push runs the full suite and uploads both representations, so it's the complete, authoritative baseline (and `--subset` would suppress deletion detection). PR/manual uploads keep `--subset`.

## Event matrix

| Event | Sheets built | Uploads |
| --- | --- | --- |
| push → develop | ✅ | **combined** (sheets + individuals), no `--subset` |
| push → master/release | ✅ | sheets only (`--subset`) |
| PR / merge_group | ✅ | sheets only (`--subset`) |
| manual, group=true | ✅ | sheets only (`--subset`) |
| manual, group=false | ❌ | individuals only (`--subset`) |

## Verification

- `js-yaml` parse + `prettier --check` pass.
- All six event paths traced — exactly one upload per run.
- Merge simulated locally: confirmed no path collisions and that combined names equal the union of grouped + individual upload names; `.json` manifests are ignored by Argos's default image glob.

> Note: scoped to `develop` only (the Argos reference branch). Say the word if `master`/`release` baselines should also carry both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)