### PR TITLE
Update reference to initialize() call in documentation

### DIFF
--- a/docs/intro/syntax-reference.md
+++ b/docs/intro/syntax-reference.md
@@ -78,7 +78,7 @@ Here you can edit certain values to change the behavior and appearance of the di
 
 Each of these techniques are functionally equivalent, but better for different deployments.
 
-### [The initialize() call](./getting-started.md#_3-calling-the-javascript-api)
+### [The initialize() call](./getting-started.md#_4-calling-the-mermaid-javascript-api)
 
 Used when Mermaid is called via an API, or through a `<script>` tag.
 

--- a/docs/intro/syntax-reference.md
+++ b/docs/intro/syntax-reference.md
@@ -78,7 +78,7 @@ Here you can edit certain values to change the behavior and appearance of the di
 
 Each of these techniques are functionally equivalent, but better for different deployments.
 
-### [The initialize() call](./getting-started.md#_4-calling-the-mermaid-javascript-api)
+### [The initialize() call](./getting-started.md#_3-calling-the-javascript-api)
 
 Used when Mermaid is called via an API, or through a `<script>` tag.
 

--- a/packages/mermaid/src/docs/intro/syntax-reference.md
+++ b/packages/mermaid/src/docs/intro/syntax-reference.md
@@ -60,7 +60,7 @@ Here you can edit certain values to change the behavior and appearance of the di
 
 Each of these techniques are functionally equivalent, but better for different deployments.
 
-### [The initialize() call](./getting-started.md#_3-calling-the-javascript-api)
+### [The initialize() call](./getting-started.md#_4-calling-the-mermaid-javascript-api)
 
 Used when Mermaid is called via an API, or through a `<script>` tag.
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fix a link reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated the `initialize()` documentation link to point to the new `_4-calling-the-mermaid-javascript-api` anchor (from `_3-calling-the-javascript-api`) in `syntax-reference.md` (both `packages/mermaid/src/docs/intro/` and the top-level `docs/intro/` copy).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->