### PR TITLE
ci: disable Link Checker automatic runs

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -7,17 +7,10 @@
 name: Link Checker
 
 on:
-  push:
-    branches:
-      - develop
-      - master
-  pull_request:
-    branches:
-      - master
+  # The Link Checker is disabled from running automatically. It can still be
+  # triggered manually via workflow_dispatch. To re-enable automatic runs,
+  # restore the push/pull_request/schedule triggers below.
   workflow_dispatch:
-  schedule:
-    # * is a special character in YAML so you have to quote this string
-    - cron: '30 8 * * *'
 
 permissions: # added using https://github.com/step-security/secure-repo
   contents: read


### PR DESCRIPTION
## :bookmark_tabs: Summary

Disables the Link Checker GitHub Action from running automatically. The `push`, `pull_request`, and scheduled (`cron`) triggers are removed, leaving only `workflow_dispatch` so the workflow can still be run manually on demand.

## :straight_ruler: Design Decisions

Rather than deleting `.github/workflows/link-checker.yml` entirely, the workflow file is kept in place with only the `workflow_dispatch` trigger. This fully disables all automatic runs while preserving the ability to trigger a link check manually, and makes re-enabling trivial — a comment in the file documents how to restore the original triggers.

### :clipboard: Tasks

Make sure you

- [ ] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QT9tvnhnWjRFWCLr5KfsLa)_