### PR TITLE
fix: avoid serializing block diagram debug objects

### DIFF
--- a/.changeset/witty-candles-grin.md
+++ b/.changeset/witty-candles-grin.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: avoid serializing block diagram layout debug objects

--- a/packages/mermaid/src/diagrams/block/layout.spec.ts
+++ b/packages/mermaid/src/diagrams/block/layout.spec.ts
@@ -46,4 +46,31 @@ describe('layout runtime config', () => {
     expect(result1).not.toEqual(result2);
     expect(result1!.width).toBeLessThan(result2!.width);
   });
+
+  it('should not throw when block size contains a non-serializable node', () => {
+    const fakeNode: any = { tagName: 'g' };
+    fakeNode.ownerSVGElement = fakeNode;
+    fakeNode.__reactFiber$abc123 = fakeNode;
+
+    const root: Block = {
+      id: 'root',
+      type: 'square',
+      columns: 1,
+      children: [
+        {
+          id: 'b1',
+          type: 'square',
+          children: [],
+          size: { width: 100, height: 50, x: 0, y: 0, node: fakeNode } as any,
+        },
+      ],
+    };
+
+    const makeDb = (block: Block): BlockDB =>
+      ({ getBlock: (id: string) => (id === 'root' ? block : undefined) }) as unknown as BlockDB;
+
+    vi.spyOn(diagramAPI, 'getConfig').mockReturnValue({ block: { padding: 8 } } as any);
+
+    expect(() => layout(makeDb(root))).not.toThrow();
+  });
 });

--- a/packages/mermaid/src/diagrams/block/layout.ts
+++ b/packages/mermaid/src/diagrams/block/layout.ts
@@ -110,7 +110,13 @@ function setBlockSizes(
     for (const child of block.children) {
       if (child.size) {
         log.debug(
-          `abc95 Setting size of children of ${block.id} id=${child.id} ${maxWidth} ${maxHeight} ${JSON.stringify(child.size)}`
+          `abc95 Setting size of children of ${block.id} id=${child.id} ${maxWidth} ${maxHeight}`,
+          {
+            width: child.size.width,
+            height: child.size.height,
+            x: child.size.x,
+            y: child.size.y,
+          }
         );
         child.size.width =
           maxWidth * (child.widthInColumns ?? 1) + padding * ((child.widthInColumns ?? 1) - 1);
@@ -359,7 +365,11 @@ export function layout(db: BlockDB) {
   layoutBlocks(root, db, padding);
   // Position blocks relative to parents
   // positionBlock(root, root, db);
-  log.debug('getBlocks', JSON.stringify(root, null, 2));
+  log.debug('getBlocks', {
+    id: root.id,
+    type: root.type,
+    childCount: root.children?.length ?? 0,
+  });
 
   const { minX, minY, maxX, maxY } = findBounds(root);
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

Resolves #7907

This fixes a block diagram render crash caused by debug logging that attempted to serialize block layout objects with `JSON.stringify`.

In some environments, DOM nodes attached to block sizes can include extra enumerable properties, such as React-related properties, which may create circular references. When the block layout debug log tried to stringify those objects, rendering could fail with `TypeError: Converting circular structure to JSON`.

## :straight_ruler: Design Decisions

Instead of serializing the full block tree or full block size object, the debug output now logs only a safe summary of primitive layout values.

This keeps the existing layout behavior unchanged while avoiding serialization of DOM nodes or other non-serializable objects.

A regression test was added to verify that layout does not throw when a block size contains a non-serializable node.

### :clipboard: Tasks

* [x] :book: have read the [[Contributing Guidelines](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/docs/community/contributing.md)](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/docs/community/contributing.md)
* [x] :computer: have added necessary unit/e2e tests.
* [x] :notebook: documentation is not needed because this is an internal bug fix with no user-facing API change.
* [x] :butterfly: have added a changeset.

### Tests

* `corepack pnpm exec vitest run packages/mermaid/src/diagrams/block/layout.spec.ts`
* `corepack pnpm exec vitest run packages/mermaid/src/diagrams/block`
* `git diff --check`