### PR TITLE
fix(elk): keep nested subgraphs inside their parent when titles are wider than their content

### DIFF
--- a/.changeset/fix-elk-nested-subgraph-overflow.md
+++ b/.changeset/fix-elk-nested-subgraph-overflow.md
@@ -1,0 +1,9 @@
+---
+'@mermaid-js/layout-elk': patch
+---
+
+Fix nested subgraphs overflowing their parent when a subgraph title is wider than its content
+
+ELK only reserves vertical space for `INSIDE` node labels on compound nodes and ignores their width, so a subgraph could be laid out narrower than its own title. The painter then widened just that rectangle after layout, pushing it outside its parent subgraph and over its siblings.
+
+The ELK renderer now measures subgraph titles the same way the painter draws them (unwrapped) and re-runs the layout with extra horizontal padding for every subgraph that is narrower than its painted title, so parents and siblings are placed around the final width.

--- a/packages/mermaid-layout-elk/src/__tests__/render.spec.ts
+++ b/packages/mermaid-layout-elk/src/__tests__/render.spec.ts
@@ -5,6 +5,7 @@ import {
   dir2ElkDirection,
   ensureEndMarkerSegmentLength,
   findCyclicEntryNodes,
+  growClusterPaddingForLabels,
   prepareLayoutForElk,
   runElkLayoutCore,
 } from '../render.js';
