### PR TITLE
fix(coverage): stop unit coverage reporting untested files at 0%

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,11 @@ export default defineConfig({
     // TODO: should we move this to a mermaid-core package?
     coverage: {
       provider: 'v8',
+      // Only report files that unit tests actually exercise. Diagram render/style
+      // files are covered by the e2e suite, not unit tests; reporting them here at
+      // 0% makes them merge with the e2e flag on Codecov and paint e2e-covered
+      // files red in the combined view.
+      all: false,
       reporter: ['text', 'json', 'html', 'lcov'],
       reportsDirectory: './coverage/vitest',
       exclude: [...defaultExclude, './tests/**', '**/__mocks__/**', '**/generated/'],


### PR DESCRIPTION
## Problem

In the **combined** Codecov view, diagram render/style files (e.g. `packages/mermaid/src/diagrams/packet/styles.ts`) show most lines **red** even though e2e exercises them — only the few statement lines istanbul credits (5/18/19/21) are green.

## Root cause

Vitest's `coverage.all` (default **true**) makes the **unit** flag synthesize a dense, all-zero coverage report for *every* source file — including files no unit test imports. For `styles.ts` that's 28 lines all at `0`. Codecov merges the `unit` and `e2e` flags, and a line is green only if some flag hit it. e2e coverage is statement-level (istanbul), so it only credits 4 lines; every other line inherits unit's `0` → red.

This surfaced once e2e coverage uploads started working — before that there was no `e2e` flag to merge against.

I confirmed it's not fixable on the e2e side: routing e2e through V8 (monocart) instead of istanbul produces the **same** 4 statement-level lines for `styles.ts`, so the mismatch with unit's dense report persists regardless of e2e tooling.

## Fix

Set `coverage.all: false` for the unit (Vitest) coverage. Unit now reports only files it actually imports, so e2e-only files show just their e2e coverage in the combined view — no red flood.

## Verification (local)

Ran `packet.spec.ts` with coverage:
- Before (`all` default true): unit reported **2663** files; `styles.ts` present at 0%.
- After (`all: false`): unit reports **28** files; `styles.ts` is **gone**, while the unit-tested `db.ts`/`parser.ts` remain.

So the combined view for `styles.ts` will show only e2e's coverage (5/18/19/21 green, the rest untracked) instead of red.

## Trade-off

Genuinely untested files no longer surface as 0% in the unit report, so the unit coverage % rises. Coverage status checks are already off (informational only), so this is a reporting/display change, not a gate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
