### PR TITLE
feat(ishikawa): support empty gap branched with `[]`

### DIFF
--- a/.changeset/olive-masks-grow.md
+++ b/.changeset/olive-masks-grow.md
@@ -1,0 +1,5 @@
+---
+'mermaid': minor
+---
+
+feat(ishikawa): support empty gap branched with `[]`

--- a/docs/syntax/ishikawa.md
+++ b/docs/syntax/ishikawa.md
@@ -64,3 +64,4 @@ ishikawa-beta
 - The first line is the event (problem) of the diagram.
 - Subsequent lines are causes of the event.
 - "Fishbone" structure is indicated by indentation.
+- Use `[]` to reserve an empty gap where a branch would otherwise be rendered.

--- a/packages/mermaid/src/diagrams/ishikawa/ishikawa.spec.ts
+++ b/packages/mermaid/src/diagrams/ishikawa/ishikawa.spec.ts
@@ -1,12 +1,40 @@
 // @ts-expect-error No types available for JISON
 import { parser as ishikawa } from './parser/ishikawa.jison';
 import { IshikawaDB } from './ishikawaDb.js';
+import { renderer } from './ishikawaRenderer.js';
+import type { Diagram } from '../../Diagram.js';
 import { setLogLevel } from '../../diagram-api/diagramAPI.js';
+import { reset } from '../../config.js';
+
+const diagramId = 'ishikawa-test';
+
+const stubSvgTextMeasurement = (): void => {
+  Object.defineProperty(SVGElement.prototype, 'getBBox', {
+    configurable: true,
+    value: function (this: SVGElement) {
+      const text = this.textContent ?? '';
+      const width = Math.max(text.length * 8, 1);
+      const height = 16;
+      const x = Number(this.getAttribute('x') ?? 0);
+      const y = Number(this.getAttribute('y') ?? 0);
+
+      return {
+        x: x - width / 2,
+        y: y - height / 2,
+        width,
+        height,
+      };
+    },
+  });
+};
 
 describe('when parsing an Ishikawa diagram', function () {
   beforeEach(function () {
+    reset();
     ishikawa.yy = new IshikawaDB();
     ishikawa.yy.clear();
+    document.body.innerHTML = `<svg id="${diagramId}"></svg>`;
+    stubSvgTextMeasurement();
     setLogLevel('trace');
   });
 
@@ -62,5 +90,44 @@ Cause B
     expect(root?.children[0].children.length).toEqual(1);
     expect(root?.children[0].children[0].text).toEqual('Subcause A1');
     expect(root?.children[1].text).toEqual('Cause B');
+  });
+
+  it('should parse an empty gap branch', function () {
+    const str = `ishikawa-beta
+Problem
+Cause A
+[]
+Cause B
+`;
+
+    ishikawa.parse(str);
+    const root = ishikawa.yy.getRoot();
+    expect(root?.children.length).toEqual(3);
+    expect(root?.children[0].text).toEqual('Cause A');
+    expect(root?.children[0].isGap).toBe(false);
+    expect(root?.children[1].text).toEqual('[]');
+    expect(root?.children[1].isGap).toBe(true);
+  });
+
+  it('should reserve space for empty gap branches without rendering them', function () {
+    const str = `ishikawa-beta
+Problem
+Cause A
+[]
+Cause B
+`;
+
+    ishikawa.parse(str);
+    void renderer.draw(str, diagramId, '1.0.0', { db: ishikawa.yy } as unknown as Diagram);
+
+    const branchLines = [...document.querySelectorAll<SVGLineElement>('line.ishikawa-branch')];
+    const labels = [...document.querySelectorAll<SVGTextElement>('text')].map(
+      (text) => text.textContent
+    );
+    const spine = document.querySelector<SVGLineElement>('line.ishikawa-spine');
+
+    expect(branchLines).toHaveLength(2);
+    expect(labels).not.toContain('[]');
+    expect(Number(spine?.getAttribute('x1'))).toBeLessThan(-80);
   });
 });