@@ -442,6 +443,144 @@ describe('runElkLayoutCore', () => {
     expect(child.offset.y).toBeCloseTo(group.offset.posY);
     expect(layoutChild.x).toBeCloseTo(child.offset.posX + child.width / 2);
     expect(layoutChild.y).toBeCloseTo(child.offset.posY + child.height / 2);
+  });
+});
+
+describe('growClusterPaddingForLabels', () => {
+  const nodeDb = {
+    wide: { id: 'wide', isGroup: true, padding: 8, labelData: { width: 300, height: 16 } },
+    narrow: { id: 'narrow', isGroup: true, padding: 8, labelData: { width: 20, height: 16 } },
+    leaf: { id: 'leaf', isGroup: false },
+  } as any;
+
+  it('reports no change when every subgraph already fits its label', () => {
+    const graph = { children: [{ id: 'narrow', width: 100, children: [] }] };
+    const overrides = new Map<string, number>();
+    expect(growClusterPaddingForLabels(graph, nodeDb, overrides)).toBe(false);
+    expect(overrides.size).toBe(0);
+  });
+
+  it('adds half the missing width per side for a too-narrow subgraph', () => {
+    // painted width = label 300 + padding 8 = 308; laid out at 100 -> 208 missing
+    const graph = { children: [{ id: 'wide', width: 100, children: [] }] };
+    const overrides = new Map<string, number>();
+    expect(growClusterPaddingForLabels(graph, nodeDb, overrides)).toBe(true);
+    expect(overrides.get('wide')).toBe(104);
+  });
+
+  it('accumulates overrides across passes', () => {
+    const overrides = new Map([['wide', 50]]);
+    // still 8 too narrow after the previous pass -> grow by 4 more per side
+    const graph = { children: [{ id: 'wide', width: 300, children: [] }] };
+    expect(growClusterPaddingForLabels(graph, nodeDb, overrides)).toBe(true);
+    expect(overrides.get('wide')).toBe(54);
+  });
+
+  it('visits nested subgraphs and ignores leaf nodes', () => {
+    const graph = {
+      children: [
+        {
+          id: 'narrow',
+          width: 400,
+          children: [
+            { id: 'wide', width: 100, children: [{ id: 'leaf', width: 40 }] },
+            { id: 'leaf', width: 40 },
+          ],
+        },
+      ],
+    };
+    const overrides = new Map<string, number>();
+    expect(growClusterPaddingForLabels(graph, nodeDb, overrides)).toBe(true);
+    expect([...overrides.keys()]).toEqual(['wide']);
+  });
+});
+
+describe('runElkLayoutCore label width handling', () => {
+  const layoutDataWithWideLabels = () =>
+    ({
+      direction: 'TB',
+      config: { elk: {} },
+      nodes: [
+        {
+          id: 'outer',
+          isGroup: true,
+          label: 'outer',
+          padding: 8,
+          labelBBox: { width: 60, height: 16 },
+        },
+        {
+          id: 'inner',
+          isGroup: true,
+          parentId: 'outer',
+          label: 'a very long inner subgraph title',
+          padding: 8,
+          // far wider than the content (a single 40px leaf)
+          labelBBox: { width: 400, height: 16 },
+        },
+        {
+          id: 'leaf',
+          isGroup: false,
+          parentId: 'inner',
+          width: 40,
+          height: 20,
+          label: 'leaf',
+          shape: 'rect',
+        },
+      ],
+      edges: [],
+    }) as any;
+
+  it('grows a subgraph to its painted label width', async () => {
+    const data = layoutDataWithWideLabels();
+    await runElkLayoutCore(data, elkRenderContext);
+
+    const inner = data.nodes.find((node: any) => node.id === 'inner');
+    expect(inner.width).toBeGreaterThanOrEqual(400 + 8);
+  });
+
+  it('keeps a label-widened subgraph inside its parent', async () => {
+    const data = layoutDataWithWideLabels();
+    await runElkLayoutCore(data, elkRenderContext);
+
+    const outer = data.nodes.find((node: any) => node.id === 'outer');
+    const inner = data.nodes.find((node: any) => node.id === 'inner');
+
+    expect(inner.x - inner.width / 2).toBeGreaterThanOrEqual(outer.x - outer.width / 2);
+    expect(inner.x + inner.width / 2).toBeLessThanOrEqual(outer.x + outer.width / 2);
+    expect(inner.y - inner.height / 2).toBeGreaterThanOrEqual(outer.y - outer.height / 2);
+    expect(inner.y + inner.height / 2).toBeLessThanOrEqual(outer.y + outer.height / 2);
+  });
+
+  it('does not add layout passes when labels already fit', async () => {
+    const data = {
+      direction: 'TB',
+      config: { elk: {} },
+      nodes: [
+        {
+          id: 'group',
+          isGroup: true,
+          label: 'g',
+          padding: 8,
+          labelBBox: { width: 10, height: 16 },
+        },
+        {
+          id: 'leaf',
+          isGroup: false,
+          parentId: 'group',
+          width: 100,
+          height: 20,
+          label: 'leaf',
+          shape: 'rect',
+        },
+      ],
+      edges: [],
+    } as any;
+
+    await runElkLayoutCore(data, elkRenderContext);
+
+    const group = data.nodes.find((node: any) => node.id === 'group');
+    // content 100 + default padding 12 per side; no label-driven growth
+    expect(group.width).toBeCloseTo(124);
   });
 });
 

--- a/packages/mermaid-layout-elk/src/render.ts
+++ b/packages/mermaid-layout-elk/src/render.ts
@@ -107,6 +107,14 @@ const ARROW_MAP: Record<string, [string, string]> = {
   double_arrow_circle: ['arrow_circle', 'arrow_circle'],
 };
 const DEFAULT_NODE_PLACEMENT_ALIGNMENT = 'NONE';
