### PR TITLE
fix: respect line breaks in labels containing KaTeX math

### DIFF
--- a/.changeset/katex-label-line-breaks.md
+++ b/.changeset/katex-label-line-breaks.md
@@ -2,4 +2,4 @@
 'mermaid': patch
 ---
 
-fix: `<br/>` line breaks are no longer ignored in flowchart node and edge labels that contain `$$…$$` KaTeX math expressions. Each `<br/>`-separated line now renders on its own row, matching the behavior of labels without math.
+fix: line breaks are no longer ignored in flowchart node and edge labels that contain `$$…$$` KaTeX math expressions. Both `<br/>` and hard line breaks in the label source now render on their own row, matching the behavior of labels without math.

--- a/.changeset/katex-label-line-breaks.md
+++ b/.changeset/katex-label-line-breaks.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: `<br/>` line breaks are no longer ignored in flowchart node and edge labels that contain `$$…$$` KaTeX math expressions. Each `<br/>`-separated line now renders on its own row, matching the behavior of labels without math.

--- a/packages/mermaid/src/rendering-util/createText.spec.ts
+++ b/packages/mermaid/src/rendering-util/createText.spec.ts
@@ -133,4 +133,41 @@ describe('createText', () => {
     expect(rows[0].querySelector('.katex')).not.toBeNull();
     expect(rows[1].querySelector('.katex')).not.toBeNull();
   });
+
+  it('renders hard line breaks on separate lines in labels containing KaTeX math', async () => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    const svgGroup = svg.appendChild(document.createElementNS('http://www.w3.org/2000/svg', 'g'));
+    // The flowchart lexer passes node text through verbatim, so a hard-wrapped label
+    // reaches createText with literal newlines rather than <br/>.
+    const output = await createText(
+      select(svgGroup),
+      'line 0\n  line 1\n  $$x=42$$',
+      { useHtmlLabels: true },
+      { forceLegacyMathML: true, securityLevel: 'strict' }
+    );
+
+    const span = output.querySelector('span.nodeLabel');
+    const rows = [...(span?.children ?? [])];
+    expect(rows).toHaveLength(3);
+    expect(rows[0].outerHTML).toEqual('<div>line 0</div>');
+    expect(rows[1].outerHTML).toEqual('<div>line 1</div>');
+    expect(rows[2].querySelector('.katex')).not.toBeNull();
+  });
+
+  it('keeps math intact when a hard line break follows a math expression', async () => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    const svgGroup = svg.appendChild(document.createElementNS('http://www.w3.org/2000/svg', 'g'));
+    const output = await createText(
+      select(svgGroup),
+      '$$a_1 + b_2$$\n$$x * y$$',
+      { useHtmlLabels: true },
+      { forceLegacyMathML: true, securityLevel: 'strict' }
+    );
+
+    const span = output.querySelector('span.nodeLabel');
+    const rows = [...(span?.children ?? [])];
+    expect(rows).toHaveLength(2);
+    expect(rows[0].querySelector('.katex')).not.toBeNull();
+    expect(rows[1].querySelector('.katex')).not.toBeNull();
+  });
 });

--- a/packages/mermaid/src/rendering-util/createText.spec.ts
+++ b/packages/mermaid/src/rendering-util/createText.spec.ts
@@ -99,4 +99,38 @@ describe('createText', () => {
       expect(output.textContent).toEqual(expected);
     }
   );
+
+  it('renders text after <br/> on a new line in labels containing KaTeX math', async () => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    const svgGroup = svg.appendChild(document.createElementNS('http://www.w3.org/2000/svg', 'g'));
+    const output = await createText(
+      select(svgGroup),
+      'Input<br/>$$x$$',
+      { useHtmlLabels: true },
+      { forceLegacyMathML: true, securityLevel: 'strict' }
+    );
+
+    const span = output.querySelector('span.nodeLabel');
+    const rows = [...(span?.children ?? [])];
+    expect(rows).toHaveLength(2);
+    expect(rows[0].outerHTML).toEqual('<div>Input</div>');
+    expect(rows[1].querySelector('.katex')).not.toBeNull();
+  });
+
+  it('renders each KaTeX line separately when <br/> separates two math expressions', async () => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    const svgGroup = svg.appendChild(document.createElementNS('http://www.w3.org/2000/svg', 'g'));
+    const output = await createText(
+      select(svgGroup),
+      '$$x$$<br/>$$f(x)$$',
+      { useHtmlLabels: true },
+      { forceLegacyMathML: true, securityLevel: 'strict' }
+    );
+
+    const span = output.querySelector('span.nodeLabel');
+    const rows = [...(span?.children ?? [])];
+    expect(rows).toHaveLength(2);
+    expect(rows[0].querySelector('.katex')).not.toBeNull();
+    expect(rows[1].querySelector('.katex')).not.toBeNull();
+  });
 });

--- a/packages/mermaid/src/rendering-util/createText.ts
+++ b/packages/mermaid/src/rendering-util/createText.ts
@@ -1,7 +1,7 @@
 import { select } from 'd3';
 import type { MermaidConfig } from '../config.type.js';
 import type { SVGGroup } from '../diagram-api/types.js';
-import common, { hasKatex, renderKatexSanitized, sanitizeText } from '../diagrams/common/common.js';
+import { hasKatex, renderKatexSanitized, sanitizeText } from '../diagrams/common/common.js';
 import type { D3TSpanElement, D3TextElement } from '../diagrams/common/commonTypes.js';
 import { log } from '../logger.js';
 import { profiler } from '../profiler.js';
