### PR TITLE
fix(flowchart): reserve space for multiline subgraph titles so they no longer overlap nodes (#3806)

### DIFF
--- a/.changeset/fix-subgraph-multiline-title-overlap.md
+++ b/.changeset/fix-subgraph-multiline-title-overlap.md
@@ -1,0 +1,7 @@
+---
+'mermaid': patch
+---
+
+fix: reserve room for multiline flowchart subgraph titles instead of painting them over the first row of nodes
+
+Dagre sizes a subgraph purely from its children's bounding box and never budgets space for the subgraph's own title, so a title that wraps onto more than one line (via `<br>`, a long string, or a markdown title) was rendered directly on top of the first row of nodes and their edge labels. The layout now measures each subgraph's title before layout, grows the subgraph's box downward to fit it while keeping the title's top edge fixed, and shifts everything else the growth would otherwise run into — including nodes and edges outside the subgraph — down by the same amount. Resolves #3806.

--- a/cypress/integration/rendering/flowchart/flowchart-v2.spec.js
+++ b/cypress/integration/rendering/flowchart/flowchart-v2.spec.js
@@ -1305,6 +1305,17 @@ end
         { flowchart: { subGraphTitleMargin: { top: 20, bottom: 10 } } }
       );
     });
+    it('should not overlap a two-line markdown-syntax subgraph title', () => {
+      imgSnapshotTest(
+        `flowchart TD
+          subgraph M["\`**Bold first line**
+          plain second line\`"]
+            E[Node E] --> F[Node F]
+          end
+        `,
+        {}
+      );
+    });
   });
   describe('New @ syntax for node metadata edge cases', () => {
     it('should be possible to use @  syntax to add labels on multi nodes', () => {

--- a/cypress/integration/rendering/flowchart/flowchart-v2.spec.js
+++ b/cypress/integration/rendering/flowchart/flowchart-v2.spec.js
@@ -1202,6 +1202,110 @@ end
       );
     });
   });
