### PR TITLE
fix(sequence): don't remeasure KaTeX notes over a single actor as plain text

### DIFF
--- a/.changeset/sequence-katex-note-over-padding.md
+++ b/.changeset/sequence-katex-note-over-padding.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix(sequence): `Note over` a single actor no longer measures KaTeX content as plain text, which inflated the note's width with huge padding.

--- a/cypress/integration/rendering/katex.spec.js
+++ b/cypress/integration/rendering/katex.spec.js
@@ -41,4 +41,15 @@ describe('Katex', () => {
       { fontFamily: 'courier' }
     );
   });
+  it('5: should render a KaTeX note over a single actor without extra padding', () => {
+    imgSnapshotTest(
+      `sequenceDiagram
+      participant A
+      participant B
+      Note over B: $$(sk_B, pk_B)\\leftarrow KeyGen(1^\\lambda)$$
+      Note left of B: $$(sk_B, pk_B)\\leftarrow KeyGen(1^\\lambda)$$
+      A->>B: Message`,
+      { sequence: { useMaxWidth: false } }
+    );
+  });
 });

--- a/packages/mermaid/src/diagrams/sequence/sequenceRenderer.spec.js
+++ b/packages/mermaid/src/diagrams/sequence/sequenceRenderer.spec.js
@@ -20,8 +20,18 @@ vi.mock('../../utils.js', async (importOriginal) => {
   };
 });
 
+vi.mock('../common/common.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    calculateMathMLDimensions: vi.fn(() => Promise.resolve({ width: 200, height: 30 })),
+  };
+});
+
 import * as svgDraw from './svgDraw.js';
-import { drawMessage, setConf } from './sequenceRenderer.js';
+import { calculateMathMLDimensions } from '../common/common.js';
+import utils from '../../utils.js';
+import { buildNoteModel, drawMessage, setConf } from './sequenceRenderer.js';
 
 function mockDiagram(name = 'svg') {
   const children = [];
@@ -92,5 +102,65 @@ describe('drawMessage (#3594)', () => {
     const textObj = messageTextCalls[0][1];
     expect(textObj.x).toBe(Math.min(startx, stopx));
     expect(textObj.width).toBe(Math.abs(stopx - startx));
+  });
+});
+
+describe('buildNoteModel (#6993)', () => {
+  const diagObj = { db: { PLACEMENT: { LEFTOF: 0, RIGHTOF: 1, OVER: 2 } } };
+
+  beforeEach(() => {
+    setConf({
+      width: 80,
+      noteMargin: 10,
+      wrapPadding: 10,
+      noteFontFamily: 'sans-serif',
+      noteFontSize: 14,
+      noteFontWeight: '400',
+    });
+    vi.mocked(calculateMathMLDimensions).mockClear();
+    vi.mocked(utils.calculateTextDimensions).mockClear();
+  });
+
+  it('sizes a KaTeX note over a single actor from its MathML dimensions', async () => {
+    const actors = new Map([['B', { x: 100, width: 150 }]]);
+    const msg = {
+      from: 'B',
+      to: 'B',
+      message: '$$(sk_B, pk_B)\\leftarrow KeyGen(1^\\lambda)$$',
+      wrap: false,
+      placement: diagObj.db.PLACEMENT.OVER,
+    };
+
+    const noteModel = await buildNoteModel(msg, actors, diagObj);
+
+    // max(actor width, conf.width, MathML width (200) + 2 * noteMargin)
+    expect(noteModel.width).toBe(220);
+    expect(noteModel.startx).toBe(100 + (150 - 220) / 2);
+    expect(calculateMathMLDimensions).toHaveBeenCalledTimes(1);
+    // The raw `$$...$$` source must not be measured as plain text: doing so is
+    // what inflated the note's padding.
+    expect(utils.calculateTextDimensions).not.toHaveBeenCalled();
+  });
+
+  it('still sizes a plain-text note over a single actor from its text dimensions', async () => {
+    const actors = new Map([['B', { x: 100, width: 150 }]]);
+    const msg = {
+      from: 'B',
+      to: 'B',
+      message: 'a plain note',
+      wrap: false,
+      placement: diagObj.db.PLACEMENT.OVER,
+    };
+
+    const noteModel = await buildNoteModel(msg, actors, diagObj);
+
+    // max(actor width, conf.width, text width (40) + 2 * noteMargin)
+    expect(noteModel.width).toBe(150);
+    expect(calculateMathMLDimensions).not.toHaveBeenCalled();
+    expect(utils.calculateTextDimensions).toHaveBeenCalledWith('a plain note', {
+      fontFamily: 'sans-serif',
+      fontSize: 14,
+      fontWeight: '400',
+    });
   });
 });