--- a/packages/mermaid/src/diagrams/ishikawa/ishikawaDb.ts
+++ b/packages/mermaid/src/diagrams/ishikawa/ishikawaDb.ts
@@ -12,6 +12,8 @@ import {
 } from '../common/commonDb.js';
 import type { IshikawaNode } from './ishikawaTypes.js';
 
+const GAP_TEXT = '[]';
+
 interface StackEntry {
   level: number;
   node: IshikawaNode;
@@ -65,7 +67,7 @@ export class IshikawaDB implements DiagramDB {
     }
 
     const parent = this.stack[this.stack.length - 1].node;
-    const node: IshikawaNode = { text: label, children: [] };
+    const node: IshikawaNode = { text: label, children: [], isGap: label === GAP_TEXT };
     parent.children.push(node);
     this.stack.push({ level, node });
   }

--- a/packages/mermaid/src/diagrams/ishikawa/ishikawaRenderer.ts
+++ b/packages/mermaid/src/diagrams/ishikawa/ishikawaRenderer.ts
@@ -21,6 +21,7 @@ const SPINE_BASE_LENGTH = 250;
 const BONE_STUB = 30;
 const BONE_BASE = 60;
 const BONE_PER_CHILD = 5;
+const GAP_WIDTH = BONE_BASE;
 const ANGLE = (82 * Math.PI) / 180;
 const COS_A = Math.cos(ANGLE);
 const SIN_A = Math.sin(ANGLE);
