### PR TITLE
fix(e2e): canonicalize Argos screenshot paths so names are shard-independent

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -317,6 +317,12 @@ jobs:
   # upload them to Argos in a single build. PR / merge-queue runs upload only the
   # sheets; a push to develop additionally uploads the individual screenshots so
   # the baseline is a superset (see ARGOS_UPLOAD_BOTH).
+  #
+  # Only runs when the e2e matrix fully succeeded: a failed/partial e2e run would
+  # otherwise upload an incomplete or wrong set of screenshots — and on develop
+  # that set becomes the baseline. `needs.e2e.result == 'success'` requires every
+  # shard to pass (the matrix is fail-fast: false, so its result is failure if any
+  # shard failed).
   argos-batch:
     if: >-
       ${{
@@ -324,7 +330,7 @@ jobs:
         (github.event_name == 'workflow_dispatch' ||
           (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'renovate/'))) &&
         needs.detect-scope.outputs.spec_pattern != 'SKIP' &&
-        !cancelled()
+        needs.e2e.result == 'success'
       }}
     needs: [detect-scope, e2e]
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -349,6 +349,14 @@ jobs:
           merge-multiple: true
           path: cypress/screenshots
 
+      # cypress-split gives each shard a different spec subset, so Cypress names
+      # screenshots relative to that shard's spec common-ancestor (the rendering/
+      # prefix is kept or stripped depending on the mix). Re-root every screenshot
+      # under its spec's true cypress/integration path so names are deterministic
+      # across runs — otherwise the same diagram churns the Argos baseline.
+      - name: Canonicalize screenshot paths
+        run: pnpm run argos:canonicalize
+
       - name: Build composite sheets
         if: env.GROUP_ARGOS_IMAGES == 'true'
         run: pnpm run argos:batch

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "e2e:scope:run": "tsx scripts/run-e2e-scoped.ts",
     "e2e:scope:detect": "git diff --name-only ${E2E_BASE_REF:-develop} HEAD | node scripts/e2e-diagram-scope.mjs",
     "argos:batch": "tsx scripts/argos-batch-sheets.ts",
+    "argos:canonicalize": "tsx scripts/argos-canonicalize-screenshots.ts",
     "load:env": "dotenv -e .env",
     "test": "pnpm lint && vitest run",
     "test:watch": "vitest --watch",

--- a/scripts/argos-canonicalize-screenshots.spec.ts
+++ b/scripts/argos-canonicalize-screenshots.spec.ts
@@ -1,0 +1,86 @@
+import { afterAll, beforeAll, describe, it, expect } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { canonicalScreenshotPath, buildSpecMap } from './argos-canonicalize-screenshots.ts';
+
+const specMap = new Map<string, string>([
+  ['stateDiagram.spec.js', 'rendering/state/stateDiagram.spec.js'],
+  ['iconShape.spec.ts', 'rendering/iconShape.spec.ts'],
+  ['xss.spec.js', 'other/xss.spec.js'],
+]);
+
+describe('canonicalScreenshotPath', () => {
+  it('re-roots a stripped path to its true spec location', () => {
+    expect(canonicalScreenshotPath('state/stateDiagram.spec.js/argos/State-foo.png', specMap)).toBe(
+      'rendering/state/stateDiagram.spec.js/argos/State-foo.png'
+    );
+  });
+
+  it('re-roots a fully-stripped path (spec dir only)', () => {
+    expect(canonicalScreenshotPath('stateDiagram.spec.js/argos/State-foo.png', specMap)).toBe(
+      'rendering/state/stateDiagram.spec.js/argos/State-foo.png'
+    );
+  });
+
+  it('leaves an already-canonical path unchanged', () => {
+    const p = 'rendering/state/stateDiagram.spec.js/argos/State-foo.png';
+    expect(canonicalScreenshotPath(p, specMap)).toBe(p);
+  });
+
+  it('different stripped variants converge to the same canonical name (determinism)', () => {
+    const variants = [
+      'state/stateDiagram.spec.js/argos/x.png',
+      'stateDiagram.spec.js/argos/x.png',
+      'rendering/state/stateDiagram.spec.js/argos/x.png',
+    ];
+    const canon = variants.map((v) => canonicalScreenshotPath(v, specMap));
+    expect(new Set(canon).size).toBe(1);
+  });
+
+  it('re-roots the .argos.json metadata sidecar alongside its png', () => {
+    expect(
+      canonicalScreenshotPath('state/stateDiagram.spec.js/argos/x.png.argos.json', specMap)
+    ).toBe('rendering/state/stateDiagram.spec.js/argos/x.png.argos.json');
+  });
+
+  it('preserves nested names (test titles containing a slash)', () => {
+    expect(canonicalScreenshotPath('state/stateDiagram.spec.js/argos/group/x.png', specMap)).toBe(
+      'rendering/state/stateDiagram.spec.js/argos/group/x.png'
+    );
+  });
+
+  it('leaves paths without an /argos/ marker untouched', () => {
+    expect(canonicalScreenshotPath('rendering/state/state-001.png', specMap)).toBe(
+      'rendering/state/state-001.png'
+    );
+  });
+
+  it('leaves screenshots of unknown specs untouched', () => {
+    const p = 'whatever/unknown.spec.js/argos/x.png';
+    expect(canonicalScreenshotPath(p, specMap)).toBe(p);
+  });
+});
+
+describe('buildSpecMap', () => {
+  let dir: string;
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'argos-specmap-'));
+    await mkdir(join(dir, 'rendering/state'), { recursive: true });
+    await writeFile(join(dir, 'rendering/state/stateDiagram.spec.js'), '');
+    await mkdir(join(dir, 'other'), { recursive: true });
+    await writeFile(join(dir, 'other/xss.spec.js'), '');
+    await writeFile(join(dir, 'other/notaspec.js'), '');
+  });
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('maps each spec basename to its path relative to the integration dir', async () => {
+    const map = await buildSpecMap(dir);
+    expect(Object.fromEntries(map)).toEqual({
+      'stateDiagram.spec.js': 'rendering/state/stateDiagram.spec.js',
+      'xss.spec.js': 'other/xss.spec.js',
+    });
+  });
+});

