### PR TITLE
fix(eventmodeling): preserve last character of data spec content

### DIFF
--- a/.changeset/eventmodeling-data-spec-truncation.md
+++ b/.changeset/eventmodeling-data-spec-truncation.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix(eventmodeling): data spec labels no longer lose their final character. The `{ … }` strip logic used `substring(0, lastIndexOf('}') - 1)`, whose exclusive end index already excludes the brace — the extra `- 1` chopped the last content character (`{item, quantity}` rendered as `item, quantit`).

--- a/packages/mermaid/src/diagrams/eventmodeling/db.ts
+++ b/packages/mermaid/src/diagrams/eventmodeling/db.ts
@@ -317,6 +317,31 @@ function calculateEntityVisualProps(frame: EmFrame): VisualProps {
   }
 }
 
+/**
+ * Strips the `{ … }` framing off an inline data spec, e.g. `{item, quantity}` → `item, quantity`.
+ *
+ * `String#substring`'s end index is exclusive, so `lastIndexOf('}')` already excludes the brace.
+ * Mirrors `stripInlineValue` in the event-modeling-tools source project.
+ */
+export function stripInlineValue(dataInlineValue: string): string {
+  let value = dataInlineValue;
+  value = value.substring(value.indexOf('{') + 1);
+  value = value.substring(0, value.lastIndexOf('}'));
+  return value;
+}
+
+/**
+ * Strips the `{\n … }` framing off a block data spec, keeping the inner lines
+ * (including the trailing newline before the closing brace).
+ * Mirrors `stripBlockValue` in the event-modeling-tools source project.
+ */
+export function stripBlockValue(dataBlockValue: string): string {
+  let value = dataBlockValue;
+  value = value.substring(value.indexOf('{\n') + 2);
+  value = value.substring(0, value.lastIndexOf('}'));
+  return value;
+}
+
 function calculateTextProps(
   frame: EmFrame,
   dataEntities: EmDataEntity[],
@@ -337,9 +362,7 @@ function calculateTextProps(
   let content = `<b>${wrappedName}</b>`;
 
   if (frame.dataInlineValue) {
-    toHtml = frame.dataInlineValue;
-    toHtml = toHtml.substring(toHtml.indexOf('{') + 1);
-    toHtml = toHtml.substring(0, toHtml.lastIndexOf('}') - 1);
+    toHtml = stripInlineValue(frame.dataInlineValue);
     toHtml = sanitizeText(toHtml, config);
     toHtml = wrapLabel(toHtml, diagramProps.textMaxWidth, wrapLabelConfig);
     toHtml = toHtml.replaceAll(' ', '&nbsp;');
@@ -351,9 +374,7 @@ function calculateTextProps(
     );
 
     if (dataEntity) {
-      toHtml = dataEntity.dataBlockValue;
-      toHtml = toHtml.substring(toHtml.indexOf('{\n') + 2);
-      toHtml = toHtml.substring(0, toHtml.lastIndexOf('}') - 1);
+      toHtml = stripBlockValue(dataEntity.dataBlockValue);
       toHtml = sanitizeText(toHtml, config);
       toHtml = wrapLabel(toHtml, diagramProps.textMaxWidth, wrapLabelConfig);
       toHtml = toHtml.replaceAll(' ', '&nbsp;');

--- a/packages/mermaid/src/diagrams/eventmodeling/eventmodeling.spec.ts
+++ b/packages/mermaid/src/diagrams/eventmodeling/eventmodeling.spec.ts
@@ -1,6 +1,6 @@
 import { it, describe, expect } from 'vitest';
 
-import { db } from './db.js';
+import { db, stripInlineValue, stripBlockValue } from './db.js';
 import { parser } from './parser.js';
 
 const { clear } = db;
@@ -75,5 +75,45 @@ data ItemAddedData
     tf 09 rmo ReadModel
     tf 10 readmodel ReadModel2`;
     await expect(parser.parse(str)).resolves.not.toThrow();
+  });
+});
+
+describe('stripInlineValue', () => {
+  it('keeps the last character of an inline data spec', () => {
+    // cspell:ignore quantit
+    // Regression: previously `substring(0, lastIndexOf('}') - 1)` chopped
+    // the last char, so "{item, quantity}" rendered as "item, quantit".
+    expect(stripInlineValue('{item, quantity}')).toBe('item, quantity');
+  });
+
+  it('returns content verbatim for multi-field specs', () => {
+    expect(stripInlineValue('{cartId, item, quantity}')).toBe('cartId, item, quantity');
+  });
+
+  it('handles a single-character content', () => {
+    // Edge case where the off-by-one was easiest to spot: a single char
+    // body became the empty string under the old behavior.
+    expect(stripInlineValue('{x}')).toBe('x');
+  });
+
+  it('handles an empty body', () => {
+    expect(stripInlineValue('{}')).toBe('');
+  });
+
+  it('preserves leading/trailing whitespace inside the braces', () => {
+    expect(stripInlineValue('{ item, quantity }')).toBe(' item, quantity ');
+  });
+});
+
+describe('stripBlockValue', () => {
+  it('keeps the last character of a block data spec', () => {
+    // Block notation: `data Foo {\n  ...lines...\n}`. The buggy version
+    // chopped the trailing newline (and on the last line, the last char).
+    const input = '{\n  item: string\n  quantity: number\n}';
+    expect(stripBlockValue(input)).toBe('  item: string\n  quantity: number\n');
+  });
+
+  it('keeps single-line block content intact', () => {
+    expect(stripBlockValue('{\n  field: value\n}')).toBe('  field: value\n');
   });
 });


### PR DESCRIPTION
## :bookmark_tabs: Summary

Data-spec labels in `eventmodeling` diagrams drop their last character: `{item, quantity}` renders as `item, quantit`.

Both strip sites in `packages/mermaid/src/diagrams/eventmodeling/db.ts` used `substring(0, lastIndexOf('}') - 1)`. `String#substring`'s end index is already exclusive, so `lastIndexOf('}')` alone excludes the brace — the extra `- 1` chopped one more character. For inline specs that's the last content character (user-visible truncation); for block references it silently ate the newline before the closing `}` (and would eat a content character for any value not ending in a newline).

Resolves #7935

## :straight_ruler: Design Decisions

- **Mirrors the source project's merged fix.** This diagram is a port of [lgazo/event-modeling-tools](https://github.com/lgazo/event-modeling-tools), which fixed the identical bug in [event-modeling-tools#20](https://github.com/lgazo/event-modeling-tools/pull/20) (merged 2026-06-30). @lgazo invited this PR there ("Feel free to open a PR in Mermaid as well"). Same helper names (`stripInlineValue` / `stripBlockValue`), same semantics — both codebases stay in sync.
- The two strip operations are extracted from `calculateTextProps` into exported helpers so they can be unit-tested directly; call sites otherwise unchanged (sanitize/wrap/escape pipeline untouched).
- Block values keep the trailing newline before `}` (upstream-blessed semantics; the old `- 1` happened to eat it). Downstream `wrapLabel` → HTML is insensitive to it.

## Tests

Ported the 7 unit tests from event-modeling-tools#20 into `eventmodeling.spec.ts` (inline + block notations, single-char body, empty body, whitespace preservation).

- With fix: **14/14 pass** (7 existing + 7 new).
- With `- 1` reintroduced: **6/7 new tests fail**, proving regression coverage (the one that passes either way is the empty-body `{}` case — nothing to chop).

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure `MERMAID_RELEASE_VERSION` is used for all new features. — N/A, bug fix, no new syntax or feature.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset — added (`mermaid`: patch, `fix:` prefix).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixed the eventmodeling data-spec truncation bug so labels like `{item, quantity}` now keep their final character.

What changed:
- Extracted inline/block stripping into exported helpers:
  - `stripInlineValue`
  - `stripBlockValue`
- Updated the eventmodeling text rendering path to use those helpers while keeping the existing sanitize/wrap/escape flow intact.
- Preserved trailing newline handling for block values.
- Added a changeset note for the fix.
- Added unit tests covering:
  - inline and block notation
  - single-character and empty bodies
  - whitespace preservation
  - regression cases for the truncation bug

This addresses the off-by-one caused by `substring(0, lastIndexOf('}') - 1)`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->