@@ -129,14 +130,18 @@ const draw: DrawDefinition = (_text, id, _version, diagram: Diagram) => {
       [causes[p * 2], -1, upperLen] as const,
       [causes[p * 2 + 1], 1, lowerLen] as const,
     ]) {
-      if (cause) {
+      if (cause && !cause.isGap) {
         drawBranch(pg, cause, spineX, spineY, dir, len, fontSize, roughContext);
       }
     }
-    spineX = pg
+    let pairLeftX = pg
       .selectAll('text')
       .nodes()
       .reduce((left, n) => Math.min(left, (n as SVGGraphicsElement).getBBox().x), Infinity);
+    if (causes[p * 2]?.isGap || causes[p * 2 + 1]?.isGap) {
+      pairLeftX = Math.min(pairLeftX, spineX - GAP_WIDTH);
+    }
+    spineX = pairLeftX;
   }
 
   if (isHandDrawn) {
@@ -151,7 +156,7 @@ const draw: DrawDefinition = (_text, id, _version, diagram: Diagram) => {
 
 const sideStats = (nodes: IshikawaNode[]) => {
   const countDescendants = (node: IshikawaNode): number =>
-    node.children.reduce((sum, child) => sum + 1 + countDescendants(child), 0);
+    node.isGap ? 0 : node.children.reduce((sum, child) => sum + 1 + countDescendants(child), 0);
 
   return nodes.reduce(
     (stats, node) => {
@@ -215,6 +220,7 @@ interface LabelEntry {
   depth: number;
   parentIndex: number;
   childCount: number;
+  isGap?: boolean;
 }
 
 interface BoneInfo {
@@ -236,12 +242,13 @@ const flattenTree = (children: IshikawaNode[], direction: 1 | -1) => {
     const ordered = direction === -1 ? [...nodes].reverse() : nodes;
     for (const child of ordered) {
       const idx = entries.length;
-      const gc = child.children ?? [];
+      const gc = child.isGap ? [] : (child.children ?? []);
       entries.push({
         depth,
-        text: wrapText(child.text, 15),
+        text: child.isGap ? '' : wrapText(child.text, 15),
         parentIndex: pid,
         childCount: gc.length,
+        isGap: child.isGap,
       });
       if (depth % 2 === 0) {
         // Even-depth: pre-order (closer to spine)
@@ -405,25 +412,29 @@ const drawBranch = (
       bx0 = lerp(par.x0, par.x1, dyP ? (y - par.y0) / dyP : 0.5);
       by0 = y;
       bx1 = bx0 - (e.childCount > 0 ? BONE_BASE + e.childCount * BONE_PER_CHILD : BONE_STUB);
-      drawLine(grp, bx0, y, bx1, y, 'ishikawa-sub-branch', roughContext);
-      if (roughContext) {
-        drawArrowMarker(grp, bx0, y, 1, 0, roughContext);
+      if (!e.isGap) {
+        drawLine(grp, bx0, y, bx1, y, 'ishikawa-sub-branch', roughContext);
+        if (roughContext) {
+          drawArrowMarker(grp, bx0, y, 1, 0, roughContext);
+        }
+        drawMultilineText(grp, e.text, bx1, y, 'ishikawa-label align', 'end', fontSize);
       }
-      drawMultilineText(grp, e.text, bx1, y, 'ishikawa-label align', 'end', fontSize);
     } else {
       // Diagonal bone: start from evenly-spaced point on parent's horizontal, angle toward target Y
       const k = par.childrenDrawn++;
       bx0 = lerp(par.x0, par.x1, (par.childCount - k) / (par.childCount + 1));
       by0 = par.y0;
       bx1 = bx0 + diagonalX * ((y - by0) / diagonalY);
-      drawLine(grp, bx0, by0, bx1, y, 'ishikawa-sub-branch', roughContext);
-      if (roughContext) {
-        drawArrowMarker(grp, bx0, by0, bx0 - bx1, by0 - y, roughContext);
+      if (!e.isGap) {
+        drawLine(grp, bx0, by0, bx1, y, 'ishikawa-sub-branch', roughContext);
+        if (roughContext) {
+          drawArrowMarker(grp, bx0, by0, bx0 - bx1, by0 - y, roughContext);
+        }
+        drawMultilineText(grp, e.text, bx1, y, oddLabel, 'end', fontSize);
       }
-      drawMultilineText(grp, e.text, bx1, y, oddLabel, 'end', fontSize);
     }
 
-    if (e.childCount > 0) {
+    if (!e.isGap && e.childCount > 0) {
       bones.set(i, {
         x0: bx0,
         y0: by0,

--- a/packages/mermaid/src/diagrams/ishikawa/ishikawaTypes.ts
+++ b/packages/mermaid/src/diagrams/ishikawa/ishikawaTypes.ts
@@ -1,4 +1,5 @@
 export interface IshikawaNode {
   text: string;
   children: IshikawaNode[];
+  isGap?: boolean;
 }

--- a/packages/mermaid/src/docs/syntax/ishikawa.md
+++ b/packages/mermaid/src/docs/syntax/ishikawa.md
@@ -36,3 +36,4 @@ ishikawa-beta
 - The first line is the event (problem) of the diagram.
 - Subsequent lines are causes of the event.
 - "Fishbone" structure is indicated by indentation.
+- Use `[]` to reserve an empty gap where a branch would otherwise be rendered.


### PR DESCRIPTION
## :bookmark_tabs: Summary

This PR adds the possibility of specifying an "empty" branch in ishikawa diagrams. This is useful when you have long branch descriptions that would have the text collide with other branches.


Demonstration of the problem:

```mermaid
ishikawa
    Demo
    Category
        Very long branch description that is cool and more text goes here describing the potential cause
        Another long branch name that is less cool, but also describes another potential cause
    Category2
        Very long branch description that is cool and more text goes here describing the potential cause
        Another long branch name that is less cool, but also describes another potential cause
```

This PR enables you to add extra spacing between the branches.

```txt
ishikawa
    Demo
    Category
        Very long branch description that is cool and more text goes here describing the potential cause
        []
        []
        Another long branch name that is less cool, but also describes another potential cause
    Category2
        Very long branch description that is cool and more text goes here describing the potential cause
        []
        []
        Another long branch name that is less cool, but also describes another potential cause
```

## :straight_ruler: Design Decisions

I'm unsure about the overall approach here - maybe the real solution is to calculate the bounding boxes of the labels better instead?

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
