### PR TITLE
docs: document ELK layout registration for flowcharts

### DIFF
--- a/docs/syntax/flowchart.md
+++ b/docs/syntax/flowchart.md
@@ -2139,6 +2139,7 @@ When loading Mermaid from a CDN, import the ELK layout package and register it i
 
 > **Note**
 > Registering the ELK layout makes the renderer available to Mermaid. You can then select it with the `flowchart.defaultRenderer` configuration or with the `layout: elk` diagram configuration.
+
 ### Width
 
 It is possible to adjust the width of the rendered flowchart.

--- a/docs/syntax/flowchart.md
+++ b/docs/syntax/flowchart.md
@@ -2100,6 +2100,45 @@ config:
 > **Note**
 > Note that the site needs to use mermaid version 9.4+ for this to work and have this featured enabled in the lazy-loading configuration.
 
+#### Using the ELK renderer outside the Mermaid Live Editor
+
+The Mermaid Live Editor registers the ELK layout automatically. When you use Mermaid as a package, you need to install and register the ELK layout before diagrams can use `defaultRenderer: "elk"`.
+
+With a bundler, install the ELK layout package:
+
+```sh
+npm install @mermaid-js/layout-elk
+```
+
+Then import the package and register the layout loaders before calling `mermaid.initialize` or `mermaid.run`:
+
+```javascript
+import mermaid from 'mermaid';
+import elkLayouts from '@mermaid-js/layout-elk';
+
+mermaid.registerLayoutLoaders(elkLayouts);
+mermaid.initialize({
+  startOnLoad: true,
+  flowchart: {
+    defaultRenderer: 'elk',
+  },
+});
+```
+
+When loading Mermaid from a CDN, import the ELK layout package and register it in the same module:
+
+```html
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  import elkLayouts from 'https://cdn.jsdelivr.net/npm/@mermaid-js/layout-elk@latest/dist/mermaid-layout-elk.esm.min.mjs';
+
+  mermaid.registerLayoutLoaders(elkLayouts);
+  mermaid.initialize({ startOnLoad: true });
+</script>
+```
+
+> **Note**
+> Registering the ELK layout makes the renderer available to Mermaid. You can then select it with the `flowchart.defaultRenderer` configuration or with the `layout: elk` diagram configuration.
 ### Width
 
 It is possible to adjust the width of the rendered flowchart.

--- a/packages/mermaid/src/docs/syntax/flowchart.md
+++ b/packages/mermaid/src/docs/syntax/flowchart.md
@@ -1413,6 +1413,7 @@ When loading Mermaid from a CDN, import the ELK layout package and register it i
 ```note
 Registering the ELK layout makes the renderer available to Mermaid. You can then select it with the `flowchart.defaultRenderer` configuration or with the `layout: elk` diagram configuration.
 ```
+
 ### Width
 
 It is possible to adjust the width of the rendered flowchart.

--- a/packages/mermaid/src/docs/syntax/flowchart.md
+++ b/packages/mermaid/src/docs/syntax/flowchart.md
@@ -1373,6 +1373,46 @@ config:
 Note that the site needs to use mermaid version 9.4+ for this to work and have this featured enabled in the lazy-loading configuration.
 ```
 
+#### Using the ELK renderer outside the Mermaid Live Editor
+
+The Mermaid Live Editor registers the ELK layout automatically. When you use Mermaid as a package, you need to install and register the ELK layout before diagrams can use `defaultRenderer: "elk"`.
+
+With a bundler, install the ELK layout package:
+
+```sh
+npm install @mermaid-js/layout-elk
+```
+
+Then import the package and register the layout loaders before calling `mermaid.initialize` or `mermaid.run`:
+
+```javascript
+import mermaid from 'mermaid';
+import elkLayouts from '@mermaid-js/layout-elk';
+
+mermaid.registerLayoutLoaders(elkLayouts);
+mermaid.initialize({
+  startOnLoad: true,
+  flowchart: {
+    defaultRenderer: 'elk',
+  },
+});
+```
+
+When loading Mermaid from a CDN, import the ELK layout package and register it in the same module:
+
+```html
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+  import elkLayouts from 'https://cdn.jsdelivr.net/npm/@mermaid-js/layout-elk@latest/dist/mermaid-layout-elk.esm.min.mjs';
+
+  mermaid.registerLayoutLoaders(elkLayouts);
+  mermaid.initialize({ startOnLoad: true });
+</script>
+```
+
+```note
+Registering the ELK layout makes the renderer available to Mermaid. You can then select it with the `flowchart.defaultRenderer` configuration or with the `layout: elk` diagram configuration.
+```
 ### Width
 
 It is possible to adjust the width of the rendered flowchart.


### PR DESCRIPTION
## Summary

- documents how to install and register `@mermaid-js/layout-elk` when using Mermaid outside the Live Editor
- adds bundler and CDN examples using `mermaid.registerLayoutLoaders`
- clarifies that ELK can then be selected with `flowchart.defaultRenderer` or `layout: elk`

Fixes #5969

## Checklist

- [x] Documentation only
- [ ] Tests are not needed for this documentation-only change