### PR TITLE
ci(e2e): run the full Cypress suite across 8 shards instead of 5

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -122,7 +122,7 @@ jobs:
               echo "[detect-scope] Manual run — scoped to: ${SPEC}"
             else
               echo "spec_pattern=" >> "$GITHUB_OUTPUT"
-              echo "matrix=[1,2,3,4,5]" >> "$GITHUB_OUTPUT"
+              echo "matrix=[1,2,3,4,5,6,7,8]" >> "$GITHUB_OUTPUT"
               echo "[detect-scope] Manual run — full suite."
             fi
             exit 0
@@ -133,7 +133,7 @@ jobs:
           # (where repository variables are unavailable) still benefit from it.
           if [ "${E2E_SCOPE_BY_DIAGRAM}" = "false" ]; then
             echo "spec_pattern=" >> "$GITHUB_OUTPUT"
-            echo "matrix=[1,2,3,4,5]" >> "$GITHUB_OUTPUT"
+            echo "matrix=[1,2,3,4,5,6,7,8]" >> "$GITHUB_OUTPUT"
             echo "[detect-scope] Scoping disabled via kill-switch — full suite."
             exit 0
           fi
@@ -144,7 +144,7 @@ jobs:
           # full suite (no PR diff to scope against).
           if [ "$BASE" = "develop" ] || [ "$BASE" = "master" ]; then
             echo "spec_pattern=" >> "$GITHUB_OUTPUT"
-            echo "matrix=[1,2,3,4,5]" >> "$GITHUB_OUTPUT"
+            echo "matrix=[1,2,3,4,5,6,7,8]" >> "$GITHUB_OUTPUT"
             echo "[detect-scope] Direct push to ${BASE} — full suite."
             exit 0
           fi
@@ -155,7 +155,7 @@ jobs:
 
           if [ -z "$MERGE_BASE" ]; then
             echo "spec_pattern=" >> "$GITHUB_OUTPUT"
-            echo "matrix=[1,2,3,4,5]" >> "$GITHUB_OUTPUT"
+            echo "matrix=[1,2,3,4,5,6,7,8]" >> "$GITHUB_OUTPUT"
             echo "[detect-scope] Could not determine merge-base — full suite."
             exit 0
           fi
@@ -178,7 +178,7 @@ jobs:
             echo "[detect-scope] Scoped to: ${SPEC}"
           else
             echo "spec_pattern=" >> "$GITHUB_OUTPUT"
-            echo "matrix=[1,2,3,4,5]" >> "$GITHUB_OUTPUT"
+            echo "matrix=[1,2,3,4,5,6,7,8]" >> "$GITHUB_OUTPUT"
             echo "[detect-scope] Cannot scope — full suite."
           fi
           echo "[detect-scope] matrix output: $(grep '^matrix=' "$GITHUB_OUTPUT" | tail -1)"


### PR DESCRIPTION
## Why

The actual Cypress run dominates each shard's wall-clock. Measured on a recent full 5-shard run:

| | install | build (size) | **Cypress run** | overhead | total |
|---|---|---|---|---|---|
| per shard | ~60s | ~14s (shard 1) | **~455s (≈80%)** | ~43s | ~570s |

Since test execution is the bulk, sharding is the main lever on e2e duration.

## What

Bump every **full-suite** matrix in `detect-scope` from `[1,2,3,4,5]` to `[1,2,3,4,5,6,7,8]`. Scoped single-shard runs (`[1]`) are unchanged.

Nothing else needs touching: `cypress-split` reads `SPLIT`/`SPLIT_INDEX`, which derive from `strategy.job-total`/`job-index` (i.e. the matrix length) automatically, and per-shard artifacts are named by `matrix.containers` (unique 1–8).

## Expected impact

Full-suite critical path **~570s → ~385s (~32%)**, for 3 more concurrent runners per full run (≈+300 runner-seconds total). This is a runner-minutes/concurrency-for-wall-clock trade.

## The floor (follow-up)

`cypress-split` balances whole **spec files** — it can't split within a file — so the single heaviest spec is a hard floor:

```
252s  rendering/iconShape.spec.ts   ← floor ≈ 352s with overhead
138s  rendering/newShapes.spec.ts
104s  rendering/oldShapes.spec.ts
```

Past ~9 shards, one shard runs only `iconShape.spec.ts` while the extras idle — pure runner waste. Splitting that spec (so sharding can scale further) is a **separate PR**. `cypress/timings.json` is also stale (totals 3328s vs. the ~2276s actually run, with duplicate moved-spec entries) and could use a refresh.

## Verification
- `js-yaml` parse + `prettier --check` pass.
- All five full-suite branches updated; the two `[1]` scoped branches left intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)