### PR TITLE
docs: change `mermaidAPI.setConfig()` changeset

### DIFF
--- a/.changeset/proud-breads-stick.md
+++ b/.changeset/proud-breads-stick.md
@@ -1,8 +1,11 @@
 ---
-'mermaid': minor
+'mermaid': patch
 ---
 
 deprecate: Deprecate the `mermaidAPI.setConfig()` function
+
+Calling this function has no observable effect, as the next time a
+`render()` or `parse()` is called, the `currentConfig` is cleared.
 
 commit: 2cd6dcf735533b323507e3e889ffdea870540b43
 author: @aloisklink


### PR DESCRIPTION
## :bookmark_tabs: Summary

Add some more information the the deprecation of `mermaidAPI.setConfig()` to explain why it's been deprecated, and to change the changeset level to just a `patch` change instead of a `minor` change.

## :straight_ruler: Design Decisions

Technically, under semver, deprecation are supposed to be `minor` version bumps, but considering that this function is currently broken and not doing anything, and has been broken for a while, I think we can make this a `patch` version instead.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
