### PR TITLE
Add 'intersection' alias for 'union' in venn feature

### DIFF
--- a/docs/syntax/venn.md
+++ b/docs/syntax/venn.md
@@ -15,8 +15,8 @@ Venn diagrams show relationships between sets using overlapping circles.
 
 - Start with `venn-beta`.
 - Use `set` for a single set name.
-- Use `union` for an overlap of two or more set names.
-- Identifiers in `union` must be defined by earlier `set` lines.
+- Use `intersection` for an overlap of two or more set names (the older `union` keyword is also supported for backward compatibility).
+- Identifiers in `intersection` / `union` must be defined by earlier `set` lines.
 - Set identifiers can be bare words (`A`, `Set_1`) or quoted strings (`"Foo Bar"`).
 
 ```mermaid-example
@@ -24,7 +24,7 @@ venn-beta
   title "Team overlap"
   set Frontend
   set Backend
-  union Frontend,Backend["APIs"]
+  intersection Frontend,Backend["APIs"]
 ```
 
 ```mermaid
@@ -32,7 +32,7 @@ venn-beta
   title "Team overlap"
   set Frontend
   set Backend
-  union Frontend,Backend["APIs"]
+  intersection Frontend,Backend["APIs"]
 ```
 
 ### Labels
@@ -43,20 +43,20 @@ Use bracket syntax `["..."]` to set a display label while keeping the identifier
 venn-beta
   set A["Alpha"]
   set B["Beta"]
-  union A,B["AB"]
+  intersection A,B["AB"]
 ```
 
 ```mermaid
 venn-beta
   set A["Alpha"]
   set B["Beta"]
-  union A,B["AB"]
+  intersection A,B["AB"]
 ```
 
-### Higher-arity unions
+### Higher-arity intersections / unions
 
-`union` accepts three or more set names. The diagram renders the implied
-pairwise overlaps automatically, so the label on the higher-arity union has a
+`intersection` (or `union`) accepts three or more set names. The diagram renders the implied
+pairwise overlaps automatically, so the label on the higher-arity intersection has a
 visible region to sit in:
 
 ```mermaid-example
@@ -64,7 +64,7 @@ venn-beta
   set Desirable
   set Feasible
   set Viable
-  union Desirable,Feasible,Viable["Innovation"]
+  intersection Desirable,Feasible,Viable["Innovation"]
 ```
 
 ```mermaid
@@ -72,31 +72,31 @@ venn-beta
   set Desirable
   set Feasible
   set Viable
-  union Desirable,Feasible,Viable["Innovation"]
+  intersection Desirable,Feasible,Viable["Innovation"]
 ```
 
 ### Sizes
 
-Use `:N` suffix to set the size of a set or union:
+Use `:N` suffix to set the size of a set or intersection:
 
 ```mermaid-example
 venn-beta
   set A["Alpha"]:20
   set B["Beta"]:12
-  union A,B["AB"]:3
+  intersection A,B["AB"]:3
 ```
 
 ```mermaid
 venn-beta
   set A["Alpha"]:20
   set B["Beta"]:12
-  union A,B["AB"]:3
+  intersection A,B["AB"]:3
 ```
 
 ### Text nodes
 
-- Use `text` to place labels inside a set or union.
-- Indented `text` lines attach to the most recent `set` or `union`.
+- Use `text` to place labels inside a set or intersection.
+- Indented `text` lines attach to the most recent `set` or `intersection` / `union`.
 - Use bracket syntax `["..."]` to set a display label for text nodes.
 
 ```mermaid-example
@@ -106,7 +106,7 @@ venn-beta
     text A2["Design Systems"]
   set B["Backend"]
     text B1["API"]
-  union A,B["Shared"]
+  intersection A,B["Shared"]
     text AB1["OpenAPI"]
 ```
 
@@ -117,13 +117,13 @@ venn-beta
     text A2["Design Systems"]
   set B["Backend"]
     text B1["API"]
-  union A,B["Shared"]
+  intersection A,B["Shared"]
     text AB1["OpenAPI"]
 ```
 
 ### Styling
 
