### PR TITLE
fix(class): support nested generics in class names (#7648)

### DIFF
--- a/.changeset/class-nested-generics.md
+++ b/.changeset/class-nested-generics.md
@@ -1,0 +1,9 @@
+---
+'mermaid': patch
+---
+
+fix(class): support nested generics such as `List~List~Person~~` in class names and shorthand definitions.
+
+Previously the class-diagram lexer's `generic` state could not handle nested `~` delimiters, so a class defined with a nested generic type (e.g. `class People List~List~Person~~`) threw `Syntax error in text`. The lexer now tracks generic nesting depth and captures the full balanced generic type, and `splitClassNameAndType` renders nested generics correctly (e.g. `List<List<Person>>`).
+
+Fixes #7648, #7480.

--- a/packages/mermaid/src/diagrams/class/classDb.ts
+++ b/packages/mermaid/src/diagrams/class/classDb.ts
@@ -96,18 +96,24 @@ export class ClassDB implements DiagramDB {
 
   /**
    * Convert mermaid's `~`-delimited generic notation to angle brackets, with
-   * support for nested generics, e.g. `List~Person~` becomes `List&lt;Person&gt;`.
-   * Angle brackets are emitted as HTML entities to match how class labels are
-   * escaped elsewhere in this file.
+   * support for nested and sibling generics, e.g. `List~Person~` becomes
+   * `List&lt;Person&gt;` and `List~K~,List~V~` becomes
+   * `List&lt;K&gt;,List&lt;V&gt;`. A `~` opens a generic when it is followed by
+   * a word character and otherwise closes one, mirroring the lexer. Angle
+   * brackets are emitted as HTML entities to match how class labels are escaped
+   * elsewhere in this file.
    */
   private formatGenericType(type: string): string {
-    const firstTilde = type.indexOf('~');
-    if (firstTilde === -1) {
-      return type;
+    let result = '';
+    for (let i = 0; i < type.length; i++) {
+      const char = type[i];
+      if (char === '~') {
+        result += /\w/.test(type[i + 1] ?? '') ? '&lt;' : '&gt;';
+      } else {
+        result += char;
+      }
     }
-    const name = type.substring(0, firstTilde);
-    const inner = type.substring(firstTilde + 1, type.lastIndexOf('~'));
-    return `${name}&lt;${this.formatGenericType(inner)}&gt;`;
+    return result;
   }
 
   public setClassLabel(_id: string, label: string) {

--- a/packages/mermaid/src/diagrams/class/classDb.ts
+++ b/packages/mermaid/src/diagrams/class/classDb.ts
@@ -82,13 +82,32 @@ export class ClassDB implements DiagramDB {
     let genericType = '';
     let className = id;
 
-    if (id.indexOf('~') > 0) {
-      const split = id.split('~');
-      className = sanitizeText(split[0]);
-      genericType = sanitizeText(split[1]);
+    const firstTilde = id.indexOf('~');
+    if (firstTilde > 0) {
+      className = sanitizeText(id.substring(0, firstTilde));
+      // Everything between the first and last tilde is the (possibly nested)
+      // generic type, e.g. `List~List~Person~~` -> `List<Person>`.
+      const innerType = id.substring(firstTilde + 1, id.lastIndexOf('~'));
+      genericType = this.formatGenericType(sanitizeText(innerType));
     }
 
     return { className: className, type: genericType };
+  }
+
+  /**
+   * Convert mermaid's `~`-delimited generic notation to angle brackets, with
+   * support for nested generics, e.g. `List~Person~` becomes `List&lt;Person&gt;`.
+   * Angle brackets are emitted as HTML entities to match how class labels are
+   * escaped elsewhere in this file.
+   */
+  private formatGenericType(type: string): string {
+    const firstTilde = type.indexOf('~');
+    if (firstTilde === -1) {
+      return type;
+    }
+    const name = type.substring(0, firstTilde);
+    const inner = type.substring(firstTilde + 1, type.lastIndexOf('~'));
+    return `${name}&lt;${this.formatGenericType(inner)}&gt;`;
   }
 
   public setClassLabel(_id: string, label: string) {

--- a/packages/mermaid/src/diagrams/class/classDiagram.spec.ts
+++ b/packages/mermaid/src/diagrams/class/classDiagram.spec.ts
@@ -1471,6 +1471,16 @@ describe('given a class diagram with generics, ', function () {
       expect(list.type).toBe('List&lt;Person&gt;');
     });
 
+    it('should handle sibling nested generics in a class name (#7648)', function () {
+      const str = 'classDiagram\n' + 'class Map~List~K~,List~V~~';
+
+      expect(() => parser.parse(str)).not.toThrow();
+      const map = classDb.getClass('Map');
+      // Each nested generic must keep its own type argument, not be merged.
+      expect(map.type).toBe('List&lt;K&gt;,List&lt;V&gt;');
+      expect(map.text).toBe('Map&lt;List&lt;K&gt;,List&lt;V&gt;&gt;');
+    });
+
     it('should handle the full nested-generics sample from #7648', function () {
       const str =
         'classDiagram\n' +
@@ -1480,6 +1490,11 @@ describe('given a class diagram with generics, ', function () {
         'class People List~List~Person~~';
 
       expect(() => parser.parse(str)).not.toThrow();
+      // The nested generic in the inline member is preserved and rendered.
+      const person = classDb.getClass('Person');
+      expect(person.members[0].getDisplayDetails().displayText).toBe(
+        '~AnotherInternalProperty : List<List<string>>'
+      );
     });
 
     it('should handle "namespace"', function () {

--- a/packages/mermaid/src/diagrams/class/classDiagram.spec.ts
+++ b/packages/mermaid/src/diagrams/class/classDiagram.spec.ts
@@ -1445,6 +1445,43 @@ describe('given a class diagram with generics, ', function () {
       parser.parse(str);
     });
 
+    it('should handle a nested generic class (#7648)', function () {
+      const str = 'classDiagram\n' + 'class List~List~Person~~';
+
+      expect(() => parser.parse(str)).not.toThrow();
+      const list = classDb.getClass('List');
+      expect(list.type).toBe('List&lt;Person&gt;');
+      expect(list.text).toBe('List&lt;List&lt;Person&gt;&gt;');
+    });
+
+    it('should handle a deeply nested generic class (#7648)', function () {
+      const str = 'classDiagram\n' + 'class Container~Map~String,List~Int~~~';
+
+      expect(() => parser.parse(str)).not.toThrow();
+      const container = classDb.getClass('Container');
+      expect(container.type).toBe('Map&lt;String,List&lt;Int&gt;&gt;');
+      expect(container.text).toBe('Container&lt;Map&lt;String,List&lt;Int&gt;&gt;&gt;');
+    });
+
+    it('should handle a nested generic class with a literal name (#7648)', function () {
+      const str = 'classDiagram\n' + 'class `My.List`~List~Person~~';
+
+      expect(() => parser.parse(str)).not.toThrow();
+      const list = classDb.getClass('My.List');
+      expect(list.type).toBe('List&lt;Person&gt;');
+    });
+
+    it('should handle the full nested-generics sample from #7648', function () {
+      const str =
+        'classDiagram\n' +
+        'class Person {\n' +
+        '  ~AnotherInternalProperty : List~List~string~~\n' +
+        '}\n' +
+        'class People List~List~Person~~';
+
+      expect(() => parser.parse(str)).not.toThrow();
+    });
+
     it('should handle "namespace"', function () {
       const str = `classDiagram
 namespace Namespace1 { class Class1 }

--- a/packages/mermaid/src/diagrams/class/parser/classDiagram.jison
+++ b/packages/mermaid/src/diagrams/class/parser/classDiagram.jison
@@ -103,9 +103,10 @@ line was introduced with 'click'.
 */
 <*>"href"                       return 'HREF';
 
-<generic>[~]                    this.popState();
-<generic>[^~]*                  return "GENERICTYPE";
-<*>"~"                          this.begin("generic");
+<generic>[^~]+                  { this.genericText += yytext; }
+<generic>"~"(?=\w)              { this.genericDepth++; this.genericText += '~'; }
+<generic>[~]                    { if (--this.genericDepth === 0) { this.popState(); yytext = this.genericText; return 'GENERICTYPE'; } this.genericText += '~'; }
+<*>"~"                          { this.begin("generic"); this.genericDepth = 1; this.genericText = ''; }
 
 <bqstring>[`]                   this.popState();
 <bqstring>[^`]+                 return "BQUOTE_STR";


### PR DESCRIPTION
## Summary

Class definitions that use a **nested generic** in the class name — e.g. `class People List~List~Person~~` or `class List~List~Person~~` — currently fail with **"Syntax error in text"**.

Nested generics in *attribute* and *method* positions (inside `{ }`) already work, because those lines are consumed whole as `MEMBER` tokens. The bug is specific to the class-name / shorthand position, which flows through the lexer's `generic` start-condition.

Closes #7648
Closes #7480

## Root cause

1. **Lexer** (`classDiagram.jison`): the `generic` start-condition was flat — `<generic>[~]` popped on the first `~`, so it could not balance nested `~` delimiters. `List~List~Person~~` tokenized as `ALPHA GENERICTYPE ALPHA …`, which no `className` rule can assemble.
2. **`splitClassNameAndType`** (`classDb.ts`): kept only `id.split('~')[1]`, so even once parsed the nested inner type was dropped.

## Fix

- The `generic` lexer state now tracks nesting **depth** and captures the full balanced generic as a single `GENERICTYPE` token. A `~` immediately followed by a word character opens a nested level; the matching `~` closes it.
- `splitClassNameAndType` now takes everything between the first and last `~` and converts nested generics to angle-bracket notation, e.g. `List~List~Person~~` → `List<List<Person>>` (emitted as `&lt;`/`&gt;` to match how class labels are escaped elsewhere in the file).

Single-level generics (`Class~T~`) are unchanged.

## Before / after

| Input | Before | After |
|---|---|---|
| `class List~List~Person~~` | ❌ Syntax error | ✅ `List<List<Person>>` |
| `class Container~Map~String,List~Int~~~` | ❌ Syntax error | ✅ `Container<Map<String,List<Int>>>` |
| `class Class1~T~` | ✅ `Class1<T>` | ✅ `Class1<T>` (unchanged) |

## Tests

Added 4 regression tests in `classDiagram.spec.ts` (nested class name, deeply nested, literal name, and the exact sample from #7648). They fail on `develop` and pass with this change; the full class-diagram suite (495 tests) stays green. Added a changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed class diagram parsing for nested generic types in class names and shorthand definitions.
- Updated the lexer to track nested `~` delimiters and emit balanced `GENERICTYPE` tokens.
- Updated generic formatting to preserve nested types as escaped angle brackets, such as `List<List<Person>>`.
- Added four regression tests covering nested, deeply nested, backticked, and larger generic definitions.
- Added a `fix(class)` changeset referencing issues `#7648` and `#7480`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->