### PR TITLE
fix(state): keep composite states parented where they are declared

### DIFF
--- a/.changeset/state-nested-composite-parent.md
+++ b/.changeset/state-nested-composite-parent.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix(state): prevent `No such shape: roundedWithTitle` render errors for composite states. A transition that references a nested composite state from an outer document no longer re-parents it away from where it was declared, a transition pointing back to the enclosing composite no longer makes the state its own parent, and a composite state with an empty body is rendered as a regular state instead of an empty cluster.

--- a/.changeset/state-nested-composite-parent.md
+++ b/.changeset/state-nested-composite-parent.md
@@ -2,4 +2,4 @@
 'mermaid': patch
 ---
 
-fix(state): prevent `No such shape: roundedWithTitle` render errors for composite states. A transition that references a nested composite state from an outer document no longer re-parents it away from where it was declared, a transition pointing back to the enclosing composite no longer makes the state its own parent, and a composite state with an empty body is rendered as a regular state instead of an empty cluster.
+fix(state): prevent `No such shape: roundedWithTitle` render errors for composite states. A transition that references a nested composite state from an outer document no longer re-parents it away from where it was declared, a transition pointing back to the enclosing composite no longer makes the state its own parent, and a composite state whose body produces no child nodes (empty or direction-only) is rendered as a regular state instead of an empty cluster. Note: a state referenced from multiple composite contexts now keeps its first parent (the document where it was declared) instead of the parent of the last reference.

--- a/cypress/integration/rendering/state/stateDiagram-v2.spec.js
+++ b/cypress/integration/rendering/state/stateDiagram-v2.spec.js
@@ -887,4 +887,45 @@ State9_____________ --> State10_____________   : Transition9_____
       {}
     );
   });
+  it('v2 should render nested composite states referenced by transitions in an outer document (#6337)', () => {
+    imgSnapshotTest(
+      `
+    stateDiagram-v2
+    direction TB
+    state Client {
+      direction TB
+      state ClientMobX {
+        direction LR
+        state WebSocketStore {
+          isConnected
+          connect
+        }
+        state ChatStore {
+          messages
+          sendMessage
+        }
+        state GraphStore {
+          nodes
+          edges
+        }
+      }
+      state ClientUI {
+        direction TB
+        state ChatComponent {
+          ChatStreamMultimodalGraphMobX
+        }
+        state GraphComponent {
+          GraphVisualization
+        }
+      }
+      WebSocketStore --> ChatStore: Provides events
+      WebSocketStore --> GraphStore: Updates data
+      ChatStore --> ClientUI: Updates Chat UI
+      GraphStore --> ClientUI: Updates Graph UI
+      ClientUI --> WebSocketStore: Triggers events
+    }
+      `,
+      { logLevel: 0, fontFamily: 'courier' }
+    );
+  });
 });

--- a/packages/mermaid/src/diagrams/state/dataFetcher.ts
+++ b/packages/mermaid/src/diagrams/state/dataFetcher.ts
@@ -166,6 +166,11 @@ function insertOrUpdateNode(
   }
   const existingNodeData = nodes.find((node) => node.id === nodeData.id);
   if (existingNodeData) {
+    // Keep the parent from where the state was first placed; a later reference
+    // (e.g. a transition in an outer document) must not re-parent it (#6337)
+    if (existingNodeData.parentId) {
+      nodeData.parentId = existingNodeData.parentId;
+    }
     //update the existing nodeData
     Object.assign(existingNodeData, nodeData);
   } else {
@@ -265,8 +270,8 @@ export const dataFetcher = (
       }
     }
 
