### PR TITLE
docs: add Grist document diagram integration

### DIFF
--- a/docs/ecosystem/integrations-community.md
+++ b/docs/ecosystem/integrations-community.md
@@ -58,6 +58,7 @@ To add an integration to this list, see the [Integrations - create page](./integ
 - [GitLab](https://docs.gitlab.com/ee/user/markdown.html#diagrams-and-flowcharts) ✅
 - [GNU Octave](https://octave.org/) ✅
   - [octave_mermaid_js](https://github.com/CNOCTAVE/octave_mermaid_js) ✅
+- [Grist](https://grist-diagram.enliberte.fr/about)
 - [HackMD](https://hackmd.io/c/tutorials/%2F%40docs%2Fflowchart-en#Create-more-complex-flowcharts) ✅
 - [JetBrains IDEs](https://www.jetbrains.com)
   - [Mermaid Plugin](https://plugins.jetbrains.com/plugin/20146-mermaid)

--- a/packages/mermaid/src/docs/ecosystem/integrations-community.md
+++ b/packages/mermaid/src/docs/ecosystem/integrations-community.md
@@ -53,6 +53,7 @@ To add an integration to this list, see the [Integrations - create page](./integ
 - [GitLab](https://docs.gitlab.com/ee/user/markdown.html#diagrams-and-flowcharts) ✅
 - [GNU Octave](https://octave.org/) ✅
   - [octave_mermaid_js](https://github.com/CNOCTAVE/octave_mermaid_js) ✅
+- [Grist](https://grist-diagram.enliberte.fr/about)
 - [HackMD](https://hackmd.io/c/tutorials/%2F%40docs%2Fflowchart-en#Create-more-complex-flowcharts) ✅
 - [JetBrains IDEs](https://www.jetbrains.com)
   - [Mermaid Plugin](https://plugins.jetbrains.com/plugin/20146-mermaid)


### PR DESCRIPTION
Add a basic custom widget for Grist in order to show a document structure with a entity relationship diagram.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds **Grist** to Mermaid’s community productivity tool integration list. The entry links to Grist’s Mermaid document diagram integration page.

## Changes

- Updated `packages/mermaid/src/docs/ecosystem/integrations-community.md`.
- Updated `docs/ecosystem/integrations-community.md`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->