### PR TITLE
docs: replace remaining directive examples with frontmatter

### DIFF
--- a/docs/syntax/architecture.md
+++ b/docs/syntax/architecture.md
@@ -350,7 +350,11 @@ By default, architecture diagrams start nodes at deterministic seed positions (`
 Via frontmatter:
 
 ```
-%%{init: {"architecture": {"randomize": true}}}%%
+---
+config:
+  architecture:
+    randomize: true
+---
 architecture-beta
     group api(cloud)[API]
     service db(database)[Database] in api
@@ -387,7 +391,11 @@ The following options pass through to the underlying [fcose](https://github.com/
 Example — bumping `idealEdgeLengthMultiplier` stretches the spacing between connected nodes in a chain:
 
 ```
-%%{init: {"architecture": {"idealEdgeLengthMultiplier": 3}}}%%
+---
+config:
+  architecture:
+    idealEdgeLengthMultiplier: 3
+---
 architecture-beta
     service a(server)[A]
     service b(server)[B]

--- a/docs/syntax/cynefin.md
+++ b/docs/syntax/cynefin.md
@@ -228,7 +228,12 @@ Cynefin diagrams accept the following configuration under the `cynefin` key in t
 Example:
 
 ```
-%%{init: {'cynefin': {'width': 1000, 'showDomainDescriptions': false}}}%%
+---
+config:
+  cynefin:
+    width: 1000
+    showDomainDescriptions: false
+---
 cynefin-beta
   complex
     "Adaptive work"

--- a/packages/mermaid/src/docs/syntax/architecture.md
+++ b/packages/mermaid/src/docs/syntax/architecture.md
@@ -254,7 +254,11 @@ By default, architecture diagrams start nodes at deterministic seed positions (`
 Via frontmatter:
 
 ```
-%%{init: {"architecture": {"randomize": true}}}%%
+---
+config:
+  architecture:
+    randomize: true
+---
 architecture-beta
     group api(cloud)[API]
     service db(database)[Database] in api
@@ -291,7 +295,11 @@ The following options pass through to the underlying [fcose](https://github.com/
 Example — bumping `idealEdgeLengthMultiplier` stretches the spacing between connected nodes in a chain:
 
 ```
-%%{init: {"architecture": {"idealEdgeLengthMultiplier": 3}}}%%
+---
+config:
+  architecture:
+    idealEdgeLengthMultiplier: 3
+---
 architecture-beta
     service a(server)[A]
     service b(server)[B]

--- a/packages/mermaid/src/docs/syntax/cynefin.md
+++ b/packages/mermaid/src/docs/syntax/cynefin.md
@@ -167,7 +167,12 @@ Cynefin diagrams accept the following configuration under the `cynefin` key in t
 Example:
 
 ```
-%%{init: {'cynefin': {'width': 1000, 'showDomainDescriptions': false}}}%%
+---
+config:
+  cynefin:
+    width: 1000
+    showDomainDescriptions: false
+---
 cynefin-beta
   complex
     "Adaptive work"


### PR DESCRIPTION
## Summary

Resolves #4756

- Convert architecture and cynefin configuration examples from deprecated `%%{init}%%` directives to YAML frontmatter.
- Leave `directives.md` and historical `8.6.0_docs.md` unchanged as reference for older versions.

Architecture docs already labeled those snippets as "Via frontmatter" but still showed directive syntax; they now match the frontmatter format used elsewhere in the docs.

## Test plan

- [ ] Confirm architecture and cynefin example blocks render with frontmatter config in the docs preview
- [ ] Confirm `packages/mermaid/src/docs/config/directives.md` still documents the old directive syntax

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated architecture and Cynefin documentation examples to replace deprecated `%%{init}%%` directive snippets with YAML frontmatter `config:` blocks.
- Adjusted architecture examples for `randomize: true` and `idealEdgeLengthMultiplier: 3`, and Cynefin examples for `width: 1000` and `showDomainDescriptions: false`, keeping the surrounding diagram examples intact and aligning with existing “Via frontmatter” wording.
- Preserved `directives.md` and the historical `8.6.0_docs.md` as references for older Mermaid versions (`packages/mermaid/src/docs/config/*` and `docs/config/*`).

## Testing

- Documentation-only changes; no tests added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->