### PR TITLE
docs: add Sharayeh to community integrations

### DIFF
--- a/docs/ecosystem/integrations-community.md
+++ b/docs/ecosystem/integrations-community.md
@@ -282,8 +282,9 @@ Communication tools and platforms
 - [Reveal CK](https://github.com/jedcn/reveal-ck)
   - [reveal-ck-mermaid-plugin](https://github.com/tmtm/reveal-ck-mermaid-plugin)
 - [SchemaCrawler - Generate Mermaid diagrams from your database](https://dev.to/sualeh/how-to-generate-mermaid-diagrams-for-your-database-33bn)
+- [Sharayeh: Render Mermaid diagrams onto PowerPoint slides](https://sharayeh.com/en/tools/mermaid-to-powerpoint)
 - [speccharts: Turn your test suites into specification diagrams](https://github.com/arnaudrenaud/speccharts)
 - [termaid: Render Mermaid diagrams as Unicode art in the terminal](https://github.com/fasouto/termaid)
 - [Vitepress Plugin](https://github.com/sametcn99/vitepress-mermaid-renderer)
 
-<!--- cspell:ignore Blazorade HueHive --->
+<!--- cspell:ignore Blazorade HueHive Sharayeh --->

--- a/packages/mermaid/src/docs/ecosystem/integrations-community.md
+++ b/packages/mermaid/src/docs/ecosystem/integrations-community.md
@@ -277,8 +277,9 @@ Communication tools and platforms
 - [Reveal CK](https://github.com/jedcn/reveal-ck)
   - [reveal-ck-mermaid-plugin](https://github.com/tmtm/reveal-ck-mermaid-plugin)
 - [SchemaCrawler - Generate Mermaid diagrams from your database](https://dev.to/sualeh/how-to-generate-mermaid-diagrams-for-your-database-33bn)
+- [Sharayeh: Render Mermaid diagrams onto PowerPoint slides](https://sharayeh.com/en/tools/mermaid-to-powerpoint)
 - [speccharts: Turn your test suites into specification diagrams](https://github.com/arnaudrenaud/speccharts)
 - [termaid: Render Mermaid diagrams as Unicode art in the terminal](https://github.com/fasouto/termaid)
 - [Vitepress Plugin](https://github.com/sametcn99/vitepress-mermaid-renderer)
 
-<!--- cspell:ignore Blazorade HueHive --->
+<!--- cspell:ignore Blazorade HueHive Sharayeh --->


### PR DESCRIPTION
Adds Sharayeh to the **Other** section of the community integrations list.

**What it does:** paste a Mermaid definition and get a `.pptx` with the diagram rendered onto a slide — for people who need a diagram inside a PowerPoint deck without exporting a PNG by hand and placing it themselves. It renders with Mermaid itself (currently 10.9), so the output matches the source exactly.

**To be upfront:** the diagram is placed as a high-resolution rendering, not as native PowerPoint shapes, and it's a paid product — converting and previewing work without signing up, and downloading the file uses credits. Happy to reword the entry or drop it if that doesn't meet the bar for this list.

Also adds `Sharayeh` to the file's inline `cspell:ignore` comment so the spellcheck job passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added Sharayeh to the **Other** community integrations list.
- Documented Mermaid-to-PowerPoint conversion support.
- Added `Sharayeh` to the inline cspell ignore comment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->