### PR TITLE
feat(state): entry/do/exit actions for state diagrams (#2899)

### DIFF
--- a/.changeset/state-entry-do-exit-actions.md
+++ b/.changeset/state-entry-do-exit-actions.md
@@ -6,4 +6,6 @@ feat(state): support entry/do/exit actions in state diagrams
 
 State body lines prefixed with `entry /`, `do /`, or `exit /` are now collected as structured actions and rendered in a UML actions compartment beneath the state name, rather than replacing the name as plain descriptions. Lines without one of these keywords are still treated as ordinary descriptions.
 
+Note: an existing diagram whose plain description happens to begin with `entry /`, `do /`, or `exit /` (case-insensitive) will now render that line as an action below the state name rather than as the title. Collision is unlikely and the new rendering is the more correct one.
+
 Addresses mermaid-js/mermaid#2899

--- a/.changeset/state-entry-do-exit-actions.md
+++ b/.changeset/state-entry-do-exit-actions.md
@@ -1,0 +1,9 @@
+---
+'mermaid': minor
+---
+
+feat(state): support entry/do/exit actions in state diagrams
+
+State body lines prefixed with `entry /`, `do /`, or `exit /` are now collected as structured actions and rendered in a UML actions compartment beneath the state name, rather than replacing the name as plain descriptions. Lines without one of these keywords are still treated as ordinary descriptions.
+
+Addresses mermaid-js/mermaid#2899

--- a/cypress/integration/rendering/state/stateDiagram-v2.spec.js
+++ b/cypress/integration/rendering/state/stateDiagram-v2.spec.js
@@ -887,4 +887,17 @@ State9_____________ --> State10_____________   : Transition9_____
       {}
     );
   });
+  it('should render entry, do and exit actions in a state', () => {
+    imgSnapshotTest(
+      `
+    stateDiagram-v2
+      [*] --> Active
+      Active : entry / openValve
+      Active : do / heat
+      Active : exit / closeValve
+      Active --> [*]
+      `,
+      { logLevel: 0, fontFamily: 'courier' }
+    );
+  });
 });

--- a/demos/state.html
+++ b/demos/state.html
@@ -25,7 +25,15 @@
       accDescr:This is an accessible description
       State1 --> State2
     </pre>
-
+    <pre class="mermaid">
+    stateDiagram-v2
+    [*] --> Idle
+    Idle --> Running : start
+    Running : entry / energiseCoils
+    Running : do / commutate
+    Running : exit / deEnergise
+    Running --> Idle : stop
+    </pre>
     <hr />
 
     <h2>This has classDef statements to apply style classes to specific states</h2>

--- a/docs/syntax/stateDiagram.md
+++ b/docs/syntax/stateDiagram.md
@@ -108,6 +108,32 @@ stateDiagram-v2
     s2 : This is a state description
 ```
 
+## Entry, do, and exit actions (v\<MERMAID_RELEASE_VERSION>+)
+
+A state can declare the actions performed on entry, while active, and on exit, following the UML state machine model. Write them as state body lines prefixed with `entry /`, `do /`, or `exit /`:
+
+```mermaid-example
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Active : start
+    Active : entry / openValve
+    Active : do / heat
+    Active : exit / closeValve
+    Active --> Idle : stop
+```
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Active : start
+    Active : entry / openValve
+    Active : do / heat
+    Active : exit / closeValve
+    Active --> Idle : stop
+```
+
+The state name stays as the title, and the actions are listed in their own compartment beneath it. Lines that do not begin with one of these keywords are treated as ordinary descriptions.
+
 ## Transitions
 
 Transitions are path/edges when one state passes into another. This is represented using text arrow, "-->".

--- a/packages/mermaid/src/diagrams/state/dataFetcher.ts
+++ b/packages/mermaid/src/diagrams/state/dataFetcher.ts
@@ -31,6 +31,7 @@ import {
   SHAPE_START,
   SHAPE_STATE,
   SHAPE_STATE_WITH_DESC,
+  parseStateAction,
   STMT_RELATION,
   STMT_STATE,
 } from './stateCommon.js';
