### PR TITLE
fix(flowchart): image shape NaN sizes on Firefox for SVGs without intrinsic dimensions

### DIFF
--- a/.changeset/image-shape-svg-natural-size-fallback.md
+++ b/.changeset/image-shape-svg-natural-size-fallback.md
@@ -1,0 +1,15 @@
+---
+'mermaid': patch
+---
+
+fix(flowchart): image shape no longer produces NaN sizes on Firefox for SVG images without intrinsic dimensions
+
+Firefox reports `naturalWidth`/`naturalHeight` as `0` (instead of the rendered
+size) for SVG images that lack explicit `width`/`height` attributes. The image
+shape divided by these values to compute the aspect ratio, so with
+`constraint: on` the node width, height and transforms all became `NaN`
+("Unexpected value NaN parsing width/height attribute", `translate(NaN,NaN)`).
+
+The natural dimensions now fall back to the requested asset size (`w`/`h`), or
+to the same 48px default the icon shapes use, whenever the browser reports a
+non-positive or non-finite natural size.

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/imageSquare.spec.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/imageSquare.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { getImageDimensions } from './imageSquare.js';
+
+describe('getImageDimensions', () => {
+  it('should return the natural dimensions when they are valid', () => {
+    const dims = getImageDimensions({ naturalWidth: 120, naturalHeight: 60 }, {});
+    expect(dims).toEqual({ width: 120, height: 60 });
+  });
+
+  // Firefox returns 0 for naturalWidth/naturalHeight of SVGs without
+  // explicit width/height attributes (#6362)
+  it('should fall back to the asset size when natural dimensions are 0', () => {
+    const dims = getImageDimensions(
+      { naturalWidth: 0, naturalHeight: 0 },
+      { assetWidth: 100, assetHeight: 80 }
+    );
+    expect(dims).toEqual({ width: 100, height: 80 });
+  });
+
+  it('should fall back to assetHeight for both dimensions when only h is set', () => {
+    const dims = getImageDimensions({ naturalWidth: 0, naturalHeight: 0 }, { assetHeight: 80 });
+    expect(dims).toEqual({ width: 80, height: 80 });
+  });
+
+  it('should fall back to assetWidth for both dimensions when only w is set', () => {
+    const dims = getImageDimensions({ naturalWidth: 0, naturalHeight: 0 }, { assetWidth: 100 });
+    expect(dims).toEqual({ width: 100, height: 100 });
+  });
+
+  it('should fall back to the default size when nothing else is available', () => {
+    const dims = getImageDimensions({ naturalWidth: 0, naturalHeight: 0 }, {});
+    expect(dims).toEqual({ width: 48, height: 48 });
+  });
+
+  it('should handle non-finite natural dimensions', () => {
+    const dims = getImageDimensions({ naturalWidth: NaN, naturalHeight: NaN }, {});
+    expect(dims).toEqual({ width: 48, height: 48 });
+  });
+
+  it('should keep a partially valid natural dimension', () => {
+    const dims = getImageDimensions({ naturalWidth: 120, naturalHeight: 0 }, { assetHeight: 80 });
+    expect(dims).toEqual({ width: 120, height: 80 });
+  });
+
+  it('should produce finite sizes for the constraint: on math (Firefox svg case)', () => {
+    // mirrors the sizing math in imageSquare for `h: 80, constraint: on`
+    const node = { assetHeight: 80 };
+    const { width, height } = getImageDimensions({ naturalWidth: 0, naturalHeight: 0 }, node);
+    const aspectRatio = width / height;
+    const imageWidth = node.assetHeight * aspectRatio;
+    const imageHeight = imageWidth / aspectRatio;
+    expect(Number.isFinite(aspectRatio)).toBe(true);
+    expect(imageWidth).toBe(80);
+    expect(imageHeight).toBe(80);
+  });
+});

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/imageSquare.spec.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/imageSquare.spec.ts
@@ -37,6 +37,46 @@ describe('getImageDimensions', () => {
     expect(dims).toEqual({ width: 48, height: 48 });
   });
 
