### PR TITLE
Fix dashed stroke on stadium flowchart nodes

### DIFF
--- a/.changeset/stadium-dashed-stroke.md
+++ b/.changeset/stadium-dashed-stroke.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix(flowchart): stroke-dasharray now applies to the straight sides of stadium nodes. The default (non hand-drawn) stadium is rendered as a single SVG path instead of rough.js segments, and user styles are merged with compiled node styles instead of being overwritten.

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/stadium.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/stadium.ts
@@ -10,6 +10,7 @@ import type { Node } from '../../types.js';
 import { styles2String, userNodeOverrides } from './handDrawnShapeStyles.js';
 import rough from 'roughjs';
 import type { D3Selection } from '../../../types.js';
+import { handleUndefinedAttr } from '../../../utils.js';
 
 export const createStadiumPathD = (
   x: number,
@@ -68,14 +69,6 @@ export async function stadium<T extends SVGGraphicsElement>(parent: D3Selection<
 
   const radius = h / 2;
   const { cssStyles } = node;
-  // @ts-expect-error -- Passing a D3.Selection seems to work for some reason
-  const rc = rough.svg(shapeSvg);
-  const options = userNodeOverrides(node, {});
-
-  if (node.look !== 'handDrawn') {
-    options.roughness = 0;
-    options.fillStyle = 'solid';
-  }
 
   const points = [
     { x: -w / 2 + radius, y: -h / 2 },
@@ -86,17 +79,23 @@ export async function stadium<T extends SVGGraphicsElement>(parent: D3Selection<
   ];
 
   const pathData = createPathFromPoints(points);
-  const shapeNode = rc.path(pathData, options);
+  let polygon;
 
-  const polygon = shapeSvg.insert(() => shapeNode, ':first-child');
-  polygon.attr('class', 'basic label-container outer-path');
-
-  if (cssStyles && node.look !== 'handDrawn') {
-    polygon.selectChildren('path').attr('style', cssStyles);
-  }
-
-  if (nodeStyles && node.look !== 'handDrawn') {
-    polygon.selectChildren('path').attr('style', nodeStyles);
+  if (node.look === 'handDrawn') {
+    // @ts-expect-error -- Passing a D3.Selection seems to work for some reason
+    const rc = rough.svg(shapeSvg);
+    const options = userNodeOverrides(node, {});
+    const shapeNode = rc.path(pathData, options);
+    polygon = shapeSvg.insert(() => shapeNode, ':first-child');
+    polygon.attr('class', 'basic label-container outer-path');
+  } else {
+    // Rough.js splits paths into segments, which breaks CSS stroke-dasharray on straight sides.
+    polygon = shapeSvg
+      .insert('path', ':first-child')
+      .attr('d', pathData)
+      .attr('class', 'basic label-container outer-path')
+      .attr('style', handleUndefinedAttr(cssStyles))
+      .attr('style', nodeStyles);
   }
 
   updateNodeBounds(node, polygon);

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/stadium.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/stadium.ts
@@ -90,12 +90,13 @@ export async function stadium<T extends SVGGraphicsElement>(parent: D3Selection<
     polygon.attr('class', 'basic label-container outer-path');
   } else {
     // Rough.js splits paths into segments, which breaks CSS stroke-dasharray on straight sides.
+    // Merge cssStyles and nodeStyles into one style attribute; nodeStyles goes last so it wins.
+    const combinedStyles = [...(cssStyles ?? []), nodeStyles].filter(Boolean).join(';');
     polygon = shapeSvg
       .insert('path', ':first-child')
       .attr('d', pathData)
       .attr('class', 'basic label-container outer-path')
-      .attr('style', handleUndefinedAttr(cssStyles))
-      .attr('style', nodeStyles);
+      .attr('style', handleUndefinedAttr(combinedStyles || undefined));
   }
 
   updateNodeBounds(node, polygon);


### PR DESCRIPTION
## Summary
- Render default (non hand-drawn) stadium nodes with a single SVG path instead of rough.js segments.
- Fixes `stroke-dasharray` styling on the straight sides of `([...])` nodes (fixes #7969).

## Test plan
- [ ] Render a flowchart with `style`/`classDef` using `stroke-dasharray` on stadium nodes and confirm dashes on top, bottom, and cap arcs.
- [ ] Confirm hand-drawn look stadium nodes still render with rough.js.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated default stadium flowchart nodes (`([foo])`, non-`handDrawn`) to render the stadium outline as a single SVG `<path>` (fixes `stroke-dasharray` styling being broken on straight sides when rough.js segments are used).
- Preserved rough.js-based rendering for `handDrawn` stadium nodes.
- Applied the outer-path `style` using `handleUndefinedAttr` with a merged style string from compiled `cssStyles` + `nodeStyles` (with `nodeStyles` taking precedence), ensuring user-provided styling like `stroke-dasharray` is not overwritten.
- Added a changeset documenting the `stroke-dasharray` fix and the rendering behavior change for default stadium nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->