### PR TITLE
fix(class): reuse declared classes in lollipop relationships

### DIFF
--- a/.changeset/fix-lollipop-class-reuse.md
+++ b/.changeset/fix-lollipop-class-reuse.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix(class): reuse declared classes in lollipop relationships instead of creating duplicate interface nodes

--- a/packages/mermaid/src/diagrams/class/classDb.ts
+++ b/packages/mermaid/src/diagrams/class/classDb.ts
@@ -222,15 +222,21 @@ export class ClassDB implements DiagramDB {
       !invalidTypes.includes(classRelation.relation.type2)
     ) {
       this.addClass(classRelation.id2);
-      this.addInterface(classRelation.id1, classRelation.id2);
-      classRelation.id1 = `interface${this.interfaces.length - 1}`;
+      const interfaceClassName = this.splitClassNameAndType(classRelation.id1).className;
+      if (!this.classes.has(interfaceClassName)) {
+        this.addInterface(classRelation.id1, classRelation.id2);
+        classRelation.id1 = `interface${this.interfaces.length - 1}`;
+      }
     } else if (
       classRelation.relation.type2 === this.relationType.LOLLIPOP &&
       !invalidTypes.includes(classRelation.relation.type1)
     ) {
       this.addClass(classRelation.id1);
-      this.addInterface(classRelation.id2, classRelation.id1);
-      classRelation.id2 = `interface${this.interfaces.length - 1}`;
+      const interfaceClassName = this.splitClassNameAndType(classRelation.id2).className;
+      if (!this.classes.has(interfaceClassName)) {
+        this.addInterface(classRelation.id2, classRelation.id1);
+        classRelation.id2 = `interface${this.interfaces.length - 1}`;
+      }
     } else {
       this.addClass(classRelation.id1);
       this.addClass(classRelation.id2);

--- a/packages/mermaid/src/diagrams/class/classDiagram.spec.ts
+++ b/packages/mermaid/src/diagrams/class/classDiagram.spec.ts
@@ -1549,6 +1549,27 @@ describe('given a class diagram with relationships, ', function () {
       parser.parse(str);
     });
 
+    it('should reuse a declared class in a lollipop relationship', function () {
+      const str = `classDiagram
+        class IPerson {
+          <<interface>>
+          +name: string
+        }
+        class Person
+        IPerson ()-- Person`;
+
+      parser.parse(str);
+
+      const { nodes, edges } = classDb.getData();
+      expect(nodes.filter((node) => node.label === 'IPerson')).toHaveLength(1);
+      expect(nodes.map((node) => node.id).sort()).toEqual(['IPerson', 'Person']);
+      expect(edges[0]).toMatchObject({
+        start: 'IPerson',
+        end: 'Person',
+        arrowTypeStart: 'lollipop',
+      });
+    });
+
     it('should handle relation definitions EXTENSION', function () {
       const str = 'classDiagram\n' + 'Class1 <|-- Class02';
 

--- a/packages/mermaid/src/diagrams/class/classDiagram.spec.ts
+++ b/packages/mermaid/src/diagrams/class/classDiagram.spec.ts
@@ -1549,7 +1549,7 @@ describe('given a class diagram with relationships, ', function () {
       parser.parse(str);
     });
 
-    it('should reuse a declared class in a lollipop relationship', function () {
+    it('should reuse a declared class on the left of a lollipop relationship', function () {
       const str = `classDiagram
         class IPerson {
           <<interface>>
@@ -1567,6 +1567,65 @@ describe('given a class diagram with relationships, ', function () {
         start: 'IPerson',
         end: 'Person',
         arrowTypeStart: 'lollipop',
+      });
+    });
+
+    it('should reuse a declared class on the right of a lollipop relationship', function () {
+      const str = `classDiagram
+        class IPerson {
+          <<interface>>
+          +name: string
+        }
+        class Person
+        Person --() IPerson`;
+
+      parser.parse(str);
+
+      const { nodes, edges } = classDb.getData();
+      expect(nodes.filter((node) => node.label === 'IPerson')).toHaveLength(1);
+      expect(nodes.map((node) => node.id).sort()).toEqual(['IPerson', 'Person']);
+      expect(edges[0]).toMatchObject({
+        start: 'Person',
+        end: 'IPerson',
+        arrowTypeEnd: 'lollipop',
+      });
+    });
+
+    it('should create a synthetic interface for an undeclared class on the left', function () {
+      parser.parse(`classDiagram
+        IWorker ()-- Worker`);
+
+      const { nodes, edges } = classDb.getData();
+      expect(nodes).toHaveLength(2);
+      expect(nodes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: 'Worker', label: 'Worker' }),
+          expect.objectContaining({ id: 'interface0', label: 'IWorker' }),
+        ])
+      );
+      expect(edges[0]).toMatchObject({
+        start: 'interface0',
+        end: 'Worker',
+        arrowTypeStart: 'lollipop',
+      });
+    });
+
+    it('should create a synthetic interface for an undeclared class on the right', function () {
+      parser.parse(`classDiagram
+        Worker --() IWorker`);
+
+      const { nodes, edges } = classDb.getData();
+      expect(nodes).toHaveLength(2);
+      expect(nodes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: 'Worker', label: 'Worker' }),
+          expect.objectContaining({ id: 'interface0', label: 'IWorker' }),
+        ])
+      );
+      expect(edges[0]).toMatchObject({
+        start: 'Worker',
+        end: 'interface0',
+        arrowTypeEnd: 'lollipop',
       });
     });
 


### PR DESCRIPTION
## :bookmark_tabs: Summary

Class diagrams currently create a synthetic interface node for a lollipop
relationship even when the endpoint was already declared as a class. This can
produce duplicate nodes with the same label.

The parser now reuses an existing declared class on either side of a lollipop
relationship and only creates a synthetic interface when the endpoint has not
already been declared.

Resolves #6980

## :straight_ruler: Design Decisions

The fix uses the existing `splitClassNameAndType` normalization before checking
the class map, so names with type information follow the same lookup behavior as
other class relations. Regression tests cover declared and undeclared interface
endpoints on both sides of a lollipop relationship.

### :clipboard: Tasks

- [x] :book: have read the contribution guidelines.
- [x] :computer: have added necessary unit tests.
- [x] :notebook: documentation is not needed for this parser bug fix.
- [x] :butterfly: added a patch changeset.

Validation:

- GitHub Unit Tests workflow passed
- GitHub E2E workflow passed
- Lint, CodeQL, dependency review, docs build, preview release, and autofix workflows passed
- Codecov reports all modified and coverable lines are covered
- Argos reports no visual changes
- Local class diagram suite, targeted ESLint, Prettier, and `git diff --check` passed before publication

AI assistance disclosure: OpenAI Codex was used to investigate, implement, and
test this change. The assisted workflow verified the exact published tree,
coverage follow-up, and results reported above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes duplicate synthetic interface nodes in class diagram lollipop relationships by reusing declared classes or interfaces when endpoints match.

### Changes
- Normalize lollipop endpoint names.
- Reuse declared endpoints on either side of the relationship.
- Create synthetic interfaces only for undeclared endpoints.
- Add regression tests for both relationship directions.
- Include a patch changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->