### PR TITLE
Fix ELK link in layouts documentation

### DIFF
--- a/docs/config/layouts.md
+++ b/docs/config/layouts.md
@@ -10,7 +10,7 @@ This page lists the available layout algorithms supported in Mermaid diagrams.
 
 ## Supported Layouts
 
-- **elk**: [ELK (Eclipse Layout Kernel)](https://www.eclipse.org/elk/)
+- **elk**: [ELK (Eclipse Layout Kernel)](https://eclipse.dev/elk/)
 - **tidy-tree**: Tidy tree layout for hierarchical diagrams [Tidy Tree Configuration](/config/tidy-tree)
 - **cose-bilkent**: Cose Bilkent layout for force-directed graphs
 - **dagre**: Dagre layout for layered graphs

--- a/packages/mermaid/src/docs/config/layouts.md
+++ b/packages/mermaid/src/docs/config/layouts.md
@@ -4,7 +4,7 @@ This page lists the available layout algorithms supported in Mermaid diagrams.
 
 ## Supported Layouts
 
-- **elk**: [ELK (Eclipse Layout Kernel)](https://www.eclipse.org/elk/)
+- **elk**: [ELK (Eclipse Layout Kernel)](https://eclipse.dev/elk/)
 - **tidy-tree**: Tidy tree layout for hierarchical diagrams [Tidy Tree Configuration](/config/tidy-tree)
 - **cose-bilkent**: Cose Bilkent layout for force-directed graphs
 - **dagre**: Dagre layout for layered graphs


### PR DESCRIPTION
Updated the ELK link to the new domain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated Mermaid “Supported Layouts” documentation to change the ELK (**elk**) hyperlink to `https://eclipse.dev/elk/` (replacing the prior `https://www.eclipse.org/elk/`). No other documentation content was modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->