### PR TITLE
fix(eventmodeling): reuse a namespace's swimlane when it re-enters it…

### DIFF
--- a/.changeset/eventmodeling-swimlane-reuse.md
+++ b/.changeset/eventmodeling-swimlane-reuse.md
@@ -1,0 +1,12 @@
+---
+'mermaid': patch
+---
+
+fix(eventmodeling): reuse a namespace's swimlane when it re-enters its lane
+
+Each namespace + band (UI/automation, command/read-model, event) combination should
+map to a single swimlane. When a namespace returned to a band after another namespace
+had appeared in it, a duplicate lane was created, because the generated swimlanes never
+stored their namespace and the reuse lookup was not scoped to the band. Swimlanes now
+carry their namespace and are matched within the correct band, so a namespace reuses its
+existing lane instead of opening a new one.

--- a/packages/mermaid/src/diagrams/eventmodeling/db.ts
+++ b/packages/mermaid/src/diagrams/eventmodeling/db.ts
@@ -194,12 +194,19 @@ function extractName(entityIdentifier: string): string | undefined {
 
 function findSwimlaneByNamespace(
   swimlanes: Record<string, Swimlane>,
-  namespace: string | undefined
+  namespace: string | undefined,
+  boundaryMin: number,
+  boundaryMax: number
 ): Swimlane | undefined {
   if (!namespace || namespace.length === 0) {
     return undefined;
   }
-  return Object.values(swimlanes).find((swimlane) => swimlane.namespace === namespace);
+  return Object.values(swimlanes).find(
+    (swimlane) =>
+      swimlane.namespace === namespace &&
+      swimlane.index > boundaryMin &&
+      swimlane.index < boundaryMax
+  );
 }
 
 function findNextAvailableIndex(
@@ -225,55 +232,54 @@ function calculateSwimlaneProps(
   swimlanes: Record<string, Swimlane>
 ): SwimlaneProps {
   const namespace = extractNamespace(frame.entityIdentifier);
-  const sw = findSwimlaneByNamespace(swimlanes, namespace);
 
   switch (frame.modelEntityType) {
     case 'ui':
     case 'pcr':
-    case 'processor':
+    case 'processor': {
+      const sw = findSwimlaneByNamespace(swimlanes, namespace, 0, 100);
       if (sw) {
-        return {
-          index: sw.index,
-          label: sw.namespace || diagramProps.labelUiAutomation,
-        };
+        return { index: sw.index, label: sw.label, namespace: sw.namespace };
       } else if (namespace) {
         return {
           index: findNextAvailableIndex(swimlanes, 0, 100),
           label: diagramProps.labelUiAutomationPrefix + namespace,
+          namespace,
         };
       }
       return { index: 0, label: diagramProps.labelUiAutomation };
+    }
     case 'rmo':
     case 'readmodel':
     case 'cmd':
-    case 'command':
+    case 'command': {
+      const sw = findSwimlaneByNamespace(swimlanes, namespace, 100, 200);
       if (sw) {
-        return {
-          index: sw.index,
-          label: sw.namespace || diagramProps.labelCommandReadModel,
-        };
+        return { index: sw.index, label: sw.label, namespace: sw.namespace };
       } else if (namespace) {
         return {
           index: findNextAvailableIndex(swimlanes, 100, 200),
           label: diagramProps.labelCommandReadModelPrefix + namespace,
+          namespace,
         };
       }
       return { index: 100, label: diagramProps.labelCommandReadModel };
+    }
     case 'evt':
     case 'event':
-    default:
+    default: {
+      const sw = findSwimlaneByNamespace(swimlanes, namespace, 200, 300);
       if (sw) {
-        return {
-          index: sw.index,
-          label: sw.namespace || diagramProps.labelEvents,
-        };
+        return { index: sw.index, label: sw.label, namespace: sw.namespace };
       } else if (namespace) {
         return {
           index: findNextAvailableIndex(swimlanes, 200, 300),
           label: diagramProps.labelEventsPrefix + namespace,
+          namespace,
         };
       }
       return { index: 200, label: diagramProps.labelEvents };
+    }
   }
 }
 
@@ -447,6 +453,7 @@ function evolveFramePositioned(state: Context, _event: Event): Context {
     swimlane = {
       index: swimlaneProps.index,
       label: swimlaneProps.label,
+      namespace: swimlaneProps.namespace,
       r: 0,
       y: swimlaneProps.index * diagramProps.swimlaneMinHeight + diagramProps.swimlaneGap,
       height: diagramProps.swimlaneMinHeight,

--- a/packages/mermaid/src/diagrams/eventmodeling/eventmodeling.spec.ts
+++ b/packages/mermaid/src/diagrams/eventmodeling/eventmodeling.spec.ts
@@ -5,6 +5,14 @@ import { parser } from './parser.js';
 
 const { clear } = db;
 
+// jsdom does not implement SVGElement.getBBox, which eventmodeling's getState()
+// relies on for text measurement. Provide a stub returning non-zero dimensions so
+// getState() can run in the test environment (the values do not affect swimlane logic).
+Object.defineProperty(SVGElement.prototype, 'getBBox', {
+  configurable: true,
+  value: () => ({ x: 0, y: 0, width: 10, height: 10 }),
+});
+
 describe('eventmodeling diagrams', () => {
   beforeEach(() => {
     clear();
@@ -75,5 +83,33 @@ data ItemAddedData
     tf 09 rmo ReadModel
     tf 10 readmodel ReadModel2`;
     await expect(parser.parse(str)).resolves.not.toThrow();
+  });
+
+  it('should reuse a namespace swimlane when the namespace re-enters its lane', async () => {
+    // https://github.com/mermaid-js/mermaid/issues/7925
+    // Order acts, Payment reacts, then Order returns to each band. Each
+    // (namespace + band) pair must map to exactly one swimlane, so this flow
+    // has 6 swimlanes (Order and Payment across the UI, command and event bands),
+    // not 9 with Order duplicated in every band.
+    const str = `eventmodeling
+    tf 01 ui Order.NewOrderScreen
+    tf 02 cmd Order.PlaceOrder
+    tf 03 evt Order.OrderPlaced
+    tf 04 pcr Payment.ChargeOnOrderPlaced
+    tf 05 cmd Payment.Charge
+    tf 06 evt Payment.Charged
+    tf 07 pcr Order.ConfirmOnPaymentCharged
+    tf 08 cmd Order.Confirm
+    tf 09 evt Order.Confirmed`;
+    await parser.parse(str);
+
+    const { sortedSwimlanesArray } = db.getState();
+    expect(sortedSwimlanesArray).toHaveLength(6);
+    expect(sortedSwimlanesArray.filter((swimlane) => swimlane.namespace === 'Order')).toHaveLength(
+      3
+    );
+    expect(
+      sortedSwimlanesArray.filter((swimlane) => swimlane.namespace === 'Payment')
+    ).toHaveLength(3);
   });
 });


### PR DESCRIPTION
## Description
In `eventmodeling` diagrams, when a namespace returns to a band after another
namespace has appeared in it, a duplicate swimlane is created. The issue's flow
(Order → Payment → Order) produced 9 swimlanes instead of the expected 6.

## Root cause
Swimlanes are keyed per namespace + band, and reuse relies on
`findSwimlaneByNamespace`. But the generated swimlane objects never stored their
`namespace`, so the lookup always returned `undefined`, and it wasn't scoped to the
band either. Every namespace re-entry therefore allocated a new lane.

## Fix
Store `namespace` on each created swimlane and match it within the correct band
range, so a namespace reuses its existing lane. `SwimlaneProps` already had an
optional `namespace`, so no type change was needed.

## Tests
Added a parser test for the issue's Order/Payment flow asserting exactly 6
swimlanes (Order and Payment across the UI, command and event bands).

Fixes #7925

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fix duplicate `eventmodeling` swimlanes when a namespace re-enters a band.

### Changes
- Store each swimlane’s namespace for reliable reuse.
- Scope namespace matching to the appropriate entity-type band.
- Reuse existing UI, command, and event lanes for recurring namespaces.
- Add parser coverage for the Order → Payment → Order flow.

The flow now creates six swimlanes instead of nine, with three lanes each for Order and Payment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->