### PR TITLE
fix(e2e): scope combined Argos baseline upload globs to image files

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -357,7 +357,14 @@ jobs:
           for i in $(seq 1 "$K"); do
             globs=()
             for j in "${!groups[@]}"; do
-              if [ $(( j % K + 1 )) -eq "$i" ]; then globs+=( "${groups[$j]}/**" ); fi
+              # Match only image files. A bare `<group>/**` also matches the
+              # `<name>.png.argos.json` metadata sidecars; Argos then treats each
+              # sidecar as a screenshot and reads `<sidecar>.argos.json`, doubling
+              # the suffix. For long screenshot names that path exceeds the 255-byte
+              # filename limit (ENAMETOOLONG), which Argos rethrows as
+              # "Failed to read metadata". Restricting to images avoids this and
+              # keeps the `.json` manifests / sidecars out of the upload entirely.
+              if [ $(( j % K + 1 )) -eq "$i" ]; then globs+=( "${groups[$j]}/**/*.{png,jpg,jpeg}" ); fi
             done
             [ ${#globs[@]} -eq 0 ] && continue
             npx argos upload cypress/argos-baseline \


### PR DESCRIPTION
Fixes the failing `argos-batch` job on develop (e.g. [run 27788277755](https://github.com/mermaid-js/mermaid/actions/runs/27788277755/job/82232128243)), which fails with `Build failed: Failed to read metadata`.

## Root cause

The develop-only **Upload combined baseline** step merges the composite sheets + individual screenshots and round-robins the tree into K=3 `--parallel` uploads using `--files "<group>/**"`.

That bare `/**` glob has **no extension filter** (Argos's default is `**/*.{png,jpg,jpeg}`), so it also discovers the per-screenshot `<name>.png.argos.json` **metadata sidecars** as if they were screenshots. Argos then reads each "screenshot's" metadata at `path + ".argos.json"`, producing a **doubled** suffix:

```
<name>.png.argos.json   →   <name>.png.argos.json.argos.json
```

For long screenshot names (several `sequencediagram-v2` tests), that filename component reaches **264 bytes > the 255-byte filesystem limit → ENAMETOOLONG**. `readMetadata` only swallows `ENOENT`; any other error is rethrown as **"Failed to read metadata"**, failing the job.

This is why the earlier *simple* single-upload version (default image-only glob) never hit it — it only got as far as the 413 that motivated the parallel split.

## Fix

Restrict the per-bucket globs to images:

```diff
- globs+=( "${groups[$j]}/**" )
+ globs+=( "${groups[$j]}/**/*.{png,jpg,jpeg}" )
```

This restores the default discovery behaviour, keeps the `.json` manifests and `.png.argos.json` sidecars out of the upload (they were being uploaded as bogus screenshots too), and shrinks each finalize body.

## Verification

Reproduced and fixed with the **real** Argos CLI at CI's exact versions (`@argos-ci/util@4.0.0`, `core@6.1.1`, `cli@5.0.5`), over the actual develop screenshot set (2977 screenshots + 274 sheets):

| `--files` | result |
|---|---|
| `"<group>/**"` (current) | ✖ `Failed to read metadata` at `readMetadata (util@4.0.0 …:78)` — matches CI |
| `"<group>/**/*.{png,jpg,jpeg}"` (this PR) | passes discovery — 3251 images, **0** metadata throws |

YAML parses; `prettier --check` passes.

> Note: this fixes the ENAMETOOLONG crash. The K=3 split already exists to keep each finalize body under the 413 limit; with images-only each bucket is smaller, so it stays well within it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)