+  it('should ignore NaN asset dimensions and use the default size', () => {
+    const dims = getImageDimensions(
+      { naturalWidth: 0, naturalHeight: 0 },
+      { assetWidth: NaN, assetHeight: NaN }
+    );
+    expect(dims).toEqual({ width: 48, height: 48 });
+  });
+
+  it('should ignore zero asset dimensions and use the default size', () => {
+    const dims = getImageDimensions(
+      { naturalWidth: 0, naturalHeight: 0 },
+      { assetWidth: 0, assetHeight: 0 }
+    );
+    expect(dims).toEqual({ width: 48, height: 48 });
+  });
+
+  it('should ignore negative asset dimensions and use the default size', () => {
+    const dims = getImageDimensions(
+      { naturalWidth: 0, naturalHeight: 0 },
+      { assetWidth: -100, assetHeight: -80 }
+    );
+    expect(dims).toEqual({ width: 48, height: 48 });
+  });
+
+  it('should ignore Infinity asset dimensions and use the default size', () => {
+    const dims = getImageDimensions(
+      { naturalWidth: 0, naturalHeight: 0 },
+      { assetWidth: Infinity, assetHeight: -Infinity }
+    );
+    expect(dims).toEqual({ width: 48, height: 48 });
+  });
+
+  it('should skip an invalid asset dimension and use the other valid one', () => {
+    const dims = getImageDimensions(
+      { naturalWidth: 0, naturalHeight: 0 },
+      { assetWidth: NaN, assetHeight: 80 }
+    );
+    expect(dims).toEqual({ width: 80, height: 80 });
+  });
+
   it('should keep a partially valid natural dimension', () => {
     const dims = getImageDimensions({ naturalWidth: 120, naturalHeight: 0 }, { assetHeight: 80 });
     expect(dims).toEqual({ width: 120, height: 80 });

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/imageSquare.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/imageSquare.ts
@@ -6,6 +6,30 @@ import { styles2String, userNodeOverrides } from './handDrawnShapeStyles.js';
 import { labelHelper, updateNodeBounds } from './util.js';
 import type { D3Selection } from '../../../types.js';
 
+// same default the icon shapes use when no explicit size is given
+const DEFAULT_IMAGE_SIZE = 48;
+
+export function getImageDimensions(
+  img: Pick<HTMLImageElement, 'naturalWidth' | 'naturalHeight'>,
+  node: Pick<Node, 'assetWidth' | 'assetHeight'>
+): { width: number; height: number } {
+  let width = Number(img.naturalWidth.toString().replace('px', ''));
+  let height = Number(img.naturalHeight.toString().replace('px', ''));
+
+  // Firefox reports 0 (instead of the rendered size) for the natural dimensions
+  // of SVG images that lack explicit width/height attributes, which would turn
+  // the sizing math below into NaN (#6362). Fall back to the requested asset
+  // size, or the same 48px default the icon shapes use.
+  if (!Number.isFinite(width) || width <= 0) {
+    width = node.assetWidth ?? node.assetHeight ?? DEFAULT_IMAGE_SIZE;
+  }
+  if (!Number.isFinite(height) || height <= 0) {
+    height = node.assetHeight ?? node.assetWidth ?? DEFAULT_IMAGE_SIZE;
+  }
+
+  return { width, height };
+}
+
 export async function imageSquare<T extends SVGGraphicsElement>(
   parent: D3Selection<T>,
   node: Node,
@@ -15,8 +39,7 @@ export async function imageSquare<T extends SVGGraphicsElement>(
   img.src = node?.img ?? '';
   await img.decode();
 
-  const imageNaturalWidth = Number(img.naturalWidth.toString().replace('px', ''));
-  const imageNaturalHeight = Number(img.naturalHeight.toString().replace('px', ''));
+  const { width: imageNaturalWidth, height: imageNaturalHeight } = getImageDimensions(img, node);
   node.imageAspectRatio = imageNaturalWidth / imageNaturalHeight;
 
   const { labelStyles } = styles2String(node);

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/imageSquare.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/imageSquare.ts
@@ -9,23 +9,24 @@ import type { D3Selection } from '../../../types.js';
 // same default the icon shapes use when no explicit size is given
 const DEFAULT_IMAGE_SIZE = 48;
 
+const isValidDimension = (value?: number): value is number =>
+  value !== undefined && Number.isFinite(value) && value > 0;
+
 export function getImageDimensions(
   img: Pick<HTMLImageElement, 'naturalWidth' | 'naturalHeight'>,
   node: Pick<Node, 'assetWidth' | 'assetHeight'>
 ): { width: number; height: number } {
-  let width = Number(img.naturalWidth.toString().replace('px', ''));
-  let height = Number(img.naturalHeight.toString().replace('px', ''));
+  const naturalWidth = Number(img.naturalWidth.toString().replace('px', ''));
+  const naturalHeight = Number(img.naturalHeight.toString().replace('px', ''));
 
   // Firefox reports 0 (instead of the rendered size) for the natural dimensions
   // of SVG images that lack explicit width/height attributes, which would turn
-  // the sizing math below into NaN (#6362). Fall back to the requested asset
-  // size, or the same 48px default the icon shapes use.
-  if (!Number.isFinite(width) || width <= 0) {
-    width = node.assetWidth ?? node.assetHeight ?? DEFAULT_IMAGE_SIZE;
-  }
-  if (!Number.isFinite(height) || height <= 0) {
-    height = node.assetHeight ?? node.assetWidth ?? DEFAULT_IMAGE_SIZE;
-  }
+  // the sizing math below into NaN (#6362). Fall back to the first finite,
+  // positive requested asset size, or the same 48px default the icon shapes use.
+  const width =
+    [naturalWidth, node.assetWidth, node.assetHeight].find(isValidDimension) ?? DEFAULT_IMAGE_SIZE;
+  const height =
+    [naturalHeight, node.assetHeight, node.assetWidth].find(isValidDimension) ?? DEFAULT_IMAGE_SIZE;
 
   return { width, height };
 }


### PR DESCRIPTION
Fixes #6362

## :bug: Root cause

Firefox reports `naturalWidth`/`naturalHeight` as `0` (instead of the rendered size) for SVG images that lack explicit `width`/`height` attributes. In `imageSquare.ts` the aspect ratio is computed as `naturalWidth / naturalHeight`, so for such SVGs it became `0 / 0 = NaN`. With `constraint: on` (and `h` set) this cascaded into `imageWidth = assetHeight * NaN` and `imageHeight = NaN / NaN`, producing the reported Firefox console errors:

```
Unexpected value NaN parsing width/height attribute
Unexpected value translate(NaN,NaN) parsing transform attribute
```

Chrome/Edge are unaffected because they synthesize natural dimensions for dimensionless SVGs.

## :hammer: Fix

Extracted the natural-size resolution into a small `getImageDimensions` helper that falls back whenever the browser reports a non-positive or non-finite natural dimension:

1. the user-requested asset size (`w`/`h` from the shape data), preferring the matching axis and falling back to the other axis (so `h: 80` alone yields a finite 1:1 aspect ratio instead of NaN), then
2. the same `48`px default the icon shapes (`icon.ts`, `iconSquare.ts`, `iconCircle.ts`, `iconRounded.ts`) already use via `node.assetWidth ?? 48`.

Valid natural dimensions are used exactly as before, so behavior in Chrome/Edge (and for raster images everywhere) is unchanged.

## :white_check_mark: Tests

- Added `imageSquare.spec.ts` covering the helper: valid natural dimensions pass through unchanged, the Firefox `0`/`0` SVG case falls back to `w`/`h` or the 48px default, partially-valid and non-finite inputs, and a case mirroring the issue's `h: 80, constraint: on` math verifying all downstream values stay finite (8 tests, all passing).
- `vitest run packages/mermaid/src/rendering-util` — only pre-existing failures unrelated to this change (multi-diagram id uniqueness, swimlanes DDLT; they fail identically on a clean `develop` checkout).
- ESLint, Prettier and cSpell pass on the changed files; `tsc --noEmit` reports no errors for them.
- Added a patch changeset for `mermaid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes Firefox `NaN` sizing/transform errors for Mermaid flowchart “image shape” SVGs that report zero/invalid intrinsic dimensions (no naturalWidth/naturalHeight), especially when `constraint: on` is enabled.

- Added `getImageDimensions` (with `DEFAULT_IMAGE_SIZE`) to validate natural image dimensions and safely fall back when they’re non-positive or non-finite (including `NaN`/`Infinity`).
- Fallback order: use requested `assetWidth`/`assetHeight` when present/usable, otherwise use the existing 48px default sizing; preserves behavior when natural dimensions are valid.
- Strengthened validation to treat unusable asset dimensions (zero/negative/`NaN`/infinite) as missing and to correctly handle partially valid dimension inputs.
- Replaced direct `naturalWidth`/`naturalHeight` usage in `imageSquare` with the new helper.
- Added `vitest` coverage for valid naturals, Firefox’s `0x0` natural scenario, partial/invalid dimensions, and constraint-based finite sizing.
- Included a patch-level changeset documenting the Firefox SVG natural-dimension fallback fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->