### PR TITLE
Revert `fix: make e2e scoping on-by-default so fork PRs benefit`

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -134,13 +134,11 @@ jobs:
             exit 0
           fi
 
-          # Kill-switch: set the repo variable E2E_SCOPE_BY_DIAGRAM to 'false'
-          # to disable scoping.  Scoping is ON by default so that fork PRs
-          # (where repository variables are unavailable) still benefit from it.
-          if [ "${E2E_SCOPE_BY_DIAGRAM}" = "false" ]; then
+          # Feature flag off → always use full matrix
+          if [ "${E2E_SCOPE_BY_DIAGRAM}" != "true" ]; then
             echo "spec_pattern=" >> "$GITHUB_OUTPUT"
             echo "matrix=[1,2,3,4,5,6,7,8]" >> "$GITHUB_OUTPUT"
-            echo "[detect-scope] Scoping disabled via kill-switch — full suite."
+            echo "[detect-scope] Feature flag disabled — full suite."
             exit 0
           fi
 
@@ -189,11 +187,9 @@ jobs:
           fi
           echo "[detect-scope] matrix output: $(grep '^matrix=' "$GITHUB_OUTPUT" | tail -1)"
         env:
-          # Scoping is ON by default.  To disable, set this repository variable
-          # to 'false' (GitHub → Settings → Secrets and variables → Actions → Variables).
-          # Using == 'false' (instead of == 'true') ensures fork PRs — where
-          # repository variables are not exposed — still get scoped runs.
-          E2E_SCOPE_BY_DIAGRAM: "${{ vars.E2E_SCOPE_BY_DIAGRAM == 'false' && 'false' || 'true' }}"
+          # Toggle diagram-scoped e2e: set this repository variable to 'true'
+          # (GitHub → Settings → Secrets and variables → Actions → Variables)
+          E2E_SCOPE_BY_DIAGRAM: "${{ vars.E2E_SCOPE_BY_DIAGRAM == 'true' }}"
 
   e2e:
     # Skip the entire e2e job when only docs/ignorable files changed.


### PR DESCRIPTION
## :bookmark_tabs: Summary

This reverts commit 71f973176/#7709, which will disable E2E scoping from PRs from forks.

The E2E scoping seems to be broken with Argos (causing it to be stuck with **Waiting for status to be reported — Build is queued**), and it's much less important now that we're batching image uploads by default since 1265ee125.

Without reverting 71f973176, we can disable E2E scoping for our own internal PRs by setting `E2E_SCOPE_BY_DIAGRAM`, but this won't help with PRs from forks.

<img width="1152" height="293" alt="image" src="https://github.com/user-attachments/assets/970e398d-7224-44b5-9fd3-9ead3aaf5656" />


See: 1265ee12506aff2bc795467d45393afa6385426a

## :straight_ruler: Design Decisions

I'm sure we can probably modify how we're calling Argos to tell it when a build is queued when running a CI subset, but considering we're batching screenshots anyway, it's not too big of a deal to disable this code completely.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR reverts the E2E scoping change that disabled forked-PR scoped runs.

- Removes the `detect-scope` kill-switch behavior that treated scoping as disabled only when `E2E_SCOPE_BY_DIAGRAM` was explicitly `"false"`.
- Updates the `E2E_SCOPE_BY_DIAGRAM` env derivation so the scoped workflow is no longer enabled by default via the repo variable fallback.
- Effectively turns off this code path entirely to avoid Argos getting stuck on queued E2E checks for forked PRs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->