### PR TITLE
test(e2e): use a solid-color image in imageShape specs instead of a remote photo

### DIFF
--- a/cypress/integration/rendering/imageShape.spec.ts
+++ b/cypress/integration/rendering/imageShape.spec.ts
@@ -15,13 +15,13 @@ looks.forEach((look) => {
       describe(`Test imageShape in ${look} look and dir ${direction} with label position ${pos ? pos : 'not defined'}`, () => {
         it(`without label`, () => {
           let flowchartCode = `flowchart ${direction}\n`;
-          flowchartCode += `  nA --> A@{ img: 'https://cdn.pixabay.com/photo/2020/02/22/18/49/paper-4871356_1280.jpg', w: '100', h: '100' }\n`;
+          flowchartCode += `  nA --> A@{ img: 'https://dummyimage.com/100x100/2c3e50/2c3e50.png', w: '100', h: '100' }\n`;
           imgSnapshotTest(flowchartCode, { look });
         });
 
         it(`with label`, () => {
           let flowchartCode = `flowchart ${direction}\n`;
-          flowchartCode += `  nA --> A@{ img: 'https://cdn.pixabay.com/photo/2020/02/22/18/49/paper-4871356_1280.jpg', label: 'This is a label for image shape'`;
+          flowchartCode += `  nA --> A@{ img: 'https://dummyimage.com/100x100/2c3e50/2c3e50.png', label: 'This is a label for image shape'`;
 
           flowchartCode += `, w: '100', h: '200'`;
           if (pos) {
@@ -33,7 +33,7 @@ looks.forEach((look) => {
 
         it(`with very long label`, () => {
           let flowchartCode = `flowchart ${direction}\n`;
-          flowchartCode += `  nA --> A@{ img: 'https://cdn.pixabay.com/photo/2020/02/22/18/49/paper-4871356_1280.jpg', label: 'This is a very very very very very long long long label for image shape'`;
+          flowchartCode += `  nA --> A@{ img: 'https://dummyimage.com/100x100/2c3e50/2c3e50.png', label: 'This is a very very very very very long long long label for image shape'`;
 
           flowchartCode += `, w: '100', h: '250'`;
           if (pos) {
@@ -45,7 +45,7 @@ looks.forEach((look) => {
 
         it(`with markdown htmlLabels:true`, () => {
           let flowchartCode = `flowchart ${direction}\n`;
-          flowchartCode += `  nA --> A@{ img: 'https://cdn.pixabay.com/photo/2020/02/22/18/49/paper-4871356_1280.jpg', label: 'This is **bold** </br>and <strong>strong</strong> for image shape'`;
+          flowchartCode += `  nA --> A@{ img: 'https://dummyimage.com/100x100/2c3e50/2c3e50.png', label: 'This is **bold** </br>and <strong>strong</strong> for image shape'`;
 
           flowchartCode += `, w: '550', h: '200'`;
           if (pos) {
@@ -57,7 +57,7 @@ looks.forEach((look) => {
 
         it(`with markdown htmlLabels:false`, () => {
           let flowchartCode = `flowchart ${direction}\n`;
-          flowchartCode += `  nA --> A@{ img: 'https://cdn.pixabay.com/photo/2020/02/22/18/49/paper-4871356_1280.jpg', label: 'This is **bold** </br>and <strong>strong</strong> for image shape'`;
+          flowchartCode += `  nA --> A@{ img: 'https://dummyimage.com/100x100/2c3e50/2c3e50.png', label: 'This is **bold** </br>and <strong>strong</strong> for image shape'`;
           flowchartCode += `, w: '250', h: '200'`;
 
           if (pos) {
@@ -73,7 +73,7 @@ looks.forEach((look) => {
 
         it(`with styles`, () => {
           let flowchartCode = `flowchart ${direction}\n`;
-          flowchartCode += `  nA --> A@{ img: 'https://cdn.pixabay.com/photo/2020/02/22/18/49/paper-4871356_1280.jpg', label: 'new image shape'`;
+          flowchartCode += `  nA --> A@{ img: 'https://dummyimage.com/100x100/2c3e50/2c3e50.png', label: 'new image shape'`;
           flowchartCode += `, w: '550', h: '200'`;
 
           if (pos) {
@@ -87,7 +87,7 @@ looks.forEach((look) => {
         it(`with classDef`, () => {
           let flowchartCode = `flowchart ${direction}\n`;
           flowchartCode += `  classDef customClazz fill:#bbf,stroke:#f66,stroke-width:2px,color:#000000,stroke-dasharray: 5 5\n`;
-          flowchartCode += `  nA --> A@{ img: 'https://cdn.pixabay.com/photo/2020/02/22/18/49/paper-4871356_1280.jpg', label: 'new image shape'`;
+          flowchartCode += `  nA --> A@{ img: 'https://dummyimage.com/100x100/2c3e50/2c3e50.png', label: 'new image shape'`;
 
           flowchartCode += `, w: '500', h: '550'`;
           if (pos) {


### PR DESCRIPTION
## Why

The `imageShape` specs embedded a Pixabay paper-texture JPEG (`paper-4871356_1280.jpg`). Two problems:

1. **Huge Argos sheets.** That high-entropy photo barely compresses. In the batched Argos sheets it was the single largest output — the seven `imageShape` sheets were ~2.7–3.0 MB each (biggest: `imageShape-006.png` at 2.99 MB), vs <1 MB for comparable line-art sheets. (Measured by running the grouping script locally over a full develop screenshot set.)
2. **External CDN dependency** fetched live during every run.

## Change

Swap the URL (7 occurrences) for a tiny, pixel-uniform solid-color PNG from `dummyimage.com`:

```
https://cdn.pixabay.com/photo/2020/02/22/18/49/paper-4871356_1280.jpg
→ https://dummyimage.com/100x100/2c3e50/2c3e50.png
```

(Per request, kept network-hosted rather than a `data:` URI. `dummyimage.com` returns a genuinely uniform image — `placehold.co` renders faint dimension text, so it isn't truly solid.)

## Why geometry is unchanged

These specs always pass `w`/`h` and never set `constraint`. In `imageSquare.ts`, when `constraint !== 'on'` the rendered box is `w`×`h` directly and the image is drawn with `preserveAspectRatio="none"` — so the source image's dimensions/aspect ratio are never used. Only the fill content changes (texture → solid).

## Expected Argos impact

The `imageShape` baselines will update (texture → solid slate fill) and those sheets shrink dramatically. This is intended.

## Verification

- 0 `pixabay` refs remain, 7 `dummyimage` refs; prettier passes.
- Confirmed `dummyimage.com/100x100/2c3e50/2c3e50.png` → HTTP 200, `image/png`, 116 bytes, every pixel exactly `#2c3e50`.
- Rendered an `imageShape` diagram locally: solid fill, with node/arrow/label laid out exactly as before.