--- a/packages/mermaid/src/diagrams/sequence/sequenceRenderer.ts
+++ b/packages/mermaid/src/diagrams/sequence/sequenceRenderer.ts
@@ -1689,14 +1689,16 @@ async function calculateActorMargins(
   return common.getMax(maxHeight, conf.height);
 }
 
-const buildNoteModel = async function (msg, actors, diagObj) {
+export const buildNoteModel = async function (msg, actors, diagObj) {
   const fromActor = actors.get(msg.from);
   const toActor = actors.get(msg.to);
   const startx = fromActor.x;
   const stopx = toActor.x;
   const shouldWrap = msg.wrap && msg.message;
 
-  let textDimensions: { width: number; height: number; lineHeight?: number } = hasKatex(msg.message)
+  const textDimensions: { width: number; height: number; lineHeight?: number } = hasKatex(
+    msg.message
+  )
     ? await calculateMathMLDimensions(msg.message, getConfig())
     : utils.calculateTextDimensions(
         shouldWrap ? utils.wrapLabel(msg.message, conf.width, noteFont(conf)) : msg.message,
@@ -1730,12 +1732,6 @@ const buildNoteModel = async function (msg, actors, diagObj) {
         );
     noteModel.startx = startx - noteModel.width + (fromActor.width - conf.actorMargin) / 2;
   } else if (msg.to === msg.from) {
-    textDimensions = utils.calculateTextDimensions(
-      shouldWrap
-        ? utils.wrapLabel(msg.message, common.getMax(conf.width, fromActor.width), noteFont(conf))
-        : msg.message,
-      noteFont(conf)
-    );
     noteModel.width = shouldWrap
       ? common.getMax(conf.width, fromActor.width)
       : common.getMax(fromActor.width, conf.width, textDimensions.width + 2 * conf.noteMargin);


### PR DESCRIPTION
## 📑 Summary

`Note over` a single actor rendered KaTeX content with enormous padding, while `Note left of` / `Note right of` looked fine.

Resolves #6993

## 📏 Design Decisions

`buildNoteModel` computes KaTeX-aware dimensions up front (`calculateMathMLDimensions`), but the `msg.to === msg.from` branch unconditionally re-measured the raw `$$...$$` source as plain text, overwriting them — LaTeX source measures much wider than the rendered math, which is what inflated the note.

The re-measurement is removed rather than guarded, because for non-KaTeX notes it was a no-op: with wrapping off it re-measures identical input with the identical font, and with wrapping on its result was never read (the width comes from `conf.width`/actor width, and the note text is re-wrapped from `noteModel.width` afterwards). Plain-text sizing is therefore unchanged, which the new regression test pins down.

`buildNoteModel` is now exported so the unit tests can exercise it directly, following `drawMessage` and `adjustValueByDirection` which are already exported for the existing spec.

Unit tests: KaTeX note over a single actor is sized from its MathML dimensions (and the raw source is never measured as text); plain-text notes keep their existing sizing. E2E: added a KaTeX sequence-diagram snapshot (`katex.spec.js` test 5) with the formula from the issue.

### 📋 Tasks

- [x] 📖 have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] 💻 have added necessary unit/e2e tests.
- [ ] 📓 have added documentation. (n/a — bug fix, no API change)
- [x] 🦋 changeset added (`patch`, `fix:` prefix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What's working well

- 🎉 Fixes KaTeX-aware sizing for single-actor `Note over` annotations.
- 🎉 Preserves plain-text note sizing.
- 🎉 Adds unit coverage for KaTeX and plain-text dimensions.
- 🎉 Adds an E2E regression test for `Note over` and `Note left of`.
- 🎉 Includes a patch changeset.

## Review

No blocking or important issues identified.

The changes are focused and include suitable regression coverage. Exporting `buildNoteModel` supports direct unit testing of the sizing behavior.

## Security

No XSS or injection issues identified.

## Verdict

**APPROVE**

- [x] At least one 🎉 praise item exists.
- [x] No duplicate findings.
- [x] Severity tally: 0 blocking / 0 important / 0 nit / 0 suggestion / 5 praise.
- [x] Verdict matches the findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->