-Use `style` statements to apply visual styles to sets, unions, and text nodes:
+Use `style` statements to apply visual styles to sets, intersections, and text nodes:
 
 - `fill`: change the fill color
 - `color`: change the text color
@@ -137,7 +137,7 @@ venn-beta
     text A1["React"]
     text A2["Design Systems"]
   set B["Beta"]:12
-  union A,B["AB"]:3
+  intersection A,B["AB"]:3
   style A fill:#ff6b6b
   style A,B color:#333
   style A1 color:red
@@ -149,7 +149,7 @@ venn-beta
     text A1["React"]
     text A2["Design Systems"]
   set B["Beta"]:12
-  union A,B["AB"]:3
+  intersection A,B["AB"]:3
   style A fill:#ff6b6b
   style A,B color:#333
   style A1 color:red

--- a/packages/mermaid/src/diagrams/venn/parser/venn.jison
+++ b/packages/mermaid/src/diagrams/venn/parser/venn.jison
@@ -27,6 +27,7 @@
 "venn-beta"        { return 'VENN'; }
 "set"              { return 'SET'; }
 "union"            { return 'UNION'; }
+"intersection"     { return 'INTERSECTION'; }
 "text"             { if (yy.consumeIndentText) { yy.consumeIndentText = false; } else { return 'TEXT'; } }
 "style"            { return 'STYLE'; }
 
@@ -74,10 +75,10 @@ statement
   | SET identifier BRACKET_LABEL                     { yy.addSubsetData([$identifier], $BRACKET_LABEL, undefined); if (yy.setIndentMode) { yy.setIndentMode(true); } }
   | SET identifier COLON NUMERIC                     { yy.addSubsetData([$identifier], undefined, parseFloat($NUMERIC)); if (yy.setIndentMode) { yy.setIndentMode(true); } }
   | SET identifier BRACKET_LABEL COLON NUMERIC       { yy.addSubsetData([$identifier], $BRACKET_LABEL, parseFloat($NUMERIC)); if (yy.setIndentMode) { yy.setIndentMode(true); } }
-  | UNION identifierList                             { if ($identifierList.length < 2) { throw new Error('union requires multiple identifiers'); } if (yy.validateUnionIdentifiers) { yy.validateUnionIdentifiers($identifierList); } yy.addSubsetData($identifierList, undefined, undefined); if (yy.setIndentMode) { yy.setIndentMode(true); } }
-  | UNION identifierList BRACKET_LABEL               { if ($identifierList.length < 2) { throw new Error('union requires multiple identifiers'); } if (yy.validateUnionIdentifiers) { yy.validateUnionIdentifiers($identifierList); } yy.addSubsetData($identifierList, $BRACKET_LABEL, undefined); if (yy.setIndentMode) { yy.setIndentMode(true); } }
-  | UNION identifierList COLON NUMERIC               { if ($identifierList.length < 2) { throw new Error('union requires multiple identifiers'); } if (yy.validateUnionIdentifiers) { yy.validateUnionIdentifiers($identifierList); } yy.addSubsetData($identifierList, undefined, parseFloat($NUMERIC)); if (yy.setIndentMode) { yy.setIndentMode(true); } }
-  | UNION identifierList BRACKET_LABEL COLON NUMERIC { if ($identifierList.length < 2) { throw new Error('union requires multiple identifiers'); } if (yy.validateUnionIdentifiers) { yy.validateUnionIdentifiers($identifierList); } yy.addSubsetData($identifierList, $BRACKET_LABEL, parseFloat($NUMERIC)); if (yy.setIndentMode) { yy.setIndentMode(true); } }
+  | union_or_intersection identifierList                             { if ($identifierList.length < 2) { throw new Error($1 + ' requires multiple identifiers'); } if (yy.validateUnionIdentifiers) { yy.validateUnionIdentifiers($identifierList); } yy.addSubsetData($identifierList, undefined, undefined); if (yy.setIndentMode) { yy.setIndentMode(true); } }
+  | union_or_intersection identifierList BRACKET_LABEL               { if ($identifierList.length < 2) { throw new Error($1 + ' requires multiple identifiers'); } if (yy.validateUnionIdentifiers) { yy.validateUnionIdentifiers($identifierList); } yy.addSubsetData($identifierList, $BRACKET_LABEL, undefined); if (yy.setIndentMode) { yy.setIndentMode(true); } }
+  | union_or_intersection identifierList COLON NUMERIC               { if ($identifierList.length < 2) { throw new Error($1 + ' requires multiple identifiers'); } if (yy.validateUnionIdentifiers) { yy.validateUnionIdentifiers($identifierList); } yy.addSubsetData($identifierList, undefined, parseFloat($NUMERIC)); if (yy.setIndentMode) { yy.setIndentMode(true); } }
+  | union_or_intersection identifierList BRACKET_LABEL COLON NUMERIC { if ($identifierList.length < 2) { throw new Error($1 + ' requires multiple identifiers'); } if (yy.validateUnionIdentifiers) { yy.validateUnionIdentifiers($identifierList); } yy.addSubsetData($identifierList, $BRACKET_LABEL, parseFloat($NUMERIC)); if (yy.setIndentMode) { yy.setIndentMode(true); } }
   | TEXT identifierList IDENTIFIER                     { yy.addTextData($identifierList, $IDENTIFIER, undefined); }
   | TEXT identifierList STRING                          { yy.addTextData($identifierList, $STRING, undefined); }
   | TEXT identifierList NUMERIC                         { yy.addTextData($identifierList, $NUMERIC, undefined); }