+// ELK's default padding for compound nodes ('elk.padding'), applied on every
+// side when the option is not set explicitly.
+const ELK_DEFAULT_CLUSTER_PADDING = 12;
+// Upper bound for label-width layout passes. The first pass fixes every
+// subgraph that is narrower than its own label; later passes only trigger in
+// the rare case where the re-layout reshuffles content enough to expose a new
+// too-narrow subgraph.
+const MAX_LABEL_WIDTH_PASSES = 4;
 
 export function dir2ElkDirection(dir: unknown): 'RIGHT' | 'LEFT' | 'DOWN' | 'UP' {
   switch (dir) {
@@ -291,16 +299,128 @@ export async function runElkLayoutCore(
   context: CommonLayoutRenderContext<ElkPreparedLayout>
 ): Promise<ElkLayoutResult> {
   const elkContext = getElkLayoutContext(context);
-  const layoutState = buildElkGraphFromLayoutData(data4Layout, elkContext);
+  await remeasureClusterLabels(data4Layout, context);
+  let layoutState = buildElkGraphFromLayoutData(data4Layout, elkContext);
 
   // @ts-ignore - ELK is not typed
   const elk = new ELK();
   elkContext.log.info('Drawing flowchart using v4 renderer', elk);
 
-  const graph = await runElkLayout(elk, layoutState.elkGraph, elkContext.log);
+  let graph = await runElkLayout(elk, layoutState.elkGraph, elkContext.log);
+
+  // ELK reserves vertical space for INSIDE node labels on compound nodes but
+  // ignores their width, so a subgraph can come back narrower than its own
+  // title. The painter would then widen just that rectangle after layout,
+  // pushing it outside its parent and over its siblings. Detect such
+  // subgraphs and re-run the layout with extra horizontal padding so parents
+  // and siblings are placed around the final painted width.
+  const paddingOverrides = new Map<string, number>();
+  for (let pass = 0; pass < MAX_LABEL_WIDTH_PASSES; pass++) {
+    if (!growClusterPaddingForLabels(graph, layoutState.nodeDb, paddingOverrides)) {
+      break;
+    }
+    elkContext.log.debug('ELK re-running layout for subgraph label widths', paddingOverrides);
+    layoutState = buildElkGraphFromLayoutData(data4Layout, elkContext);
+    applyClusterPaddingOverrides(layoutState.nodeDb, paddingOverrides);
+    graph = await runElkLayout(elk, layoutState.elkGraph, elkContext.log);
+  }
+
   applyElkLayoutResult(data4Layout, graph, layoutState, elkContext.log);
   orderNodesForElkPaint(data4Layout.nodes);
   return graph;
+}
+
+/**
+ * Re-measure subgraph labels the way the cluster painter will draw them.
+ *
+ * The generic measure pass wraps labels at `flowchart.wrappingWidth`, but the
+ * cluster painter renders non-markdown titles without wrapping. A long title
+ * therefore paints wider than the `labelBBox` the layout was computed with,
+ * and the subgraph rectangle ends up overflowing its parent. Override
+ * `labelBBox` with the unwrapped size so the layout sees the painted width.
+ */
+async function remeasureClusterLabels(
+  data4Layout: LayoutData,
+  context: CommonLayoutRenderContext<ElkPreparedLayout>
+): Promise<void> {
+  const element = context.element;
+  const labelHelper = context.helpers?.labelHelper;
+  if (!labelHelper || !element?.node()) {
+    return;
+  }
+  for (const node of data4Layout.nodes) {
+    if (!node.isGroup || !node.label || node.labelType === 'markdown') {
+      continue;
+    }
+    // `element` is the root `<g>` (a graphics element); the context types it as the
+    // wider `SVGElement`, so cast to what `labelHelper` expects.
+    const { shapeSvg, bbox } = await labelHelper(
+      element as unknown as Parameters<typeof labelHelper>[0],
+      {
+        ...node,
+        width: Number.POSITIVE_INFINITY,
+      }
+    );
+    shapeSvg.remove();
+    node.labelBBox = { width: bbox.width, height: bbox.height };
+  }
+}
+
+/**
+ * Find subgraphs whose laid-out width is smaller than the width the painter
+ * will actually draw (label width plus cluster padding) and increase their
+ * horizontal padding override accordingly.
+ *
+ * @param graph - the laid-out ELK graph of the previous pass
+ * @param nodeDb - lookup with the measured `labelData` and `padding` per node
+ * @param paddingOverrides - accumulated extra horizontal padding per subgraph
+ *   id, mutated in place
+ * @returns true when any override was added or increased, i.e. another layout
+ *   pass is needed
+ */
+export function growClusterPaddingForLabels(
+  graph: ElkLayoutResult,
+  nodeDb: Record<string, NodeWithVertex>,
+  paddingOverrides: Map<string, number>
+): boolean {
+  let changed = false;
+  const visit = (children: any[] | undefined) => {
+    for (const child of children ?? []) {
+      if (!child) {
+        continue;
+      }
+      const dbNode = nodeDb[child.id];
+      if (dbNode?.isGroup) {
+        const requiredWidth = (dbNode.labelData?.width ?? 0) + (dbNode.padding ?? 0);
+        const missing = requiredWidth - (child.width ?? 0);
+        if (missing > 0) {
+          const extra = Math.ceil(missing / 2);
+          paddingOverrides.set(child.id, (paddingOverrides.get(child.id) ?? 0) + extra);
+          changed = true;
+        }
+        visit(child.children);
+      }
+    }
+  };
+  visit(graph.children);
+  return changed;
+}
+
+function applyClusterPaddingOverrides(
+  nodeDb: Record<string, NodeWithVertex>,
+  paddingOverrides: Map<string, number>
+): void {
+  for (const [id, extra] of paddingOverrides) {
+    const node = nodeDb[id];
+    if (!node) {
+      continue;
+    }
+    const horizontal = ELK_DEFAULT_CLUSTER_PADDING + extra;
+    node.layoutOptions = {
+      ...node.layoutOptions,
+      'elk.padding': `[top=${ELK_DEFAULT_CLUSTER_PADDING},left=${horizontal},bottom=${ELK_DEFAULT_CLUSTER_PADDING},right=${horizontal}]`,
+    };
+  }
 }
 
 export function buildElkGraphFromLayoutData(


### PR DESCRIPTION
## :bookmark_tabs: Summary

With `layout: elk`, a nested subgraph whose **title is wider than its content** is drawn
overflowing its parent subgraph and overlapping its sibling subgraphs. The same diagram
renders correctly with the default dagre layout.

This PR makes the ELK renderer lay out subgraphs against the width their title will
actually be painted at, so parents and siblings are placed around the final rectangle.

Resolves #7901

Related: #4967 (ELK + subgraphs broken, no detailed repro), follow-up to #6027 (single
clusters with ELK were fixed in #6028; the nested-cluster containment issue remained).

### Repro

```text
---
config:
  layout: elk
---
flowchart TB
  subgraph Outer["Outer"]
    subgraph Mid["A subgraph title that is much wider than the subgraph's content"]
      entry["entry"]
      subgraph Inner["Another long title, wider than the two nodes below"]
        a["a"] --> b["b"]
      end
      done["done"]
      entry --> Inner --> done
    end
  end
```

The repro above shows the smallest trigger (`Mid` overflows `Outer` by 72px per side).
The screenshots below are the production diagram from #7901 (deeply nested subgraphs
with long titles): **before**, inner subgraphs overflow their parents and overlap
siblings; **after**, every subgraph rectangle is fully contained in its parent.

<!-- 下の表に画像をドラッグ&ドロップしてください (左=Before, 右=After) -->
| Before | After |
| ------ | ----- |
| <img width="918" height="231" alt="スクリーンショット 2026-06-21 192926" src="https://github.com/user-attachments/assets/4179a719-722a-412a-8ad3-27872d6530c7" /> | <img width="955" height="178" alt="スクリーンショット 2026-06-21 192540" src="https://github.com/user-attachments/assets/f326f96d-5962-420c-b796-c21b8ae2c074" /> |

## :straight_ruler: Design Decisions

### Problem

Two mismatches stack up, both specific to the ELK path:

1. **ELK ignores the width of `INSIDE` node labels on compound nodes.** It reserves
   vertical space for the title, but the compound node's width is computed from its
   children only. Verified directly against elkjs 0.9.3: a compound node with a
   600px-wide label and two 80px children comes back 104px wide. Neither
   `nodeSize.constraints: NODE_LABELS` nor `nodeSize.minimum` affects the width of a
   hierarchical node, so there is no ELK option that fixes this declaratively.
2. **Labels are measured wrapped but painted unwrapped.** The generic measure pass
   (`createGraph.ts` → `labelHelper`) wraps group labels at `flowchart.wrappingWidth`,
   while the cluster painter (`clusters.js` → `createLabel`) renders non-markdown titles
   at infinite width. A long title therefore paints far wider than the `labelBBox` the
   layout was computed with.

The cluster painter compensates by widening just that rectangle after layout
(`width = max(node.width, labelBBox.width + padding)`, centered on the node), but at that
point ELK has already placed the parent and the siblings — so the widened rectangle
spills out of its parent and over its neighbors.

### Approach

All changes are contained in `@mermaid-js/layout-elk` (`render.ts`):

- **`remeasureClusterLabels`** — before building the ELK graph, re-measure subgraph
  titles the way the painter will draw them (via the exposed `labelHelper` at
  `width: Number.POSITIVE_INFINITY`) and override `labelBBox`. Markdown titles are
  skipped: the painter wraps those at the node's final width, so the wrapped
  measurement is the right input for them.
- **`growClusterPaddingForLabels` + re-layout** — after a layout pass, find every
  subgraph whose laid-out width is smaller than its painted width
  (`labelBBox.width + padding`) and add half the missing width to its left/right
  `elk.padding`. If anything grew, run the layout again so parents expand and siblings
  move out of the way. ELK applies compound padding natively, so containment and edge
  routing stay consistent. The loop converges immediately in practice (label widths are
  fixed; padding only grows) and is capped at 4 passes as a safety bound.

Diagrams whose subgraphs are already wider than their titles take the early-exit path
(zero extra layout passes) and render byte-identical to before. The painter's
post-layout widening in `clusters.js` is left in place as a fallback for other layouts;
with ELK it simply no longer triggers because the laid-out width already fits the title.

### Why not fix the measurement or the painter in core mermaid?

- Making the painter wrap titles (or the measure pass not wrap) would change rendering
  for **dagre** too — `clusters.js` and `createGraph.ts` are shared — and `labelBBox`'s
  height feeds dagre's spacing. Keeping the fix in the ELK renderer leaves dagre
  pixel-identical.
- An ELK-side option doesn't exist (see Problem 1), so padding is the supported way to
  make a compound node wider than its content.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. <!-- behavior fix, no new API — n/a -->
- [x] :butterfly: changeset added (`patch` for `@mermaid-js/layout-elk`, prefixed `fix:`)

## Tests

- **Unit** (`packages/mermaid-layout-elk/src/__tests__/render.spec.ts`):
  - `growClusterPaddingForLabels` — no-op when titles fit, exact per-side growth,
    accumulation across passes, nested-group traversal, leaf nodes ignored.
  - Through `runElkLayoutCore` (real elkjs, no DOM): a label-widened subgraph reaches
    `labelBBox.width + padding`, stays inside its parent's rectangle, and a fitting
    label triggers no growth (width stays content + default padding).

## Verification

Verified in a real browser (the built bundles) by measuring every cluster
rectangle's bounding box and asserting parent containment and sibling non-overlap:

- The repro above and a production diagram with 21 nested subgraphs (3 levels deep,
  long CJK titles, edges terminating on subgraph ids): **before** — 3 containment
  violations and 3 sibling overlaps; **after** — zero violations in all fixtures.
- Diagrams with short titles (pure 3-level nesting, subgraph-id edge endpoints) were
  unaffected before and after, confirming the root cause is the title width and that
  the fix doesn't disturb already-correct layouts.