@@ -234,26 +235,34 @@ export const dataFetcher = (
 
     // Build of the array of description strings
     if (parsedItem.description) {
-      if (Array.isArray(newNode.description)) {
-        // There already is an array of strings,add to it
+      // entry/do/exit lines are collected as structured actions so the state name
+      // is kept as the title and the actions render in their own compartment (issue #2899)
+      const action = parseStateAction(parsedItem.description);
+      if (action) {
+        (newNode.actions ??= []).push(action);
         newNode.shape = SHAPE_STATE_WITH_DESC;
-        newNode.description.push(parsedItem.description);
       } else {
-        if (newNode.description?.length && newNode.description.length > 0) {
-          // if there is a description already transform it to an array
+        if (Array.isArray(newNode.description)) {
+          // There already is an array of strings,add to it
           newNode.shape = SHAPE_STATE_WITH_DESC;
-          if (newNode.description === itemId) {
-            // If the previous description was this, remove it
-            newNode.description = [parsedItem.description];
-          } else {
-            newNode.description = [newNode.description, parsedItem.description];
-          }
+          newNode.description.push(parsedItem.description);
         } else {
-          newNode.shape = SHAPE_STATE;
-          newNode.description = parsedItem.description;
+          if (newNode.description?.length && newNode.description.length > 0) {
+            // if there is a description already transform it to an array
+            newNode.shape = SHAPE_STATE_WITH_DESC;
+            if (newNode.description === itemId) {
+              // If the previous description was this, remove it
+              newNode.description = [parsedItem.description];
+            } else {
+              newNode.description = [newNode.description, parsedItem.description];
+            }
+          } else {
+            newNode.shape = SHAPE_STATE;
+            newNode.description = parsedItem.description;
+          }
         }
+        newNode.description = common.sanitizeTextOrArray(newNode.description, config);
       }
-      newNode.description = common.sanitizeTextOrArray(newNode.description, config);
     }
 
     // If there's only 1 description entry, just use a regular state shape
@@ -298,6 +307,7 @@ export const dataFetcher = (
       ry: 10,
       look,
       labelType: 'markdown',
+      actions: newNode.actions,
     };
 
     // Clear the label for dividers who have no description

--- a/packages/mermaid/src/diagrams/state/stateActions.spec.js
+++ b/packages/mermaid/src/diagrams/state/stateActions.spec.js
@@ -1,0 +1,101 @@
+import stateDiagram, { parser } from './parser/stateDiagram.jison';
+import { StateDB } from './stateDb.js';
+import { parseStateAction } from './stateCommon.js';
+
+describe('state diagram entry/do/exit actions (#2899)', () => {
+  /** @type {StateDB} */
+  let stateDb;
+  beforeEach(() => {
+    stateDb = new StateDB(2);
+    parser.yy = stateDb;
+    stateDiagram.parser.yy = stateDb;
+    stateDiagram.parser.yy.clear();
+  });
+
+  const nodeFor = (id) => stateDb.getData().nodes.find((node) => node.id === id);
+
+  it('keeps the state name as the title and lists actions below it', () => {
+    parser.parse(`stateDiagram-v2
+[*] --> Idle
+Idle --> Running : start
+Running : entry / energiseCoils
+Running : do / commutate
+Running : exit / deEnergise
+Running --> Idle : stop`);
+
+    const running = nodeFor('Running');
+    expect(running.shape).toBe('rectWithTitle');
+    // The id is preserved as the title rather than being evicted by the first action.
+    expect(running.label).toBe('Running');
+    // Actions render below the divider, in source order, with no duplication.
+    expect(running.description).toEqual([
+      'entry / energiseCoils',
+      'do / commutate',
+      'exit / deEnergise',
+    ]);
+  });
+
+  it('exposes the actions as structured data on the node', () => {
+    parser.parse(`stateDiagram-v2
+Running : entry / energiseCoils
+Running : do / commutate
+Running : exit / deEnergise`);
+
+    expect(nodeFor('Running').actions).toEqual([
+      { kind: 'entry', body: 'energiseCoils' },
+      { kind: 'do', body: 'commutate' },
+      { kind: 'exit', body: 'deEnergise' },
+    ]);
+  });
+
+  it('treats a single action the same way, not as a plain description', () => {
+    parser.parse(`stateDiagram-v2
+Active : entry / openValve`);
+
+    const active = nodeFor('Active');
+    expect(active.shape).toBe('rectWithTitle');
+    expect(active.label).toBe('Active');
+    expect(active.description).toEqual(['entry / openValve']);
+  });
+
+  it('keeps plain descriptions and actions distinct', () => {
+    parser.parse(`stateDiagram-v2
+Active : Spinning up the motor
+Active : entry / energiseCoils`);
+
+    const active = nodeFor('Active');
+    // Plain descriptions occupy the title block; actions follow them, once.
+    expect(active.label).toBe('Spinning up the motor');
+    expect(active.description).toEqual(['entry / energiseCoils']);
+  });
+
+  it('does not choke on a quoted long name combined with a description', () => {
+    // Regression: this form yields a non-string description, which the action
+    // detection must ignore rather than calling string methods on it (#2899).
+    expect(() => {
+      parser.parse(`stateDiagram-v2
+[*] --> S1
+state "Some long name" as S1: The description`);
+      stateDb.getData();
+    }).not.toThrow();
+    expect(nodeFor('S1').label).toBe('Some long name');
+  });
+});
+
+describe('parseStateAction (#2899)', () => {
+  it('parses each action kind and trims the body', () => {
+    expect(parseStateAction('entry / turnOn')).toEqual({ kind: 'entry', body: 'turnOn' });
+    expect(parseStateAction('do/run')).toEqual({ kind: 'do', body: 'run' });
+    expect(parseStateAction('  exit  /  turnOff  ')).toEqual({ kind: 'exit', body: 'turnOff' });
+  });
+
+  it('is case-insensitive on the keyword', () => {
+    expect(parseStateAction('ENTRY / boot')).toEqual({ kind: 'entry', body: 'boot' });
+  });
+
+  it('returns null for ordinary descriptions', () => {
+    expect(parseStateAction('this is a description')).toBeNull();
+    expect(parseStateAction('entrypoint / not an action')).toBeNull();
+    expect(parseStateAction('entry only, no slash')).toBeNull();
+  });
+});

--- a/packages/mermaid/src/diagrams/state/stateCommon.ts
+++ b/packages/mermaid/src/diagrams/state/stateCommon.ts
@@ -66,6 +66,30 @@ export const NOTE_ID = `${DOMID_TYPE_SPACER}${NOTE}`;
 export const PARENT_ID = `${DOMID_TYPE_SPACER}${PARENT}`;
 // --------------------------------------
 
+// entry / do / exit actions inside a state, per the UML state machine model (issue #2899)
+export const STATE_ACTION_KINDS = ['entry', 'do', 'exit'] as const;
+export type StateActionKind = (typeof STATE_ACTION_KINDS)[number];
+export interface StateAction {
+  kind: StateActionKind;
+  body: string;
+}
+
+/**
+ * Parse a state body line as an entry/do/exit action.
+ * Returns the structured action, or null when the line is an ordinary description.
+ * For example the line "entry / turnOnMotor" yields kind 'entry' and body 'turnOnMotor'.
+ */
+export function parseStateAction(text: string): StateAction | null {
+  if (typeof text !== 'string') {
+    return null;
+  }
+  const match = /^(entry|do|exit)\s*\/\s*(.+)$/i.exec(text.trim());
+  if (!match) {
+    return null;
+  }
+  return { kind: match[1].toLowerCase() as StateActionKind, body: match[2].trim() };
+}
+
 export default {
   DEFAULT_DIAGRAM_DIRECTION,
   DEFAULT_NESTED_DOC_DIR,

--- a/packages/mermaid/src/diagrams/state/stateDb.ts
+++ b/packages/mermaid/src/diagrams/state/stateDb.ts
@@ -282,7 +282,9 @@ export class StateDB {
       // Fold entry/do/exit actions into the label beneath the state name (issue #2899).
       // Done once here, not per parsed line, so actions are not duplicated.
       if (node.actions?.length) {
-        const actionLines = node.actions.map((action) => `${action.kind} / ${action.body}`);
+        const actionLines = node.actions.map((action) =>
+          common.sanitizeText(`${action.kind} / ${action.body}`, config)
+        );
         const head = Array.isArray(node.label) ? node.label : node.label ? [node.label] : [node.id];
         node.label = [...head, ...actionLines];
       }

--- a/packages/mermaid/src/diagrams/state/stateDb.ts
+++ b/packages/mermaid/src/diagrams/state/stateDb.ts
@@ -28,6 +28,7 @@ import {
   STMT_STATE,
   STMT_STYLEDEF,
 } from './stateCommon.js';
+import type { StateAction } from './stateCommon.js';
 import type { MermaidConfig } from '../../config.type.js';
 
 const CONSTANTS = {
@@ -166,6 +167,7 @@ export interface NodeData {
   position?: string;
   description?: string | string[];
   labelType?: string;
+  actions?: StateAction[];
 }
 
 export interface Edge {
@@ -277,6 +279,14 @@ export class StateDB {
 
     // Process node labels
     for (const node of this.nodes) {
+      // Fold entry/do/exit actions into the label beneath the state name (issue #2899).
+      // Done once here, not per parsed line, so actions are not duplicated.
+      if (node.actions?.length) {
+        const actionLines = node.actions.map((action) => `${action.kind} / ${action.body}`);
+        const head = Array.isArray(node.label) ? node.label : node.label ? [node.label] : [node.id];
+        node.label = [...head, ...actionLines];
+      }
+
       if (!Array.isArray(node.label)) {
         continue;
       }

--- a/packages/mermaid/src/docs/syntax/stateDiagram.md
+++ b/packages/mermaid/src/docs/syntax/stateDiagram.md
@@ -62,6 +62,22 @@ stateDiagram-v2
     s2 : This is a state description
 ```
 
+## Entry, do, and exit actions (v<MERMAID_RELEASE_VERSION>+)
+
+A state can declare the actions performed on entry, while active, and on exit, following the UML state machine model. Write them as state body lines prefixed with `entry /`, `do /`, or `exit /`:
+
+```mermaid-example
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Active : start
+    Active : entry / openValve
+    Active : do / heat
+    Active : exit / closeValve
+    Active --> Idle : stop
+```
+
+The state name stays as the title, and the actions are listed in their own compartment beneath it. Lines that do not begin with one of these keywords are treated as ordinary descriptions.
+
 ## Transitions
 
 Transitions are path/edges when one state passes into another. This is represented using text arrow, "\-\-\>".


### PR DESCRIPTION
## :bookmark_tabs: Summary

Adds entry/do/exit actions to state diagrams. State body lines prefixed with
`entry /`, `do /`, or `exit /` are collected as structured actions and rendered
in a UML actions compartment beneath the state name. Lines without one of these
keywords are unchanged and still render as ordinary descriptions.

Resolves #2899

## :straight_ruler: Design Decisions

- The actions reuse the existing colon description form (`State : entry / ...`),
  so `stateDiagram.jison` is untouched and the diff stays small. `parseStateAction`
  in `stateCommon.ts` is the single source of truth for the syntax.
- Previously the first description took the title slot and evicted the state name.
  Action lines are now diverted out of the description path into a structured
  `actions` list on the node, so the name is kept as the title and the actions
  render below the divider, in source order.
- The actions are folded into the label once, in `stateDb`'s post-processing loop,
  rather than per parsed line. `insertOrUpdateNode` merges the per-line nodes, so
  composing per line duplicated the actions; composing once avoids that.
- The structured actions are also exposed on the node, so a follow-up that draws a
  distinctly styled compartment is render-only.
- A state mixing a plain description with actions keeps the description in the
  title block and lists the actions after it.

One question for maintainers: I parse the actions out of the description form to
keep the grammar untouched. If you'd prefer first-class `entry`/`do`/`exit`
keywords in the grammar, say so and I'll switch the population path; the
structured model and rendering stay the same.

### :clipboard: Tasks

- [x] :book: have read the contribution guidelines
- [x] :computer: have added necessary unit tests
- [x] :notebook: have added documentation (section tagged `(v<MERMAID_RELEASE_VERSION>+)`)
- [x] :butterfly: changeset added (`minor`, `feat:`)