@@ -130,6 +131,11 @@ identifierList
 identifier
   : IDENTIFIER                         { $$ = $1 }
   | STRING                             { $$ = $1 }
+  ;
+
+union_or_intersection
+  : UNION
+  | INTERSECTION
   ;
 
 %%

--- a/packages/mermaid/src/diagrams/venn/parser/venn.spec.ts
+++ b/packages/mermaid/src/diagrams/venn/parser/venn.spec.ts
@@ -231,12 +231,55 @@ describe('Venn diagram', function () {
     expect(() => venn.parse(str)).toThrow('union requires multiple identifiers');
   });
 
+  test('intersection requires multiple identifiers', () => {
+    const str = `venn-beta
+        intersection A
+    `;
+    expect(() => venn.parse(str)).toThrow('intersection requires multiple identifiers');
+  });
+
   test('union requires known identifiers', () => {
     const str = `venn-beta
         set Foo
         union Foo,Buz
     `;
     expect(() => venn.parse(str)).toThrow('unknown set identifier');
+  });
+
+  test('intersection requires known identifiers', () => {
+    const str = `venn-beta
+        set Foo
+        intersection Foo,Buz
+    `;
+    expect(() => venn.parse(str)).toThrow('unknown set identifier');
+  });
+
+  test('intersection simple', () => {
+    const str = `venn-beta
+          set A
+          set B
+          intersection A,B
+      `;
+    venn.parse(str);
+    expect(db.getSubsetData()).toEqual([
+      expect.objectContaining({ sets: ['A'], size: 10 }),
+      expect.objectContaining({ sets: ['B'], size: 10 }),
+      expect.objectContaining({ sets: ['A', 'B'], size: 2.5 }),
+    ]);
+  });
+
+  test('intersection with bracket label and size suffix', () => {
+    const str = `venn-beta
+          set A["Alpha"]:20
+          set B["Beta"]:12
+          intersection A,B["AB"]:5.3
+      `;
+    venn.parse(str);
+    expect(db.getSubsetData()).toEqual([
+      expect.objectContaining({ sets: ['A'], size: 20, label: 'Alpha' }),
+      expect.objectContaining({ sets: ['B'], size: 12, label: 'Beta' }),
+      expect.objectContaining({ sets: ['A', 'B'], size: 5.3, label: 'AB' }),
+    ]);
   });
 
   test('quoted identifiers', () => {

--- a/packages/mermaid/src/docs/syntax/venn.md
+++ b/packages/mermaid/src/docs/syntax/venn.md
@@ -9,8 +9,8 @@ Venn diagrams show relationships between sets using overlapping circles.
 
 - Start with `venn-beta`.
 - Use `set` for a single set name.
-- Use `union` for an overlap of two or more set names.
-- Identifiers in `union` must be defined by earlier `set` lines.
+- Use `intersection` for an overlap of two or more set names (the older `union` keyword is also supported for backward compatibility).
+- Identifiers in `intersection` / `union` must be defined by earlier `set` lines.
 - Set identifiers can be bare words (`A`, `Set_1`) or quoted strings (`"Foo Bar"`).
 
 ```mermaid-example
@@ -18,7 +18,7 @@ venn-beta
   title "Team overlap"
   set Frontend
   set Backend
-  union Frontend,Backend["APIs"]
+  intersection Frontend,Backend["APIs"]
 ```
 
 ### Labels
@@ -29,13 +29,13 @@ Use bracket syntax `["..."]` to set a display label while keeping the identifier
 venn-beta
   set A["Alpha"]
   set B["Beta"]
-  union A,B["AB"]
+  intersection A,B["AB"]
 ```
 
-### Higher-arity unions
+### Higher-arity intersections / unions
 
-`union` accepts three or more set names. The diagram renders the implied
-pairwise overlaps automatically, so the label on the higher-arity union has a
+`intersection` (or `union`) accepts three or more set names. The diagram renders the implied
+pairwise overlaps automatically, so the label on the higher-arity intersection has a
 visible region to sit in:
 
 ```mermaid-example
@@ -43,24 +43,24 @@ venn-beta
   set Desirable
   set Feasible
   set Viable
-  union Desirable,Feasible,Viable["Innovation"]
+  intersection Desirable,Feasible,Viable["Innovation"]
 ```
 
 ### Sizes
 
-Use `:N` suffix to set the size of a set or union:
+Use `:N` suffix to set the size of a set or intersection:
 
 ```mermaid-example
 venn-beta
   set A["Alpha"]:20
   set B["Beta"]:12
-  union A,B["AB"]:3
+  intersection A,B["AB"]:3
 ```
 
 ### Text nodes
 
-- Use `text` to place labels inside a set or union.
-- Indented `text` lines attach to the most recent `set` or `union`.
+- Use `text` to place labels inside a set or intersection.
+- Indented `text` lines attach to the most recent `set` or `intersection` / `union`.
 - Use bracket syntax `["..."]` to set a display label for text nodes.
 
 ```mermaid-example
@@ -70,13 +70,13 @@ venn-beta
     text A2["Design Systems"]
   set B["Backend"]
     text B1["API"]
-  union A,B["Shared"]
+  intersection A,B["Shared"]
     text AB1["OpenAPI"]
 ```
 
 ### Styling
 
-Use `style` statements to apply visual styles to sets, unions, and text nodes:
+Use `style` statements to apply visual styles to sets, intersections, and text nodes:
 
 - `fill`: change the fill color
 - `color`: change the text color
@@ -90,7 +90,7 @@ venn-beta
     text A1["React"]
     text A2["Design Systems"]
   set B["Beta"]:12
-  union A,B["AB"]:3
+  intersection A,B["AB"]:3
   style A fill:#ff6b6b
   style A,B color:#333
   style A1 color:red


### PR DESCRIPTION
## :bookmark_tabs: Summary

Introduces `intersection` as a mathematically accurate keyword for Venn diagram overlapping sets, while maintaining `union` as a fully backward-compatible alias.

Resolves #7879

## :straight_ruler: Design Decisions

- **Parser-level Alias**: Treated both `union` and `intersection` keywords identically within `venn.jison` to ensure zero breaking changes or database-level migration effort.
- **Improved Errors**: Dynamic grammar matches ensure the syntax error reports the keyword used in the user's diagram (e.g. `intersection requires multiple identifiers` or `union requires multiple identifiers`).

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
