### PR TITLE
ci(validate-workflow): update CI to fix PRs from forks

### DIFF
--- a/.github/workflows/validate-lockfile.yml
+++ b/.github/workflows/validate-lockfile.yml
@@ -1,11 +1,14 @@
 name: Validate pnpm-lock.yaml
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - 'pnpm-lock.yaml'
       - '**/package.json'
       - '.github/workflows/validate-lockfile.yml'
+
+permissions:
+  contents: read
 
 jobs:
   validate-lockfile:
@@ -15,8 +18,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Validate pnpm-lock.yaml entries
         id: validate # give this step an ID so we can reference its outputs
@@ -25,18 +26,18 @@ jobs:
 
           # 1) No tarball references
           if grep -qF 'tarball:' pnpm-lock.yaml; then
-            issues+=("• Tarball references found (forbidden)")
+            issues+=('- Tarball references found (forbidden)')
           fi
 
           # 2) No unwanted vitepress paths
           if grep -qF 'packages/mermaid/src/vitepress' pnpm-lock.yaml; then
-            issues+=("• Disallowed path 'packages/mermaid/src/vitepress' present. Run \`rm -rf packages/mermaid/src/vitepress && pnpm install\` to regenerate.")
+            issues+=('- Disallowed path `packages/mermaid/src/vitepress` present. Run `rm -rf packages/mermaid/src/vitepress && pnpm install` to regenerate.')
           fi
 
           # 3) Lockfile only changes when package.json changes
           git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} > changed.txt
           if grep -q '^pnpm-lock.yaml$' changed.txt && ! grep -q 'package.json' changed.txt; then
-            issues+=("• pnpm-lock.yaml changed without any package.json modification")
+            issues+=('- `pnpm-lock.yaml` changed without any `**/package.json` modification')
           fi
 
           # If any issues, output them and fail
@@ -50,41 +51,16 @@ jobs:
             exit 1
           fi
 
-      - name: Find existing lockfile validation comment
-        if: always()
-        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
-        id: find-comment
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: 'Lockfile Validation Failed'
-
-      - name: Comment on PR if validation failed
+      - name: Comment on CI Step Summary if validation fails
         if: failure()
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          edit-mode: replace
-          body: |
-            ❌ **Lockfile Validation Failed**
-
-            The following issue(s) were detected:
-            ${{ steps.validate.outputs.errors }}
-
-            Please address these and push an update.
-
-            _Posted automatically by GitHub Actions_
-
-      - name: Delete comment if validation passed
-        if: success() && steps.find-comment.outputs.comment-id != ''
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            await github.rest.issues.deleteComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: ${{ steps.find-comment.outputs.comment-id }},
-            });
+        run: |
+          {
+            echo "❌ **Lockfile Validation Failed**"
+            echo ""
+            echo "The following issue(s) were detected:"
+            echo ""
+            echo "$VALIDATION_ERRORS"
+            echo "Please address these and push an update."
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+        env:
+          VALIDATION_ERRORS: ${{ steps.validate.outputs.errors }}

--- a/.github/workflows/validate-lockfile.yml
+++ b/.github/workflows/validate-lockfile.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: 'blob:none'
 
       - name: Validate pnpm-lock.yaml entries
         id: validate # give this step an ID so we can reference its outputs

--- a/.github/workflows/validate-lockfile.yml
+++ b/.github/workflows/validate-lockfile.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   validate-lockfile:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/validate-lockfile.yml
+++ b/.github/workflows/validate-lockfile.yml
@@ -36,7 +36,7 @@ jobs:
           fi
 
           # 3) Lockfile only changes when package.json changes
-          git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} > changed.txt
+          git diff --name-only "$GITHUB_BASE_SHA" "$GITHUB_HEAD_SHA" > changed.txt
           if grep -q '^pnpm-lock.yaml$' changed.txt && ! grep -q 'package.json' changed.txt; then
             issues+=('- `pnpm-lock.yaml` changed without any `**/package.json` modification')
           fi
@@ -51,6 +51,9 @@ jobs:
             } >> $GITHUB_OUTPUT
             exit 1
           fi
+        env:
+          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
 
       - name: Comment on CI Step Summary if validation fails
         if: failure()

--- a/.github/workflows/validate-lockfile.yml
+++ b/.github/workflows/validate-lockfile.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           filter: 'blob:none'


### PR DESCRIPTION
## :bookmark_tabs: Summary

`actions/checkout@v4` now throws an error when trying to checkout code from forks when using `pull_request_target`, see https://github.com/actions/checkout/releases/tag/v4.4.0.

Additionally, we get a lot of warnings and even attempted automated attacks on this file, even though it's 100% safe, since we never actually run any checked-out code.

Changing this to `on: pull_request` means we can't make a comment in the PR, but it is still marked as a failing CI, and the step summary contains a description.

> <img width="1523" height="922" alt="image" src="https://github.com/user-attachments/assets/e1666812-0877-497c-b3ff-3e4b1409252c" />
>
> See https://github.com/aloisklink/mermaid/pull/43 for an example.

## :straight_ruler: Design Decisions

I've also taken the time to other fixes on this action, e.g. to use `ubuntu-slim`, pinning the dependency, using blobless clone, etc. See each individual commit message for it's own documentation.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
  - N/A, but tested, see screenshot.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
  - N/A
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
  - N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Switched `validate-lockfile` from `pull_request_target` to `pull_request` with read-only contents permissions.
- Updated the job to use `ubuntu-slim`, a pinned `actions/checkout` revision, and blobless checkout.
- Uses `GITHUB_BASE_SHA` and `GITHUB_HEAD_SHA` for changed-file detection.
- Replaced PR comment reporting with GitHub Actions step summaries, while keeping failed checks visible.
- Simplified shell expressions and standardized validation error formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->