### PR TITLE
fix(layout): let a diagram's own nodeSpacing/rankSpacing win over flowchart defaults in the unified dagre layout

### DIFF
--- a/.changeset/layout-spacing-precedence.md
+++ b/.changeset/layout-spacing-precedence.md
@@ -1,0 +1,13 @@
+---
+'mermaid': patch
+---
+
+fix(layout): let a diagram's own nodeSpacing/rankSpacing take effect in the unified dagre layout
+
+The spacing resolution read the flowchart config before the value the diagram's
+renderer set on the layout data - and since the flowchart keys have schema
+defaults that always exist, every diagram's own spacing (class, state,
+requirement, ...) was silently ignored in favour of flowchart's defaults. The
+diagram-provided value now wins over the flowchart fallback; an explicit
+top-level `nodeSpacing`/`rankSpacing` config override still takes precedence
+over both.

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
@@ -653,14 +653,20 @@ export const prepareLayoutForDagre = (data4Layout) => {
   })
     .setGraph({
       rankdir: data4Layout.direction,
+      // Precedence: an explicit top-level config override (only present when a
+      // user sets it - it has no schema default) > the value the diagram's own
+      // renderer put on data4Layout (usually derived from that diagram's config)
+      // > the flowchart config as a generic fallback. The flowchart keys have
+      // schema defaults and therefore always exist, so they must come last or
+      // they silently shadow every diagram's own spacing (see #7932).
       nodesep:
         data4Layout.config?.nodeSpacing ||
-        data4Layout.config?.flowchart?.nodeSpacing ||
-        data4Layout.nodeSpacing,
+        data4Layout.nodeSpacing ||
+        data4Layout.config?.flowchart?.nodeSpacing,
       ranksep:
         data4Layout.config?.rankSpacing ||
-        data4Layout.config?.flowchart?.rankSpacing ||
-        data4Layout.rankSpacing,
+        data4Layout.rankSpacing ||
+        data4Layout.config?.flowchart?.rankSpacing,
       marginx: 8,
       marginy: 8,
     })

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.spec.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.spec.js
@@ -792,3 +792,43 @@ Gateway --> Repository : delegates`
     }
   });
 });
+
+describe('prepareLayoutForDagre spacing precedence (#7932)', () => {
+  const base = { direction: 'TB', nodes: [], edges: [] };
+
+  it('honours the spacing the diagram renderer set on data4Layout over the flowchart config defaults', () => {
+    const { graph } = prepareLayoutForDagre({
+      ...base,
+      nodeSpacing: 120,
+      rankSpacing: 130,
+      // The resolved site config always carries the flowchart schema defaults.
+      config: { flowchart: { nodeSpacing: 50, rankSpacing: 50 } },
+    });
+    expect(graph.graph().nodesep).toBe(120);
+    expect(graph.graph().ranksep).toBe(130);
+  });
+
+  it('lets an explicit top-level config override win over the diagram value', () => {
+    const { graph } = prepareLayoutForDagre({
+      ...base,
+      nodeSpacing: 120,
+      rankSpacing: 130,
+      config: {
+        nodeSpacing: 200,
+        rankSpacing: 210,
+        flowchart: { nodeSpacing: 50, rankSpacing: 50 },
+      },
+    });
+    expect(graph.graph().nodesep).toBe(200);
+    expect(graph.graph().ranksep).toBe(210);
+  });
+
+  it('falls back to the flowchart config when the diagram sets no spacing', () => {
+    const { graph } = prepareLayoutForDagre({
+      ...base,
+      config: { flowchart: { nodeSpacing: 60, rankSpacing: 70 } },
+    });
+    expect(graph.graph().nodesep).toBe(60);
+    expect(graph.graph().ranksep).toBe(70);
+  });
+});


### PR DESCRIPTION
### 📑 Summary

Fixes the unified dagre layout so a diagram's own `nodeSpacing`/`rankSpacing` actually take effect.

Fixes #7932

### 📏 Design Decisions

The spacing resolution in `prepareLayoutForDagre` was:

```js
config.nodeSpacing || config.flowchart.nodeSpacing || data4Layout.nodeSpacing
```

`config.flowchart.nodeSpacing`/`rankSpacing` have schema defaults (50/50), so they always exist in the resolved config - making the third operand unreachable. Every value a diagram renderer set on `data4Layout` (class, state, requirement set them from **their own** config) was silently ignored, and all unified-renderer diagrams laid out with flowchart's spacing.

New precedence, most-specific first:

1. **explicit top-level `config.nodeSpacing`/`rankSpacing`** - these have no schema default, so they are only present when a user explicitly sets them (kept as the strongest override, same as before);
2. **the diagram-provided `data4Layout` value** - the diagram renderer's intent, usually derived from that diagram's own config;
3. **the flowchart config** as the generic fallback for diagrams that set nothing.

Notes:

- Flowchart itself is unaffected: its renderer already copies `flowchart.nodeSpacing` onto `data4Layout`, so levels 2 and 3 agree.
- The ER renderer's existing workaround (writing `config.flowchart.*` directly, `erRenderer-unified.ts:26-27`) keeps working unchanged; it could be simplified in a follow-up.
- Behaviour note: users who discovered that setting `flowchart.nodeSpacing` changed their **class/state/requirement** diagrams were relying on this bug; after this fix those diagrams honour their own config keys (as documented) instead.
- The ELK layout package does not share this pattern (checked) - dagre-only fix.

### 📋 Tasks

- [x] 📓 unit tests: 3 new cases covering all precedence levels (`dagre/index.spec.js`); dagre suite 38/38 green
- [x] no regressions: flowchart/class/state/requirement/er unit suites all pass (2296 tests)
- [x] 🦋 changeset (patch)
- [ ] 📖 documentation - no docs change needed (this makes documented config keys work as documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ftYK49bbNLySKsY1Pg1Rg
