### PR TITLE
fix(railroad): correct EBNF demo keywords

### DIFF
--- a/demos/railroad.html
+++ b/demos/railroad.html
@@ -16,13 +16,13 @@
     <h1>Railroad diagram demos</h1>
 
     <pre class="mermaid">
-railroad-beta
+railroad-ebnf-beta
 digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
     </pre>
     <hr />
 
     <pre class="mermaid">
-railroad-beta
+railroad-ebnf-beta
 title "Identifier Grammar"
 
 identifier = letter ( letter | digit | "_" )* ;
@@ -32,7 +32,7 @@ digit = "0" | "1" | "2" ;
     <hr />
 
     <pre class="mermaid">
-railroad-beta
+railroad-ebnf-beta
 title "Optional Sign"
 
 sign = "+" | "-" ;
@@ -42,7 +42,7 @@ digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
     <hr />
 
     <pre class="mermaid">
-railroad-beta
+railroad-ebnf-beta
 title "Expression Grammar"
 
 expression = term ( ( "+" | "-" ) term )* ;
@@ -54,7 +54,7 @@ digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
     <hr />
 
     <pre class="mermaid">
-railroad-beta
+railroad-ebnf-beta
 title "JSON Grammar"
 
 json = element ;
@@ -66,7 +66,7 @@ member = string ":" element ;
     <hr />
 
     <pre class="mermaid">
-railroad-beta
+railroad-ebnf-beta
 title "URL Grammar"
 
 url = protocol "://" domain path? ;
@@ -78,7 +78,7 @@ path = "/" segment ( "/" segment )* ;
     <hr />
 
     <pre class="mermaid">
-railroad-beta
+railroad-ebnf-beta
 title "ISO Style Notation"
 
 list = "[" element { "," element } "]" ;
@@ -89,7 +89,7 @@ digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
     <hr />
 
     <pre class="mermaid">
-railroad-beta
+railroad-ebnf-beta
 title "BNF Style Definition"
 
 rule ::= "A" | "B" ;


### PR DESCRIPTION
## :bookmark_tabs: Summary

Correct all eight EBNF examples in `demos/railroad.html` to use the registered `railroad-ebnf-beta` diagram keyword instead of the constructor-based `railroad-beta` keyword.

Resolves #7979

## :straight_ruler: Design Decisions

Kept the fix to identifier-only changes in the affected demo file. No parser, detector, dependency, documentation, or generated-file changes were needed.

Verification performed:

- Focused EBNF parser tests passed (14/14).
- The local demo rendered all 8 SVGs with no page or console errors.
- `pnpm lint` passed.
- `git diff --check` passed.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
  - No new test file is needed for this identifier-only demo correction; the existing focused parser tests and local rendering check passed.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
  - Not applicable: this changes an incorrect demo keyword and does not add a feature.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
  - Not applicable: this demo-only correction does not require a package changelog entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated all eight railroad EBNF examples in `demos/railroad.html` to use `railroad-ebnf-beta`.
- Corrected the first example’s EBNF header and grammar declaration.
- Verified with focused parser tests, SVG rendering, linting, and whitespace checks.
- Resolves issue `#7979`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->