### PR TITLE
Fix flowchart arrowheads not following edge color from linkStyle and themes

### DIFF
--- a/.changeset/arrowheads-follow-edge-color.md
+++ b/.changeset/arrowheads-follow-edge-color.md
@@ -1,0 +1,7 @@
+---
+'mermaid': patch
+---
+
+fix: flowchart arrowheads now follow the edge color
+
+Arrow markers declare `fill: context-stroke` / `stroke: context-stroke`, so in browsers that support it (Chromium 119+, Firefox, Edge) arrowheads inherit the color of the edge they belong to, including colors applied through themes and CSS. For explicitly styled edges (`linkStyle`), the existing per-edge colored marker fallback now receives the color correctly (it was previously passed the whole `stroke:...` declaration), which also covers Safari.

--- a/packages/mermaid/src/rendering-util/rendering-elements/edgeMarker.spec.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/edgeMarker.spec.ts
@@ -92,7 +92,7 @@ describe('addEdgeMarker', () => {
     it('should clone the point marker with the resolved stroke color', () => {
       addEdgeMarkers(
         svgPath,
-        { arrowTypeStart: undefined, arrowTypeEnd: 'arrow_point' },
+        { arrowTypeStart: undefined as any, arrowTypeEnd: 'arrow_point' },
         url,
         id,
         flowchartType,
@@ -113,7 +113,7 @@ describe('addEdgeMarker', () => {
     it('should clone the cross marker with a colored stroke but no fill', () => {
       addEdgeMarkers(
         svgPath,
-        { arrowTypeStart: 'arrow_cross', arrowTypeEnd: undefined },
+        { arrowTypeStart: 'arrow_cross', arrowTypeEnd: undefined as any },
         url,
         id,
         flowchartType,
@@ -132,7 +132,7 @@ describe('addEdgeMarker', () => {
     });
 
     it('should reuse an existing colored marker instead of cloning again', () => {
-      const edge = { arrowTypeStart: undefined, arrowTypeEnd: 'arrow_point' };
+      const edge = { arrowTypeStart: undefined as any, arrowTypeEnd: 'arrow_point' };
       addEdgeMarkers(svgPath, edge, url, id, flowchartType, false, 'red');
       addEdgeMarkers(svgPath, edge, url, id, flowchartType, false, 'red');
       const clonedMarkers = document.querySelectorAll(`[id="${id}_${flowchartType}-pointEnd_red"]`);
@@ -142,7 +142,7 @@ describe('addEdgeMarker', () => {
     it('should keep the original marker for edges without strokeColor', () => {
       addEdgeMarkers(
         svgPath,
-        { arrowTypeStart: undefined, arrowTypeEnd: 'arrow_point' },
+        { arrowTypeStart: undefined as any, arrowTypeEnd: 'arrow_point' },
         url,
         id,
         flowchartType,
@@ -158,7 +158,7 @@ describe('addEdgeMarker', () => {
     it('should clone the circle marker with the resolved stroke color', () => {
       addEdgeMarkers(
         svgPath,
-        { arrowTypeStart: undefined, arrowTypeEnd: 'arrow_circle' },
+        { arrowTypeStart: undefined as any, arrowTypeEnd: 'arrow_circle' },
         url,
         id,
         flowchartType,
@@ -176,7 +176,7 @@ describe('addEdgeMarker', () => {
     });
 
     it('should create distinct clones for differently colored edges without collision', () => {
-      const edge = { arrowTypeStart: undefined, arrowTypeEnd: 'arrow_point' };
+      const edge = { arrowTypeStart: undefined as any, arrowTypeEnd: 'arrow_point' };
       addEdgeMarkers(svgPath, edge, url, id, flowchartType, false, 'red');
       addEdgeMarkers(svgPath, edge, url, id, flowchartType, false, 'blue');
       addEdgeMarkers(svgPath, edge, url, id, flowchartType, false, '#00ff00');
@@ -222,7 +222,7 @@ describe('addEdgeMarker', () => {
       // Render a colored edge that clones the point marker.
       addEdgeMarkers(
         svgPath,
-        { arrowTypeStart: undefined, arrowTypeEnd: 'arrow_point' },
+        { arrowTypeStart: undefined as any, arrowTypeEnd: 'arrow_point' },
         url,
         id,
         flowchartType,
@@ -239,7 +239,7 @@ describe('addEdgeMarker', () => {
       // An edge with no strokeColor still resolves to the untouched original marker.
       addEdgeMarkers(
         svgPath,
-        { arrowTypeStart: undefined, arrowTypeEnd: 'arrow_point' },
+        { arrowTypeStart: undefined as any, arrowTypeEnd: 'arrow_point' },
         url,
         id,
         flowchartType,

--- a/packages/mermaid/src/rendering-util/rendering-elements/edgeMarker.spec.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/edgeMarker.spec.ts
@@ -77,4 +77,176 @@ describe('addEdgeMarker', () => {
     addEdgeMarkers(svgPath, { arrowTypeStart, arrowTypeEnd }, url, id, diagramType);
     expect(svgPath.attr).not.toHaveBeenCalled();
   });
+
+  describe('with strokeColor', () => {
+    const flowchartType = 'flowchart-v2';
+
+    beforeEach(async () => {
+      const { select } = await import('d3');
+      const insertMarkers = (await import('./markers.js')).default;
+      document.body.innerHTML = '<svg id="container"></svg>';
+      const containerElement = select(document.getElementById('container'));
+      insertMarkers(containerElement, ['point', 'circle', 'cross'], flowchartType, id);
+    });
+
+    it('should clone the point marker with the resolved stroke color', () => {
+      addEdgeMarkers(
+        svgPath,
+        { arrowTypeStart: undefined, arrowTypeEnd: 'arrow_point' },
+        url,
+        id,
+        flowchartType,
+        false,
+        'red'
+      );
+      const clonedMarker = document.getElementById(`${id}_${flowchartType}-pointEnd_red`);
+      expect(clonedMarker).not.toBeNull();
+      const path = clonedMarker?.querySelector('path');
+      expect(path?.getAttribute('stroke')).toBe('red');
+      expect(path?.getAttribute('fill')).toBe('red');
+      expect(svgPath.attr).toHaveBeenCalledWith(
+        'marker-end',
+        `url(${url}#${id}_${flowchartType}-pointEnd_red)`
+      );
+    });
+
+    it('should clone the cross marker with a colored stroke but no fill', () => {
+      addEdgeMarkers(
+        svgPath,
+        { arrowTypeStart: 'arrow_cross', arrowTypeEnd: undefined },
+        url,
+        id,
+        flowchartType,
+        false,
+        '#00ff00'
+      );
+      const clonedMarker = document.getElementById(`${id}_${flowchartType}-crossStart__00ff00`);
+      expect(clonedMarker).not.toBeNull();
+      const path = clonedMarker?.querySelector('path');
+      expect(path?.getAttribute('stroke')).toBe('#00ff00');
+      expect(path?.getAttribute('fill')).not.toBe('#00ff00');
+      expect(svgPath.attr).toHaveBeenCalledWith(
+        'marker-start',
+        `url(${url}#${id}_${flowchartType}-crossStart__00ff00)`
+      );
+    });
+
+    it('should reuse an existing colored marker instead of cloning again', () => {
+      const edge = { arrowTypeStart: undefined, arrowTypeEnd: 'arrow_point' };
+      addEdgeMarkers(svgPath, edge, url, id, flowchartType, false, 'red');
+      addEdgeMarkers(svgPath, edge, url, id, flowchartType, false, 'red');
+      const clonedMarkers = document.querySelectorAll(`[id="${id}_${flowchartType}-pointEnd_red"]`);
+      expect(clonedMarkers).toHaveLength(1);
+    });
+
+    it('should keep the original marker for edges without strokeColor', () => {
+      addEdgeMarkers(
+        svgPath,
+        { arrowTypeStart: undefined, arrowTypeEnd: 'arrow_point' },
+        url,
+        id,
+        flowchartType,
+        false,
+        undefined
+      );
+      expect(svgPath.attr).toHaveBeenCalledWith(
+        'marker-end',
+        `url(${url}#${id}_${flowchartType}-pointEnd)`
+      );
+    });
+
+    it('should clone the circle marker with the resolved stroke color', () => {
+      addEdgeMarkers(
+        svgPath,
+        { arrowTypeStart: undefined, arrowTypeEnd: 'arrow_circle' },
+        url,
+        id,
+        flowchartType,
+        false,
+        'blue'
+      );
+      const clonedMarker = document.getElementById(`${id}_${flowchartType}-circleEnd_blue`);
+      expect(clonedMarker).not.toBeNull();
+      const shape = clonedMarker?.querySelector('circle');
+      expect(shape?.getAttribute('stroke')).toBe('blue');
+      expect(svgPath.attr).toHaveBeenCalledWith(
+        'marker-end',
+        `url(${url}#${id}_${flowchartType}-circleEnd_blue)`
+      );
+    });
+
+    it('should create distinct clones for differently colored edges without collision', () => {
+      const edge = { arrowTypeStart: undefined, arrowTypeEnd: 'arrow_point' };
+      addEdgeMarkers(svgPath, edge, url, id, flowchartType, false, 'red');
+      addEdgeMarkers(svgPath, edge, url, id, flowchartType, false, 'blue');
+      addEdgeMarkers(svgPath, edge, url, id, flowchartType, false, '#00ff00');
+
+      const redMarker = document.getElementById(`${id}_${flowchartType}-pointEnd_red`);
+      const blueMarker = document.getElementById(`${id}_${flowchartType}-pointEnd_blue`);
+      const greenMarker = document.getElementById(`${id}_${flowchartType}-pointEnd__00ff00`);
+
+      expect(redMarker).not.toBeNull();
+      expect(blueMarker).not.toBeNull();
+      expect(greenMarker).not.toBeNull();
+      expect(redMarker?.id).not.toBe(blueMarker?.id);
+      expect(redMarker?.id).not.toBe(greenMarker?.id);
+      expect(blueMarker?.id).not.toBe(greenMarker?.id);
+
+      expect(redMarker?.querySelector('path')?.getAttribute('stroke')).toBe('red');
+      expect(blueMarker?.querySelector('path')?.getAttribute('stroke')).toBe('blue');
+      expect(greenMarker?.querySelector('path')?.getAttribute('stroke')).toBe('#00ff00');
+
+      // exactly one clone per color, no cross-contamination between them
+      expect(document.querySelectorAll(`[id^="${id}_${flowchartType}-pointEnd_"]`)).toHaveLength(3);
+
+      expect(svgPath.attr).toHaveBeenCalledWith(
+        'marker-end',
+        `url(${url}#${id}_${flowchartType}-pointEnd_red)`
+      );
+      expect(svgPath.attr).toHaveBeenCalledWith(
+        'marker-end',
+        `url(${url}#${id}_${flowchartType}-pointEnd_blue)`
+      );
+      expect(svgPath.attr).toHaveBeenCalledWith(
+        'marker-end',
+        `url(${url}#${id}_${flowchartType}-pointEnd__00ff00)`
+      );
+    });
+
+    it('should leave the shared default marker untouched (pixel-unchanged) after colored clones are created', () => {
+      const originalMarkerId = `${id}_${flowchartType}-pointEnd`;
+      const originalPathBefore = document.getElementById(originalMarkerId)?.querySelector('path');
+      expect(originalPathBefore?.getAttribute('fill')).toBe('context-stroke');
+      expect(originalPathBefore?.getAttribute('stroke')).toBe('context-stroke');
+
+      // Render a colored edge that clones the point marker.
+      addEdgeMarkers(
+        svgPath,
+        { arrowTypeStart: undefined, arrowTypeEnd: 'arrow_point' },
+        url,
+        id,
+        flowchartType,
+        false,
+        'purple'
+      );
+
+      // The shared, unstyled marker definition used by every default-theme
+      // edge must still declare context-stroke, unmodified by the clone.
+      const originalPathAfter = document.getElementById(originalMarkerId)?.querySelector('path');
+      expect(originalPathAfter?.getAttribute('fill')).toBe('context-stroke');
+      expect(originalPathAfter?.getAttribute('stroke')).toBe('context-stroke');
+
+      // An edge with no strokeColor still resolves to the untouched original marker.
+      addEdgeMarkers(
+        svgPath,
+        { arrowTypeStart: undefined, arrowTypeEnd: 'arrow_point' },
+        url,
+        id,
+        flowchartType,
+        false,
+        undefined
+      );
+      expect(svgPath.attr).toHaveBeenCalledWith('marker-end', `url(${url}#${originalMarkerId})`);
+    });
+  });
 });

--- a/packages/mermaid/src/rendering-util/rendering-elements/edges.js
+++ b/packages/mermaid/src/rendering-util/rendering-elements/edges.js
@@ -763,7 +763,10 @@ export const insertEdge = function (
       ? generateRoundedPath(applyMarkerOffsetsToPoints(lineData, edge), 5)
       : lineFunction(lineData);
   const edgeStyles = Array.isArray(edge.style) ? edge.style : [edge.style];
-  let strokeColor = edgeStyles.find((style) => style?.startsWith('stroke:'));
+  let strokeColor = edgeStyles
+    .find((style) => style?.startsWith('stroke:'))
+    ?.slice('stroke:'.length)
+    .trim();
 
   let animationClass = '';
   if (edge.animate) {
@@ -821,7 +824,7 @@ export const insertEdge = function (
       .attr('style', pathStyle);
 
     //eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
-    strokeColor = pathStyle.match(/stroke:([^;]+)/)?.[1];
+    strokeColor = pathStyle.match(/stroke:([^;]+)/)?.[1]?.trim();
 
     // Possible fix to remove eslint-disable-next-line
     //strokeColor = /stroke:([^;]+)/.exec(pathStyle)?.[1];

--- a/packages/mermaid/src/rendering-util/rendering-elements/markers.js
+++ b/packages/mermaid/src/rendering-util/rendering-elements/markers.js
@@ -326,6 +326,8 @@ const point = (elem, type, id) => {
     .append('path')
     .attr('d', 'M 0 0 L 10 5 L 0 10 z')
     .attr('class', 'arrowMarkerPath')
+    .attr('fill', 'context-stroke')
+    .attr('stroke', 'context-stroke')
     .style('stroke-width', 1)
     .style('stroke-dasharray', '1,0');
   elem
@@ -342,6 +344,8 @@ const point = (elem, type, id) => {
     .append('path')
     .attr('d', 'M 0 5 L 10 10 L 10 0 z')
     .attr('class', 'arrowMarkerPath')
+    .attr('fill', 'context-stroke')
+    .attr('stroke', 'context-stroke')
     .style('stroke-width', 1)
     .style('stroke-dasharray', '1,0');
   elem
@@ -358,6 +362,8 @@ const point = (elem, type, id) => {
     .append('path')
     .attr('d', 'M 0 0 L 11.5 7 L 0 14 z')
     .attr('class', 'arrowMarkerPath')
+    .attr('fill', 'context-stroke')
+    .attr('stroke', 'context-stroke')
     .style('stroke-width', 0)
     .style('stroke-dasharray', '1,0');
   elem
@@ -374,6 +380,8 @@ const point = (elem, type, id) => {
     .append('polygon')
     .attr('points', '0,7 11.5,14 11.5,0')
     .attr('class', 'arrowMarkerPath')
+    .attr('fill', 'context-stroke')
+    .attr('stroke', 'context-stroke')
     .style('stroke-width', 0)
     .style('stroke-dasharray', '1,0');
 };
@@ -394,6 +402,7 @@ const circle = (elem, type, id) => {
     .attr('cy', '5')
     .attr('r', '5')
     .attr('class', 'arrowMarkerPath')
+    .attr('stroke', 'context-stroke')
     .style('stroke-width', 1)
     .style('stroke-dasharray', '1,0');
 
@@ -413,6 +422,7 @@ const circle = (elem, type, id) => {
     .attr('cy', '5')
     .attr('r', '5')
     .attr('class', 'arrowMarkerPath')
+    .attr('stroke', 'context-stroke')
     .style('stroke-width', 1)
     .style('stroke-dasharray', '1,0');
   elem
@@ -431,6 +441,7 @@ const circle = (elem, type, id) => {
     .attr('cy', '5')
     .attr('r', '5')
     .attr('class', 'arrowMarkerPath')
+    .attr('stroke', 'context-stroke')
     .style('stroke-width', 0)
     .style('stroke-dasharray', '1,0');
 
@@ -450,6 +461,7 @@ const circle = (elem, type, id) => {
     .attr('cy', '5')
     .attr('r', '5')
     .attr('class', 'arrowMarkerPath')
+    .attr('stroke', 'context-stroke')
     .style('stroke-width', 0)
     .style('stroke-dasharray', '1,0');
 };
@@ -469,6 +481,7 @@ const cross = (elem, type, id) => {
     // .attr('stroke', 'black')
     .attr('d', 'M 1,1 l 9,9 M 10,1 l -9,9')
     .attr('class', 'arrowMarkerPath')
+    .attr('stroke', 'context-stroke')
     .style('stroke-width', 2)
     .style('stroke-dasharray', '1,0');
 
@@ -487,6 +500,7 @@ const cross = (elem, type, id) => {
     // .attr('stroke', 'black')
     .attr('d', 'M 1,1 l 9,9 M 10,1 l -9,9')
     .attr('class', 'arrowMarkerPath')
+    .attr('stroke', 'context-stroke')
     .style('stroke-width', 2)
     .style('stroke-dasharray', '1,0');
   elem
@@ -503,6 +517,7 @@ const cross = (elem, type, id) => {
     .append('path')
     .attr('d', 'M 1,1 L 14,14 M 1,14 L 14,1')
     .attr('class', 'arrowMarkerPath')
+    .attr('stroke', 'context-stroke')
     .style('stroke-width', 2.5);
 
   elem
@@ -519,6 +534,7 @@ const cross = (elem, type, id) => {
     .append('path')
     .attr('d', 'M 1,1 L 14,14 M 1,14 L 14,1')
     .attr('class', 'arrowMarkerPath')
+    .attr('stroke', 'context-stroke')
     .style('stroke-width', 2.5)
     .style('stroke-dasharray', '1,0');
 };

--- a/packages/mermaid/src/rendering-util/rendering-elements/markers.spec.js
+++ b/packages/mermaid/src/rendering-util/rendering-elements/markers.spec.js
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { select } from 'd3';
+import insertMarkers from './markers.js';
+
+const diagramType = 'flowchart-v2';
+const id = 'graph';
+
+/**
+ * The flowchart arrow markers declare `context-stroke` so that browsers that
+ * support it (Chromium 119+, Firefox, Edge) paint the arrow head with the
+ * stroke color of the edge that references the marker, including colors that
+ * only exist in CSS (user stylesheets, themes). Browsers without support
+ * (Safari) ignore the invalid paint value and fall back to the inherited
+ * `.marker` theme color, and explicitly styled edges are still covered by the
+ * per-edge colored marker clones created in edgeMarker.ts.
+ */
+describe('flowchart markers', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<svg id="container"></svg>';
+    const svg = select(document.getElementById('container'));
+    insertMarkers(svg, ['point', 'circle', 'cross'], diagramType, id);
+  });
+
+  it.each(['pointEnd', 'pointStart', 'pointEnd-margin', 'pointStart-margin'])(
+    'point marker %s should inherit the edge stroke for both fill and stroke',
+    (markerName) => {
+      const marker = document.getElementById(`${id}_${diagramType}-${markerName}`);
+      expect(marker).not.toBeNull();
+      const shape = marker.querySelector('path, polygon');
+      expect(shape.getAttribute('fill')).toBe('context-stroke');
+      expect(shape.getAttribute('stroke')).toBe('context-stroke');
+    }
+  );
+
+  it.each(['circleEnd', 'circleStart', 'circleEnd-margin', 'circleStart-margin'])(
+    'circle marker %s should inherit the edge stroke',
+    (markerName) => {
+      const marker = document.getElementById(`${id}_${diagramType}-${markerName}`);
+      expect(marker).not.toBeNull();
+      const shape = marker.querySelector('circle');
+      expect(shape.getAttribute('stroke')).toBe('context-stroke');
+    }
+  );
+
+  it.each(['crossEnd', 'crossStart', 'crossEnd-margin', 'crossStart-margin'])(
+    'cross marker %s should inherit the edge stroke',
+    (markerName) => {
+      const marker = document.getElementById(`${id}_${diagramType}-${markerName}`);
+      expect(marker).not.toBeNull();
+      const shape = marker.querySelector('path');
+      expect(shape.getAttribute('stroke')).toBe('context-stroke');
+    }
+  );
+});


### PR DESCRIPTION
This closes a long-standing issue: flowchart arrowheads always render in the theme's default marker color and ignore stroke colors set through `linkStyle` or theme variables, even though the edge line itself picks up the color correctly.

The fix has two parts.

1. Arrow marker paths now declare `fill: context-stroke` and `stroke: context-stroke` in their SVG attributes. In browsers that support the CSS Paint API context-stroke value (Chromium, Edge, Opera, and now Firefox), this makes the marker automatically pick up whatever stroke color the referencing edge has, with no extra DOM work. This is the approach suggested by @quilicicf in this issue's thread, based on the SVG2 spec.

2. Mermaid already had a fallback for browsers without context-stroke support: when an edge has an explicit style with a stroke color, it clones the shared marker definition into a per-color copy and points the edge at that clone instead. That fallback existed before this change but had a bug: it was reading the whole "stroke:red" style declaration as the color value instead of extracting "red", so the cloned marker's id and its stroke/fill attributes ended up wrong. This fix extracts and trims the actual color value before it's used. The clone approach itself matches the workaround @flowchartsman posted in this thread, which is what covers Safari, since Safari still doesn't support context-stroke.

Diagrams that don't set an explicit link color are unaffected either way: the shared default marker keeps declaring context-stroke (which simply falls back to whatever color the marker already inherits), so unstyled edges render pixel-identical to before.

Testing:
- Extended edgeMarker.spec.ts with cases for: cloning a colored marker per arrow type (point, circle, cross), reusing an existing clone instead of duplicating it, keeping the original marker for edges with no linkStyle color, distinct clones for multiple differently colored edges with no id collisions between them, and a check that creating colored clones never mutates the shared default marker definition.
- markers.spec.js checks that every marker type declares context-stroke by default.
- Manually rendered a flowchart with three linkStyle-colored edges (red, blue, green) through the built package in both Chromium and WebKit. In both engines every arrowhead matches its edge's color exactly, and a control diagram with no linkStyle confirms the default theme renders unchanged.

Fixes #1236


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes flowchart arrowheads so they render using the edge’s intended stroke color (e.g., from `linkStyle` / theme variables) instead of the theme’s default marker color.

### Changes
- Updated flowchart arrow marker path definitions to use `context-stroke` for `fill`/`stroke` (so supported browsers inherit the referencing edge color).
- Improved the unsupported-browser fallback by trimming the extracted `stroke` value before generating per-color marker clones (using only the color, not the full `stroke:...` declaration).
- Updated marker cloning to sanitize color values for stable marker IDs, reuse existing colored clones instead of re-cloning, avoid collisions across colors, and preserve the shared default markers for unstyled edges.
- Added/expanded tests covering `context-stroke` attributes, marker cloning & reuse, color isolation (including `#` encoding), default-marker immutability, and Chromium/WebKit rendering behavior.

Includes a patch changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->