### PR TITLE
Add node notes to flowcharts and graphs

### DIFF
--- a/.changeset/flowchart-node-notes.md
+++ b/.changeset/flowchart-node-notes.md
@@ -1,0 +1,5 @@
+---
+'mermaid': minor
+---
+
+feat: add node notes to flowchart and graph diagrams

--- a/docs/config/setup/mermaid/interfaces/LayoutData.md
+++ b/docs/config/setup/mermaid/interfaces/LayoutData.md
@@ -10,7 +10,7 @@
 
 # Interface: LayoutData
 
-Defined in: [packages/mermaid/src/rendering-util/types.ts:203](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L203)
+Defined in: [packages/mermaid/src/rendering-util/types.ts:211](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L211)
 
 ## Indexable
 
@@ -22,7 +22,7 @@ Defined in: [packages/mermaid/src/rendering-util/types.ts:203](https://github.co
 
 > **config**: [`MermaidConfig`](MermaidConfig.md)
 
-Defined in: [packages/mermaid/src/rendering-util/types.ts:206](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L206)
+Defined in: [packages/mermaid/src/rendering-util/types.ts:215](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L215)
 
 ---
 
@@ -30,7 +30,7 @@ Defined in: [packages/mermaid/src/rendering-util/types.ts:206](https://github.co
 
 > `optional` **diagramId**: `string`
 
-Defined in: [packages/mermaid/src/rendering-util/types.ts:207](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L207)
+Defined in: [packages/mermaid/src/rendering-util/types.ts:216](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L216)
 
 ---
 
@@ -38,7 +38,7 @@ Defined in: [packages/mermaid/src/rendering-util/types.ts:207](https://github.co
 
 > **edges**: `Edge`\[]
 
-Defined in: [packages/mermaid/src/rendering-util/types.ts:205](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L205)
+Defined in: [packages/mermaid/src/rendering-util/types.ts:213](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L213)
 
 ---
 
@@ -46,4 +46,12 @@ Defined in: [packages/mermaid/src/rendering-util/types.ts:205](https://github.co
 
 > **nodes**: `Node`\[]
 
-Defined in: [packages/mermaid/src/rendering-util/types.ts:204](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L204)
+Defined in: [packages/mermaid/src/rendering-util/types.ts:212](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L212)
+
+---
+
+### notes?
+
+> `optional` **notes**: `NodeNote`\[]
+
+Defined in: [packages/mermaid/src/rendering-util/types.ts:214](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L214)

--- a/docs/syntax/flowchart.md
+++ b/docs/syntax/flowchart.md
@@ -1014,6 +1014,70 @@ flowchart TD
   A@{ img: "https://mermaid.js.org/favicon.svg", label: "My example image label", pos: "t", h: 60, constraint: "on" }
 ```
 
+## Node notes (v\<MERMAID_RELEASE_VERSION>+)
+
+You can attach a note to a flowchart node by using a `note ... of ...` block. Notes are rendered next to the target node and do not add layout nodes or edges to the graph.
+
+Supported placements are `right`, `left`, `top`, and `bottom`.
+
+```mermaid-example
+flowchart TD
+    A[Start] --> B[Process]
+    B --> C[Done]
+
+    note right of A
+      Input assumptions
+    end note
+
+    note left of B
+      Internal state:
+      cache enabled
+    end note
+
+    note bottom of C
+      Final result
+    end note
+```
+
+```mermaid
+flowchart TD
+    A[Start] --> B[Process]
+    B --> C[Done]
+
+    note right of A
+      Input assumptions
+    end note
+
+    note left of B
+      Internal state:
+      cache enabled
+    end note
+
+    note bottom of C
+      Final result
+    end note
+```
+
+The same syntax is also available when using `graph` instead of `flowchart`.
+
+```mermaid-example
+graph LR
+    A[A] --> B[B]
+
+    note top of A
+      graph note
+    end note
+```
+
+```mermaid
+graph LR
+    A[A] --> B[B]
+
+    note top of A
+      graph note
+    end note
+```
+
 ## Links between nodes
 
 Nodes can be connected with links/edges. It is possible to have different types of links or attach a text string to a link.

--- a/packages/mermaid/src/diagrams/flowchart/flowDb.spec.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.spec.ts
@@ -83,6 +83,7 @@ describe('flow db class', () => {
       'setAccDescription',
       'addVertex',
       'addLink',
+      'addNote',
       'setClass',
       'destructLink',
       'addClass',
@@ -163,6 +164,58 @@ describe('flow db getData', () => {
     expect(edges[1].curve).toBe('monotoneX');
     expect(edges[2].curve).toBe('catmullRom');
     expect(edges[3].curve).toBe('stepBefore');
+  });
+
+  it('should expose node notes without adding layout nodes or edges', () => {
+    flowDb.addVertex('A', { text: 'A', type: 'text' }, undefined, [], [], '', {}, undefined);
+    flowDb.addVertex('B', { text: 'B', type: 'text' }, undefined, [], [], '', {}, undefined);
+    flowDb.addLink(['A'], ['B'], {});
+    flowDb.addNote(
+      'right',
+      ' B ',
+      `
+        description:
+          details for B
+      `
+    );
+
+    const data = flowDb.getData();
+
+    expect(data.nodes.map((node) => node.id)).toEqual(['A', 'B']);
+    expect(data.edges).toHaveLength(1);
+    expect(data.notes).toEqual([
+      {
+        position: 'right',
+        target: 'B',
+        text: 'description:\n  details for B',
+      },
+    ]);
+  });
+
+  it('should return getData notes as a copy', () => {
+    flowDb.addNote('top', 'A', 'above');
+
+    const data = flowDb.getData();
+    data.notes?.push({ position: 'bottom', target: 'B', text: 'below' });
+
+    expect(flowDb.getNotes()).toEqual([{ position: 'top', target: 'A', text: 'above' }]);
+  });
+
+  it('should return getNotes result as a copy', () => {
+    flowDb.addNote('top', 'A', 'above');
+
+    const notes = flowDb.getNotes();
+    notes.push({ position: 'bottom', target: 'B', text: 'below' });
+
+    expect(flowDb.getNotes()).toEqual([{ position: 'top', target: 'A', text: 'above' }]);
+  });
+
+  it('should clear node notes', () => {
+    flowDb.addNote('left', 'A', 'note text');
+
+    flowDb.clear();
+
+    expect(flowDb.getNotes()).toEqual([]);
   });
 });
 

--- a/packages/mermaid/src/diagrams/flowchart/flowDb.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.ts
@@ -22,6 +22,7 @@ import type {
   FlowClass,
   FlowEdge,
   FlowLink,
+  FlowNote,
   FlowSubGraph,
   FlowText,
   FlowVertex,
@@ -41,6 +42,7 @@ export class FlowDB implements DiagramDB {
   private diagramId = '';
   private vertices = new Map<string, FlowVertex>();
   private edges: FlowEdge[] & { defaultInterpolate?: string; defaultStyle?: string[] } = [];
+  private notes: FlowNote[] = [];
   private classes = new Map<string, FlowClass>();
   private subGraphs: FlowSubGraph[] = [];
   private subGraphLookup = new Map<string, FlowSubGraph>();
@@ -63,6 +65,7 @@ export class FlowDB implements DiagramDB {
     this.firstGraph = this.firstGraph.bind(this);
     this.setDirection = this.setDirection.bind(this);
     this.addSubGraph = this.addSubGraph.bind(this);
+    this.addNote = this.addNote.bind(this);
     this.addLink = this.addLink.bind(this);
     this.setLink = this.setLink.bind(this);
     this.updateLink = this.updateLink.bind(this);
@@ -594,6 +597,38 @@ You have to call mermaid.initialize.`
     return this.edges;
   }
 
+  public addNote(position: FlowNote['position'], target: string, text: string) {
+    const normalizedText = this.normalizeNoteText(text);
+    this.notes.push({
+      position,
+      target: target.trim(),
+      text: this.sanitizeText(normalizedText),
+    });
+  }
+
+  private normalizeNoteText(text: string) {
+    const lines = text.replace(/\r\n/g, '\n').split('\n');
+
+    while (lines.length > 0 && lines[0].trim() === '') {
+      lines.shift();
+    }
+    while (lines.length > 0 && lines[lines.length - 1].trim() === '') {
+      lines.pop();
+    }
+
+    const getIndentLength = (line: string) => /^[\t ]*/.exec(line)?.[0].length ?? 0;
+    const indents = lines
+      .filter((line) => line.trim().length > 0)
+      .map((line) => getIndentLength(line));
+    const indent = indents.length > 0 ? Math.min(...indents) : 0;
+
+    return lines.map((line) => line.slice(Math.min(indent, getIndentLength(line)))).join('\n');
+  }
+
+  public getNotes() {
+    return [...this.notes];
+  }
+
   /**
    * Retrieval function for fetching the found class definitions after parsing has completed.
    *
@@ -642,6 +677,7 @@ You have to call mermaid.initialize.`
     this.vertices = new Map();
     this.classes = new Map();
     this.edges = [];
+    this.notes = [];
     this.funs = [this.setupToolTips.bind(this)];
     this.diagramId = '';
     this.subGraphs = [];
@@ -1181,7 +1217,7 @@ You have to call mermaid.initialize.`
       edges.push(edge);
     });
 
-    return { nodes, edges, other: {}, config };
+    return { nodes, edges, notes: this.getNotes(), other: {}, config };
   }
 
   public defaultConfig() {

--- a/packages/mermaid/src/diagrams/flowchart/flowNoteRenderer.spec.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowNoteRenderer.spec.ts
@@ -13,7 +13,9 @@ describe('flowNoteRenderer', () => {
       edges: [],
       notes: [
         { position: 'right', target: 'A', text: 'right note' },
+        { position: 'left', target: 'A', text: 'left' },
         { position: 'top', target: 'A', text: 'above' },
+        { position: 'bottom', target: 'A', text: 'below' },
       ],
       config: {
         themeVariables: {
@@ -30,10 +32,12 @@ describe('flowNoteRenderer', () => {
     expect(notesLayer.getAttribute('class')).toBe('flowchart-notes');
 
     const notes = notesLayer.querySelectorAll('g.flowchart-note');
-    expect(notes).toHaveLength(2);
+    expect(notes).toHaveLength(4);
     expect(notes[0].getAttribute('data-target')).toBe('A');
-    expect(notes[0].getAttribute('transform')).toBe('translate(120, 70.5)');
-    expect(notes[1].getAttribute('transform')).toBe('translate(75, 46)');
+    expect(notes[0].getAttribute('transform')).toBe('translate(121, 70.5)');
+    expect(notes[1].getAttribute('transform')).toBe('translate(29, 70.5)');
+    expect(notes[2].getAttribute('transform')).toBe('translate(75, 45)');
+    expect(notes[3].getAttribute('transform')).toBe('translate(75, 96)');
 
     const background = notes[0].querySelector('rect.flowchart-note-background')!;
     expect(background.hasAttribute('fill')).toBe(false);
@@ -85,7 +89,7 @@ describe('flowNoteRenderer', () => {
     drawFlowchartNotes(svg, data4Layout);
 
     const note = svgElement.querySelector('g.flowchart-note')!;
-    expect(note.getAttribute('transform')).toBe('translate(120, 70.5)');
+    expect(note.getAttribute('transform')).toBe('translate(121, 70.5)');
     expect(note.textContent).toBe('right note');
   });
 

--- a/packages/mermaid/src/diagrams/flowchart/flowNoteRenderer.spec.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowNoteRenderer.spec.ts
@@ -1,0 +1,110 @@
+import { select } from 'd3';
+import type { SVG } from '../../diagram-api/types.js';
+import type { LayoutData } from '../../rendering-util/types.js';
+import { drawFlowchartNotes } from './flowNoteRenderer.js';
+
+describe('flowNoteRenderer', () => {
+  it('draws positioned node notes above the rendered flowchart', () => {
+    document.body.innerHTML = '<svg><g><g class="root"><g class="node"></g></g></g></svg>';
+    const svgElement = document.querySelector('svg')!;
+    const svg = select(svgElement) as unknown as SVG;
+    const data4Layout = {
+      nodes: [{ id: 'A', isGroup: false, x: 100, y: 80, width: 40, height: 30 }],
+      edges: [],
+      notes: [
+        { position: 'right', target: 'A', text: 'right note' },
+        { position: 'top', target: 'A', text: 'above' },
+      ],
+      config: {
+        themeVariables: {
+          fontFamily: 'Arial, sans-serif',
+          textColor: '#111',
+        },
+      },
+    } as LayoutData;
+
+    drawFlowchartNotes(svg, data4Layout);
+
+    const root = svgElement.querySelector('g.root')!;
+    const notesLayer = root.lastElementChild!;
+    expect(notesLayer.getAttribute('class')).toBe('flowchart-notes');
+
+    const notes = notesLayer.querySelectorAll('g.flowchart-note');
+    expect(notes).toHaveLength(2);
+    expect(notes[0].getAttribute('data-target')).toBe('A');
+    expect(notes[0].getAttribute('transform')).toBe('translate(120, 70.5)');
+    expect(notes[1].getAttribute('transform')).toBe('translate(75, 46)');
+
+    const background = notes[0].querySelector('rect.flowchart-note-background')!;
+    expect(background.hasAttribute('fill')).toBe(false);
+    expect(background.hasAttribute('stroke')).toBe(false);
+    expect(Number(background.getAttribute('width'))).toBeGreaterThanOrEqual(50);
+    expect(background.getAttribute('height')).toBe('19');
+    expect(notes[0].querySelector('text.flowchart-note-text')?.hasAttribute('fill')).toBe(false);
+    expect(notes[0].textContent).toBe('right note');
+  });
+
+  it('uses rendered SVG node positions when layout nodes have no coordinates', () => {
+    document.body.innerHTML = `
+      <svg>
+        <g>
+          <g class="root">
+            <g class="nodes">
+              <g class="node" id="diagram-flowchart-A-0" transform="translate(100, 80)"></g>
+            </g>
+          </g>
+        </g>
+      </svg>
+    `;
+    const renderedNode = document.querySelector<SVGGElement>('g.node')!;
+    renderedNode.getBBox = vi.fn(() => ({
+      x: -20,
+      y: -15,
+      width: 40,
+      height: 30,
+      top: -15,
+      right: 20,
+      bottom: 15,
+      left: -20,
+      toJSON: () => '',
+    }));
+    const svgElement = document.querySelector('svg')!;
+    const svg = select(svgElement) as unknown as SVG;
+    const data4Layout = {
+      nodes: [{ id: 'A', isGroup: false, domId: 'diagram-flowchart-A-0' }],
+      edges: [],
+      notes: [{ position: 'right', target: 'A', text: 'right note' }],
+      config: {
+        themeVariables: {
+          fontFamily: 'Arial, sans-serif',
+          textColor: '#111',
+        },
+      },
+    } as LayoutData;
+
+    drawFlowchartNotes(svg, data4Layout);
+
+    const note = svgElement.querySelector('g.flowchart-note')!;
+    expect(note.getAttribute('transform')).toBe('translate(120, 70.5)');
+    expect(note.textContent).toBe('right note');
+  });
+
+  it('skips notes whose target node is missing or not positioned', () => {
+    document.body.innerHTML = '<svg><g><g class="root"></g></g></svg>';
+    const svgElement = document.querySelector('svg')!;
+    const svg = select(svgElement) as unknown as SVG;
+    const data4Layout = {
+      nodes: [{ id: 'A', isGroup: false }],
+      edges: [],
+      notes: [
+        { position: 'right', target: 'A', text: 'not positioned' },
+        { position: 'right', target: 'B', text: 'missing' },
+      ],
+      config: { themeVariables: {} },
+    } as LayoutData;
+
+    drawFlowchartNotes(svg, data4Layout);
+
+    expect(svgElement.querySelectorAll('g.flowchart-note')).toHaveLength(0);
+  });
+});

--- a/packages/mermaid/src/diagrams/flowchart/flowNoteRenderer.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowNoteRenderer.ts
@@ -9,6 +9,7 @@ const NOTE_PADDING_Y = 2;
 const NOTE_FONT_SIZE = 12;
 const NOTE_LINE_HEIGHT = 15;
 const NOTE_OPACITY = 0.96;
+const NOTE_TARGET_GAP = 1;
 
 type NotesLayer = D3Selection<SVGGElement>;
 type PositionedNode = Node & Required<Pick<Node, 'x' | 'y'>>;
@@ -178,13 +179,13 @@ const getNoteTranslate = (target: Node, note: NodeNote, width: number, height: n
 
   switch (note.position) {
     case 'left':
-      return { x: targetLeft - width, y: target.y! - height / 2 };
+      return { x: targetLeft - width - NOTE_TARGET_GAP, y: target.y! - height / 2 };
     case 'right':
-      return { x: targetRight, y: target.y! - height / 2 };
+      return { x: targetRight + NOTE_TARGET_GAP, y: target.y! - height / 2 };
     case 'top':
-      return { x: target.x! - width / 2, y: targetTop - height };
+      return { x: target.x! - width / 2, y: targetTop - height - NOTE_TARGET_GAP };
     case 'bottom':
-      return { x: target.x! - width / 2, y: targetBottom };
+      return { x: target.x! - width / 2, y: targetBottom + NOTE_TARGET_GAP };
   }
 };
 

--- a/packages/mermaid/src/diagrams/flowchart/flowNoteRenderer.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowNoteRenderer.ts
@@ -1,0 +1,251 @@
+import type { SVG } from '../../diagram-api/types.js';
+import type { D3Selection } from '../../types.js';
+import type { LayoutData, Node, NodeNote } from '../../rendering-util/types.js';
+
+const NOTE_MIN_WIDTH = 50;
+const NOTE_MAX_WIDTH = 230;
+const NOTE_PADDING_X = 5;
+const NOTE_PADDING_Y = 2;
+const NOTE_FONT_SIZE = 12;
+const NOTE_LINE_HEIGHT = 15;
+const NOTE_OPACITY = 0.96;
+
+type NotesLayer = D3Selection<SVGGElement>;
+type PositionedNode = Node & Required<Pick<Node, 'x' | 'y'>>;
+
+const isPositionedNode = (node: Node | undefined): node is Node & Required<Pick<Node, 'x' | 'y'>> =>
+  node?.x !== undefined && node?.y !== undefined;
+
+const getRootGroup = (svg: SVG): NotesLayer => {
+  const svgGroup = svg.select<SVGGElement>('g');
+  const rootGroup = svgGroup.select<SVGGElement>('g.root');
+  return rootGroup.empty() ? svgGroup : rootGroup;
+};
+
+const estimateTextWidth = (text: string) => text.length * NOTE_FONT_SIZE * 0.58;
+
+const measureText = (layer: NotesLayer, text: string, fontFamily: string) => {
+  if (text.length === 0) {
+    return 0;
+  }
+
+  const measuringText = layer
+    .append('text')
+    .attr('font-family', fontFamily)
+    .attr('font-size', NOTE_FONT_SIZE)
+    .attr('visibility', 'hidden')
+    .text(text);
+
+  let width = estimateTextWidth(text);
+  const node = measuringText.node();
+  try {
+    const measuredWidth = node?.getComputedTextLength?.();
+    if (measuredWidth !== undefined && Number.isFinite(measuredWidth)) {
+      width = measuredWidth;
+    }
+  } finally {
+    measuringText.remove();
+  }
+
+  return width;
+};
+
+const splitLongToken = (layer: NotesLayer, token: string, maxWidth: number, fontFamily: string) => {
+  const chunks: string[] = [];
+  let chunk = '';
+
+  for (const char of token) {
+    const candidate = chunk + char;
+    if (chunk.length > 0 && measureText(layer, candidate, fontFamily) > maxWidth) {
+      chunks.push(chunk);
+      chunk = char;
+    } else {
+      chunk = candidate;
+    }
+  }
+
+  if (chunk.length > 0) {
+    chunks.push(chunk);
+  }
+
+  return chunks;
+};
+
+const wrapLine = (layer: NotesLayer, line: string, maxWidth: number, fontFamily: string) => {
+  if (measureText(layer, line, fontFamily) <= maxWidth) {
+    return [line];
+  }
+
+  const wrappedLines: string[] = [];
+  let currentLine = '';
+  const tokens = line.split(/(\s+)/).filter((token) => token.length > 0);
+
+  for (const token of tokens) {
+    const candidate = currentLine + token;
+    if (candidate.trim().length === 0 || measureText(layer, candidate, fontFamily) <= maxWidth) {
+      currentLine = candidate;
+      continue;
+    }
+
+    if (currentLine.trim().length > 0) {
+      wrappedLines.push(currentLine.trimEnd());
+      currentLine = token.trimStart();
+    }
+
+    if (measureText(layer, currentLine, fontFamily) > maxWidth) {
+      const chunks = splitLongToken(layer, currentLine, maxWidth, fontFamily);
+      wrappedLines.push(...chunks.slice(0, -1));
+      currentLine = chunks.at(-1) ?? '';
+    }
+  }
+
+  if (currentLine.trim().length > 0) {
+    wrappedLines.push(currentLine.trimEnd());
+  }
+
+  return wrappedLines.length > 0 ? wrappedLines : [''];
+};
+
+const wrapNoteText = (layer: NotesLayer, text: string, fontFamily: string) => {
+  const maxTextWidth = NOTE_MAX_WIDTH - NOTE_PADDING_X * 2;
+  return text
+    .split('\n')
+    .flatMap((line) => wrapLine(layer, line.trimEnd(), maxTextWidth, fontFamily));
+};
+
+const noteFontFamily = (data4Layout: LayoutData) =>
+  data4Layout.config.themeVariables?.fontFamily ?? 'Arial, sans-serif';
+
+const parseTranslate = (transform: string | null) => {
+  const match = transform?.match(
+    /translate\(\s*(-?\d+(?:\.\d+)?)(?:[\s,]+(-?\d+(?:\.\d+)?))?\s*\)/
+  );
+  if (!match) {
+    return undefined;
+  }
+
+  return {
+    x: Number(match[1]),
+    y: Number(match[2] ?? 0),
+  };
+};
+
+const findRenderedNodeElement = (root: SVGGElement | null, node: Node) => {
+  if (!root) {
+    return undefined;
+  }
+
+  return [...root.querySelectorAll<SVGGElement>('g.node')].find(
+    (element) => element.id === node.domId || element.id === node.id
+  );
+};
+
+const getRenderedPositionedNode = (
+  root: SVGGElement | null,
+  node: Node | undefined
+): PositionedNode | undefined => {
+  if (!node) {
+    return undefined;
+  }
+
+  if (isPositionedNode(node)) {
+    return node;
+  }
+
+  const renderedNode = findRenderedNodeElement(root, node);
+  const position = parseTranslate(renderedNode?.getAttribute('transform') ?? null);
+  if (!renderedNode || !position) {
+    return undefined;
+  }
+
+  const bbox = renderedNode.getBBox();
+  return {
+    ...node,
+    x: position.x,
+    y: position.y,
+    width: bbox.width,
+    height: bbox.height,
+  };
+};
+
+const getNoteTranslate = (target: Node, note: NodeNote, width: number, height: number) => {
+  const targetWidth = target.width ?? 0;
+  const targetHeight = target.height ?? 0;
+  const targetLeft = target.x! - targetWidth / 2;
+  const targetRight = target.x! + targetWidth / 2;
+  const targetTop = target.y! - targetHeight / 2;
+  const targetBottom = target.y! + targetHeight / 2;
+
+  switch (note.position) {
+    case 'left':
+      return { x: targetLeft - width, y: target.y! - height / 2 };
+    case 'right':
+      return { x: targetRight, y: target.y! - height / 2 };
+    case 'top':
+      return { x: target.x! - width / 2, y: targetTop - height };
+    case 'bottom':
+      return { x: target.x! - width / 2, y: targetBottom };
+  }
+};
+
+const drawNote = (layer: NotesLayer, target: Node, note: NodeNote, data4Layout: LayoutData) => {
+  const fontFamily = noteFontFamily(data4Layout);
+  const lines = wrapNoteText(layer, note.text, fontFamily);
+  const textWidth = Math.max(...lines.map((line) => measureText(layer, line, fontFamily)), 0);
+  const noteWidth = Math.max(
+    NOTE_MIN_WIDTH,
+    Math.min(NOTE_MAX_WIDTH, textWidth + NOTE_PADDING_X * 2)
+  );
+  const noteHeight = lines.length * NOTE_LINE_HEIGHT + NOTE_PADDING_Y * 2;
+  const { x, y } = getNoteTranslate(target, note, noteWidth, noteHeight);
+
+  const noteGroup = layer
+    .append('g')
+    .attr('class', `flowchart-note flowchart-note-${note.position}`)
+    .attr('data-target', note.target)
+    .attr('transform', `translate(${x}, ${y})`);
+
+  noteGroup
+    .append('rect')
+    .attr('class', 'flowchart-note-background')
+    .attr('x', 0)
+    .attr('y', 0)
+    .attr('width', noteWidth)
+    .attr('height', noteHeight)
+    .attr('opacity', NOTE_OPACITY);
+
+  const text = noteGroup
+    .append('text')
+    .attr('class', 'flowchart-note-text')
+    .attr('x', NOTE_PADDING_X)
+    .attr('y', NOTE_PADDING_Y + NOTE_FONT_SIZE)
+    .attr('font-family', fontFamily)
+    .attr('font-size', NOTE_FONT_SIZE);
+
+  lines.forEach((line, index) => {
+    text
+      .append('tspan')
+      .attr('x', NOTE_PADDING_X)
+      .attr('dy', index === 0 ? 0 : NOTE_LINE_HEIGHT)
+      .text(line);
+  });
+};
+
+export const drawFlowchartNotes = (svg: SVG, data4Layout: LayoutData) => {
+  const notes = data4Layout.notes ?? [];
+  if (notes.length === 0) {
+    return;
+  }
+
+  const rootGroup = getRootGroup(svg);
+  const rootElement = rootGroup.node();
+  const nodes = new Map(data4Layout.nodes.map((node) => [node.id, node]));
+  const layer = rootGroup.append('g').attr('class', 'flowchart-notes');
+
+  for (const note of notes) {
+    const target = getRenderedPositionedNode(rootElement, nodes.get(note.target));
+    if (target) {
+      drawNote(layer, target, note, data4Layout);
+    }
+  }
+};

--- a/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.spec.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.spec.ts
@@ -5,6 +5,10 @@ vi.mock('../../rendering-util/render.js', () => ({
   render: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock('./flowNoteRenderer.js', () => ({
+  drawFlowchartNotes: vi.fn(),
+}));
+
 vi.mock('../../rendering-util/insertElementsForSize.js', () => ({
   getDiagramElement: vi.fn().mockReturnValue({
     attr: vi.fn().mockReturnThis(),
@@ -44,5 +48,38 @@ describe('flowRenderer-v3-unified', () => {
 
     await draw('graph TB; A', 'test-id', '1.0.0', diag);
     expect(setDiagramId).toHaveBeenCalledWith('test-id');
+  });
+
+  it('draws node notes after layout render and before viewport setup', async () => {
+    const { draw } = await import('./flowRenderer-v3-unified.js');
+    const { render } = await import('../../rendering-util/render.js');
+    const { setupViewPortForSVG } = await import('../../rendering-util/setupViewPortForSVG.js');
+    const { drawFlowchartNotes } = await import('./flowNoteRenderer.js');
+
+    const data4Layout = {
+      nodes: [],
+      edges: [],
+      notes: [{ position: 'right', target: 'B', text: 'description' }],
+      config: { flowchart: {} },
+    };
+    const diag = {
+      type: 'flowchart-v2',
+      db: {
+        setDiagramId: vi.fn(),
+        getData: vi.fn().mockReturnValue(data4Layout),
+        getDirection: vi.fn().mockReturnValue('TB'),
+        getDiagramTitle: vi.fn().mockReturnValue(''),
+      },
+    };
+
+    await draw('graph TB; A', 'test-id', '1.0.0', diag);
+
+    expect(drawFlowchartNotes).toHaveBeenCalledWith(expect.anything(), data4Layout);
+    expect(vi.mocked(render).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(drawFlowchartNotes).mock.invocationCallOrder[0]
+    );
+    expect(vi.mocked(drawFlowchartNotes).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(setupViewPortForSVG).mock.invocationCallOrder[0]
+    );
   });
 });

--- a/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.ts
@@ -6,6 +6,7 @@ import { getRegisteredLayoutAlgorithm, render } from '../../rendering-util/rende
 import { setupViewPortForSVG } from '../../rendering-util/setupViewPortForSVG.js';
 import type { LayoutData } from '../../rendering-util/types.js';
 import utils from '../../utils.js';
+import { drawFlowchartNotes } from './flowNoteRenderer.js';
 
 export const getClasses = function (
   text: string,
@@ -46,6 +47,7 @@ export const draw = async function (text: string, id: string, _version: string, 
   data4Layout.diagramId = id;
   log.debug('REF1:', data4Layout);
   await render(data4Layout, svg);
+  drawFlowchartNotes(svg, data4Layout);
   const padding = data4Layout.config.flowchart?.diagramPadding ?? 8;
   utils.insertTitle(
     svg,

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
@@ -26,6 +26,8 @@
 %x shapeData
 %x shapeDataStr
 %x shapeDataEndBracket
+%x flowNoteId
+%x flowNoteText
 
 %%
 accTitle\s*":"\s*                               { this.begin("acc_title");return 'acc_title'; }
@@ -112,6 +114,17 @@ that id.
 "click"[\s]+             this.begin("click");
 <click>[\s\n]            this.popState();
 <click>[^\s\n]*          return 'CLICK';
+
+"note"[ \t]+"left"[ \t]+"of"[ \t]+    { this.begin("flowNoteId"); return 'NOTE_LEFT_OF'; }
+"note"[ \t]+"right"[ \t]+"of"[ \t]+   { this.begin("flowNoteId"); return 'NOTE_RIGHT_OF'; }
+"note"[ \t]+"top"[ \t]+"of"[ \t]+     { this.begin("flowNoteId"); return 'NOTE_TOP_OF'; }
+"note"[ \t]+"bottom"[ \t]+"of"[ \t]+  { this.begin("flowNoteId"); return 'NOTE_BOTTOM_OF'; }
+<flowNoteId>[^\n]+                    { this.popState(); this.begin("flowNoteText"); return 'NOTE_TARGET'; }
+<flowNoteText>[\s\S]*?\n[ \t]*"end note"[ \t]* {
+                                          this.popState();
+                                          yytext = yytext.replace(/\n[ \t]*end note[ \t]*$/, '');
+                                          return 'NOTE_TEXT';
+                                      }
 
 "flowchart-elk"          {if(yy.lex.firstGraph()){this.begin("dir");}  return 'GRAPH';}
 "swimlane"               {if(yy.lex.firstGraph()){this.begin("dir");}  return 'GRAPH';}
@@ -367,6 +380,8 @@ spaceList
 statement
     : vertexStatement separator
     { $$=$vertexStatement.nodes}
+    | noteStatement separator
+    {$$=[];}
     | styleStatement separator
     {$$=[];}
     | linkStyleStatement separator
@@ -392,6 +407,22 @@ statement
     ;
 
 separator: NEWLINE | SEMI | EOF ;
+
+noteStatement
+    : notePosition NOTE_TARGET NOTE_TEXT
+    { yy.addNote($notePosition, $NOTE_TARGET, $NOTE_TEXT); $$=[]; }
+    ;
+
+notePosition
+    : NOTE_LEFT_OF
+    { $$='left'; }
+    | NOTE_RIGHT_OF
+    { $$='right'; }
+    | NOTE_TOP_OF
+    { $$='top'; }
+    | NOTE_BOTTOM_OF
+    { $$='bottom'; }
+    ;
 
 shapeData:
     shapeData SHAPE_DATA

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow.spec.js
@@ -42,6 +42,234 @@ describe('parsing a flow chart', function () {
     expect(edges[0].end).toBe('B');
   });
 
+  it('should parse flowchart node notes without adding layout nodes or edges', function () {
+    flow.parser.parse(`flowchart TD
+      A[A] --> B[B]
+
+      note right of B
+        description:
+          Some properties of B
+      end note
+    `);
+
+    const data4Layout = flow.parser.yy.getData();
+
+    expect(data4Layout.nodes.map((node) => node.id)).toEqual(['A', 'B']);
+    expect(data4Layout.edges).toHaveLength(1);
+    expect(data4Layout.notes).toEqual([
+      {
+        position: 'right',
+        target: 'B',
+        text: 'description:\n  Some properties of B',
+      },
+    ]);
+  });
+
+  it('should parse graph node notes in each supported direction', function () {
+    const graph = `graph LR
+      A[A] --> B[B]
+      B --> C[C]
+
+      note left of A
+        left note
+      end note
+
+      note right of B
+        right note
+      end note
+
+      note top of B
+        top note
+      END_NOTE_WITH_SPACES
+
+      note bottom of C
+        bottom note
+      end note
+    `.replace('END_NOTE_WITH_SPACES', 'end note   ');
+
+    flow.parser.parse(graph);
+
+    const data4Layout = flow.parser.yy.getData();
+
+    expect(data4Layout.nodes.map((node) => node.id)).toEqual(['A', 'B', 'C']);
+    expect(data4Layout.edges).toHaveLength(2);
+    expect(data4Layout.notes).toEqual([
+      { position: 'left', target: 'A', text: 'left note' },
+      { position: 'right', target: 'B', text: 'right note' },
+      { position: 'top', target: 'B', text: 'top note' },
+      { position: 'bottom', target: 'C', text: 'bottom note' },
+    ]);
+  });
+
+  it('should continue parsing statements after node notes', function () {
+    flow.parser.parse(`flowchart TD
+      A[A]
+      note right of A
+        right note
+      end note
+      A --> B[B]
+    `);
+
+    const data4Layout = flow.parser.yy.getData();
+
+    expect(data4Layout.nodes.map((node) => node.id)).toEqual(['A', 'B']);
+    expect(data4Layout.edges).toHaveLength(1);
+    expect(data4Layout.edges[0].start).toBe('A');
+    expect(data4Layout.edges[0].end).toBe('B');
+    expect(data4Layout.notes).toEqual([{ position: 'right', target: 'A', text: 'right note' }]);
+  });
+
+  it('should parse empty node notes', function () {
+    flow.parser.parse(`flowchart TD
+      A[A]
+      note right of A
+      end note
+    `);
+
+    expect(flow.parser.yy.getData().notes).toEqual([{ position: 'right', target: 'A', text: '' }]);
+  });
+
+  it('should keep regular nodes named note working', function () {
+    flow.parser.parse(`flowchart
+      note["I am a regular node named note"]
+      note --> A[A]
+    `);
+
+    const data4Layout = flow.parser.yy.getData();
+
+    expect(data4Layout.nodes.map((node) => node.id)).toEqual(['note', 'A']);
+    expect(data4Layout.edges).toHaveLength(1);
+    expect(data4Layout.edges[0].start).toBe('note');
+    expect(data4Layout.edges[0].end).toBe('A');
+    expect(data4Layout.notes).toEqual([]);
+  });
+
+  it('should keep complex flowchart layout data identical when node notes are removed', function () {
+    const parseLayout = (diagram) => {
+      flow.parser.yy = new FlowDB();
+      flow.parser.yy.clear();
+      flow.parser.parse(diagram);
+      const data4Layout = flow.parser.yy.getData();
+
+      return {
+        direction: flow.parser.yy.getDirection(),
+        nodes: data4Layout.nodes.map(({ id, label, shape, isGroup, parentId }) => ({
+          id,
+          label,
+          shape,
+          isGroup,
+          parentId,
+        })),
+        edges: data4Layout.edges.map(
+          ({ start, end, label, type, arrowTypeStart, arrowTypeEnd }) => ({
+            start,
+            end,
+            label,
+            type,
+            arrowTypeStart,
+            arrowTypeEnd,
+          })
+        ),
+        notes: data4Layout.notes,
+      };
+    };
+    const diagramWithNotes = `flowchart TD
+      A[A] -->|Description2: A how to B| B[B]
+      B --> D[D]
+      B --> C[C]
+      D --> F[F]
+      C --> F
+      F --> H[H]
+      F --> G[G]
+      F --> K[K]
+      H --> M[M]
+      G --> M
+      K --> M
+
+      note right of A
+        Description1: Properties of A
+      end note
+
+      note top of A
+        above
+      end note
+
+      note right of B
+        description2:
+        Some properties of B
+      end note
+
+      note right of K
+        Description3:
+        This note is right of K
+      end note
+
+      note left of F
+        Description1: Properties of F
+      end note
+
+      note bottom of M
+        Description5:This note is below M
+      end note
+    `;
+    const diagramWithoutNotes = `flowchart TD
+      A[A] -->|Description2: A how to B| B[B]
+      B --> D[D]
+      B --> C[C]
+      D --> F[F]
+      C --> F
+      F --> H[H]
+      F --> G[G]
+      F --> K[K]
+      H --> M[M]
+      G --> M
+      K --> M
+    `;
+    const withNotes = parseLayout(diagramWithNotes);
+    const withoutNotes = parseLayout(diagramWithoutNotes);
+
+    expect(withNotes.nodes).toEqual(withoutNotes.nodes);
+    expect(withNotes.edges).toEqual(withoutNotes.edges);
+    expect(withNotes.direction).toBe(withoutNotes.direction);
+    expect(withNotes.notes).toEqual([
+      { position: 'right', target: 'A', text: 'Description1: Properties of A' },
+      { position: 'top', target: 'A', text: 'above' },
+      { position: 'right', target: 'B', text: 'description2:\nSome properties of B' },
+      { position: 'right', target: 'K', text: 'Description3:\nThis note is right of K' },
+      { position: 'left', target: 'F', text: 'Description1: Properties of F' },
+      { position: 'bottom', target: 'M', text: 'Description5:This note is below M' },
+    ]);
+  });
+
+  it.each([
+    ['flowchart', 'TD', 'TB'],
+    ['flowchart', 'TB', 'TB'],
+    ['flowchart', 'LR', 'LR'],
+    ['flowchart', 'RL', 'RL'],
+    ['flowchart', 'BT', 'BT'],
+    ['graph', 'TD', 'TB'],
+    ['graph', 'TB', 'TB'],
+    ['graph', 'LR', 'LR'],
+    ['graph', 'RL', 'RL'],
+    ['graph', 'BT', 'BT'],
+  ])('should parse node notes in %s %s', function (keyword, direction, expectedDirection) {
+    flow.parser.parse(`${keyword} ${direction}
+      A[A] --> B[B]
+      note right of A
+        ${keyword} ${direction} note
+      end note
+    `);
+
+    const data4Layout = flow.parser.yy.getData();
+
+    expect(flow.parser.yy.getDirection()).toBe(expectedDirection);
+    expect(data4Layout.nodes.map((node) => node.id)).toEqual(['A', 'B']);
+    expect(data4Layout.edges).toHaveLength(1);
+    expect(data4Layout.notes).toEqual([
+      { position: 'right', target: 'A', text: `${keyword} ${direction} note` },
+    ]);
+  });
+
   it('should handle node names with "end" substring', function () {
     const res = flow.parser.parse('graph TD\nendpoint --> sender');
 

--- a/packages/mermaid/src/diagrams/flowchart/styles.spec.ts
+++ b/packages/mermaid/src/diagrams/flowchart/styles.spec.ts
@@ -1,0 +1,40 @@
+import getStyles, { type FlowChartStyleOptions } from './styles.js';
+
+const getStyleOptions = (
+  overrides: Partial<FlowChartStyleOptions> = {}
+): FlowChartStyleOptions => ({
+  arrowheadColor: '#333333',
+  border2: '#666666',
+  clusterBkg: '#eeeeee',
+  clusterBorder: '#999999',
+  edgeLabelBackground: '#ffffff',
+  fontFamily: 'Arial',
+  lineColor: '#111111',
+  mainBkg: '#f8f8f8',
+  nodeBorder: '#222222',
+  nodeTextColor: '#000000',
+  noteBkgColor: '#fff5ad',
+  noteTextColor: '#333333',
+  tertiaryColor: '#dddddd',
+  textColor: '#444444',
+  titleColor: '#555555',
+  strokeWidth: '1',
+  ...overrides,
+});
+
+describe('flowchart styles', () => {
+  it('styles node notes from theme variables', () => {
+    const styles = getStyles(
+      getStyleOptions({
+        noteBkgColor: '#fef3c7',
+        noteTextColor: '#1f2937',
+      })
+    );
+
+    expect(styles).toContain('.flowchart-note-background');
+    expect(styles).toContain('fill: #fef3c7');
+    expect(styles).toContain('stroke: none');
+    expect(styles).toContain('.flowchart-note-text, .flowchart-note-text > tspan');
+    expect(styles).toContain('fill: #1f2937');
+  });
+});

--- a/packages/mermaid/src/diagrams/flowchart/styles.ts
+++ b/packages/mermaid/src/diagrams/flowchart/styles.ts
@@ -14,6 +14,8 @@ export interface FlowChartStyleOptions {
   mainBkg: string;
   nodeBorder: string;
   nodeTextColor: string;
+  noteBkgColor: string;
+  noteTextColor: string;
   tertiaryColor: string;
   textColor: string;
   titleColor: string;
@@ -153,6 +155,16 @@ const getStyles = (options: FlowChartStyleOptions) =>
     text-anchor: middle;
     font-size: 18px;
     fill: ${options.textColor};
+  }
+
+  .flowchart-note-background {
+    fill: ${options.noteBkgColor};
+    stroke: none;
+  }
+
+  .flowchart-note-text, .flowchart-note-text > tspan {
+    fill: ${options.noteTextColor};
+    stroke: none;
   }
 
   rect.text {

--- a/packages/mermaid/src/diagrams/flowchart/types.ts
+++ b/packages/mermaid/src/diagrams/flowchart/types.ts
@@ -85,6 +85,12 @@ export interface FlowSubGraph {
   title: string;
 }
 
+export interface FlowNote {
+  position: 'left' | 'right' | 'top' | 'bottom';
+  target: string;
+  text: string;
+}
+
 export interface FlowLink {
   length?: number;
   stroke: string;

--- a/packages/mermaid/src/docs/syntax/flowchart.md
+++ b/packages/mermaid/src/docs/syntax/flowchart.md
@@ -608,6 +608,42 @@ flowchart TD
   A@{ img: "https://mermaid.js.org/favicon.svg", label: "My example image label", pos: "t", h: 60, constraint: "on" }
 ```
 
+## Node notes (v<MERMAID_RELEASE_VERSION>+)
+
+You can attach a note to a flowchart node by using a `note ... of ...` block. Notes are rendered next to the target node and do not add layout nodes or edges to the graph.
+
+Supported placements are `right`, `left`, `top`, and `bottom`.
+
+```mermaid-example
+flowchart TD
+    A[Start] --> B[Process]
+    B --> C[Done]
+
+    note right of A
+      Input assumptions
+    end note
+
+    note left of B
+      Internal state:
+      cache enabled
+    end note
+
+    note bottom of C
+      Final result
+    end note
+```
+
+The same syntax is also available when using `graph` instead of `flowchart`.
+
+```mermaid-example
+graph LR
+    A[A] --> B[B]
+
+    note top of A
+      graph note
+    end note
+```
+
 ## Links between nodes
 
 Nodes can be connected with links/edges. It is possible to have different types of links or attach a text string to a link.

--- a/packages/mermaid/src/rendering-util/types.ts
+++ b/packages/mermaid/src/rendering-util/types.ts
@@ -182,6 +182,14 @@ export interface Edge {
   isLayoutOnly?: boolean;
 }
 
+export type NodeNotePosition = 'left' | 'right' | 'top' | 'bottom';
+
+export interface NodeNote {
+  target: string;
+  position: NodeNotePosition;
+  text: string;
+}
+
 export interface RectOptions {
   rx: number;
   ry: number;
@@ -203,6 +211,7 @@ export type ClassDiagramNode = Node & {
 export interface LayoutData {
   nodes: Node[];
   edges: Edge[];
+  notes?: NodeNote[];
   config: MermaidConfig;
   diagramId?: string;
   [key: string]: any; // Additional properties not yet defined


### PR DESCRIPTION
## Summary

This PR adds node notes to flowchart diagrams using a block syntax inspired by the existing note syntax in state diagrams.

State diagrams already support the `note right of ...` and `note left of ...` form. This PR brings the same note-block style to flowchart/graph diagrams, and extends the placement options to include `top` and `bottom` as well:

```text
flowchart TD
  A[A] --> B[B]

  note right of B
    description:
    Some properties of B
  end note
```

> GitHub's current Mermaid renderer does not support this PR's new syntax yet, so the examples in this PR description are fenced as plain text.

Supported placements are:

- `note right of NODE_ID`
- `note left of NODE_ID`
- `note top of NODE_ID`
- `note bottom of NODE_ID`

The same syntax works for both `flowchart` and `graph` diagrams.

Refs #2712.

## Current behavior

- Works for both `flowchart` and `graph`.
- Works with the usual graph directions tested here: `TD`, `TB`, `LR`, `RL`, and `BT`.
- The parsed note model is intentionally small: `{ target, position, text }`.
- Multi-line note text is supported.
- Long lines are automatically wrapped.
- Notes do not participate in graph layout, so they do not move target nodes the way dummy edges/subgraphs would.
- Notes are rendered after the normal flowchart layout, on top of the existing graph.
- Current visual defaults are a pale yellow note background, no border, small text, `50px` minimum width, `230px` maximum width, and a `1px` gap from the target node so the note does not cover the node border. These are implementation defaults and can be adjusted for Mermaid style/theme conventions.

## Intentional behavior

Some behaviors are intentional consequences of the overlay design rather than bugs:

- Multiple notes attached to the same node on the same side will overlap.
- Notes may overlap edges or nearby nodes. This is intentional for this version because notes are drawn as an overlay and do not affect layout.
- A standalone `end note` line closes the note block. If users need the words `end note` as note text, they should not put that text alone on its own line.

Keeping notes out of layout is deliberate: it preserves the existing flowchart node/edge positions exactly, and users can move a note to another side (`left`, `right`, `top`, or `bottom`) when overlap is undesirable.

## Design

The notes are stored separately from flowchart nodes and edges, then rendered as an overlay after layout rendering:

- notes are parsed into `LayoutData.notes`
- notes do not add layout nodes
- notes do not add layout edges
- flowchart node/edge layout remains unchanged when notes are removed
- notes are drawn after the graph render step and before viewport setup, so they can be included in the final SVG bounds

## Syntax compatibility

This PR includes a regression test for regular nodes named `note`, such as:

```text
flowchart
  note["I am a regular node named note"]
  note --> A[A]
```

That syntax continues to parse as a normal flowchart node. The new parser rules only match the explicit `note POSITION of NODE_ID` block form.

## Styling

Node notes reuse existing theme variables:

- `noteBkgColor`
- `noteTextColor`

The note background is rendered without a border, matching the overlay style used here.

## Documentation

Added a new `Node notes` section to the flowchart syntax docs, including both `flowchart` and `graph` examples.

## Tests

Added coverage for:

- parsing node notes in `flowchart`
- parsing node notes in `graph`
- all supported directions: `left`, `right`, `top`, `bottom`
- `TD`, `TB`, `LR`, `RL`, and `BT` graph directions
- continuing to parse statements after a note block
- empty note blocks
- preserving regular nodes named `note`
- proving layout nodes/edges are unchanged when notes are removed
- DB note normalization and state clearing
- preventing note arrays from mutating internal DB state
- renderer placement for positioned nodes
- renderer fallback to rendered SVG node positions
- skipping missing/unpositioned note targets
- note styles from theme variables
- render ordering: notes are drawn after graph layout and before viewport setup

Locally verified:

```bash
pnpm vitest run packages/mermaid/src/diagrams/flowchart/flowDb.spec.ts packages/mermaid/src/diagrams/flowchart/parser/flow.spec.js packages/mermaid/src/diagrams/flowchart/flowRenderer-v3-unified.spec.ts packages/mermaid/src/diagrams/flowchart/flowNoteRenderer.spec.ts packages/mermaid/src/diagrams/flowchart/styles.spec.ts
pnpm lint
pnpm --filter mermaid docs:spellcheck
pnpm build:mermaid
git diff --check
```