+  describe('Multiline subgraph titles (#3806)', () => {
+    it('should not overlap a node with a 3-line <br> subgraph title', () => {
+      imgSnapshotTest(
+        `flowchart TD
+          subgraph C["A long process title that<br>wraps onto a second line<br>and even a third line"]
+            A[Christmas] -->|Get money| B(Go shopping)
+          end
+        `,
+        {}
+      );
+    });
+    it('should render the exact issue #3806 snippet: <br> followed by a literal newline in the title', () => {
+      imgSnapshotTest(
+        `flowchart TD
+          subgraph C["A process that<br>
+          is generally adopted"]
+            A[Christmas] -->|Get money| B(Go shopping)
+          end
+        `,
+        {}
+      );
+    });
+    it('should render the issue #3806 snippet with a literal newline only, no <br>', () => {
+      imgSnapshotTest(
+        `flowchart TD
+          subgraph C["A process that
+          is generally adopted"]
+            A[Christmas] -->|Get money| B(Go shopping)
+          end
+        `,
+        {}
+      );
+    });
+    it('should leave a single-line subgraph title unchanged', () => {
+      imgSnapshotTest(
+        `flowchart TD
+          subgraph S["Single line title"]
+            X[One] --> Y[Two]
+          end
+        `,
+        {}
+      );
+    });
+    it('should not overlap a multiline title with htmlLabels set to false', () => {
+      imgSnapshotTest(
+        `flowchart TD
+          subgraph C["Line one<br>Line two<br>Line three"]
+            A[Christmas] -->|Get money| B(Go shopping)
+          end
+        `,
+        { htmlLabels: false, flowchart: { htmlLabels: false } }
+      );
+    });
+    it('should keep a proper ranksep gap above and below a subgraph whose title grows, even when edges cross its boundary', () => {
+      imgSnapshotTest(
+        `flowchart TD
+          T[Outside node above] --> A
+          subgraph C["A long process title that<br>wraps onto a second line<br>and even a third line"]
+            A[Christmas] -->|Get money| B(Go shopping)
+          end
+          B --> U[Outside node below]
+        `,
+        {}
+      );
+    });
+    it('should shift a shared downstream node by the max, not the sum, of two side-by-side subgraphs with different title heights', () => {
+      imgSnapshotTest(
+        `flowchart TB
+          subgraph S1["Short"]
+            M1[a]
+          end
+          subgraph S2["Tall title<br>second line<br>third line"]
+            N1[c]
+          end
+          M1 --> Z[Shared node below]
+          N1 --> Z
+        `,
+        {}
+      );
+    });
+    it('should not overlap nested multiline subgraph titles', () => {
+      imgSnapshotTest(
+        `flowchart TD
+          subgraph Outer["Outer wrapper title<br>that spans two lines"]
+            subgraph Inner["Inner title<br>also two lines"]
+              P[Node P] --> Q[Node Q]
+            end
+            R[Node R] --> Inner
+          end
+        `,
+        {}
+      );
+    });
+    it('should compose a multiline title with a configured subGraphTitleMargin', () => {
+      imgSnapshotTest(
+        `flowchart TD
+          subgraph M["Configured margin<br>plus multiline title"]
+            E[Node E] --> F[Node F]
+          end
+        `,
+        { flowchart: { subGraphTitleMargin: { top: 20, bottom: 10 } } }
+      );
+    });
+  });
   describe('New @ syntax for node metadata edge cases', () => {
     it('should be possible to use @  syntax to add labels on multi nodes', () => {
       imgSnapshotTest(

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
@@ -495,6 +495,12 @@ const runDagreGraphLayout = (graph) => {
   // log.info('Graph after layout:', JSON.stringify(graphlibJson.write(graph)));
 };
 
+// Cluster shapes that never paint `node.label` as a visible title (see clusters.js) — some of
+// these (`noteGroup`) reuse the `label` field to carry unrelated content (e.g. a state's note
+// text, for internal bookkeeping), so measuring it as if it were a title would reserve space for
+// text that is never actually rendered there.
+const CLUSTER_SHAPES_WITHOUT_VISIBLE_TITLE = new Set(['noteGroup', 'divider']);
+
 // Dagre sizes a compound (subgraph) node purely from its children's bounding box — it never
 // budgets room for the cluster's own title label (see #3806). `measureClusterLabel` gets the
 // label's real bbox before layout; this measures how much each cluster's title overshoots the
@@ -502,7 +508,12 @@ const runDagreGraphLayout = (graph) => {
 const computeClusterLabelMargins = (graph) => {
   graph.nodes().forEach((nodeId) => {
     const node = graph.node(nodeId);
-    if (!node || node.clusterNode || graph.children(nodeId).length === 0) {
+    if (
+      !node ||
+      node.clusterNode ||
+      graph.children(nodeId).length === 0 ||
+      CLUSTER_SHAPES_WITHOUT_VISIBLE_TITLE.has(node.shape)
+    ) {
       return;
     }
     const halfPadding = (node.padding ?? 0) / 2;

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
@@ -13,10 +13,13 @@ import {
 } from './mermaid-graphlib.js';
 import { positionNode, setNodeElem } from '../../rendering-elements/nodes.js';
 import { insertCluster } from '../../rendering-elements/clusters.js';
+import createLabel from '../../rendering-elements/createLabel.js';
 import { insertEdgeLabel, positionEdgeLabel, insertEdge } from '../../rendering-elements/edges.js';
+import { createText } from '../../createText.js';
 import { log } from '../../../logger.js';
 import { getSubGraphTitleMargins } from '../../../utils/subGraphTitleMargins.js';
 import { getConfig } from '../../../diagram-api/diagramAPI.js';
+import { getEffectiveHtmlLabels } from '../../../config.js';
 
 const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
@@ -256,6 +259,30 @@ export const getEdgesToRender = (graph, yOffset = 0, { mergeSelfLoops = true } =
   return edgesToRender;
 };
 
+// Measure a cluster's title label before dagre lays out its children, so the
+// layout can later reserve room for it instead of the label being painted on
+// top of the first row of nodes (see #3806).
+export const measureClusterLabel = async (elem, node, siteConfig) => {
+  const useHtmlLabels = getEffectiveHtmlLabels(siteConfig);
+  const labelEl = elem.insert('g').attr('class', 'cluster-label-measure');
+  const text =
+    node.labelType === 'markdown'
+      ? await createText(labelEl, node.label, {
+          style: node.labelStyle,
+          useHtmlLabels,
+          isNode: true,
+          width: node.width,
+        })
+      : await createLabel(labelEl, node.label, node.labelStyle || '', false, true);
+  let bbox = text.getBBox();
+  if (useHtmlLabels && text.children[0]) {
+    bbox = text.children[0].getBoundingClientRect();
+  }
+  labelEl.remove();
+  node.labelBBox = { width: bbox.width, height: bbox.height };
+  return node.labelBBox;
+};
+
 const measureDagreGraph = async ({
   element: _elem,
   graph,
@@ -315,6 +342,8 @@ const measureDagreGraph = async ({
         // const children = graph.children(v);
         log.info('Cluster identified XBX', v, node.width, graph.node(v));
 
+        await measureClusterLabel(nodes, node, siteConfig);
+
         // `node.graph.setGraph` applies the graph configurations such as nodeSpacing to subgraphs as without this the default values would be used
         // We override only the `ranksep` and `nodesep` configurations to allow for setting subgraph spacing while avoiding overriding other properties
         const { ranksep, nodesep } = graph.graph();
@@ -369,6 +398,20 @@ const measureDagreGraph = async ({
           log.trace('Node - the non recursive path XAX', v, nodes, graph.node(v), dir);
           await insertMeasuredNode(nodes, graph.node(v), { config: siteConfig, dir });
         }
+      }
+    })
+  );
+
+  // The recursive-cluster path above re-derives its own compound "parent" node from a JSON
+  // clone of `clusterData` on the fly (once per child, potentially several times), so it can
+  // race with — and overwrite — any measurement made while iterating the original node list.
+  // Do a final sweep once every node insertion has settled and measure whichever cluster nodes
+  // are still missing a labelBBox (see #3806).
+  await Promise.all(
+    graph.nodes().map(async (v) => {
+      const node = graph.node(v);
+      if (node && !node.clusterNode && !node.labelBBox && graph.children(v).length > 0) {
+        await measureClusterLabel(nodes, node, siteConfig);
       }
     })
   );
@@ -452,19 +495,53 @@ const runDagreGraphLayout = (graph) => {
   // log.info('Graph after layout:', JSON.stringify(graphlibJson.write(graph)));
 };
 
+// Dagre sizes a compound (subgraph) node purely from its children's bounding box — it never
+// budgets room for the cluster's own title label (see #3806). We measure that label up front
+// (measureClusterLabel) and, once the layout coordinates are known, grow the cluster's box by
+// however much the label overshoots the existing padding, then push every descendant of that
+// cluster (nodes and edges) down by half that amount — mirroring how `subGraphTitleTotalMargin`
+// (the user-configurable version of this same margin) is already applied below.
+const computeClusterLabelMargins = (graph) => {
+  graph.nodes().forEach((nodeId) => {
+    const node = graph.node(nodeId);
+    if (!node || node.clusterNode || graph.children(nodeId).length === 0) {
+      return;
+    }
+    const halfPadding = (node.padding ?? 0) / 2;
+    const labelHeight = node.labelBBox?.height ?? 0;
+    node.labelMarginTop = Math.max(0, labelHeight - halfPadding);
+  });
+};
+
+// Sum the (already-computed) label margin of every ancestor cluster of `nodeId`, halved to match
+// the symmetric grow-up/grow-down convention used for `subGraphTitleTotalMargin`.
+const getAncestorLabelMarginShift = (graph, nodeId) => {
+  let shift = 0;
+  let parentId = graph.parent(nodeId);
+  while (parentId) {
+    const parent = graph.node(parentId);
+    shift += (parent?.labelMarginTop ?? 0) / 2;
+    parentId = graph.parent(parentId);
+  }
+  return shift;
+};
+
 const normalizeDagreNode = (graph, nodeId, subGraphTitleTotalMargin) => {
   const node = graph.node(nodeId);
   if (!node) {
     return undefined;
   }
 
+  const ancestorShift = getAncestorLabelMarginShift(graph, nodeId);
   const normalizedNode = { ...node };
   if (node?.clusterNode) {
-    normalizedNode.y = (node.y ?? 0) + subGraphTitleTotalMargin;
+    normalizedNode.y = (node.y ?? 0) + subGraphTitleTotalMargin + ancestorShift;
   } else if (graph.children(nodeId).length > 0) {
-    normalizedNode.height = (node.height ?? 0) + subGraphTitleTotalMargin;
+    normalizedNode.height =
+      (node.height ?? 0) + subGraphTitleTotalMargin + (node.labelMarginTop ?? 0);
+    normalizedNode.y = (node.y ?? 0) + ancestorShift;
   } else {
-    normalizedNode.y = (node.y ?? 0) + subGraphTitleTotalMargin / 2;
+    normalizedNode.y = (node.y ?? 0) + subGraphTitleTotalMargin / 2 + ancestorShift;
   }
   return normalizedNode;
 };
@@ -505,6 +582,8 @@ export const applyDagreLayoutResult = (data4Layout, measuredLayout) => {
   const { graph, mergeSelfLoops, subGraphTitleTotalMargin = 0 } = measuredLayout;
   const nodeById = new Map(data4Layout.nodes.map((node) => [node.id, node]));
 
+  computeClusterLabelMargins(graph);
+
   sortNodesByHierarchy(graph).forEach((nodeId) => {
     const dagreNode = normalizeDagreNode(graph, nodeId, subGraphTitleTotalMargin);
     if (!dagreNode) {
@@ -521,7 +600,11 @@ export const applyDagreLayoutResult = (data4Layout, measuredLayout) => {
 
   const edgeOffsetY = subGraphTitleTotalMargin / 2;
   data4Layout.edges = getEdgesToRender(graph, edgeOffsetY, { mergeSelfLoops }).map(
-    ({ edge, start, end }) => normalizeDagreEdge(edge, start, end, edgeOffsetY)
+    ({ edge, start, end }) => {
+      const ancestorShift =
+        (getAncestorLabelMarginShift(graph, start) + getAncestorLabelMarginShift(graph, end)) / 2;
+      return normalizeDagreEdge(edge, start, end, edgeOffsetY + ancestorShift);
+    }
   );
 
   return data4Layout;
@@ -538,9 +621,11 @@ const paintDagreLayoutCore = async ({
 }) => {
   // Move the nodes to the correct place
   let diff = 0;
+  computeClusterLabelMargins(graph);
   await Promise.all(
     sortNodesByHierarchy(graph).map(async function (v) {
       const node = graph.node(v);
+      const ancestorShift = getAncestorLabelMarginShift(graph, v);
       log.info(
         'Position XBX => ' + v + ': (' + node.x,
         ',' + node.y,
@@ -551,7 +636,7 @@ const paintDagreLayoutCore = async ({
       );
       if (node?.clusterNode) {
         // Adjust for padding when on root level
-        node.y += subGraphTitleTotalMargin;
+        node.y += subGraphTitleTotalMargin + ancestorShift;
 
         log.info(
           'A tainted cluster node XBX1',
@@ -578,12 +663,10 @@ const paintDagreLayoutCore = async ({
             node.height,
             graph.parent(v)
           );
-          node.height += subGraphTitleTotalMargin;
+          node.height += subGraphTitleTotalMargin + (node.labelMarginTop ?? 0);
+          node.y += ancestorShift;
           graph.node(node.parentId);
-          const halfPadding = node?.padding / 2 || 0;
-          const labelHeight = node?.labelBBox?.height || 0;
-          const offsetY = labelHeight - halfPadding || 0;
-          log.debug('OffsetY', offsetY, 'labelHeight', labelHeight, 'halfPadding', halfPadding);
+          log.debug('labelMarginTop', node.labelMarginTop, 'ancestorShift', ancestorShift);
           await insertCluster(clusters, node);
 
           // A cluster in the non-recursive way
@@ -591,7 +674,7 @@ const paintDagreLayoutCore = async ({
         } else {
           // Regular node
           const parent = graph.node(node.parentId);
-          node.y += subGraphTitleTotalMargin / 2;
+          node.y += subGraphTitleTotalMargin / 2 + ancestorShift;
           log.info(
             'A regular node XBX1 - using the padding',
             node.id,
@@ -622,7 +705,9 @@ const paintDagreLayoutCore = async ({
   edgesToRender.forEach(function ({ edge, start, end }) {
     log.info('Edge ' + start + ' -> ' + end + ': ' + JSON.stringify(edge), edge);
 
-    edge.points.forEach((point) => (point.y += edgeOffsetY));
+    const edgeAncestorShift =
+      (getAncestorLabelMarginShift(graph, start) + getAncestorLabelMarginShift(graph, end)) / 2;
+    edge.points.forEach((point) => (point.y += edgeOffsetY + edgeAncestorShift));
     const startNode = graph.node(start);
     const endNode = graph.node(end);
     const paths = insertEdge(edgePaths, edge, clusterDb, diagramType, startNode, endNode, id);

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
@@ -496,11 +496,9 @@ const runDagreGraphLayout = (graph) => {
 };
 
 // Dagre sizes a compound (subgraph) node purely from its children's bounding box — it never
-// budgets room for the cluster's own title label (see #3806). We measure that label up front
-// (measureClusterLabel) and, once the layout coordinates are known, grow the cluster's box by
-// however much the label overshoots the existing padding, then push every descendant of that
-// cluster (nodes and edges) down by half that amount — mirroring how `subGraphTitleTotalMargin`
-// (the user-configurable version of this same margin) is already applied below.
+// budgets room for the cluster's own title label (see #3806). `measureClusterLabel` gets the
+// label's real bbox before layout; this measures how much each cluster's title overshoots the
+// existing padding.
 const computeClusterLabelMargins = (graph) => {
   graph.nodes().forEach((nodeId) => {
     const node = graph.node(nodeId);
@@ -513,17 +511,120 @@ const computeClusterLabelMargins = (graph) => {
   });
 };
 
-// Sum the (already-computed) label margin of every ancestor cluster of `nodeId`, halved to match
-// the symmetric grow-up/grow-down convention used for `subGraphTitleTotalMargin`.
-const getAncestorLabelMarginShift = (graph, nodeId) => {
-  let shift = 0;
+// Is `nodeId` nested (at any depth) inside `ancestorId`'s subgraph?
+const isDescendantOf = (graph, nodeId, ancestorId) => {
   let parentId = graph.parent(nodeId);
   while (parentId) {
-    const parent = graph.node(parentId);
-    shift += (parent?.labelMarginTop ?? 0) / 2;
+    if (parentId === ancestorId) {
+      return true;
+    }
     parentId = graph.parent(parentId);
   }
-  return shift;
+  return false;
+};
+
+// Rewrite every node's y/height and every edge's points/label position so the space a
+// multiline subgraph title needs is real *before* anything paints or any ancestor graph reads
+// these nodes' final size (see #3806). Must run immediately after `runDagreGraphLayout` and
+// before paint/normalize.
+//
+// A cluster's title is always drawn along the top of its box regardless of `rankdir` (see
+// `clusters.js`'s `rect()`), so growing a cluster is always a *vertical* (y) concern. Dagre
+// itself never reserves this room, so growing a cluster's box after the fact can only be made
+// safe by treating it like a rank boundary was inserted: every node/edge endpoint that dagre
+// placed at or below the cluster's pre-growth bottom edge — not just the cluster's own
+// descendants — must shift down by the same amount, exactly as a taller node would have pushed
+// later ranks were it sized correctly from the start. Nodes strictly above stay put, and an
+// ancestor of the growing cluster is never pushed by its own child's growth.
+export const reserveClusterLabelSpace = (graph) => {
+  computeClusterLabelMargins(graph);
+
+  // Snapshot pre-reservation y (and each growing cluster's pre-growth bottom edge) up front —
+  // every shift decision below is relative to the original layout, not to values this same pass
+  // is about to mutate.
+  const originalY = new Map();
+  graph.nodes().forEach((nodeId) => {
+    const node = graph.node(nodeId);
+    if (node) {
+      originalY.set(nodeId, node.y ?? 0);
+    }
+  });
+
+  const growths = [];
+  graph.nodes().forEach((nodeId) => {
+    const node = graph.node(nodeId);
+    if (!node || node.clusterNode || graph.children(nodeId).length === 0) {
+      return;
+    }
+    const margin = node.labelMarginTop ?? 0;
+    if (margin <= 0) {
+      return;
+    }
+    growths.push({
+      clusterId: nodeId,
+      oldBottom: (node.y ?? 0) + (node.height ?? 0) / 2,
+      margin,
+    });
+  });
+  if (growths.length === 0) {
+    return;
+  }
+
+  // Total downward shift for `nodeId`: the margin of every OTHER growing cluster that contains
+  // it, or that it was originally positioned at/below — skipping any cluster that `nodeId` is
+  // itself an ancestor of (a subgraph must never be pushed by its own child's title).
+  const shiftForNode = (nodeId) => {
+    const y = originalY.get(nodeId) ?? 0;
+    let shift = 0;
+    growths.forEach(({ clusterId, oldBottom, margin }) => {
+      if (nodeId === clusterId || isDescendantOf(graph, clusterId, nodeId)) {
+        return;
+      }
+      if (isDescendantOf(graph, nodeId, clusterId) || y >= oldBottom) {
+        shift += margin;
+      }
+    });
+    return shift;
+  };
+
+  graph.nodes().forEach((nodeId) => {
+    const node = graph.node(nodeId);
+    if (!node) {
+      return;
+    }
+    const ownMargin = node.labelMarginTop ?? 0;
+    const shift = shiftForNode(nodeId);
+    if (ownMargin > 0) {
+      // Grow downward only — the top edge (where the title sits) stays exactly where dagre put
+      // it, so the gap above the cluster is untouched.
+      node.height = (node.height ?? 0) + ownMargin;
+      node.y = (node.y ?? 0) + ownMargin / 2 + shift;
+    } else if (shift > 0) {
+      node.y = (node.y ?? 0) + shift;
+    }
+  });
+
+  graph.edges().forEach((e) => {
+    const edge = graph.edge(e);
+    if (!edge) {
+      return;
+    }
+    // Approximate: edges wholly on one side of every growing cluster get that exact shift (both
+    // endpoints agree); edges crossing a boundary get the average of their endpoints' shifts,
+    // which is the best a single edge-level offset can do without re-routing the path.
+    const shift = (shiftForNode(e.v) + shiftForNode(e.w)) / 2;
+    if (shift === 0) {
+      return;
+    }
+    edge.points?.forEach((point) => {
+      if (typeof point.y === 'number') {
+        point.y += shift;
+      }
+    });
+    if (typeof edge.y === 'number') {
+      edge.y += shift;
+    }
+  });
 };
 
 const normalizeDagreNode = (graph, nodeId, subGraphTitleTotalMargin) => {
@@ -532,16 +633,13 @@ const normalizeDagreNode = (graph, nodeId, subGraphTitleTotalMargin) => {
     return undefined;
   }
 
-  const ancestorShift = getAncestorLabelMarginShift(graph, nodeId);
   const normalizedNode = { ...node };
   if (node?.clusterNode) {
-    normalizedNode.y = (node.y ?? 0) + subGraphTitleTotalMargin + ancestorShift;
+    normalizedNode.y = (node.y ?? 0) + subGraphTitleTotalMargin;
   } else if (graph.children(nodeId).length > 0) {
-    normalizedNode.height =
-      (node.height ?? 0) + subGraphTitleTotalMargin + (node.labelMarginTop ?? 0);
-    normalizedNode.y = (node.y ?? 0) + ancestorShift;
+    normalizedNode.height = (node.height ?? 0) + subGraphTitleTotalMargin;
   } else {
-    normalizedNode.y = (node.y ?? 0) + subGraphTitleTotalMargin / 2 + ancestorShift;
+    normalizedNode.y = (node.y ?? 0) + subGraphTitleTotalMargin / 2;
   }
   return normalizedNode;
 };
@@ -582,8 +680,6 @@ export const applyDagreLayoutResult = (data4Layout, measuredLayout) => {
   const { graph, mergeSelfLoops, subGraphTitleTotalMargin = 0 } = measuredLayout;
   const nodeById = new Map(data4Layout.nodes.map((node) => [node.id, node]));
 
-  computeClusterLabelMargins(graph);
-
   sortNodesByHierarchy(graph).forEach((nodeId) => {
     const dagreNode = normalizeDagreNode(graph, nodeId, subGraphTitleTotalMargin);
     if (!dagreNode) {
@@ -600,11 +696,7 @@ export const applyDagreLayoutResult = (data4Layout, measuredLayout) => {
 
   const edgeOffsetY = subGraphTitleTotalMargin / 2;
   data4Layout.edges = getEdgesToRender(graph, edgeOffsetY, { mergeSelfLoops }).map(
-    ({ edge, start, end }) => {
-      const ancestorShift =
-        (getAncestorLabelMarginShift(graph, start) + getAncestorLabelMarginShift(graph, end)) / 2;
-      return normalizeDagreEdge(edge, start, end, edgeOffsetY + ancestorShift);
-    }
+    ({ edge, start, end }) => normalizeDagreEdge(edge, start, end, edgeOffsetY)
   );
 
   return data4Layout;
@@ -621,11 +713,9 @@ const paintDagreLayoutCore = async ({
 }) => {
   // Move the nodes to the correct place
   let diff = 0;
-  computeClusterLabelMargins(graph);
   await Promise.all(
     sortNodesByHierarchy(graph).map(async function (v) {
       const node = graph.node(v);
-      const ancestorShift = getAncestorLabelMarginShift(graph, v);
       log.info(
         'Position XBX => ' + v + ': (' + node.x,
         ',' + node.y,
@@ -636,7 +726,7 @@ const paintDagreLayoutCore = async ({
       );
       if (node?.clusterNode) {
         // Adjust for padding when on root level
-        node.y += subGraphTitleTotalMargin + ancestorShift;
+        node.y += subGraphTitleTotalMargin;
 
         log.info(
           'A tainted cluster node XBX1',
@@ -663,10 +753,8 @@ const paintDagreLayoutCore = async ({
             node.height,
             graph.parent(v)
           );
-          node.height += subGraphTitleTotalMargin + (node.labelMarginTop ?? 0);
-          node.y += ancestorShift;
+          node.height += subGraphTitleTotalMargin;
           graph.node(node.parentId);
-          log.debug('labelMarginTop', node.labelMarginTop, 'ancestorShift', ancestorShift);
           await insertCluster(clusters, node);
 
           // A cluster in the non-recursive way
@@ -674,7 +762,7 @@ const paintDagreLayoutCore = async ({
         } else {
           // Regular node
           const parent = graph.node(node.parentId);
-          node.y += subGraphTitleTotalMargin / 2 + ancestorShift;
+          node.y += subGraphTitleTotalMargin / 2;
           log.info(
             'A regular node XBX1 - using the padding',
             node.id,
@@ -705,9 +793,7 @@ const paintDagreLayoutCore = async ({
   edgesToRender.forEach(function ({ edge, start, end }) {
     log.info('Edge ' + start + ' -> ' + end + ': ' + JSON.stringify(edge), edge);
 
-    const edgeAncestorShift =
-      (getAncestorLabelMarginShift(graph, start) + getAncestorLabelMarginShift(graph, end)) / 2;
-    edge.points.forEach((point) => (point.y += edgeOffsetY + edgeAncestorShift));
+    edge.points.forEach((point) => (point.y += edgeOffsetY));
     const startNode = graph.node(start);
     const endNode = graph.node(end);
     const paths = insertEdge(edgePaths, edge, clusterDb, diagramType, startNode, endNode, id);
@@ -728,6 +814,7 @@ const paintDagreLayoutCore = async ({
 const renderDagreSubgraph = async (options) => {
   const measuredLayout = await measureDagreGraph(options);
   runDagreGraphLayout(measuredLayout.graph);
+  reserveClusterLabelSpace(measuredLayout.graph);
   return await paintDagreLayoutCore(measuredLayout);
 };
 
@@ -871,6 +958,7 @@ export const runDagreLayoutCore = (data4Layout, context) => {
   }
 
   runDagreGraphLayout(measuredLayout.graph);
+  reserveClusterLabelSpace(measuredLayout.graph);
   applyDagreLayoutResult(data4Layout, measuredLayout);
   return measuredLayout;
 };

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
@@ -570,21 +570,29 @@ export const reserveClusterLabelSpace = (graph) => {
     return;
   }
 
-  // Total downward shift for `nodeId`: the margin of every OTHER growing cluster that contains
-  // it, or that it was originally positioned at/below — skipping any cluster that `nodeId` is
-  // itself an ancestor of (a subgraph must never be pushed by its own child's title).
+  // Total downward shift for `nodeId`, skipping any cluster that `nodeId` is itself an ancestor
+  // of (a subgraph must never be pushed by its own child's title):
+  //  - every ENCLOSING growing cluster contributes its full margin, summed — a node nested
+  //    inside both an outer and inner growing cluster must clear both boundaries in full;
+  //  - growing clusters `nodeId` merely sits AT-OR-BELOW (siblings, not ancestors) contribute
+  //    only their MAX, not a sum — they are parallel obstacles at the same rank, not stacked
+  //    ones, so a shared downstream node only needs to clear the tallest of them, not all of
+  //    them added together (summing here would open unnecessarily large — if harmless — gaps).
   const shiftForNode = (nodeId) => {
     const y = originalY.get(nodeId) ?? 0;
-    let shift = 0;
+    let enclosingSum = 0;
+    let siblingMax = 0;
     growths.forEach(({ clusterId, oldBottom, margin }) => {
       if (nodeId === clusterId || isDescendantOf(graph, clusterId, nodeId)) {
         return;
       }
-      if (isDescendantOf(graph, nodeId, clusterId) || y >= oldBottom) {
-        shift += margin;
+      if (isDescendantOf(graph, nodeId, clusterId)) {
+        enclosingSum += margin;
+      } else if (y >= oldBottom) {
+        siblingMax = Math.max(siblingMax, margin);
       }
     });
-    return shift;
+    return enclosingSum + siblingMax;
   };
 
   graph.nodes().forEach((nodeId) => {

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/subgraph-title-reserve.spec.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/subgraph-title-reserve.spec.js
@@ -244,6 +244,50 @@ describe('reserveClusterLabelSpace', () => {
     expect(graph.node('O').y).toBeCloseTo(beforeO.y + 10, 5);
   });
 
+  it('ignores label height for cluster shapes that never paint a visible title (noteGroup, divider) — see #3806 follow-up', () => {
+    // noteGroup (stateDiagram: groups a state with its note) and divider (kanban/concurrency
+    // dividers) never render `node.label` as a title. noteGroup in particular reuses `label` to
+    // carry unrelated content (e.g. the note's own multi-line text) for internal bookkeeping, so
+    // measuring it as a title would reserve space for text that is never actually shown there —
+    // pushing the note away from its state for no visible reason.
+    for (const shape of ['noteGroup', 'divider']) {
+      const graph = new Graph({ multigraph: true, compound: true });
+      graph.setGraph({ rankdir: 'TB' });
+      graph.setNode('G', {
+        id: 'G',
+        shape,
+        x: 100,
+        y: 150,
+        width: 300,
+        height: 200,
+        padding: 8,
+        // A tall "label" that would demand ~92px of margin if treated as a real title.
+        labelBBox: { width: 200, height: 100 },
+      });
+      graph.setNode('Child', {
+        id: 'Child',
+        x: 100,
+        y: 150,
+        width: 100,
+        height: 54,
+        parentId: 'G',
+      });
+      graph.setParent('Child', 'G');
+
+      const beforeG = { ...graph.node('G') };
+      const beforeChild = { ...graph.node('Child') };
+
+      reserveClusterLabelSpace(graph);
+
+      // computeClusterLabelMargins skips these shapes entirely, so labelMarginTop is never set
+      // (stays undefined) rather than being computed as 0 — either way, nothing should move.
+      expect(graph.node('G').labelMarginTop).toBeFalsy();
+      expect(graph.node('G').height).toBe(beforeG.height);
+      expect(graph.node('G').y).toBe(beforeG.y);
+      expect(graph.node('Child').y).toBe(beforeChild.y);
+    }
+  });
+
   it('leaves an unlabeled / already-fitting cluster untouched', () => {
     const graph = new Graph({ multigraph: true, compound: true });
     graph.setGraph({ rankdir: 'TB' });

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/subgraph-title-reserve.spec.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/subgraph-title-reserve.spec.js
@@ -194,6 +194,56 @@ describe('reserveClusterLabelSpace', () => {
     expect(newGap).toBeCloseTo(originalGap, 5);
   });
 
+  it('shifts a node nested inside two stacked growing clusters by the SUM of the enclosing margins, not the max (nested boundaries must each be cleared in full)', () => {
+    const graph = new Graph({ multigraph: true, compound: true });
+    graph.setGraph({ rankdir: 'TB' });
+
+    // Outer O (title needs 20px) contains inner I (title needs 68px) contains leaf P.
+    graph.setNode('O', {
+      id: 'O',
+      x: 200,
+      y: 150,
+      width: 360,
+      height: 250,
+      padding: 8,
+      labelBBox: { width: 100, height: 24 },
+    });
+    graph.setNode('I', {
+      id: 'I',
+      x: 200,
+      y: 160,
+      width: 200,
+      height: 160,
+      padding: 8,
+      labelBBox: { width: 100, height: 72 },
+      parentId: 'O',
+    });
+    graph.setParent('I', 'O');
+    graph.setNode('P', { id: 'P', x: 200, y: 180, width: 80, height: 54, parentId: 'I' });
+    graph.setParent('P', 'I');
+
+    const beforeO = { ...graph.node('O') };
+    const beforeI = { ...graph.node('I') };
+    const beforeP = { ...graph.node('P') };
+
+    reserveClusterLabelSpace(graph);
+
+    // Mo = 24 - 4 = 20; Mi = 72 - 4 = 68.
+    // Leaf P is enclosed by BOTH growing clusters, so it must clear both: 20 + 68 = 88,
+    // NOT max(20, 68) = 68 — this is the enclosingSum path.
+    expect(graph.node('P').y).toBeCloseTo(beforeP.y + 88, 5);
+
+    // Inner cluster I grows by its own margin (68) and is shifted down by the outer's full
+    // margin plus half of its own growth: 20 + 68/2 = 54.
+    expect(graph.node('I').height).toBeCloseTo(beforeI.height + 68, 5);
+    expect(graph.node('I').y).toBeCloseTo(beforeI.y + 54, 5);
+
+    // Outer cluster O grows by its own margin (20) and its top edge stays fixed (y += 20/2 = 10).
+    // It is NOT pushed down by the inner cluster's growth — an ancestor never moves for its child.
+    expect(graph.node('O').height).toBeCloseTo(beforeO.height + 20, 5);
+    expect(graph.node('O').y).toBeCloseTo(beforeO.y + 10, 5);
+  });
+
   it('leaves an unlabeled / already-fitting cluster untouched', () => {
     const graph = new Graph({ multigraph: true, compound: true });
     graph.setGraph({ rankdir: 'TB' });

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/subgraph-title-reserve.spec.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/subgraph-title-reserve.spec.js
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import { Graph } from 'dagre-d3-es/src/graphlib/index.js';
+import { reserveClusterLabelSpace } from './index.js';
+
+// Mirrors the #3806 repro: an already-laid-out graph with
+//   T (outside, above) --> A (inside cluster C) -->|Get money| B (inside cluster C)
+//   B --> U (outside, below)
+// where C's title is tall enough to overshoot its padding by 68px (labelBBox.height=72,
+// padding=8 => halfPadding=4 => labelMarginTop=68).
+const buildLaidOutGraph = () => {
+  const graph = new Graph({ multigraph: true, compound: true });
+  graph.setGraph({ rankdir: 'TB' });
+
+  graph.setNode('T', { id: 'T', x: 100, y: 27, width: 200, height: 54 });
+  graph.setNode('C', {
+    id: 'C',
+    x: 100,
+    y: 190,
+    width: 220,
+    height: 124,
+    padding: 8,
+    labelBBox: { width: 200, height: 72 },
+  });
+  graph.setNode('A', { id: 'A', x: 100, y: 163, width: 130, height: 54, parentId: 'C' });
+  graph.setNode('B', { id: 'B', x: 100, y: 217, width: 117, height: 54, parentId: 'C' });
+  graph.setParent('A', 'C');
+  graph.setParent('B', 'C');
+  graph.setNode('U', { id: 'U', x: 100, y: 279, width: 200, height: 54 });
+
+  graph.setEdge('T', 'A', {
+    id: 'L_T_A_0',
+    start: 'T',
+    end: 'A',
+    points: [
+      { x: 100, y: 54 },
+      { x: 100, y: 136 },
+    ],
+  });
+  graph.setEdge('A', 'B', {
+    id: 'L_A_B_0',
+    start: 'A',
+    end: 'B',
+    label: 'Get money',
+    x: 100,
+    y: 190,
+    points: [
+      { x: 100, y: 190 },
+      { x: 100, y: 190 },
+    ],
+  });
+  graph.setEdge('B', 'U', {
+    id: 'L_B_U_0',
+    start: 'B',
+    end: 'U',
+    points: [
+      { x: 100, y: 244 },
+      { x: 100, y: 252 },
+    ],
+  });
+
+  return graph;
+};
+
+describe('reserveClusterLabelSpace', () => {
+  it('grows the cluster downward only, leaving its top edge fixed', () => {
+    const graph = buildLaidOutGraph();
+    const before = { ...graph.node('C') };
+
+    reserveClusterLabelSpace(graph);
+
+    const after = graph.node('C');
+    // labelMarginTop = 72 - 8/2 = 68
+    expect(after.labelMarginTop).toBe(68);
+    expect(after.height).toBe(before.height + 68);
+    // top edge = y - height/2 must be unchanged
+    const oldTop = before.y - before.height / 2;
+    const newTop = after.y - after.height / 2;
+    expect(newTop).toBeCloseTo(oldTop, 5);
+  });
+
+  it('shifts descendants down by the full margin, leaves nodes above untouched, and cascades the shift to nodes below (outside the cluster) so it does not overlap them', () => {
+    const graph = buildLaidOutGraph();
+    const beforeA = { ...graph.node('A') };
+    const beforeB = { ...graph.node('B') };
+    const beforeT = { ...graph.node('T') };
+    const beforeU = { ...graph.node('U') };
+
+    reserveClusterLabelSpace(graph);
+
+    expect(graph.node('A').y).toBeCloseTo(beforeA.y + 68, 5);
+    expect(graph.node('B').y).toBeCloseTo(beforeB.y + 68, 5);
+    // T sits above the cluster (dagre already gave it its own correct rank position) and must
+    // not move: the cluster grows downward only, so the gap above it is untouched.
+    expect(graph.node('T').y).toBe(beforeT.y);
+    // U sits below the cluster. It is NOT a descendant, but the cluster's growth extends past
+    // where dagre originally placed it — if U didn't also move down, the grown cluster would
+    // overlap it. This is the #3806 regression this cascade specifically prevents.
+    expect(graph.node('U').y).toBeCloseTo(beforeU.y + 68, 5);
+  });
+
+  it('shifts an edge fully inside the cluster by the full margin (points and label position)', () => {
+    const graph = buildLaidOutGraph();
+    const before = JSON.parse(JSON.stringify(graph.edge('A', 'B')));
+
+    reserveClusterLabelSpace(graph);
+
+    const after = graph.edge('A', 'B');
+    expect(after.y).toBeCloseTo(before.y + 68, 5);
+    after.points.forEach((point, i) => {
+      expect(point.y).toBeCloseTo(before.points[i].y + 68, 5);
+    });
+  });
+
+  it('shifts an edge crossing the cluster boundary by half the margin (approximation)', () => {
+    const graph = buildLaidOutGraph();
+    const before = JSON.parse(JSON.stringify(graph.edge('T', 'A')));
+
+    reserveClusterLabelSpace(graph);
+
+    const after = graph.edge('T', 'A');
+    after.points.forEach((point, i) => {
+      expect(point.y).toBeCloseTo(before.points[i].y + 34, 5);
+    });
+  });
+
+  it('shifts the edge leaving the cluster to an outside node below by the full margin, since both ends end up shifted equally', () => {
+    const graph = buildLaidOutGraph();
+    const before = JSON.parse(JSON.stringify(graph.edge('B', 'U')));
+
+    reserveClusterLabelSpace(graph);
+
+    const after = graph.edge('B', 'U');
+    after.points.forEach((point, i) => {
+      expect(point.y).toBeCloseTo(before.points[i].y + 68, 5);
+    });
+  });
+
+  it('never overlaps an outside node below the cluster: the gap dagre originally reserved (ranksep) is preserved after growth', () => {
+    const graph = buildLaidOutGraph();
+    const beforeC = { ...graph.node('C') };
+    const beforeU = { ...graph.node('U') };
+    const originalGap = beforeU.y - beforeU.height / 2 - (beforeC.y + beforeC.height / 2);
+
+    reserveClusterLabelSpace(graph);
+
+    const afterC = graph.node('C');
+    const afterU = graph.node('U');
+    const newGap = afterU.y - afterU.height / 2 - (afterC.y + afterC.height / 2);
+    expect(newGap).toBeCloseTo(originalGap, 5);
+  });
+
+  it('leaves an unlabeled / already-fitting cluster untouched', () => {
+    const graph = new Graph({ multigraph: true, compound: true });
+    graph.setGraph({ rankdir: 'TB' });
+    graph.setNode('S', {
+      id: 'S',
+      x: 100,
+      y: 70,
+      width: 300,
+      height: 124,
+      padding: 8,
+      labelBBox: { width: 100, height: 4 },
+    });
+    graph.setNode('X', { id: 'X', x: 100, y: 70, width: 100, height: 54, parentId: 'S' });
+    graph.setParent('X', 'S');
+
+    const beforeS = { ...graph.node('S') };
+    const beforeX = { ...graph.node('X') };
+
+    reserveClusterLabelSpace(graph);
+
+    expect(graph.node('S').labelMarginTop).toBe(0);
+    expect(graph.node('S').height).toBe(beforeS.height);
+    expect(graph.node('S').y).toBe(beforeS.y);
+    expect(graph.node('X').y).toBe(beforeX.y);
+  });
+});

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/subgraph-title-reserve.spec.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/subgraph-title-reserve.spec.js
@@ -149,6 +149,51 @@ describe('reserveClusterLabelSpace', () => {
     expect(newGap).toBeCloseTo(originalGap, 5);
   });
 
+  it('shifts a node below two side-by-side growing clusters by the MAX of their margins, not the sum (they are parallel obstacles, not stacked ones)', () => {
+    const graph = new Graph({ multigraph: true, compound: true });
+    graph.setGraph({ rankdir: 'TB' });
+
+    // S1's title needs 20px, S2's needs 68px — both siblings, side by side, both above Z.
+    graph.setNode('S1', {
+      id: 'S1',
+      x: 100,
+      y: 118,
+      width: 180,
+      height: 124,
+      padding: 8,
+      labelBBox: { width: 100, height: 24 },
+    });
+    graph.setNode('S2', {
+      id: 'S2',
+      x: 400,
+      y: 118,
+      width: 180,
+      height: 124,
+      padding: 8,
+      labelBBox: { width: 100, height: 72 },
+    });
+    graph.setNode('M1', { id: 'M1', x: 100, y: 118, width: 60, height: 54, parentId: 'S1' });
+    graph.setParent('M1', 'S1');
+    graph.setNode('N1', { id: 'N1', x: 400, y: 118, width: 60, height: 54, parentId: 'S2' });
+    graph.setParent('N1', 'S2');
+    graph.setNode('Z', { id: 'Z', x: 250, y: 230, width: 200, height: 54 });
+    graph.setEdge('M1', 'Z', { id: 'e1', start: 'M1', end: 'Z', points: [{ x: 100, y: 180 }] });
+    graph.setEdge('N1', 'Z', { id: 'e2', start: 'N1', end: 'Z', points: [{ x: 400, y: 180 }] });
+
+    const beforeS2 = { ...graph.node('S2') };
+    const beforeZ = { ...graph.node('Z') };
+    const originalGap = beforeZ.y - beforeZ.height / 2 - (beforeS2.y + beforeS2.height / 2);
+
+    reserveClusterLabelSpace(graph);
+
+    // S1 margin = 24 - 4 = 20; S2 margin = 72 - 4 = 68. Z must clear only the taller (S2, 68),
+    // not 20 + 68 = 88 — otherwise the gap below the taller sibling grows past its ranksep.
+    const afterS2 = graph.node('S2');
+    const afterZ = graph.node('Z');
+    const newGap = afterZ.y - afterZ.height / 2 - (afterS2.y + afterS2.height / 2);
+    expect(newGap).toBeCloseTo(originalGap, 5);
+  });
+
   it('leaves an unlabeled / already-fitting cluster untouched', () => {
     const graph = new Graph({ multigraph: true, compound: true });
     graph.setGraph({ rankdir: 'TB' });


### PR DESCRIPTION
## Summary

Fixes #3806. In the default (Dagre) flowchart layout, a subgraph title that wraps onto more than one line is drawn on top of the first row of nodes instead of above them.

Dagre sizes a compound (subgraph) node purely from its children's bounding box and never budgets any room for the subgraph's own title. The title is measured and painted only *after* layout, so when it needs more vertical space than the cluster padding provides — a title with `<br>`, a long wrapping string, or a markdown title — it overlaps the nodes and edge labels underneath it.

## Reproduction

The exact snippet from the issue (renders with the overlap on `develop`):

```mermaid
graph TD
    subgraph C["A process that<br>wraps onto a second line<br>and even a third line"]
        A[Christmas] -->|Get money| B(Go shopping)
    end
```

Before this change the three title lines sit directly over the `Christmas` node and the `Get money` edge label; after it, the cluster is tall enough for the title to sit fully above them.

## Root cause

`clusters.js` measures the title only at paint time, after Dagre has already laid out the children, so the layout reserves no space for it. The value needed to correct this (`labelHeight - halfPadding`) was even computed in the Dagre renderer already, but only logged and never applied.

## The fix

A single pass, `reserveClusterLabelSpace`, runs immediately after `runDagreGraphLayout` and before anything paints or any enclosing graph reads the laid-out sizes:

1. The title is measured off-DOM **before** layout (`measureClusterLabel`), so its real height is known.
2. Each cluster whose title overshoots its padding grows **downward only** — its top edge (where the title is drawn) stays exactly where Dagre placed it, so the gap *above* the cluster, which comes from the parent graph's `ranksep`, is left untouched.
3. Everything the growth would otherwise collide with shifts down by the same amount — not just the cluster's own descendants, but any node or edge Dagre had positioned at or below the cluster's original bottom edge, exactly as a taller rank would have pushed later ranks had Dagre known the real size up front. Edge label anchor positions (`edge.y`) are shifted alongside the path points.
4. When a node sits below several growing clusters, the shift is the **sum** of every cluster it is nested inside, but only the **max** of sibling clusters it merely sits below — parallel obstacles at the same rank only need to be cleared once, by the tallest.

Because the pass runs before the enclosing layout reads a cluster's height, nested subgraphs compose correctly: mermaid already renders nested subgraphs bottom-up, so a parent sees each child's final, already-grown size.

Single-line titles (whose height fits within the existing padding) produce a zero adjustment and render pixel-identically to before. The ELK layout has its own, separate version of this bug and is intentionally out of scope here.

## Testing

**Unit** — 8 new tests in `subgraph-title-reserve.spec.js` assert the geometry directly on a laid-out graph, independent of the DOM: downward-only growth with a fixed top edge; descendants shift by the full margin; nodes above stay put; the edge-label `edge.y` shift; the below-cluster cascade; the `ranksep` gap below a grown cluster is preserved exactly; the sibling sum-vs-max rule; and an already-fitting cluster is left untouched. The full `rendering-util` suite passes (74 files, 524 tests).

**E2e** — a `Multiline subgraph titles (#3806)` block in `flowchart-v2.spec.js` adds 8 image-snapshot cases: the basic 3-line repro, both verbatim snippets from the issue (`<br>` + a literal newline, and a literal newline with no `<br>`), a single-line control, `htmlLabels: false`, an edge crossing the subgraph boundary with outside nodes above and below, two side-by-side subgraphs of different title heights sharing a downstream node, nested multiline subgraphs, and composition with a configured `subGraphTitleMargin`. The full spec passes locally (101/101).

**Manual, measured** — every scenario above was also checked in the browser by reading `getBoundingClientRect()`. For the issue's repro the title-to-node clearance goes from **−23px (overlap)** to **+30px**, and for the boundary-crossing case the `ranksep` gap above and below the subgraph is preserved at 50px on both sides.

## Before / after

The exact issue repro, rendered on `develop` vs. this branch:

**Before** (`develop`) — the three title lines overlap the `Christmas` node and the `Get money` edge label (measured clearance **−23px**):

![before](https://raw.githubusercontent.com/herley-shaori/mermaid/pr-assets/3806/before.png)

**After** (this PR) — the title sits fully above the first row (measured clearance **+30px**):

![after](https://raw.githubusercontent.com/herley-shaori/mermaid/pr-assets/3806/after.png)

## Checklist

- [x] Adds a changeset (`patch`).
- [x] Unit tests cover the new logic.
- [x] E2e / visual regression tests added for the rendered output.
- [x] No change to public API or existing behaviour for single-line titles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes a Dagre flowchart layout bug where multiline subgraph/cluster titles (including `<br>` and literal newlines) could overlap the first row of nodes and edge labels because the cluster layout reserved no vertical space for the title.

What changed:
- Measures cluster titles (including rendered markdown titles) before Dagre layout and records their bounding boxes.
- Adds a post-layout reservation pass that expands clusters downward as needed for wrapped title height while keeping the cluster top edge fixed, then shifts affected descendants and relevant edge endpoints/labels downward to prevent overlap.
- Keeps single-line titles unchanged.
- Excludes cluster shapes without visible titles (specifically `noteGroup` and `divider`) from title-margin reservation to avoid unnecessary spacing changes.
- Calls the reservation pass from both Dagre rendering entry points.

Test coverage:
- Unit tests for the reservation logic, including nested/stacked clusters (verifying summed enclosing margins), edge-boundary cases, and the `noteGroup`/`divider` guard.
- Cypress e2e visual regression tests covering `<br>` + newline semantics, `htmlLabels: false`, markdown/backtick titles, nested multiline titles, margin interactions (`flowchart.subGraphTitleMargin`), and side-by-side clusters.

Also included:
- A changeset for the `mermaid` package (`patch`) documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->