### PR TITLE
feat(shapes): add folder, bucket, console and browser shapes

### DIFF
--- a/.changeset/general-shapes.md
+++ b/.changeset/general-shapes.md
@@ -1,0 +1,5 @@
+---
+'mermaid': minor
+---
+
+feat: add `folder`, `bucket`, `console` (terminal window) and `browser` shapes for flowcharts

--- a/cypress/integration/rendering/flowchart/flowchart-shape-alias.spec.ts
+++ b/cypress/integration/rendering/flowchart/flowchart-shape-alias.spec.ts
@@ -86,6 +86,7 @@ const aliasSet39 = ['tag-rect', 'tag-proc', 'tagged-rectangle', 'tagged-process'
 
 const aliasSet40 = ['collate', 'hourglass'] as const;
 const aliasSet41 = ['datastore', 'data-store'] as const;
+const aliasSet42 = ['folder', 'directory'] as const;
 
 // Aggregate all alias sets into a single array
 const aliasSets = [
@@ -130,6 +131,7 @@ const aliasSets = [
   aliasSet39,
   aliasSet40,
   aliasSet41,
+  aliasSet42,
 ] as const;
 
 aliasSets.forEach((aliasSet) => {

--- a/cypress/integration/rendering/newShapes.spec.ts
+++ b/cypress/integration/rendering/newShapes.spec.ts
@@ -50,6 +50,8 @@ const newShapesSet5 = [
 
 const newShapesSet6 = ['brace-r', 'braces', 'person'] as const;
 
+const newShapesSet7 = ['folder', 'bucket', 'console', 'browser'] as const;
+
 // Aggregate all shape sets into a single array
 const newShapesSets = [
   newShapesSet1,
@@ -58,6 +60,7 @@ const newShapesSets = [
   newShapesSet4,
   newShapesSet5,
   newShapesSet6,
+  newShapesSet7,
 ];
 
 looks.forEach((look) => {

--- a/docs/syntax/flowchart.md
+++ b/docs/syntax/flowchart.md
@@ -322,57 +322,61 @@ This syntax creates a node A as a rectangle. It renders in the same way as `A["A
 
 Below is a comprehensive list of the newly introduced shapes and their corresponding semantic meanings, short names, and aliases:
 
-| **Semantic Name**                 | **Shape Name**         | **Short Name** | **Description**                             | **Alias Supported**                                              |
-| --------------------------------- | ---------------------- | -------------- | ------------------------------------------- | ---------------------------------------------------------------- |
-| Bang                              | Bang                   | `bang`         | Bang                                        | `bang`                                                           |
-| Card                              | Notched Rectangle      | `notch-rect`   | Represents a card                           | `card`, `notched-rectangle`                                      |
-| Cloud                             | Cloud                  | `cloud`        | cloud                                       | `cloud`                                                          |
-| Collate                           | Hourglass              | `hourglass`    | Represents a collate operation              | `collate`, `hourglass`                                           |
-| Com Link                          | Lightning Bolt         | `bolt`         | Communication link                          | `com-link`, `lightning-bolt`                                     |
-| Comment                           | Curly Brace            | `brace`        | Adds a comment                              | `brace-l`, `comment`                                             |
-| Comment Right                     | Curly Brace            | `brace-r`      | Adds a comment                              |                                                                  |
-| Comment with braces on both sides | Curly Braces           | `braces`       | Adds a comment                              |                                                                  |
-| Data Input/Output                 | Lean Right             | `lean-r`       | Represents input or output                  | `in-out`, `lean-right`                                           |
-| Data Input/Output                 | Lean Left              | `lean-l`       | Represents output or input                  | `lean-left`, `out-in`                                            |
-| Data Store                        | Data Store             | `datastore`    | Data flow diagram data store                | `data-store`                                                     |
-| Database                          | Cylinder               | `cyl`          | Database storage                            | `cylinder`, `database`, `db`                                     |
-| Decision                          | Diamond                | `diam`         | Decision-making step                        | `decision`, `diamond`, `question`                                |
-| Delay                             | Half-Rounded Rectangle | `delay`        | Represents a delay                          | `half-rounded-rectangle`                                         |
-| Direct Access Storage             | Horizontal Cylinder    | `h-cyl`        | Direct access storage                       | `das`, `horizontal-cylinder`                                     |
-| Disk Storage                      | Lined Cylinder         | `lin-cyl`      | Disk storage                                | `disk`, `lined-cylinder`                                         |
-| Display                           | Curved Trapezoid       | `curv-trap`    | Represents a display                        | `curved-trapezoid`, `display`                                    |
-| Divided Process                   | Divided Rectangle      | `div-rect`     | Divided process shape                       | `div-proc`, `divided-process`, `divided-rectangle`               |
-| Document                          | Document               | `doc`          | Represents a document                       | `doc`, `document`                                                |
-| Event                             | Rounded Rectangle      | `rounded`      | Represents an event                         | `event`                                                          |
-| Extract                           | Triangle               | `tri`          | Extraction process                          | `extract`, `triangle`                                            |
-| Fork/Join                         | Filled Rectangle       | `fork`         | Fork or join in process flow                | `join`                                                           |
-| Internal Storage                  | Window Pane            | `win-pane`     | Internal storage                            | `internal-storage`, `window-pane`                                |
-| Junction                          | Filled Circle          | `f-circ`       | Junction point                              | `filled-circle`, `junction`                                      |
-| Lined Document                    | Lined Document         | `lin-doc`      | Lined document                              | `lined-document`                                                 |
-| Lined/Shaded Process              | Lined Rectangle        | `lin-rect`     | Lined process shape                         | `lin-proc`, `lined-process`, `lined-rectangle`, `shaded-process` |
-| Loop Limit                        | Trapezoidal Pentagon   | `notch-pent`   | Loop limit step                             | `loop-limit`, `notched-pentagon`                                 |
-| Manual File                       | Flipped Triangle       | `flip-tri`     | Manual file operation                       | `flipped-triangle`, `manual-file`                                |
-| Manual Input                      | Sloped Rectangle       | `sl-rect`      | Manual input step                           | `manual-input`, `sloped-rectangle`                               |
-| Manual Operation                  | Trapezoid Base Top     | `trap-t`       | Represents a manual task                    | `inv-trapezoid`, `manual`, `trapezoid-top`                       |
-| Multi-Document                    | Stacked Document       | `docs`         | Multiple documents                          | `documents`, `st-doc`, `stacked-document`                        |
-| Multi-Process                     | Stacked Rectangle      | `st-rect`      | Multiple processes                          | `processes`, `procs`, `stacked-rectangle`                        |
-| Odd                               | Odd                    | `odd`          | Odd shape                                   |                                                                  |
-| Paper Tape                        | Flag                   | `flag`         | Paper tape                                  | `paper-tape`                                                     |
-| Person                            | Person                 | `person`       | Person (circular head above a rounded body) |                                                                  |
-| Prepare Conditional               | Hexagon                | `hex`          | Preparation or condition step               | `hexagon`, `prepare`                                             |
-| Priority Action                   | Trapezoid Base Bottom  | `trap-b`       | Priority action                             | `priority`, `trapezoid`, `trapezoid-bottom`                      |
-| Process                           | Rectangle              | `rect`         | Standard process shape                      | `proc`, `process`, `rectangle`                                   |
-| Start                             | Circle                 | `circle`       | Starting point                              | `circ`                                                           |
-| Start                             | Small Circle           | `sm-circ`      | Small starting point                        | `small-circle`, `start`                                          |
-| Stop                              | Double Circle          | `dbl-circ`     | Represents a stop point                     | `double-circle`                                                  |
-| Stop                              | Framed Circle          | `fr-circ`      | Stop point                                  | `framed-circle`, `stop`                                          |
-| Stored Data                       | Bow Tie Rectangle      | `bow-rect`     | Stored data                                 | `bow-tie-rectangle`, `stored-data`                               |
-| Subprocess                        | Framed Rectangle       | `fr-rect`      | Subprocess                                  | `framed-rectangle`, `subproc`, `subprocess`, `subroutine`        |
-| Summary                           | Crossed Circle         | `cross-circ`   | Summary                                     | `crossed-circle`, `summary`                                      |
-| Tagged Document                   | Tagged Document        | `tag-doc`      | Tagged document                             | `tag-doc`, `tagged-document`                                     |
-| Tagged Process                    | Tagged Rectangle       | `tag-rect`     | Tagged process                              | `tag-proc`, `tagged-process`, `tagged-rectangle`                 |
-| Terminal Point                    | Stadium                | `stadium`      | Terminal point                              | `pill`, `terminal`                                               |
-| Text Block                        | Text Block             | `text`         | Text block                                  |                                                                  |
+| **Semantic Name**                 | **Shape Name**            | **Short Name** | **Description**                             | **Alias Supported**                                              |
+| --------------------------------- | ------------------------- | -------------- | ------------------------------------------- | ---------------------------------------------------------------- |
+| Bang                              | Bang                      | `bang`         | Bang                                        | `bang`                                                           |
+| Browser                           | Browser                   | `browser`      | Browser window                              |                                                                  |
+| Bucket                            | Bucket                    | `bucket`       | Object storage bucket                       |                                                                  |
+| Card                              | Notched Rectangle         | `notch-rect`   | Represents a card                           | `card`, `notched-rectangle`                                      |
+| Cloud                             | Cloud                     | `cloud`        | cloud                                       | `cloud`                                                          |
+| Collate                           | Hourglass                 | `hourglass`    | Represents a collate operation              | `collate`, `hourglass`                                           |
+| Com Link                          | Lightning Bolt            | `bolt`         | Communication link                          | `com-link`, `lightning-bolt`                                     |
+| Comment                           | Curly Brace               | `brace`        | Adds a comment                              | `brace-l`, `comment`                                             |
+| Comment Right                     | Curly Brace               | `brace-r`      | Adds a comment                              |                                                                  |
+| Comment with braces on both sides | Curly Braces              | `braces`       | Adds a comment                              |                                                                  |
+| Console                           | Console (terminal window) | `console`      | Terminal or console window                  |                                                                  |
+| Data Input/Output                 | Lean Right                | `lean-r`       | Represents input or output                  | `in-out`, `lean-right`                                           |
+| Data Input/Output                 | Lean Left                 | `lean-l`       | Represents output or input                  | `lean-left`, `out-in`                                            |
+| Data Store                        | Data Store                | `datastore`    | Data flow diagram data store                | `data-store`                                                     |
+| Database                          | Cylinder                  | `cyl`          | Database storage                            | `cylinder`, `database`, `db`                                     |
+| Decision                          | Diamond                   | `diam`         | Decision-making step                        | `decision`, `diamond`, `question`                                |
+| Delay                             | Half-Rounded Rectangle    | `delay`        | Represents a delay                          | `half-rounded-rectangle`                                         |
+| Direct Access Storage             | Horizontal Cylinder       | `h-cyl`        | Direct access storage                       | `das`, `horizontal-cylinder`                                     |
+| Disk Storage                      | Lined Cylinder            | `lin-cyl`      | Disk storage                                | `disk`, `lined-cylinder`                                         |
+| Display                           | Curved Trapezoid          | `curv-trap`    | Represents a display                        | `curved-trapezoid`, `display`                                    |
+| Divided Process                   | Divided Rectangle         | `div-rect`     | Divided process shape                       | `div-proc`, `divided-process`, `divided-rectangle`               |
+| Document                          | Document                  | `doc`          | Represents a document                       | `doc`, `document`                                                |
+| Event                             | Rounded Rectangle         | `rounded`      | Represents an event                         | `event`                                                          |
+| Extract                           | Triangle                  | `tri`          | Extraction process                          | `extract`, `triangle`                                            |
+| Folder                            | Folder                    | `folder`       | Folder or directory                         | `directory`                                                      |
+| Fork/Join                         | Filled Rectangle          | `fork`         | Fork or join in process flow                | `join`                                                           |
+| Internal Storage                  | Window Pane               | `win-pane`     | Internal storage                            | `internal-storage`, `window-pane`                                |
+| Junction                          | Filled Circle             | `f-circ`       | Junction point                              | `filled-circle`, `junction`                                      |
+| Lined Document                    | Lined Document            | `lin-doc`      | Lined document                              | `lined-document`                                                 |
+| Lined/Shaded Process              | Lined Rectangle           | `lin-rect`     | Lined process shape                         | `lin-proc`, `lined-process`, `lined-rectangle`, `shaded-process` |
+| Loop Limit                        | Trapezoidal Pentagon      | `notch-pent`   | Loop limit step                             | `loop-limit`, `notched-pentagon`                                 |
+| Manual File                       | Flipped Triangle          | `flip-tri`     | Manual file operation                       | `flipped-triangle`, `manual-file`                                |
+| Manual Input                      | Sloped Rectangle          | `sl-rect`      | Manual input step                           | `manual-input`, `sloped-rectangle`                               |
+| Manual Operation                  | Trapezoid Base Top        | `trap-t`       | Represents a manual task                    | `inv-trapezoid`, `manual`, `trapezoid-top`                       |
+| Multi-Document                    | Stacked Document          | `docs`         | Multiple documents                          | `documents`, `st-doc`, `stacked-document`                        |
+| Multi-Process                     | Stacked Rectangle         | `st-rect`      | Multiple processes                          | `processes`, `procs`, `stacked-rectangle`                        |
+| Odd                               | Odd                       | `odd`          | Odd shape                                   |                                                                  |
+| Paper Tape                        | Flag                      | `flag`         | Paper tape                                  | `paper-tape`                                                     |
+| Person                            | Person                    | `person`       | Person (circular head above a rounded body) |                                                                  |
+| Prepare Conditional               | Hexagon                   | `hex`          | Preparation or condition step               | `hexagon`, `prepare`                                             |
+| Priority Action                   | Trapezoid Base Bottom     | `trap-b`       | Priority action                             | `priority`, `trapezoid`, `trapezoid-bottom`                      |
+| Process                           | Rectangle                 | `rect`         | Standard process shape                      | `proc`, `process`, `rectangle`                                   |
+| Start                             | Circle                    | `circle`       | Starting point                              | `circ`                                                           |
+| Start                             | Small Circle              | `sm-circ`      | Small starting point                        | `small-circle`, `start`                                          |
+| Stop                              | Double Circle             | `dbl-circ`     | Represents a stop point                     | `double-circle`                                                  |
+| Stop                              | Framed Circle             | `fr-circ`      | Stop point                                  | `framed-circle`, `stop`                                          |
+| Stored Data                       | Bow Tie Rectangle         | `bow-rect`     | Stored data                                 | `bow-tie-rectangle`, `stored-data`                               |
+| Subprocess                        | Framed Rectangle          | `fr-rect`      | Subprocess                                  | `framed-rectangle`, `subproc`, `subprocess`, `subroutine`        |
+| Summary                           | Crossed Circle            | `cross-circ`   | Summary                                     | `crossed-circle`, `summary`                                      |
+| Tagged Document                   | Tagged Document           | `tag-doc`      | Tagged document                             | `tag-doc`, `tagged-document`                                     |
+| Tagged Process                    | Tagged Rectangle          | `tag-rect`     | Tagged process                              | `tag-proc`, `tagged-process`, `tagged-rectangle`                 |
+| Terminal Point                    | Stadium                   | `stadium`      | Terminal point                              | `pill`, `terminal`                                               |
+| Text Block                        | Text Block                | `text`         | Text block                                  |                                                                  |
 
 ### Example Flowchart with New Shapes
 

--- a/packages/mermaid/scripts/docs.spec.ts
+++ b/packages/mermaid/scripts/docs.spec.ts
@@ -175,57 +175,61 @@ This Markdown should be kept.
   describe('buildShapeDoc', () => {
     it('should build shapesTable based on the shapeDefs', () => {
       expect(buildShapeDoc()).toMatchInlineSnapshot(`
-        "| **Semantic Name**                 | **Shape Name**         | **Short Name** | **Description**                             | **Alias Supported**                                              |
-        | --------------------------------- | ---------------------- | -------------- | ------------------------------------------- | ---------------------------------------------------------------- |
-        | Bang                              | Bang                   | \`bang\`         | Bang                                        | \`bang\`                                                           |
-        | Card                              | Notched Rectangle      | \`notch-rect\`   | Represents a card                           | \`card\`, \`notched-rectangle\`                                      |
-        | Cloud                             | Cloud                  | \`cloud\`        | cloud                                       | \`cloud\`                                                          |
-        | Collate                           | Hourglass              | \`hourglass\`    | Represents a collate operation              | \`collate\`, \`hourglass\`                                           |
-        | Com Link                          | Lightning Bolt         | \`bolt\`         | Communication link                          | \`com-link\`, \`lightning-bolt\`                                     |
-        | Comment                           | Curly Brace            | \`brace\`        | Adds a comment                              | \`brace-l\`, \`comment\`                                             |
-        | Comment Right                     | Curly Brace            | \`brace-r\`      | Adds a comment                              |                                                                  |
-        | Comment with braces on both sides | Curly Braces           | \`braces\`       | Adds a comment                              |                                                                  |
-        | Data Input/Output                 | Lean Right             | \`lean-r\`       | Represents input or output                  | \`in-out\`, \`lean-right\`                                           |
-        | Data Input/Output                 | Lean Left              | \`lean-l\`       | Represents output or input                  | \`lean-left\`, \`out-in\`                                            |
-        | Data Store                        | Data Store             | \`datastore\`    | Data flow diagram data store                | \`data-store\`                                                     |
-        | Database                          | Cylinder               | \`cyl\`          | Database storage                            | \`cylinder\`, \`database\`, \`db\`                                     |
-        | Decision                          | Diamond                | \`diam\`         | Decision-making step                        | \`decision\`, \`diamond\`, \`question\`                                |
-        | Delay                             | Half-Rounded Rectangle | \`delay\`        | Represents a delay                          | \`half-rounded-rectangle\`                                         |
-        | Direct Access Storage             | Horizontal Cylinder    | \`h-cyl\`        | Direct access storage                       | \`das\`, \`horizontal-cylinder\`                                     |
-        | Disk Storage                      | Lined Cylinder         | \`lin-cyl\`      | Disk storage                                | \`disk\`, \`lined-cylinder\`                                         |
-        | Display                           | Curved Trapezoid       | \`curv-trap\`    | Represents a display                        | \`curved-trapezoid\`, \`display\`                                    |
-        | Divided Process                   | Divided Rectangle      | \`div-rect\`     | Divided process shape                       | \`div-proc\`, \`divided-process\`, \`divided-rectangle\`               |
-        | Document                          | Document               | \`doc\`          | Represents a document                       | \`doc\`, \`document\`                                                |
-        | Event                             | Rounded Rectangle      | \`rounded\`      | Represents an event                         | \`event\`                                                          |
-        | Extract                           | Triangle               | \`tri\`          | Extraction process                          | \`extract\`, \`triangle\`                                            |
-        | Fork/Join                         | Filled Rectangle       | \`fork\`         | Fork or join in process flow                | \`join\`                                                           |
-        | Internal Storage                  | Window Pane            | \`win-pane\`     | Internal storage                            | \`internal-storage\`, \`window-pane\`                                |
-        | Junction                          | Filled Circle          | \`f-circ\`       | Junction point                              | \`filled-circle\`, \`junction\`                                      |
-        | Lined Document                    | Lined Document         | \`lin-doc\`      | Lined document                              | \`lined-document\`                                                 |
-        | Lined/Shaded Process              | Lined Rectangle        | \`lin-rect\`     | Lined process shape                         | \`lin-proc\`, \`lined-process\`, \`lined-rectangle\`, \`shaded-process\` |
-        | Loop Limit                        | Trapezoidal Pentagon   | \`notch-pent\`   | Loop limit step                             | \`loop-limit\`, \`notched-pentagon\`                                 |
-        | Manual File                       | Flipped Triangle       | \`flip-tri\`     | Manual file operation                       | \`flipped-triangle\`, \`manual-file\`                                |
-        | Manual Input                      | Sloped Rectangle       | \`sl-rect\`      | Manual input step                           | \`manual-input\`, \`sloped-rectangle\`                               |
-        | Manual Operation                  | Trapezoid Base Top     | \`trap-t\`       | Represents a manual task                    | \`inv-trapezoid\`, \`manual\`, \`trapezoid-top\`                       |
-        | Multi-Document                    | Stacked Document       | \`docs\`         | Multiple documents                          | \`documents\`, \`st-doc\`, \`stacked-document\`                        |
-        | Multi-Process                     | Stacked Rectangle      | \`st-rect\`      | Multiple processes                          | \`processes\`, \`procs\`, \`stacked-rectangle\`                        |
-        | Odd                               | Odd                    | \`odd\`          | Odd shape                                   |                                                                  |
-        | Paper Tape                        | Flag                   | \`flag\`         | Paper tape                                  | \`paper-tape\`                                                     |
-        | Person                            | Person                 | \`person\`       | Person (circular head above a rounded body) |                                                                  |
-        | Prepare Conditional               | Hexagon                | \`hex\`          | Preparation or condition step               | \`hexagon\`, \`prepare\`                                             |
-        | Priority Action                   | Trapezoid Base Bottom  | \`trap-b\`       | Priority action                             | \`priority\`, \`trapezoid\`, \`trapezoid-bottom\`                      |
-        | Process                           | Rectangle              | \`rect\`         | Standard process shape                      | \`proc\`, \`process\`, \`rectangle\`                                   |
-        | Start                             | Circle                 | \`circle\`       | Starting point                              | \`circ\`                                                           |
-        | Start                             | Small Circle           | \`sm-circ\`      | Small starting point                        | \`small-circle\`, \`start\`                                          |
-        | Stop                              | Double Circle          | \`dbl-circ\`     | Represents a stop point                     | \`double-circle\`                                                  |
-        | Stop                              | Framed Circle          | \`fr-circ\`      | Stop point                                  | \`framed-circle\`, \`stop\`                                          |
-        | Stored Data                       | Bow Tie Rectangle      | \`bow-rect\`     | Stored data                                 | \`bow-tie-rectangle\`, \`stored-data\`                               |
-        | Subprocess                        | Framed Rectangle       | \`fr-rect\`      | Subprocess                                  | \`framed-rectangle\`, \`subproc\`, \`subprocess\`, \`subroutine\`        |
-        | Summary                           | Crossed Circle         | \`cross-circ\`   | Summary                                     | \`crossed-circle\`, \`summary\`                                      |
-        | Tagged Document                   | Tagged Document        | \`tag-doc\`      | Tagged document                             | \`tag-doc\`, \`tagged-document\`                                     |
-        | Tagged Process                    | Tagged Rectangle       | \`tag-rect\`     | Tagged process                              | \`tag-proc\`, \`tagged-process\`, \`tagged-rectangle\`                 |
-        | Terminal Point                    | Stadium                | \`stadium\`      | Terminal point                              | \`pill\`, \`terminal\`                                               |
-        | Text Block                        | Text Block             | \`text\`         | Text block                                  |                                                                  |
+        "| **Semantic Name**                 | **Shape Name**            | **Short Name** | **Description**                             | **Alias Supported**                                              |
+        | --------------------------------- | ------------------------- | -------------- | ------------------------------------------- | ---------------------------------------------------------------- |
+        | Bang                              | Bang                      | \`bang\`         | Bang                                        | \`bang\`                                                           |
+        | Browser                           | Browser                   | \`browser\`      | Browser window                              |                                                                  |
+        | Bucket                            | Bucket                    | \`bucket\`       | Object storage bucket                       |                                                                  |
+        | Card                              | Notched Rectangle         | \`notch-rect\`   | Represents a card                           | \`card\`, \`notched-rectangle\`                                      |
+        | Cloud                             | Cloud                     | \`cloud\`        | cloud                                       | \`cloud\`                                                          |
+        | Collate                           | Hourglass                 | \`hourglass\`    | Represents a collate operation              | \`collate\`, \`hourglass\`                                           |
+        | Com Link                          | Lightning Bolt            | \`bolt\`         | Communication link                          | \`com-link\`, \`lightning-bolt\`                                     |
+        | Comment                           | Curly Brace               | \`brace\`        | Adds a comment                              | \`brace-l\`, \`comment\`                                             |
+        | Comment Right                     | Curly Brace               | \`brace-r\`      | Adds a comment                              |                                                                  |
+        | Comment with braces on both sides | Curly Braces              | \`braces\`       | Adds a comment                              |                                                                  |
+        | Console                           | Console (terminal window) | \`console\`      | Terminal or console window                  |                                                                  |
+        | Data Input/Output                 | Lean Right                | \`lean-r\`       | Represents input or output                  | \`in-out\`, \`lean-right\`                                           |
+        | Data Input/Output                 | Lean Left                 | \`lean-l\`       | Represents output or input                  | \`lean-left\`, \`out-in\`                                            |
+        | Data Store                        | Data Store                | \`datastore\`    | Data flow diagram data store                | \`data-store\`                                                     |
+        | Database                          | Cylinder                  | \`cyl\`          | Database storage                            | \`cylinder\`, \`database\`, \`db\`                                     |
+        | Decision                          | Diamond                   | \`diam\`         | Decision-making step                        | \`decision\`, \`diamond\`, \`question\`                                |
+        | Delay                             | Half-Rounded Rectangle    | \`delay\`        | Represents a delay                          | \`half-rounded-rectangle\`                                         |
+        | Direct Access Storage             | Horizontal Cylinder       | \`h-cyl\`        | Direct access storage                       | \`das\`, \`horizontal-cylinder\`                                     |
+        | Disk Storage                      | Lined Cylinder            | \`lin-cyl\`      | Disk storage                                | \`disk\`, \`lined-cylinder\`                                         |
+        | Display                           | Curved Trapezoid          | \`curv-trap\`    | Represents a display                        | \`curved-trapezoid\`, \`display\`                                    |
+        | Divided Process                   | Divided Rectangle         | \`div-rect\`     | Divided process shape                       | \`div-proc\`, \`divided-process\`, \`divided-rectangle\`               |
+        | Document                          | Document                  | \`doc\`          | Represents a document                       | \`doc\`, \`document\`                                                |
+        | Event                             | Rounded Rectangle         | \`rounded\`      | Represents an event                         | \`event\`                                                          |
+        | Extract                           | Triangle                  | \`tri\`          | Extraction process                          | \`extract\`, \`triangle\`                                            |
+        | Folder                            | Folder                    | \`folder\`       | Folder or directory                         | \`directory\`                                                      |
+        | Fork/Join                         | Filled Rectangle          | \`fork\`         | Fork or join in process flow                | \`join\`                                                           |
+        | Internal Storage                  | Window Pane               | \`win-pane\`     | Internal storage                            | \`internal-storage\`, \`window-pane\`                                |
+        | Junction                          | Filled Circle             | \`f-circ\`       | Junction point                              | \`filled-circle\`, \`junction\`                                      |
+        | Lined Document                    | Lined Document            | \`lin-doc\`      | Lined document                              | \`lined-document\`                                                 |
+        | Lined/Shaded Process              | Lined Rectangle           | \`lin-rect\`     | Lined process shape                         | \`lin-proc\`, \`lined-process\`, \`lined-rectangle\`, \`shaded-process\` |
+        | Loop Limit                        | Trapezoidal Pentagon      | \`notch-pent\`   | Loop limit step                             | \`loop-limit\`, \`notched-pentagon\`                                 |
+        | Manual File                       | Flipped Triangle          | \`flip-tri\`     | Manual file operation                       | \`flipped-triangle\`, \`manual-file\`                                |
+        | Manual Input                      | Sloped Rectangle          | \`sl-rect\`      | Manual input step                           | \`manual-input\`, \`sloped-rectangle\`                               |
+        | Manual Operation                  | Trapezoid Base Top        | \`trap-t\`       | Represents a manual task                    | \`inv-trapezoid\`, \`manual\`, \`trapezoid-top\`                       |
+        | Multi-Document                    | Stacked Document          | \`docs\`         | Multiple documents                          | \`documents\`, \`st-doc\`, \`stacked-document\`                        |
+        | Multi-Process                     | Stacked Rectangle         | \`st-rect\`      | Multiple processes                          | \`processes\`, \`procs\`, \`stacked-rectangle\`                        |
+        | Odd                               | Odd                       | \`odd\`          | Odd shape                                   |                                                                  |
+        | Paper Tape                        | Flag                      | \`flag\`         | Paper tape                                  | \`paper-tape\`                                                     |
+        | Person                            | Person                    | \`person\`       | Person (circular head above a rounded body) |                                                                  |
+        | Prepare Conditional               | Hexagon                   | \`hex\`          | Preparation or condition step               | \`hexagon\`, \`prepare\`                                             |
+        | Priority Action                   | Trapezoid Base Bottom     | \`trap-b\`       | Priority action                             | \`priority\`, \`trapezoid\`, \`trapezoid-bottom\`                      |
+        | Process                           | Rectangle                 | \`rect\`         | Standard process shape                      | \`proc\`, \`process\`, \`rectangle\`                                   |
+        | Start                             | Circle                    | \`circle\`       | Starting point                              | \`circ\`                                                           |
+        | Start                             | Small Circle              | \`sm-circ\`      | Small starting point                        | \`small-circle\`, \`start\`                                          |
+        | Stop                              | Double Circle             | \`dbl-circ\`     | Represents a stop point                     | \`double-circle\`                                                  |
+        | Stop                              | Framed Circle             | \`fr-circ\`      | Stop point                                  | \`framed-circle\`, \`stop\`                                          |
+        | Stored Data                       | Bow Tie Rectangle         | \`bow-rect\`     | Stored data                                 | \`bow-tie-rectangle\`, \`stored-data\`                               |
+        | Subprocess                        | Framed Rectangle          | \`fr-rect\`      | Subprocess                                  | \`framed-rectangle\`, \`subproc\`, \`subprocess\`, \`subroutine\`        |
+        | Summary                           | Crossed Circle            | \`cross-circ\`   | Summary                                     | \`crossed-circle\`, \`summary\`                                      |
+        | Tagged Document                   | Tagged Document           | \`tag-doc\`      | Tagged document                             | \`tag-doc\`, \`tagged-document\`                                     |
+        | Tagged Process                    | Tagged Rectangle          | \`tag-rect\`     | Tagged process                              | \`tag-proc\`, \`tagged-process\`, \`tagged-rectangle\`                 |
+        | Terminal Point                    | Stadium                   | \`stadium\`      | Terminal point                              | \`pill\`, \`terminal\`                                               |
+        | Text Block                        | Text Block                | \`text\`         | Text block                                  |                                                                  |
         "
       `);
     });

--- a/packages/mermaid/src/rendering-util/rendering-elements/nodes.spec.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/nodes.spec.ts
@@ -39,6 +39,18 @@ describe('Test Alias for shapes', function () {
     expect(shapes['data-store']).toBe(shapes.datastore);
   });
 
+  // folder | directory
+  it('should support alias for folder shape ', function () {
+    expect(shapes.directory).toBe(shapes.folder);
+  });
+
+  // bucket | console | browser
+  it('should register the bucket, console and browser shapes ', function () {
+    expect(shapes.bucket).toBeDefined();
+    expect(shapes.console).toBeDefined();
+    expect(shapes.browser).toBeDefined();
+  });
+
   // diam | decision | diamond
   it('should support alias for diamond shape ', function () {
     expect(shapes.diam).toBe(shapes.decision);

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes.ts
@@ -3,12 +3,15 @@ import type { D3Selection, MaybePromise } from '../../types.js';
 import type { Node, ShapeRenderOptions } from '../types.js';
 import { anchor } from './shapes/anchor.js';
 import { bowTieRect } from './shapes/bowTieRect.js';
+import { bucket } from './shapes/bucket.js';
 import { collapsedGroup } from './shapes/collapsedGroup.js';
 import { block_arrow } from './shapes/blockArrow.js';
+import { browser } from './shapes/browser.js';
 import { card } from './shapes/card.js';
 import { choice } from './shapes/choice.js';
 import { circle } from './shapes/circle.js';
 import { composite } from './shapes/composite.js';
+import { consoleWindow } from './shapes/console.js';
 import { crossedCircle } from './shapes/crossedCircle.js';
 import { curlyBraceLeft } from './shapes/curlyBraceLeft.js';
 import { curlyBraceRight } from './shapes/curlyBraceRight.js';
@@ -21,6 +24,7 @@ import { dividedRectangle } from './shapes/dividedRect.js';
 import { doublecircle } from './shapes/doubleCircle.js';
 import { filledCircle } from './shapes/filledCircle.js';
 import { flippedTriangle } from './shapes/flippedTriangle.js';
+import { folder } from './shapes/folder.js';
 import { forkJoin } from './shapes/forkJoin.js';
 import { halfRoundedRectangle } from './shapes/halfRoundedRectangle.js';
 import { hexagon } from './shapes/hexagon.js';
@@ -143,6 +147,35 @@ export const shapesDefs = [
     description: 'Data flow diagram data store',
     aliases: ['data-store'],
     handler: datastore,
+  },
+  {
+    semanticName: 'Folder',
+    name: 'Folder',
+    shortName: 'folder',
+    description: 'Folder or directory',
+    aliases: ['directory'],
+    handler: folder,
+  },
+  {
+    semanticName: 'Bucket',
+    name: 'Bucket',
+    shortName: 'bucket',
+    description: 'Object storage bucket',
+    handler: bucket,
+  },
+  {
+    semanticName: 'Console',
+    name: 'Console (terminal window)',
+    shortName: 'console',
+    description: 'Terminal or console window',
+    handler: consoleWindow,
+  },
+  {
+    semanticName: 'Browser',
+    name: 'Browser',
+    shortName: 'browser',
+    description: 'Browser window',
+    handler: browser,
   },
   {
     semanticName: 'Person',

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/browser.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/browser.ts
@@ -1,0 +1,95 @@
+import { labelHelper, updateNodeBounds, getNodeClasses } from './util.js';
+import intersect from '../intersect/index.js';
+import type { Node, ShapeRenderOptions } from '../../types.js';
+import { createRoundedRectPathD } from './roundedRectPath.js';
+import { styles2String, userNodeOverrides } from './handDrawnShapeStyles.js';
+import rough from 'roughjs';
+import type { D3Selection } from '../../../types.js';
+
+/** Browser shape: a rounded window with a chrome bar of dots and an address-bar hint. */
+export async function browser<T extends SVGGraphicsElement>(
+  parent: D3Selection<T>,
+  node: Node,
+  { config: { themeVariables } }: ShapeRenderOptions
+) {
+  const { labelStyles, nodeStyles } = styles2String(node);
+  node.labelStyle = labelStyles;
+
+  const { shapeSvg, bbox, label } = await labelHelper(parent, node, getNodeClasses(node));
+
+  const accent = themeVariables?.nodeBorder ?? themeVariables?.lineColor ?? 'currentColor';
+  const padding = node.padding ?? 12;
+  const barHeight = 18;
+  const radius = 12;
+  const w = Math.max(bbox.width + padding * 2, node.width ?? 0, 90);
+  const h = Math.max(bbox.height + padding * 2 + barHeight, node.height ?? 0);
+  const top = -h / 2;
+
+  const { cssStyles } = node;
+  const group = shapeSvg.insert('g', ':first-child').attr('class', 'basic label-container');
+
+  if (node.look === 'handDrawn') {
+    // @ts-expect-error -- Passing a D3.Selection seems to work for some reason
+    const rc = rough.svg(shapeSvg);
+    const roughNode = rc.path(
+      createRoundedRectPathD(-w / 2, top, w, h, radius),
+      userNodeOverrides(node, {})
+    );
+    group.node()?.appendChild(roughNode);
+    if (cssStyles) {
+      group.attr('style', cssStyles);
+    }
+  } else {
+    group
+      .append('rect')
+      .attr('x', -w / 2)
+      .attr('y', top)
+      .attr('width', w)
+      .attr('height', h)
+      .attr('rx', radius)
+      .attr('ry', radius)
+      .attr('style', nodeStyles);
+  }
+
+  group
+    .append('line')
+    .attr('x1', -w / 2)
+    .attr('y1', top + barHeight)
+    .attr('x2', w / 2)
+    .attr('y2', top + barHeight)
+    .attr('style', `stroke:${accent};stroke-width:1px`);
+
+  for (let i = 0; i < 3; i++) {
+    group
+      .append('circle')
+      .attr('cx', -w / 2 + 12 + i * 9)
+      .attr('cy', top + barHeight / 2)
+      .attr('r', 2.5)
+      .attr('style', `fill:${accent};stroke:none`);
+  }
+
+  group
+    .append('rect')
+    .attr('class', 'browser-address-bar')
+    .attr('x', -w / 2 + 44)
+    .attr('y', top + 4)
+    .attr('width', Math.max(w - 56, 10))
+    .attr('height', barHeight - 8)
+    .attr('rx', 3)
+    .attr('ry', 3)
+    .attr('style', `fill:none;stroke:${accent};stroke-width:1px;opacity:0.6`);
+
+  updateNodeBounds(node, group);
+
+  const bodyCenterY = top + barHeight + (h - barHeight) / 2;
+  label.attr(
+    'transform',
+    `translate(${-(bbox.width / 2) - (bbox.x - (bbox.left ?? 0))}, ${bodyCenterY - bbox.height / 2 - (bbox.y - (bbox.top ?? 0))})`
+  );
+
+  node.intersect = function (point) {
+    return intersect.rect(node, point);
+  };
+
+  return shapeSvg;
+}

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/bucket.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/bucket.ts
@@ -1,0 +1,83 @@
+import { labelHelper, updateNodeBounds, getNodeClasses } from './util.js';
+import intersect from '../intersect/index.js';
+import type { Node, ShapeRenderOptions } from '../../types.js';
+import { styles2String, userNodeOverrides } from './handDrawnShapeStyles.js';
+import rough from 'roughjs';
+import type { D3Selection } from '../../../types.js';
+
+/** Bucket shape: an open-top container narrowing to a curved base, with an elliptical rim. */
+export async function bucket<T extends SVGGraphicsElement>(
+  parent: D3Selection<T>,
+  node: Node,
+  { config: { themeVariables } }: ShapeRenderOptions
+) {
+  const { labelStyles, nodeStyles } = styles2String(node);
+  node.labelStyle = labelStyles;
+
+  const { shapeSvg, bbox, label } = await labelHelper(parent, node, getNodeClasses(node));
+
+  const accent = themeVariables?.nodeBorder ?? themeVariables?.lineColor ?? 'currentColor';
+  const padding = node.padding ?? 12;
+  const w = Math.max(bbox.width + padding * 2, node.width ?? 0, 80);
+  const rimRy = Math.max(Math.min(w * 0.08, 12), 5);
+  const totalHeight = Math.max(bbox.height + padding * 2 + rimRy, node.height ?? 0);
+  const topY = -totalHeight / 2 + rimRy;
+  const bottomY = totalHeight / 2;
+  const bottomW = w * 0.72;
+
+  const body = [
+    `M${-w / 2},${topY}`,
+    `L${-bottomW / 2},${bottomY}`,
+    `A${bottomW / 2},${rimRy} 0 0 0 ${bottomW / 2},${bottomY}`,
+    `L${w / 2},${topY}`,
+    `A${w / 2},${rimRy} 0 0 0 ${-w / 2},${topY}`,
+    `Z`,
+  ].join(' ');
+
+  const { cssStyles } = node;
+  const group = shapeSvg.insert('g', ':first-child').attr('class', 'basic label-container');
+
+  if (node.look === 'handDrawn') {
+    // @ts-expect-error -- Passing a D3.Selection seems to work for some reason
+    const rc = rough.svg(shapeSvg);
+    const roughNode = rc.path(body, userNodeOverrides(node, {}));
+    group.node()?.appendChild(roughNode);
+    if (cssStyles) {
+      group.attr('style', cssStyles);
+    }
+  } else {
+    group.append('path').attr('d', body).attr('style', nodeStyles);
+  }
+
+  group
+    .append('ellipse')
+    .attr('cx', 0)
+    .attr('cy', topY)
+    .attr('rx', w / 2)
+    .attr('ry', rimRy)
+    .attr('style', `fill:none;stroke:${accent};stroke-width:1px`);
+
+  updateNodeBounds(node, group);
+
+  const bodyCenterY = topY + (bottomY - topY) / 2;
+  label.attr(
+    'transform',
+    `translate(${-(bbox.width / 2) - (bbox.x - (bbox.left ?? 0))}, ${bodyCenterY - bbox.height / 2 - (bbox.y - (bbox.top ?? 0))})`
+  );
+
+  // The outline for edge intersection: the rim's upper arc and the base's
+  // lower arc, joined by the tapered sides.
+  const ARC_SEGMENTS = 12;
+  const arc = (rx: number, cy: number, ySign: number) =>
+    Array.from({ length: ARC_SEGMENTS + 1 }, (_, i) => {
+      const theta = Math.PI - (i * Math.PI) / ARC_SEGMENTS;
+      return { x: rx * Math.cos(theta), y: cy + ySign * rimRy * Math.sin(theta) };
+    });
+  const outline = [...arc(w / 2, topY, -1), ...arc(bottomW / 2, bottomY, 1).reverse()];
+
+  node.intersect = function (point) {
+    return intersect.polygon(node, outline, point);
+  };
+
+  return shapeSvg;
+}

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/console.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/console.ts
@@ -1,0 +1,75 @@
+import { labelHelper, updateNodeBounds, getNodeClasses } from './util.js';
+import intersect from '../intersect/index.js';
+import type { Node, ShapeRenderOptions } from '../../types.js';
+import { createRoundedRectPathD } from './roundedRectPath.js';
+import { styles2String, userNodeOverrides } from './handDrawnShapeStyles.js';
+import rough from 'roughjs';
+import type { D3Selection } from '../../../types.js';
+
+/** Console shape: a rounded terminal window with a command prompt glyph in the top-left. */
+export async function consoleWindow<T extends SVGGraphicsElement>(
+  parent: D3Selection<T>,
+  node: Node,
+  { config: { themeVariables } }: ShapeRenderOptions
+) {
+  const { labelStyles, nodeStyles } = styles2String(node);
+  node.labelStyle = labelStyles;
+
+  const { shapeSvg, bbox, label } = await labelHelper(parent, node, getNodeClasses(node));
+
+  const accent = themeVariables?.nodeBorder ?? themeVariables?.lineColor ?? 'currentColor';
+  const padding = node.padding ?? 12;
+  const glyphBand = 20;
+  const radius = 12;
+  const w = Math.max(bbox.width + padding * 2, node.width ?? 0, 90);
+  const h = Math.max(bbox.height + padding * 2 + glyphBand, node.height ?? 0);
+  const top = -h / 2;
+
+  const { cssStyles } = node;
+  const group = shapeSvg.insert('g', ':first-child').attr('class', 'basic label-container');
+
+  if (node.look === 'handDrawn') {
+    // @ts-expect-error -- Passing a D3.Selection seems to work for some reason
+    const rc = rough.svg(shapeSvg);
+    const roughNode = rc.path(
+      createRoundedRectPathD(-w / 2, top, w, h, radius),
+      userNodeOverrides(node, {})
+    );
+    group.node()?.appendChild(roughNode);
+    if (cssStyles) {
+      group.attr('style', cssStyles);
+    }
+  } else {
+    group
+      .append('rect')
+      .attr('x', -w / 2)
+      .attr('y', top)
+      .attr('width', w)
+      .attr('height', h)
+      .attr('rx', radius)
+      .attr('ry', radius)
+      .attr('style', nodeStyles);
+  }
+
+  group
+    .append('text')
+    .attr('x', -w / 2 + 12)
+    .attr('y', top + 16)
+    .attr('class', 'console-glyph')
+    .attr('style', `font-family:monospace;font-weight:bold;font-size:14px;fill:${accent}`)
+    .text('>_');
+
+  updateNodeBounds(node, group);
+
+  const bodyCenterY = top + glyphBand + (h - glyphBand) / 2;
+  label.attr(
+    'transform',
+    `translate(${-(bbox.width / 2) - (bbox.x - (bbox.left ?? 0))}, ${bodyCenterY - bbox.height / 2 - (bbox.y - (bbox.top ?? 0))})`
+  );
+
+  node.intersect = function (point) {
+    return intersect.rect(node, point);
+  };
+
+  return shapeSvg;
+}

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/folder.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/folder.ts
@@ -1,0 +1,78 @@
+import { labelHelper, updateNodeBounds, getNodeClasses } from './util.js';
+import intersect from '../intersect/index.js';
+import type { Node } from '../../types.js';
+import { styles2String, userNodeOverrides } from './handDrawnShapeStyles.js';
+import rough from 'roughjs';
+import type { D3Selection } from '../../../types.js';
+
+/** Folder shape: a rectangle with a raised tab on its top-left edge. */
+export async function folder<T extends SVGGraphicsElement>(parent: D3Selection<T>, node: Node) {
+  const { labelStyles, nodeStyles } = styles2String(node);
+  node.labelStyle = labelStyles;
+
+  const { shapeSvg, bbox, label } = await labelHelper(parent, node, getNodeClasses(node));
+
+  const padding = node.padding ?? 12;
+  const w = Math.max(bbox.width + padding * 2, node.width ?? 0, 90);
+  const contentHeight = bbox.height + padding * 2;
+  const tabHeight = Math.max(Math.min(contentHeight * 0.16, 14), 8);
+  const totalHeight = Math.max(contentHeight + tabHeight, node.height ?? 0);
+  const bodyHeight = totalHeight - tabHeight;
+  const tabWidth = Math.max(w * 0.38, 28);
+  const top = -totalHeight / 2;
+
+  const points = [
+    { x: -w / 2, y: top },
+    { x: -w / 2 + tabWidth, y: top },
+    { x: -w / 2 + tabWidth, y: top + tabHeight },
+    { x: w / 2, y: top + tabHeight },
+    { x: w / 2, y: totalHeight / 2 },
+    { x: -w / 2, y: totalHeight / 2 },
+  ];
+
+  const pathData = [
+    `M${points[0].x},${points[0].y}`,
+    ...points.slice(1).map((p) => `L${p.x},${p.y}`),
+    'Z',
+  ].join(' ');
+
+  const { cssStyles } = node;
+  let folderShape: D3Selection<SVGPathElement> | D3Selection<SVGGElement>;
+
+  if (node.look === 'handDrawn') {
+    // @ts-expect-error -- Passing a D3.Selection seems to work for some reason
+    const rc = rough.svg(shapeSvg);
+    const roughNode = rc.path(pathData, userNodeOverrides(node, {}));
+    folderShape = shapeSvg
+      .insert(() => roughNode, ':first-child')
+      .attr('class', 'basic label-container');
+    if (cssStyles) {
+      folderShape.attr('style', cssStyles);
+    }
+  } else {
+    folderShape = shapeSvg
+      .insert('path', ':first-child')
+      .attr('d', pathData)
+      .attr('class', 'basic label-container')
+      .attr('style', nodeStyles);
+  }
+
+  if (node.look === 'handDrawn') {
+    // The rough path can overflow its nominal box, so measure the DOM.
+    updateNodeBounds(node, folderShape);
+  } else {
+    updateNodeBounds(node, folderShape, { width: w, height: totalHeight });
+  }
+
+  const bodyCenterY = top + tabHeight + bodyHeight / 2;
+  label.attr(
+    'transform',
+    `translate(${-(bbox.width / 2) - (bbox.x - (bbox.left ?? 0))}, ${bodyCenterY - bbox.height / 2 - (bbox.y - (bbox.top ?? 0))})`
+  );
+
+  node.intersect = function (point) {
+    return intersect.polygon(node, points, point);
+  };
+
+  return shapeSvg;
+}

--- a/scripts/argos-batch-sheets.spec.ts
+++ b/scripts/argos-batch-sheets.spec.ts
@@ -31,6 +31,10 @@ describe('deriveGroupKey', () => {
     expect(deriveGroupKey('rendering/flowchart/flowchart.spec.js/x.png')).toBe(FC);
     expect(deriveGroupKey('rendering/flowchart/flowchart-elk.spec.js/y.png')).toBe(FC);
   });
+  it('gives a spec directly under the top-level category its own group', () => {
+    expect(deriveGroupKey('rendering/newShapes.spec.ts/a.png')).toBe('rendering/newShapes');
+    expect(deriveGroupKey('rendering/gantt.spec.js/b.png')).toBe('rendering/gantt');
+  });
 });
 
 describe('planSheets', () => {

--- a/scripts/argos-batch-sheets.ts
+++ b/scripts/argos-batch-sheets.ts
@@ -209,11 +209,14 @@ export interface WriteSheetsOptions {
 export function deriveGroupKey(relPath: string): string {
   const parts = relPath.split('/');
   const specIdx = parts.findIndex((p) => SPEC_SEGMENT_RE.test(p));
-  if (specIdx > 0) {
+  if (specIdx > 1) {
     return parts.slice(0, specIdx).join('/');
   }
-  if (specIdx === 0) {
-    return parts[0].replace(SPEC_SEGMENT_RE, '');
+  if (specIdx >= 0) {
+    // A spec sitting directly under the top-level category gets its own group;
+    // otherwise every flat spec shares one giant group and a new test in any of
+    // them reshuffles the tile positions of all the following sheets.
+    return [...parts.slice(0, specIdx), parts[specIdx].replace(SPEC_SEGMENT_RE, '')].join('/');
   }
   return parts.slice(0, -1).join('/') || 'root';
 }


### PR DESCRIPTION
## Summary

Adds four general-purpose flowchart shapes - `folder` (alias `directory`), `bucket`, `console` (a terminal window) and `browser` - usable via `A@{ shape: folder }` etc., in both the classic and handDrawn looks.

These started as C4-specific shapes in #7842. Review feedback there asked for them to move out of that PR and come back as first-class shapes usable from flowcharts and other diagrams, so that is what this PR does. It is part of the C4 modernization plan tracked in #7849 but fully independent of the C4 stack; once this and #7842 both land, a small follow-up rewires the C4 `$shape`/`$sprite` keywords to these shapes.

## Naming question

`terminal` is already an alias of `stadium`, so the terminal-window shape is registered as `console`. Happy to rename if you would prefer something else (e.g. `terminal-window`).

## What each shape gets

- self-sizing from the label, honoring explicit width/height independently per axis
- a handDrawn variant (rough.js container, plain SVG decorations)
- `folder` uses a polygon intersect matching its outline; the others use rect
- decoration colors come from themeVariables (nodeBorder/lineColor) instead of scraping node styles
- registry entries drive the generated shapes doc table
- tests: alias assertions in `nodes.spec.ts` and `flowchart-shape-alias.spec.ts`, plus a `newShapes.spec.ts` set (classic + handDrawn, labels, long labels, markdown, styles)
- one `minor` changeset

Review by commit: one commit per shape, then a test + docs commit.

Prepared with assistance from Claude Code; all changes reviewed and tested by a human.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Review summary

🎉 Adds four new Mermaid flowchart node shapes usable via `A@{ shape: ... }`—`folder` (alias `directory`), `bucket`, `console` (terminal window), and `browser`—including shape registration/aliasing, classic + `handDrawn` rendering, theme-variable–driven decoration colors, and shape-specific geometry (folder/bucket use polygon-style outline intersection; console/browser use rectangle intersection). Includes updated syntax/docs, a minor changeset, and Cypress + unit tests covering aliasing, label variants (including long labels and markdown), and multiple looks/directions.

### Findings

No blocking or important issues identified. The Cypress suite explicitly adds `aliasSet42 = ['folder','directory']` and covers `newShapesSet7 = ['folder','bucket','console','browser']`, including long-label and markdown htmlLabels cases.

**Security**
A targeted scan of the new/modified shape renderer files (`folder.ts`, `bucket.ts`, `console.ts`, `browser.ts`) did not surface common XSS/injection sink patterns (e.g., `innerHTML`/`outerHTML`, `foreignObject`, `on*` handlers, `<script>`, `eval`/`Function`, or `javascript:` URLs).

### Notes on test stability

The PR also includes Argos sheet-batching/grouping adjustments (`scripts/argos-batch-sheets*.ts`) to prevent unrelated snapshot churn when adding new rendering specs.

### Verdict

**APPROVE**
<!-- end of auto-generated comment: release notes by coderabbit.ai -->