### PR TITLE
feat(sequence): 5023 - control location of create (future) participants

### DIFF
--- a/.changeset/soft-doodles-trade.md
+++ b/.changeset/soft-doodles-trade.md
@@ -1,0 +1,5 @@
+---
+'mermaid': minor
+---
+
+feat: adds `future` keyword for reserving placement of `create` participants

--- a/demos/sequence.html
+++ b/demos/sequence.html
@@ -249,6 +249,51 @@
       Alice<<->>Bob: Wow, we said that at the same time!
       Bob<<-->>Alice: Bidirectional Arrows are so cool
     </pre>
+
+    <hr />
+
+    <pre class="mermaid">
+    ---
+    title: With future participants
+    ---
+    sequenceDiagram
+      participant Alice
+      box land of the lost
+      future participant Bob
+      end
+      participant John
+      Alice->>John: Hello John, have you heard from Bob?
+      rect rgb(200, 220, 100)
+      create participant Bob
+      John-->>Bob: Bob, where are you?
+      Bob-->>John: I'm here!
+      end
+      John-->>Alice: Bob is here!
+    </pre>
+
+    <hr />
+    <pre class="mermaid">
+    ---
+    title: With future participants in boxes
+    ---
+    sequenceDiagram
+      box lightblue Teachers
+      actor Alice
+      end
+      box lightgreen Students
+      future actor Timmy
+      actor Suzie
+      actor Bobby
+      end
+      Alice->>Suzie: Hello Suzie
+      Suzie->>Alice: Hi Teacher!
+      Alice->>Bobby: Hello Bobby
+      Bobby->>Alice: Hi Teacher!
+      Bobby->>Alice: I brought my cousin to class today!
+      create actor Timmy
+      Alice->>Timmy: Hello Timmy, welcome to class!
+      Timmy->>Alice: Hi Teacher!
+    </pre>
     <script type="module">
       import mermaid from './mermaid.esm.mjs';
       mermaid.initialize({

--- a/docs/syntax/sequenceDiagram.md
+++ b/docs/syntax/sequenceDiagram.md
@@ -54,6 +54,41 @@ sequenceDiagram
     Alice->>Bob: Hi Bob
 ```
 
+### Future participants (v\<MERMAID_RELEASE_VERSION>+)
+
+You can reserve a participant or actor position with the `future` keyword and create it later with `create`.
+This is useful when you want the participant to appear in a specific horizontal position, even though it is
+introduced later in the sequence lifecycle.
+
+Rules:
+
+- A future declaration must be resolved later with a matching `create` directive.
+- The `create` keyword must include `participant` or `actor`.
+- The `create` kind must match the future declaration kind.
+- Messages cannot involve a future participant before it is created.
+
+```mermaid-example
+sequenceDiagram
+    participant Alice
+    future participant Carol
+    participant Bob
+
+    Alice->>Bob: Setup
+    create participant Carol
+    Bob->>Carol: Welcome Carol
+```
+
+```mermaid
+sequenceDiagram
+    participant Alice
+    future participant Carol
+    participant Bob
+
+    Alice->>Bob: Setup
+    create participant Carol
+    Bob->>Carol: Welcome Carol
+```
+
 ### Actors
 
 If you specifically want to use the actor symbol instead of a rectangle with text you can do so by using actor statements as per below.

--- a/packages/mermaid/src/diagrams/sequence/parser/sequenceDiagram.jison
+++ b/packages/mermaid/src/diagrams/sequence/parser/sequenceDiagram.jison
@@ -40,6 +40,7 @@
 "box"															{ this.begin('LINE'); return 'box'; }
 "participant"                                                   { this.begin('ID'); return 'participant'; }
 "actor"                                                   		{ this.begin('ID'); return 'participant_actor'; }
+"future"                                                        return 'future';
 "create"                                                        return 'create';
 "destroy"                                                       { this.begin('ID'); return 'destroy'; }
 <ALIAS>"as"                                                     { this.popState(); this.popState(); this.begin('LINE'); return 'AS'; }
@@ -265,11 +266,19 @@ participant_statement
 	| 'participant' actor 'NEWLINE' {$2.draw='participant'; $2.type='addParticipant';$$=$2;}
 	| 'participant_actor' actor 'AS' restOfLine 'NEWLINE' {$2.draw='actor'; $2.type='addParticipant';$2.description=yy.parseMessage($4); $$=$2;}
 	| 'participant_actor' actor 'NEWLINE' {$2.draw='actor'; $2.type='addParticipant'; $$=$2;}
+	| 'future' 'participant' actor 'AS' restOfLine 'NEWLINE' {$3.draw='participant'; $3.type='addFutureParticipant'; $3.description=yy.parseMessage($5); $$=$3;}
+	| 'future' 'participant' actor 'NEWLINE' {$3.draw='participant'; $3.type='addFutureParticipant'; $$=$3;}
+	| 'future' 'participant_actor' actor 'AS' restOfLine 'NEWLINE' {$3.draw='actor'; $3.type='addFutureParticipant'; $3.description=yy.parseMessage($5); $$=$3;}
+	| 'future' 'participant_actor' actor 'NEWLINE' {$3.draw='actor'; $3.type='addFutureParticipant'; $$=$3;}
 	| 'destroy' actor 'NEWLINE' {$2.type='destroyParticipant'; $$=$2;}
     | 'participant' actor_with_config 'AS' restOfLine 'NEWLINE' {$2.draw='participant'; $2.type='addParticipant'; $2.description=yy.parseMessage($4); $$=$2;}
     | 'participant' actor_with_config 'NEWLINE' {$2.draw='participant'; $2.type='addParticipant'; $$=$2;}
     | 'participant_actor' actor_with_config 'AS' restOfLine 'NEWLINE' {$2.draw='actor'; $2.type='addParticipant'; $2.description=yy.parseMessage($4); $$=$2;}
     | 'participant_actor' actor_with_config 'NEWLINE' {$2.draw='actor'; $2.type='addParticipant'; $$=$2;}
+    | 'future' 'participant' actor_with_config 'AS' restOfLine 'NEWLINE' {$3.draw='participant'; $3.type='addFutureParticipant'; $3.description=yy.parseMessage($5); $$=$3;}
+    | 'future' 'participant' actor_with_config 'NEWLINE' {$3.draw='participant'; $3.type='addFutureParticipant'; $$=$3;}
+    | 'future' 'participant_actor' actor_with_config 'AS' restOfLine 'NEWLINE' {$3.draw='actor'; $3.type='addFutureParticipant'; $3.description=yy.parseMessage($5); $$=$3;}
+    | 'future' 'participant_actor' actor_with_config 'NEWLINE' {$3.draw='actor'; $3.type='addFutureParticipant'; $$=$3;}
 
 	;
 
@@ -341,7 +350,7 @@ signal
 	{ $$ = [$1,$4,{type: 'addMessage', from:$1.actor, to:$4.actor, signalType:$2, msg:$5, activate: true, centralConnection: yy.LINETYPE.CENTRAL_CONNECTION},
 	              {type: 'centralConnection', signalType: yy.LINETYPE.CENTRAL_CONNECTION, actor: $4.actor, }
 	             ]}
-    
+
 	| actor '()' signaltype actor text2
 	{ $$ = [$1,$4,{type: 'addMessage', from:$1.actor, to:$4.actor, signalType:$3, msg:$5, activate: false, centralConnection: yy.LINETYPE.CENTRAL_CONNECTION_REVERSE},
 	              {type: 'centralConnectionReverse', signalType: yy.LINETYPE.CENTRAL_CONNECTION_REVERSE, actor: $1.actor}
@@ -384,13 +393,13 @@ signaltype
 	: SOLID_OPEN_ARROW  { $$ = yy.LINETYPE.SOLID_OPEN; }
 	| DOTTED_OPEN_ARROW { $$ = yy.LINETYPE.DOTTED_OPEN; }
 	| SOLID_ARROW       { $$ = yy.LINETYPE.SOLID; }
-	
+
 	| SOLID_ARROW_TOP    { $$ = yy.LINETYPE.SOLID_TOP; }
 	| SOLID_ARROW_BOTTOM { $$ = yy.LINETYPE.SOLID_BOTTOM; }
 	| STICK_ARROW_TOP    { $$ = yy.LINETYPE.STICK_TOP; }
 	| STICK_ARROW_BOTTOM { $$ = yy.LINETYPE.STICK_BOTTOM; }
 
-	| SOLID_ARROW_TOP_DOTTED    { $$ = yy.LINETYPE.SOLID_TOP_DOTTED; }	
+	| SOLID_ARROW_TOP_DOTTED    { $$ = yy.LINETYPE.SOLID_TOP_DOTTED; }
 	| SOLID_ARROW_BOTTOM_DOTTED { $$ = yy.LINETYPE.SOLID_BOTTOM_DOTTED; }
 	| STICK_ARROW_TOP_DOTTED    { $$ = yy.LINETYPE.STICK_TOP_DOTTED; }
 	| STICK_ARROW_BOTTOM_DOTTED { $$ = yy.LINETYPE.STICK_BOTTOM_DOTTED; }

--- a/packages/mermaid/src/diagrams/sequence/sequenceDb.ts
+++ b/packages/mermaid/src/diagrams/sequence/sequenceDb.ts
@@ -19,6 +19,7 @@ import type { ParticipantMetaData } from '../../types.js';
 interface SequenceState {
   prevActor?: string;
   actors: Map<string, Actor>;
+  futureActors: Set<Actor>;
   createdActors: Map<string, number>;
   destroyedActors: Map<string, number>;
   boxes: Box[];
@@ -116,6 +117,7 @@ export class SequenceDB implements DiagramDB {
   private readonly state = new ImperativeState<SequenceState>(() => ({
     prevActor: undefined,
     actors: new Map(),
+    futureActors: new Set(),
     createdActors: new Map(),
     destroyedActors: new Map(),
     boxes: [],
@@ -277,6 +279,17 @@ export class SequenceDB implements DiagramDB {
     activate = false,
     centralConnection?: number
   ) {
+    if (this.isFutureActor(idFrom)) {
+      throw new Error(
+        `Future participant ${idFrom} must be created with a matching create directive before it can be used.`
+      );
+    }
+    if (this.isFutureActor(idTo)) {
+      throw new Error(
+        `Future participant ${idTo} must be created with a matching create directive before it can be used.`
+      );
+    }
+
     if (messageType === this.LINETYPE.ACTIVE_END) {
       const cnt = this.activationCount(idFrom ?? '');
       if (cnt < 1) {
@@ -337,6 +350,53 @@ export class SequenceDB implements DiagramDB {
   }
   public getActorKeys() {
     return [...this.state.records.actors.keys()];
+  }
+
+  private findFutureActorByName(name: string) {
+    for (const actor of this.state.records.futureActors) {
+      if (actor.name === name) {
+        return actor;
+      }
+    }
+    return undefined;
+  }
+
+  private isFutureActor(name?: string) {
+    if (!name) {
+      return false;
+    }
+    return Boolean(this.findFutureActorByName(name));
+  }
+
+  private getActorOrNameRef(name: string): Actor {
+    const actor = this.state.records.actors.get(name);
+    if (actor) {
+      return actor;
+    }
+
+    return {
+      name,
+      description: name,
+      wrap: this.autoWrap(),
+      links: {},
+      properties: {},
+      actorCnt: null,
+      rectData: null,
+      type: 'participant',
+    };
+  }
+
+  private validateFutureParticipantsResolved() {
+    if (this.state.records.futureActors.size === 0) {
+      return;
+    }
+
+    const unresolvedParticipants = [...this.state.records.futureActors]
+      .map((actor) => actor.name)
+      .join(', ');
+    throw new Error(
+      `Future participant declarations must be resolved using matching create directives. Unresolved participants: ${unresolvedParticipants}.`
+    );
   }
   public enableSequenceNumbers() {
     this.state.records.sequenceNumbersEnabled = true;
@@ -553,167 +613,210 @@ export class SequenceDB implements DiagramDB {
     return undefined;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-redundant-type-constituents
-  public apply(param: any | AddMessageParams | AddMessageParams[]) {
+  public apply(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-redundant-type-constituents
+    param: any | AddMessageParams | AddMessageParams[]
+  ) {
     if (Array.isArray(param)) {
       param.forEach((item) => {
-        this.apply(item);
+        this.applyItem(item);
       });
+      this.validateFutureParticipantsResolved();
     } else {
-      switch (param.type) {
-        case 'sequenceIndex':
-          this.state.records.messages.push({
-            id: this.state.records.messages.length.toString(),
-            from: undefined,
-            to: undefined,
-            message: {
-              start: param.sequenceIndex,
-              step: param.sequenceIndexStep,
-              visible: param.sequenceVisible,
-            },
-            wrap: false,
-            type: param.signalType,
-          });
-          break;
-        case 'addParticipant':
-          this.addActor(param.actor, param.actor, param.description, param.draw, param.config);
-          break;
-        case 'createParticipant':
-          if (this.state.records.actors.has(param.actor)) {
+      this.applyItem(param);
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-redundant-type-constituents
+  private applyItem(param: any | AddMessageParams) {
+    if (Array.isArray(param)) {
+      param.forEach((item) => this.applyItem(item));
+      return;
+    }
+    switch (param.type) {
+      case 'sequenceIndex':
+        this.state.records.messages.push({
+          id: this.state.records.messages.length.toString(),
+          from: undefined,
+          to: undefined,
+          message: {
+            start: param.sequenceIndex,
+            step: param.sequenceIndexStep,
+            visible: param.sequenceVisible,
+          },
+          wrap: false,
+          type: param.signalType,
+        });
+        break;
+      case 'addParticipant':
+        this.addActor(param.actor, param.actor, param.description, param.draw, param.config);
+        break;
+      case 'addFutureParticipant':
+        this.addActor(param.actor, param.actor, param.description, param.draw, param.config);
+        {
+          const futureActor = this.state.records.actors.get(param.actor);
+          if (futureActor) {
+            this.state.records.futureActors.add(futureActor);
+          }
+        }
+        break;
+      case 'createParticipant':
+        if (this.state.records.actors.has(param.actor)) {
+          const futureActor = this.findFutureActorByName(param.actor);
+          if (!futureActor) {
             throw new Error(
               "It is not possible to have actors with the same id, even if one is destroyed before the next is created. Use 'AS' aliases to simulate the behavior"
             );
           }
-          this.state.records.lastCreated = param.actor;
-          this.addActor(param.actor, param.actor, param.description, param.draw, param.config);
+
+          const actor = this.state.records.actors.get(param.actor);
+          if (actor && actor.type !== param.draw) {
+            throw new Error(
+              `Future ${actor.type} ${param.actor} must be created using 'create ${actor.type} ${param.actor}'.`
+            );
+          }
+
+          this.state.records.futureActors.delete(futureActor);
+          this.state.records.lastCreated = actor;
           this.state.records.createdActors.set(param.actor, this.state.records.messages.length);
           break;
-        case 'destroyParticipant':
-          this.state.records.lastDestroyed = param.actor;
-          this.state.records.destroyedActors.set(param.actor, this.state.records.messages.length);
-          break;
-        case 'activeStart':
-          this.addSignal(param.actor, undefined, undefined, param.signalType);
-          break;
-        case 'centralConnection':
-          this.addSignal(param.actor, undefined, undefined, param.signalType);
-          break;
-        case 'centralConnectionReverse':
-          this.addSignal(param.actor, undefined, undefined, param.signalType);
-          break;
-        case 'activeEnd':
-          this.addSignal(param.actor, undefined, undefined, param.signalType);
-          break;
-        case 'addNote':
-          this.addNote(param.actor, param.placement, param.text);
-          break;
-        case 'addLinks':
-          this.addLinks(param.actor, param.text);
-          break;
-        case 'addALink':
-          this.addALink(param.actor, param.text);
-          break;
-        case 'addProperties':
-          this.addProperties(param.actor, param.text);
-          break;
-        case 'addDetails':
-          this.addDetails(param.actor, param.text);
-          break;
-        case 'addMessage':
-          if (this.state.records.lastCreated) {
-            if (param.to !== this.state.records.lastCreated) {
-              throw new Error(
-                'The created participant ' +
-                  this.state.records.lastCreated.name +
-                  ' does not have an associated creating message after its declaration. Please check the sequence diagram.'
-              );
-            } else {
-              this.state.records.lastCreated = undefined;
-            }
-          } else if (this.state.records.lastDestroyed) {
-            if (
-              param.to !== this.state.records.lastDestroyed &&
-              param.from !== this.state.records.lastDestroyed
-            ) {
-              throw new Error(
-                'The destroyed participant ' +
-                  this.state.records.lastDestroyed.name +
-                  ' does not have an associated destroying message after its declaration. Please check the sequence diagram.'
-              );
-            } else {
-              this.state.records.lastDestroyed = undefined;
-            }
+        }
+        this.addActor(param.actor, param.actor, param.description, param.draw, param.config);
+        this.state.records.lastCreated = this.state.records.actors.get(param.actor);
+        this.state.records.createdActors.set(param.actor, this.state.records.messages.length);
+        break;
+      case 'destroyParticipant':
+        this.state.records.lastDestroyed = this.getActorOrNameRef(param.actor);
+        this.state.records.destroyedActors.set(param.actor, this.state.records.messages.length);
+        break;
+      case 'activeStart':
+        this.addSignal(param.actor, undefined, undefined, param.signalType);
+        break;
+      case 'centralConnection':
+        this.addSignal(param.actor, undefined, undefined, param.signalType);
+        break;
+      case 'centralConnectionReverse':
+        this.addSignal(param.actor, undefined, undefined, param.signalType);
+        break;
+      case 'activeEnd':
+        this.addSignal(param.actor, undefined, undefined, param.signalType);
+        break;
+      case 'addNote':
+        this.addNote(param.actor, param.placement, param.text);
+        break;
+      case 'addLinks':
+        this.addLinks(param.actor, param.text);
+        break;
+      case 'addALink':
+        this.addALink(param.actor, param.text);
+        break;
+      case 'addProperties':
+        this.addProperties(param.actor, param.text);
+        break;
+      case 'addDetails':
+        this.addDetails(param.actor, param.text);
+        break;
+      case 'addMessage':
+        if (this.state.records.lastCreated) {
+          if (param.to !== this.state.records.lastCreated.name) {
+            throw new Error(
+              'The created participant ' +
+                this.state.records.lastCreated.name +
+                ' does not have an associated creating message after its declaration. Please check the sequence diagram.'
+            );
+          } else {
+            // Update createdActors to the actual index of the create message, which may
+            // differ from the index recorded in createParticipant if intervening signals
+            // (e.g. rectStart) were added to the messages array in between.
+            this.state.records.createdActors.set(
+              this.state.records.lastCreated.name,
+              this.state.records.messages.length
+            );
+            this.state.records.lastCreated = undefined;
           }
-          this.addSignal(
-            param.from,
-            param.to,
-            param.msg,
-            param.signalType,
-            param.activate,
-            param.centralConnection
-          );
-          break;
-        case 'boxStart':
-          this.addBox(param.boxData);
-          break;
-        case 'boxEnd':
-          this.boxEnd();
-          break;
-        case 'loopStart':
-          this.addSignal(undefined, undefined, param.loopText, param.signalType);
-          break;
-        case 'loopEnd':
-          this.addSignal(undefined, undefined, undefined, param.signalType);
-          break;
-        case 'rectStart':
-          this.addSignal(undefined, undefined, param.color, param.signalType);
-          break;
-        case 'rectEnd':
-          this.addSignal(undefined, undefined, undefined, param.signalType);
-          break;
-        case 'optStart':
-          this.addSignal(undefined, undefined, param.optText, param.signalType);
-          break;
-        case 'optEnd':
-          this.addSignal(undefined, undefined, undefined, param.signalType);
-          break;
-        case 'altStart':
-          this.addSignal(undefined, undefined, param.altText, param.signalType);
-          break;
-        case 'else':
-          this.addSignal(undefined, undefined, param.altText, param.signalType);
-          break;
-        case 'altEnd':
-          this.addSignal(undefined, undefined, undefined, param.signalType);
-          break;
-        case 'setAccTitle':
-          setAccTitle(param.text);
-          break;
-        case 'parStart':
-          this.addSignal(undefined, undefined, param.parText, param.signalType);
-          break;
-        case 'and':
-          this.addSignal(undefined, undefined, param.parText, param.signalType);
-          break;
-        case 'parEnd':
-          this.addSignal(undefined, undefined, undefined, param.signalType);
-          break;
-        case 'criticalStart':
-          this.addSignal(undefined, undefined, param.criticalText, param.signalType);
-          break;
-        case 'option':
-          this.addSignal(undefined, undefined, param.optionText, param.signalType);
-          break;
-        case 'criticalEnd':
-          this.addSignal(undefined, undefined, undefined, param.signalType);
-          break;
-        case 'breakStart':
-          this.addSignal(undefined, undefined, param.breakText, param.signalType);
-          break;
-        case 'breakEnd':
-          this.addSignal(undefined, undefined, undefined, param.signalType);
-          break;
-      }
+        } else if (this.state.records.lastDestroyed) {
+          if (
+            param.to !== this.state.records.lastDestroyed.name &&
+            param.from !== this.state.records.lastDestroyed.name
+          ) {
+            throw new Error(
+              'The destroyed participant ' +
+                this.state.records.lastDestroyed.name +
+                ' does not have an associated destroying message after its declaration. Please check the sequence diagram.'
+            );
+          } else {
+            this.state.records.lastDestroyed = undefined;
+          }
+        }
+        this.addSignal(
+          param.from,
+          param.to,
+          param.msg,
+          param.signalType,
+          param.activate,
+          param.centralConnection
+        );
+        break;
+      case 'boxStart':
+        this.addBox(param.boxData);
+        break;
+      case 'boxEnd':
+        this.boxEnd();
+        break;
+      case 'loopStart':
+        this.addSignal(undefined, undefined, param.loopText, param.signalType);
+        break;
+      case 'loopEnd':
+        this.addSignal(undefined, undefined, undefined, param.signalType);
+        break;
+      case 'rectStart':
+        this.addSignal(undefined, undefined, param.color, param.signalType);
+        break;
+      case 'rectEnd':
+        this.addSignal(undefined, undefined, undefined, param.signalType);
+        break;
+      case 'optStart':
+        this.addSignal(undefined, undefined, param.optText, param.signalType);
+        break;
+      case 'optEnd':
+        this.addSignal(undefined, undefined, undefined, param.signalType);
+        break;
+      case 'altStart':
+        this.addSignal(undefined, undefined, param.altText, param.signalType);
+        break;
+      case 'else':
+        this.addSignal(undefined, undefined, param.altText, param.signalType);
+        break;
+      case 'altEnd':
+        this.addSignal(undefined, undefined, undefined, param.signalType);
+        break;
+      case 'setAccTitle':
+        setAccTitle(param.text);
+        break;
+      case 'parStart':
+        this.addSignal(undefined, undefined, param.parText, param.signalType);
+        break;
+      case 'and':
+        this.addSignal(undefined, undefined, param.parText, param.signalType);
+        break;
+      case 'parEnd':
+        this.addSignal(undefined, undefined, undefined, param.signalType);
+        break;
+      case 'criticalStart':
+        this.addSignal(undefined, undefined, param.criticalText, param.signalType);
+        break;
+      case 'option':
+        this.addSignal(undefined, undefined, param.optionText, param.signalType);
+        break;
+      case 'criticalEnd':
+        this.addSignal(undefined, undefined, undefined, param.signalType);
+        break;
+      case 'breakStart':
+        this.addSignal(undefined, undefined, param.breakText, param.signalType);
+        break;
+      case 'breakEnd':
+        this.addSignal(undefined, undefined, undefined, param.signalType);
+        break;
     }
   }
 

--- a/packages/mermaid/src/diagrams/sequence/sequenceDiagram.spec.js
+++ b/packages/mermaid/src/diagrams/sequence/sequenceDiagram.spec.js
@@ -1731,6 +1731,107 @@ link a: Tests @ https://tests.contoso.com/?svc=alice@contoso.com
     expect(createdActors.get('c')).toEqual(1);
     expect(destroyedActors.get('c')).toEqual(3);
   });
+
+  it('should keep future participant location and create it at the correct message line', async () => {
+    const diagram = await Diagram.fromText(`
+  sequenceDiagram
+  participant a
+  future participant c
+  participant b
+  a ->> b: first
+  create participant c
+  b ->> c: create c
+  `);
+
+    const actorKeys = diagram.db.getActorKeys();
+    const createdActors = diagram.db.getCreatedActors();
+    const messages = diagram.db.getMessages();
+
+    expect(actorKeys).toEqual(['a', 'c', 'b']);
+    expect(createdActors.get('c')).toEqual(1);
+    expect(messages[1].to).toEqual('c');
+    expect(messages[1].message).toEqual('create c');
+  });
+
+  it('should support future actor declarations with matching create actor', async () => {
+    const diagram = await Diagram.fromText(`
+  sequenceDiagram
+  participant a
+  future actor c as Carl
+  participant b
+  a ->> b: first
+  create actor c
+  b ->> c: create c
+  `);
+
+    const actors = diagram.db.getActors();
+    const createdActors = diagram.db.getCreatedActors();
+
+    expect(actors.get('c').type).toEqual('actor');
+    expect(actors.get('c').description).toEqual('Carl');
+    expect(createdActors.get('c')).toEqual(1);
+  });
+
+  it('should fail when a future participant is used before create', async () => {
+    await expect(
+      Diagram.fromText(`
+  sequenceDiagram
+  participant a
+  future participant c
+  a ->> c: first
+  create participant c
+  `)
+    ).rejects.toThrow(/must be created with a matching create directive before it can be used/i);
+  });
+
+  it('should fail when a future participant is not created later', async () => {
+    await expect(
+      Diagram.fromText(`
+  sequenceDiagram
+  participant a
+  future participant c
+  a ->> a: first
+  `)
+    ).rejects.toThrow(/future participant declarations must be resolved/i);
+  });
+
+  it('should fail when future declaration type does not match create type', async () => {
+    await expect(
+      Diagram.fromText(`
+  sequenceDiagram
+  participant a
+  future actor c
+  a ->> a: first
+  create participant c
+  a ->> c: create c
+  `)
+    ).rejects.toThrow(/must be created using 'create actor c'/i);
+  });
+
+  it('should record the correct message index for create participant when rect precedes the create message', async () => {
+    const diagram = await Diagram.fromText(`
+  sequenceDiagram
+  participant a
+  future participant c
+  participant b
+  a ->> b: first
+  create participant c
+  rect rgb(200, 150, 255)
+    b ->> c: create c inside rect
+  end
+  `);
+
+    const createdActors = diagram.db.getCreatedActors();
+    const messages = diagram.db.getMessages();
+
+    // The RECT_START signal is inserted between createParticipant and the create message,
+    // so the create message lands at index 2 (not 1). The fix ensures createdActors
+    // records the actual index of the create message, not the index at createParticipant time.
+    const createMsgIndex = messages.findIndex(
+      (m) => m.to === 'c' && m.message === 'create c inside rect'
+    );
+    expect(createdActors.get('c')).toEqual(createMsgIndex);
+  });
 });
 describe('when checking the bounds in a sequenceDiagram', function () {
   beforeAll(() => {
@@ -2394,11 +2495,11 @@ Bob->>Alice:Got it!
         Bob -|/ Alice: Hello Alice, how are you?
         Bob -// Alice: Hello Alice, how are you?
         Bob -\\\\ Alice: Hello Alice, how are you?
-        
+
         Bob \\|- Alice: Hello Alice, how are you?
         Bob /|- Alice: Hello Alice, how are you?
         Bob //- Alice: Hello Alice, how are you?
-        Bob \\\\- Alice: Hello Alice, how are you?        
+        Bob \\\\- Alice: Hello Alice, how are you?
     `);
 
     const messages = diagram.db.getMessages();
@@ -2616,7 +2717,7 @@ Bob->>Alice:Got it!
       const diagram = await Diagram.fromText(`
       sequenceDiagram
       participant Q@{ "type" : "queue" }
-      Q->Q: test 
+      Q->Q: test
       `);
       const actors = diagram.db.getActors();
       expect(actors.get('Q').type).toBe('queue');

--- a/packages/mermaid/src/diagrams/sequence/types.ts
+++ b/packages/mermaid/src/diagrams/sequence/types.ts
@@ -47,6 +47,7 @@ export interface AddMessageParams {
     | 'addMessage'
     | 'sequenceIndex'
     | 'addParticipant'
+    | 'addFutureParticipant'
     | 'createParticipant'
     | 'destroyParticipant'
     | 'activeStart'

--- a/packages/mermaid/src/docs/syntax/sequenceDiagram.md
+++ b/packages/mermaid/src/docs/syntax/sequenceDiagram.md
@@ -34,6 +34,30 @@ sequenceDiagram
     Alice->>Bob: Hi Bob
 ```
 
+### Future participants (v<MERMAID_RELEASE_VERSION>+)
+
+You can reserve a participant or actor position with the `future` keyword and create it later with `create`.
+This is useful when you want the participant to appear in a specific horizontal position, even though it is
+introduced later in the sequence lifecycle.
+
+Rules:
+
+- A future declaration must be resolved later with a matching `create` directive.
+- The `create` keyword must include `participant` or `actor`.
+- The `create` kind must match the future declaration kind.
+- Messages cannot involve a future participant before it is created.
+
+```mermaid-example
+sequenceDiagram
+    participant Alice
+    future participant Carol
+    participant Bob
+
+    Alice->>Bob: Setup
+    create participant Carol
+    Bob->>Carol: Welcome Carol
+```
+
 ### Actors
 
 If you specifically want to use the actor symbol instead of a rectangle with text you can do so by using actor statements as per below.


### PR DESCRIPTION
Resolves #5023

Adds the future keyword for use with participants and create so that participant rendering location can be defined prior to the creation of the participant

## :bookmark_tabs: Summary

Added example usage to demos for the [demos/sequence.html](demos/sequence.html)

This adds the `future` keyword to the sequence diagram, allowing users to specify _where_ (horizontally) they want participants to be rendered when they use the `create` syntax inside the diagram to create a participant from a message.


## :straight_ruler: Design Decisions

creates a `Set` of `futureActors` in the `SequenceState` that tracks whether each `Actor` is resolved fully (either by definition in head of the chart without _future_, or by being declared with `create` prior to any signals being rendered for the actor.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What's working well

- 🎉 Adds a useful `future participant` / `future actor` feature for reserving sequence-diagram positions before creation.
- 🎉 Supports matching `create participant` and `create actor` directives, including validation for unresolved, prematurely used, or type-mismatched declarations.
- 🎉 Includes parser tests, resolution/error cases, demos, documentation, and a minor feature changeset.

## Things to address

No blocking or important issues identified from the provided summary.

## Review verdict

**APPROVE**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->