--- a/scripts/argos-canonicalize-screenshots.ts
+++ b/scripts/argos-canonicalize-screenshots.ts
@@ -1,0 +1,125 @@
+/**
+ * Rewrites captured Cypress screenshot paths to a deterministic, shard-independent
+ * location before they are batched/uploaded to Argos.
+ *
+ * Why: Cypress names a screenshot's folder by the spec path relative to the
+ * *common ancestor of the specs that ran in that invocation*. `cypress-split`
+ * gives each shard a different subset, so a shard running only `rendering/**`
+ * specs strips the `rendering/` prefix (`state/…`) while a shard that also got a
+ * non-rendering spec keeps it (`rendering/state/…`). The same diagram therefore
+ * gets a different Argos name run-to-run, which inflates the screenshot count and
+ * produces huge spurious diffs against the baseline.
+ *
+ * Fix: re-root every screenshot under its spec's true path relative to
+ * `cypress/integration`. Spec file names are unique across the suite, so the spec
+ * directory segment that precedes Cypress's `/argos/` marker uniquely identifies
+ * the spec. The canonical form equals the `rendering/…` ("kept") variant, so most
+ * screenshots are unchanged and the one-time churn is limited to the stripped
+ * ones.
+ *
+ * CLI usage:
+ *   pnpm run argos:canonicalize
+ *   ARGOS_SCREENSHOT_DIR=cypress/screenshots ARGOS_INTEGRATION_DIR=cypress/integration
+ *     pnpm run argos:canonicalize
+ */
+
+import { readdir, rename, mkdir } from 'node:fs/promises';
+import { join, dirname, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCREENSHOT_DIR = process.env.ARGOS_SCREENSHOT_DIR ?? 'cypress/screenshots';
+const INTEGRATION_DIR = process.env.ARGOS_INTEGRATION_DIR ?? 'cypress/integration';
+
+const SPEC_SEGMENT_RE = /\.spec\.[cm]?[jt]s$/;
+/** Cypress saves argosScreenshot files under an `argos/` namespace inside the spec folder. */
+const ARGOS_MARKER = '/argos/';
+
+/**
+ * Maps a captured screenshot path to its deterministic location.
+ *
+ * `relPath` looks like `<maybe-stripped-dirs>/<spec>.spec.js/argos/<name>.png`
+ * (or `.png.argos.json`). The segment right before `/argos/` is the spec
+ * directory, whose basename uniquely identifies the spec; we rewrite the part
+ * before `/argos/` to that spec's full path relative to `cypress/integration`.
+ *
+ * Returns `relPath` unchanged when it has no `/argos/` marker or the spec is
+ * unknown (so non-spec assets pass through untouched, and the function is a no-op
+ * on already-canonical paths).
+ */
+export function canonicalScreenshotPath(
+  relPath: string,
+  specPathByBasename: Map<string, string>
+): string {
+  const marker = relPath.indexOf(ARGOS_MARKER);
+  if (marker === -1) {
+    return relPath;
+  }
+  const specDir = relPath.slice(0, marker);
+  const rest = relPath.slice(marker + ARGOS_MARKER.length);
+  const specBasename = specDir.split('/').pop() ?? '';
+  if (!SPEC_SEGMENT_RE.test(specBasename)) {
+    return relPath;
+  }
+  const canonicalSpec = specPathByBasename.get(specBasename);
+  if (!canonicalSpec || canonicalSpec === specDir) {
+    return relPath;
+  }
+  return `${canonicalSpec}/argos/${rest}`;
+}
+
+/** Builds basename → path-relative-to-`integrationDir` for every spec file. */
+export async function buildSpecMap(integrationDir: string): Promise<Map<string, string>> {
+  const entries = await readdir(integrationDir, { recursive: true, withFileTypes: true });
+  const map = new Map<string, string>();
+  for (const entry of entries) {
+    if (!entry.isFile() || !SPEC_SEGMENT_RE.test(entry.name)) {
+      continue;
+    }
+    const abs = join(entry.parentPath ?? entry.path, entry.name);
+    const rel = relative(integrationDir, abs).split(sep).join('/');
+    const existing = map.get(entry.name);
+    if (existing && existing !== rel) {
+      throw new Error(
+        `Duplicate spec file name "${entry.name}" (${existing} vs ${rel}); canonicalization needs unique spec file names.`
+      );
+    }
+    map.set(entry.name, rel);
+  }
+  return map;
+}
+
+async function listFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { recursive: true, withFileTypes: true });
+  return entries
+    .filter((e) => e.isFile())
+    .map((e) =>
+      relative(dir, join(e.parentPath ?? e.path, e.name))
+        .split(sep)
+        .join('/')
+    );
+}
+
+async function main(): Promise<void> {
+  const specPathByBasename = await buildSpecMap(INTEGRATION_DIR);
+  const files = await listFiles(SCREENSHOT_DIR);
+
+  let moved = 0;
+  for (const rel of files) {
+    const canonical = canonicalScreenshotPath(rel, specPathByBasename);
+    if (canonical === rel) {
+      continue;
+    }
+    const from = join(SCREENSHOT_DIR, rel);
+    const to = join(SCREENSHOT_DIR, canonical);
+    await mkdir(dirname(to), { recursive: true });
+    await rename(from, to);
+    moved++;
+  }
+  process.stdout.write(
+    `[argos-canonicalize] ${files.length} files, ${moved} re-rooted to their canonical spec path\n`
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  void main();
+}


### PR DESCRIPTION
## Why the develop Argos builds show ~4638 screenshots and huge diffs

**Not duplication in our upload** — the parallel slices are disjoint (verified: 2977 individuals matched once, 0 overlap; combined ≈ 3247 = 2978 + 270 sheets).

The real cause is **non-deterministic screenshot names**. Cypress names each screenshot's folder by the spec path **relative to the common ancestor of the specs that ran on that shard**, and `cypress-split` shuffles the spec→shard assignment every run:

- A shard that drew only `rendering/**` specs → common ancestor `rendering/` → prefix **stripped** (`state/…`, `iconShape.spec.ts/…`).
- A shard that also drew a non-`rendering/` spec (e.g. `other/…`) → common ancestor `cypress/integration/` → prefix **kept** (`rendering/state/…`).

In the affected build, shards 1/5/7 stripped (**956 of 2977** screenshots) and 2/3/4/6/8 kept. The same diagram gets a different Argos name from run to run (`iconShape.spec.ts` was under `rendering/` last run, top-level this run), so vs. the baseline every flipped screenshot is **removed (old name) + added (new name)** → inflated count and massive spurious diffs, recurring on every run.

## Fix

`scripts/argos-canonicalize-screenshots.ts`, run in the `argos-batch` job right after the per-shard artifacts are merged (before batching/upload): re-root every screenshot under its spec's **true `cypress/integration` path**. All 80 spec file names are unique across the suite, so the spec-dir segment before Cypress's `/argos/` marker identifies the spec unambiguously. Canonical = the `rendering/…` ("kept") form, so most screenshots are unchanged — one-time churn is limited to the previously-stripped ones, and names are stable forever after.

## Verification

- On the real **2977-screenshot** tree from the affected build, three simulated shard splits (mixed / fully-stripped / `rendering/`-stripped) all canonicalize to the **identical 2977 names**.
- Pure functions unit-tested (`argos-canonicalize-screenshots.spec.ts`, 9 tests); eslint + prettier clean.

> Note: the first develop run after this lands will show a one-time baseline shift (the ~stripped screenshots renamed to their canonical `rendering/…` form). After that, names are deterministic and the per-run diffs should reflect only real visual changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)