### PR TITLE
[codex] fix treeView icons in strict security mode

### DIFF
--- a/.changeset/fix-treeview-icons-strict-security.md
+++ b/.changeset/fix-treeview-icons-strict-security.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+Fix treeView icons disappearing after strict security sanitization.

--- a/packages/mermaid/src/diagrams/treeView/renderer.ts
+++ b/packages/mermaid/src/diagrams/treeView/renderer.ts
@@ -25,37 +25,20 @@ interface RenderInfo {
   centerY: number;
 }
 
-/** Iconify names may contain `:` (pack:name) which is unsafe in url(#…) references */
-const iconSymbolId = (diagramId: string, icon: string) =>
-  `tv-icon-${diagramId}-${icon.replace(/[^\w-]/g, '-')}`;
-
-/**
- * Inject <defs> with all referenced icons into the SVG.
- * Each icon is resolved once through the iconify pipeline and referenced
- * per row via <use>, instead of repeating the icon markup for every node.
- */
-const injectIconDefs = async (
-  svg: D3SVGElement<SVGSVGElement>,
-  root: Node,
-  config: Required<TreeViewDiagramConfig>,
-  diagramId: string
-) => {
-  const usedIcons = new Set<string>();
+const resolveNodeIcons = async (root: Node, config: Required<TreeViewDiagramConfig>) => {
+  const nodeIcons: { icon: string; node: Node }[] = [];
   const collect = (node: Node) => {
     const icon = getNodeIcon(node, config);
     if (icon) {
-      usedIcons.add(icon);
+      nodeIcons.push({ icon, node });
     }
     node.children.forEach(collect);
   };
   collect(root);
-  if (usedIcons.size === 0) {
-    return;
-  }
 
-  const iconSVGs = await Promise.all(
-    [...usedIcons].map(async (icon) => ({
-      icon,
+  const resolvedIcons = await Promise.all(
+    nodeIcons.map(async ({ icon, node }) => ({
+      id: node.id,
       svg: await getIconSVG(icon, {
         height: ICON_SIZE,
         width: ICON_SIZE,
@@ -63,10 +46,7 @@ const injectIconDefs = async (
     }))
   );
 
-  const defs = svg.append('defs');
-  for (const { icon, svg: iconSVG } of iconSVGs) {
-    defs.append('g').attr('id', iconSymbolId(diagramId, icon)).html(iconSVG);
-  }
+  return new Map(resolvedIcons.map(({ id, svg }) => [id, svg]));
 };
 
 const positionLabel = (
@@ -75,7 +55,7 @@ const positionLabel = (
   node: Node,
   domElem: D3SVGElement<SVGGElement>,
   config: Required<TreeViewDiagramConfig>,
-  diagramId: string
+  iconSVGs: Map<number, string>
 ): RenderInfo => {
   const nodeGroup = domElem.append('g');
   let cssClasses = 'treeView-node-label';
@@ -92,11 +72,10 @@ const positionLabel = (
   const showIcon = icon !== undefined;
   if (icon) {
     nodeGroup
-      .append('use')
-      .attr('xlink:href', `#${iconSymbolId(diagramId, icon)}`)
-      .attr('x', x + config.paddingX)
-      .attr('y', y + config.paddingY)
-      .attr('class', 'treeView-node-icon');
+      .append('g')
+      .attr('class', 'treeView-node-icon')
+      .attr('transform', `translate(${x + config.paddingX}, ${y + config.paddingY})`)
+      .html(iconSVGs.get(node.id) ?? '');
   }
 
   // Label text
@@ -152,7 +131,7 @@ const drawTree = (
   elem: D3SVGElement<SVGGElement>,
   root: Node,
   config: Required<TreeViewDiagramConfig>,
-  diagramId: string
+  iconSVGs: Map<number, string>
 ) => {
   let totalHeight = 0;
   let totalWidth = 0;
@@ -165,7 +144,7 @@ const drawTree = (
     depth: number
   ) => {
     const indent = depth * (config.rowIndent + config.paddingX);
-    const info = positionLabel(indent, totalHeight, node, elem, config, diagramId);
+    const info = positionLabel(indent, totalHeight, node, elem, config, iconSVGs);
     renderInfos.push(info);
     const { height, width } = node.BBox!;
     positionLine(
@@ -245,13 +224,11 @@ const draw: DrawDefinition = async (text, id, _ver, diagObj) => {
 
   const svg = selectSvgElement(id);
 
-  // Inject icon definitions (scoped to diagramId to avoid duplicates)
-  await injectIconDefs(svg, root, config, id);
-
   const treeElem = svg.append('g');
   treeElem.attr('class', 'tree-view');
 
-  const { totalHeight, totalWidth } = drawTree(treeElem, root, config, id);
+  const iconSVGs = await resolveNodeIcons(root, config);
+  const { totalHeight, totalWidth } = drawTree(treeElem, root, config, iconSVGs);
   /* -${config.lineThickness/2} is required for a line with x coordinate = 0
      as there is overflow to the left due to the line being centered */
   svg.attr('viewBox', `-${config.lineThickness / 2} 0 ${totalWidth} ${totalHeight}`);

--- a/packages/mermaid/src/mermaidAPI.spec.ts
+++ b/packages/mermaid/src/mermaidAPI.spec.ts
@@ -905,6 +905,27 @@ graph TD;A--x|text including URL space|B;`)
         });
       });
     });
+
+    jsdomIt('preserves treeView icons after strict security sanitization', async () => {
+      mermaidAPI.initialize({ securityLevel: 'strict' });
+
+      const { svg } = await mermaidAPI.render(
+        'tree-view-strict-icons',
+        `---
+config:
+  treeView:
+    showIcons: true
+---
+treeView-beta
+  src/
+    index.js`
+      );
+
+      const dom = new JSDOM(svg);
+      const iconNode = ensureNodeFromSelector('.treeView-node-icon', dom.window.document);
+      ensureNodeFromSelector('path', iconNode);
+      expect(dom.window.document.querySelector('use')).toBeNull();
+    });
   });
 
   describe('getDiagramFromText', () => {


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fixes `treeView-beta` icons disappearing after Mermaid's strict security sanitization.

Resolves #7920

## :straight_ruler: Design Decisions

`treeView-beta` previously rendered icons through SVG `<defs>` and per-node `<use>` references. The final `mermaidAPI.render()` sanitization step removes `<use>` in strict security mode, leaving the icon definitions in the SVG but no visible icon references.

This PR keeps the fix scoped to treeView by rendering each node icon as inline SVG markup instead of widening the global DOMPurify allowlist. That preserves icons after sanitization without allowing `<use>` globally for all diagrams/user output.

It also adds a regression test that renders a `treeView-beta` diagram through the full `mermaidAPI.render()` path with `securityLevel: 'strict'`, then asserts the sanitized output contains actual icon `path` markup and no `<use>` nodes.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: documentation is not needed for this bug fix.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

## Validation

- `node_modules\.bin\vitest.cmd run --config packages/mermaid/vitest.local.config.ts packages/mermaid/src/mermaidAPI.spec.ts --testNamePattern "preserves treeView icons" --reporter verbose` passed locally using a temporary single-project config.
- `git diff --check` passed.
- `node_modules\.bin\lint-staged.cmd` passed.

Note: `node_modules\.bin\tsc.cmd -p packages/mermaid/tsconfig.json --noEmit --pretty false` is currently blocked in this local checkout by `packages/mermaid/src/docs/vite.config.ts` missing `unplugin-icons/vite`.