@@ -47,7 +47,7 @@ async function addHtmlSpan(
 
   const div = fo.append<HTMLDivElement>('xhtml:div');
   const sanitizedLabel = hasKatex(node.label)
-    ? await renderKatexSanitized(node.label.replace(common.lineBreakRegex, '\n'), config)
+    ? await renderKatexSanitized(node.label, config)
     : sanitizeText(node.label, config);
   const labelClass = node.isNode ? 'nodeLabel' : 'edgeLabel';
   const span = div.append('span');

--- a/packages/mermaid/src/rendering-util/createText.ts
+++ b/packages/mermaid/src/rendering-util/createText.ts
@@ -30,6 +30,21 @@ function applyStyle<T extends Element>(
 // We assume that nobody will want to create labels larger than 16384 pixels wide
 const maxSafeSizeForWidth = 16384;
 
+/**
+ * Creates a `<foreignObject>` containing the label as HTML.
+ *
+ * If the label contains KaTeX (`$$…$$`) delimiters, it is rendered through
+ * `renderKatexSanitized`, which places each `<br/>`-separated line in its own
+ * `<div>`; otherwise the label is sanitized as plain HTML.
+ *
+ * @param element - The parent group to append the `<foreignObject>` to.
+ * @param node - The label text, its style, and whether it belongs to a node or an edge.
+ * @param width - The maximum width of the label.
+ * @param classes - Additional CSS classes for the label span.
+ * @param addBackground - Whether to add a background class to the containing div.
+ * @param config - Mermaid configuration object.
+ * @returns The created `<foreignObject>` element.
+ */
 async function addHtmlSpan(
   element: D3Selection<SVGGElement>,
   node: { label: string; labelStyle: string; isNode: boolean },

--- a/packages/mermaid/src/rendering-util/createText.ts
+++ b/packages/mermaid/src/rendering-util/createText.ts
@@ -349,7 +349,10 @@ export const createText = async (
     const decodedReplacedText = await replaceIconSubstring(decodeEntities(htmlText), config);
 
     //for Katex the text could contain escaped characters, \\relax that should be transformed to \relax
-    const inputForKatex = text.replace(/\\\\/g, '\\');
+    //KaTeX labels bypass the markdown/non-markdown conversion above, so hard line breaks in the
+    //source label would never reach `renderKatexSanitized`, which splits its input on `<br/>`.
+    //Convert them here using the same rule `markdownToHTML` applies to plain text.
+    const inputForKatex = text.replace(/\\\\/g, '\\').replace(/\n */g, '<br/>');
 
     const node = {
       isNode,


### PR DESCRIPTION
## :bookmark_tabs: Summary

In flowchart labels, line breaks stopped working as soon as the label also contained a `$$…$$` KaTeX expression. `Input<br/>$$x$$` rendered as a single line `Inputx`, and a hard-wrapped label such as

```
plainmath["line 0
line 1
$$x=42$$"]
```

collapsed onto one line too — while the same labels without math broke into separate lines as expected.

Resolves #7873
Resolves #7194

## :straight_ruler: Design Decisions

`renderKatexUnsanitized` already handles multi-line labels: it splits the text on `<br/>` and wraps each line in its own `<div>` (this is how sequence diagrams render multi-line KaTeX labels today). Two separate things prevented labels from reaching it in that shape.

**`<br/>` was destroyed before rendering (#7873).** `addHtmlSpan` replaced every `<br/>` with `\n` *before* calling `renderKatexSanitized`. After that replacement the split never finds anything, the whole label lands in one `<div>`, and the literal newline renders as nothing in HTML. Fixed by passing the label through unchanged.

**Hard line breaks never became `<br/>` (#7194).** The flowchart lexer (`<string>[^"]+` in `flow.jison`) returns node text verbatim, so a hard-wrapped label arrives at `createText` with literal `\n`. For labels without math, `markdownToHTML` / `nonMarkdownToHTML` convert those to `<br/>`, but the KaTeX branch bypasses both (`label: hasKatex(text) ? inputForKatex : …`). Fixed by applying the same `\n` → `<br/>` rule that `markdownToHTML` uses for plain-text tokens.

The second half of this fix follows @omkarht's diagnosis in #7202 — credit to them for locating the `inputForKatex` path. I used the narrow `replace(/\n */g, '<br/>')` rather than running the label through `markdownToHTML`, because the latter wraps the label in `<p>`, and since `renderKatexUnsanitized` then splits on `<br/>`, the opening and closing `<p>` tags end up in different `<div>`s. Note also that #7202 cannot take effect on its own: on current `develop` the `<br/>` it produces are immediately converted back to `\n` by `addHtmlSpan`, so the two edits cancel out. Removing that `replace` is the prerequisite.

Multi-line math inside a single `$$…$$` is unaffected — `katexRegex` has no `s` flag, so such text is not detected as KaTeX and never enters this branch.

Verified in the demo server that both forms now render on separate rows, matching the control diagrams without math, and that single-line math labels are unaffected.

Four unit tests cover: a text line + math line via `<br/>`, two math lines via `<br/>`, a hard-wrapped label ending in math, and math followed by a hard line break.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. — not needed: behavioral bug fix, no API or syntax change
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Review Summary

🎉 Fix correctly preserves `<br/>` breaks in KaTeX flowchart node **and** edge labels by passing the original label (with `<br/>` intact) to the existing KaTeX line-splitting/rendering logic.

🎉 Added focused unit tests covering both text-plus-math (`Input<br/>$$x$$`) and multiple math-only lines (`$$x$$<br/>$$f(x)$$`), verifying each `<br/>`-separated line renders as its own row.

🎉 Included a changeset recording the behavior fix.

No blocking or important issues identified; sanitization is maintained via `renderKatexSanitized`.

**Verdict: APPROVE**
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
