### PR TITLE
fix(docs): add svg+xml favicon and apple-touch-icon links to docs site

### DIFF
--- a/packages/mermaid/src/docs/.vitepress/config.ts
+++ b/packages/mermaid/src/docs/.vitepress/config.ts
@@ -33,7 +33,8 @@ export default defineConfig({
     applyHomePageHeroCopy(pageData, docsHostname());
   },
   head: [
-    ['link', { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
+    ['link', { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' }],
+    ['link', { rel: 'apple-touch-icon', href: '/favicon.png' }],
     ['meta', { property: 'og:title', content: 'Mermaid' }],
     [
       'meta',


### PR DESCRIPTION
## :bookmark_tabs: Summary

Add two `<link>` tags to the docs site's VitePress config so modern browsers get the SVG favicon and iOS "Add to Home Screen" picks up a proper 512×512 icon instead of a page screenshot.

Replaces the single `image/x-icon` link with:

```ts
['link', { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' }],
['link', { rel: 'apple-touch-icon', href: '/favicon.png' }],
```

Legacy browsers still find `/favicon.ico` via the root auto-probe.

Resolves #7933

## :straight_ruler: Design Decisions

- Assets already ship in `docs/public/` — no new binaries. `favicon.svg` (~1kb vector), `favicon.png` (512×512 RGBA with transparent corners).
- `apple-touch-icon` reuses `favicon.png` with no `sizes` attribute; iOS Safari picks the right size from the single 512×512 source.
- Mirrors the shape of the just-merged [mermaid-js/mermaid-live-editor#1963](https://github.com/mermaid-js/mermaid-live-editor/pull/1963), including the maintainer's guidance there that root-probe fallback is sufficient for legacy browsers.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests — N/A, markup-only VitePress config change with no testable behavior delta.
- [ ] :notebook: have added documentation. Make sure `MERMAID_RELEASE_VERSION` is used for all new features. — N/A, no feature.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset — N/A, docs site config only, no library package change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the docs site VitePress head config to replace the single ICO favicon link with:
- an SVG favicon link (`/favicon.svg`)
- an Apple touch icon link (`/favicon.png`)

This keeps modern browser support for SVG favicons while letting iOS “Add to Home Screen” use the existing PNG asset, with legacy `/favicon.ico` discovery still covered by browser auto-probe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->