-    // group
-    if (!newNode.type && parsedItem.doc) {
+    // group (an empty doc means there is nothing to render as a cluster, so treat it as a regular state)
+    if (!newNode.type && parsedItem.doc && parsedItem.doc.length > 0) {
       log.info('Setting cluster for XCX', itemId, getDir(parsedItem));
       newNode.type = 'group';
       newNode.isGroup = true;
@@ -305,7 +310,9 @@ export const dataFetcher = (
       nodeData.label = '';
     }
 
-    if (parent && parent.id !== 'root') {
+    // A state can never be its own parent, e.g. a transition inside a composite
+    // state that points back to the composite state itself (#6337)
+    if (parent && parent.id !== 'root' && parent.id !== itemId) {
       log.trace('Setting node ', itemId, ' to be child of its parent ', parent.id);
       nodeData.parentId = parent.id;
     }

--- a/packages/mermaid/src/diagrams/state/dataFetcher.ts
+++ b/packages/mermaid/src/diagrams/state/dataFetcher.ts
@@ -142,6 +142,17 @@ const getDir = (parsedItem: { doc?: Stmt[] }, defaultDir = DEFAULT_NESTED_DOC_DI
   return dir;
 };
 
+/**
+ * Check whether a document contains at least one statement that produces a child node.
+ * These are the same statement types that setupDoc turns into nodes; other statements
+ * (e.g. 'direction') produce nothing to render inside a cluster (#6337).
+ */
+const docHasChildNodes = (doc: Stmt[]) =>
+  doc.some(
+    (stmt) =>
+      stmt.stmt === STMT_STATE || stmt.stmt === STMT_RELATION || stmt.stmt === DEFAULT_STATE_TYPE
+  );
+
 function insertOrUpdateNode(
   nodes: NodeData[],
   nodeData: NodeData,
@@ -270,8 +281,9 @@ export const dataFetcher = (
       }
     }
 
-    // group (an empty doc means there is nothing to render as a cluster, so treat it as a regular state)
-    if (!newNode.type && parsedItem.doc && parsedItem.doc.length > 0) {
+    // group (a body that produces no child nodes, e.g. empty or direction-only,
+    // has nothing to render as a cluster, so treat it as a regular state)
+    if (!newNode.type && parsedItem.doc && docHasChildNodes(parsedItem.doc)) {
       log.info('Setting cluster for XCX', itemId, getDir(parsedItem));
       newNode.type = 'group';
       newNode.isGroup = true;

--- a/packages/mermaid/src/diagrams/state/stateDiagram-v2.spec.js
+++ b/packages/mermaid/src/diagrams/state/stateDiagram-v2.spec.js
@@ -486,7 +486,7 @@ describe('state diagram V2, ', function () {
     const expectGroupsToHaveChildren = (nodes) => {
       for (const group of nodes.filter((node) => node.isGroup)) {
         expect(
-          nodes.some((child) => child.parentId === group.id),
+          nodes.some((child) => child.id !== group.id && child.parentId === group.id),
           `group '${group.id}' should have at least one child`
         ).toBe(true);
       }
@@ -543,6 +543,22 @@ describe('state diagram V2, ', function () {
       const l3 = nodes.find((node) => node.id === 'L3');
       expect(l3.isGroup).toBeFalsy();
       expect(l3.shape).toBe('rect');
+      expectGroupsToHaveChildren(nodes);
+    });
+
+    it('should treat a composite state with a direction-only body as a regular state', () => {
+      parser.parse(`stateDiagram-v2
+        state Wrapper {
+          state OnlyDirection {
+            direction LR
+          }
+        }
+      `);
+
+      const { nodes } = stateDb.getData();
+      const onlyDirection = nodes.find((node) => node.id === 'OnlyDirection');
+      expect(onlyDirection.isGroup).toBeFalsy();
+      expect(onlyDirection.shape).toBe('rect');
       expectGroupsToHaveChildren(nodes);
     });
 

--- a/packages/mermaid/src/diagrams/state/stateDiagram-v2.spec.js
+++ b/packages/mermaid/src/diagrams/state/stateDiagram-v2.spec.js
@@ -469,4 +469,125 @@ describe('state diagram V2, ', function () {
       expect(currentDirection).toEqual('LR');
     });
   });
+
+  describe('composite states in nested documents (#6337)', () => {
+    /** @type {StateDB} */
+    let stateDb;
+    beforeEach(function () {
+      stateDb = new StateDB(2);
+      parser.yy = stateDb;
+      stateDiagram.parser.yy = stateDb;
+      stateDiagram.parser.yy.clear();
+    });
+
+    // Rendering dispatches a node as a cluster only when it has children,
+    // so every group node must keep at least one child or rendering throws
+    // 'No such shape: roundedWithTitle'.
+    const expectGroupsToHaveChildren = (nodes) => {
+      for (const group of nodes.filter((node) => node.isGroup)) {
+        expect(
+          nodes.some((child) => child.parentId === group.id),
+          `group '${group.id}' should have at least one child`
+        ).toBe(true);
+      }
+    };
+
+    it('should keep the declared parent when a nested state is referenced in a transition of an outer document', () => {
+      parser.parse(`stateDiagram-v2
+        state Client {
+          state ClientMobX {
+            state GraphStore {
+              nodes
+            }
+          }
+          state ClientUI {
+            components
+          }
+          GraphStore --> ClientUI: Updates Graph UI
+        }
+      `);
+
+      const { nodes } = stateDb.getData();
+      const graphStore = nodes.find((node) => node.id === 'GraphStore');
+      expect(graphStore.parentId).toBe('ClientMobX');
+      expectGroupsToHaveChildren(nodes);
+    });
+
+    it('should not set a composite state as its own parent when a transition points back to it', () => {
+      parser.parse(`stateDiagram-v2
+        state Outer {
+          state Inner {
+            leaf
+          }
+          Inner --> Outer: back
+        }
+      `);
+
+      const { nodes } = stateDb.getData();
+      const outer = nodes.find((node) => node.id === 'Outer');
+      expect(outer.parentId).toBeUndefined();
+      expectGroupsToHaveChildren(nodes);
+    });
+
+    it('should treat a composite state with an empty body as a regular state', () => {
+      parser.parse(`stateDiagram-v2
+        state L1 {
+          state L2 {
+            state L3 {
+            }
+          }
+        }
+      `);
+
+      const { nodes } = stateDb.getData();
+      const l3 = nodes.find((node) => node.id === 'L3');
+      expect(l3.isGroup).toBeFalsy();
+      expect(l3.shape).toBe('rect');
+      expectGroupsToHaveChildren(nodes);
+    });
+
+    it('should render the diagram from issue #6337 without leaving empty groups', () => {
+      parser.parse(`stateDiagram-v2
+        direction TB
+        state Client {
+          direction TB
+          state ClientMobX {
+            direction LR
+            state WebSocketStore {
+              isConnected
+              connect
+            }
+            state ChatStore {
+              messages
+              sendMessage
+            }
+            state GraphStore {
+              nodes
+              edges
+            }
+          }
+          state ClientUI {
+            direction TB
+            state ChatComponent {
+              ChatStreamMultimodalGraphMobX
+            }
+            state GraphComponent {
+              GraphVisualization
+            }
+          }
+          WebSocketStore --> ChatStore: Provides events
+          WebSocketStore --> GraphStore: Updates data
+          ChatStore --> ClientUI: Updates Chat UI
+          GraphStore --> ClientUI: Updates Graph UI
+          ClientUI --> WebSocketStore: Triggers events
+        }
+      `);
+
+      const { nodes } = stateDb.getData();
+      expect(nodes.find((node) => node.id === 'GraphStore').parentId).toBe('ClientMobX');
+      expect(nodes.find((node) => node.id === 'ChatStore').parentId).toBe('ClientMobX');
+      expect(nodes.find((node) => node.id === 'WebSocketStore').parentId).toBe('ClientMobX');
+      expectGroupsToHaveChildren(nodes);
+    });
+  });
 });


### PR DESCRIPTION
## :bookmark_tabs: Summary

State diagrams threw `Error: No such shape: roundedWithTitle. Please check your syntax.` for diagrams like the one in #6337, where a composite state nested inside another composite state (e.g. `GraphStore` inside `ClientMobX`) is referenced by a transition in an outer document.

Resolves #6337

## :straight_ruler: Design Decisions

The parser is not at fault — the reported diagram parses cleanly (`"state"` in the lexer requires trailing whitespace, so state names can never partially match the keyword; the "add an `s`" workaround from the issue only works because it splits the declaration and the transition reference into two distinct states). The bug is in `packages/mermaid/src/diagrams/state/dataFetcher.ts`, which can leave a group node without any children. The dagre layout dispatches a group as a cluster only when it has children (`graph.children(v).length > 0`), so a childless group falls through to the node renderer, which does not know the cluster-only `roundedWithTitle` shape and throws.

Three code paths produced such childless groups; all are fixed with minimal guards:

1. **Re-parenting through transition references** (the reporter's case). `GraphStore` is declared inside `ClientMobX` (`parentId='ClientMobX'`), but when `setupDoc` later processes `GraphStore --> ClientUI` inside `Client`'s doc, `dataFetcher` is called again for `GraphStore` with `Client` as the parent, and `insertOrUpdateNode`'s `Object.assign` clobbered the correct `parentId`. `ClientMobX` ended up with zero children. Fix: `insertOrUpdateNode` keeps an already assigned `parentId` — the document where a state is first placed wins over later references.
2. **Self-parenting.** A transition inside a composite state that points back to the composite itself (e.g. `Inner --> Outer` inside `Outer { ... }`) assigned `parentId='Outer'` to `Outer` itself, so graphlib could not resolve its children. Fix: skip the assignment when `parent.id === itemId`.
3. **Empty composite bodies.** `state Foo { }` produced `parsedItem.doc = []`, and the truthy empty array marked the node as a group with nothing to render inside it. Fix: require `parsedItem.doc.length > 0`; an empty composite renders as a regular state.

Added four regression tests in `stateDiagram-v2.spec.js`: one per trigger plus a reduced version of the diagram from the issue, each asserting that the declared parent is kept and that every group node retains at least one child (the exact invariant the renderer relies on).

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes nested composite state rendering in `stateDiagram-v2` by preserving declared parent relationships, preventing self-parenting, and treating empty composite bodies as regular states.

Adds four regression tests, including coverage for issue `#6337` and checks preventing empty groups that cause rendering errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->