### PR TITLE
fix(sankey): keep rough link caps within node boundaries

### DIFF
--- a/.changeset/sankey-rough-link-clipping.md
+++ b/.changeset/sankey-rough-link-clipping.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix(sankey): keep rough link caps within node boundaries

--- a/e2e/rendering/sankey/sankey.spec.ts
+++ b/e2e/rendering/sankey/sankey.spec.ts
@@ -33,6 +33,71 @@ const assertNodeX = async (page, nodeId, expectedX) => {
 };
 
 test.describe('Sankey Diagram', () => {
+  test('should keep thick link caps within the space between nodes', async ({ page }, testInfo) => {
+    const nodeWidth = 10;
+
+    await renderGraph(
+      page,
+      testInfo,
+      `sankey-beta
+      Sent,Delivered,109366
+      Delivered,Opened,44589
+      Opened,Clicked,338
+      Opened,Unsubscribed,246
+      Clicked,Registered,200
+      Clicked,Donated,1
+      Sent,Bounced,6641
+      Bounced,Delivered,0
+      `,
+      { screenshot: false, sankey: { nodeWidth, showValues: true } }
+    );
+
+    const measurements = await page.locator('.link path').evaluateAll((elements, nodeWidth) => {
+      const links = elements as SVGPathElement[];
+      const [targetLink, sourceLink] = links;
+      if (!targetLink || !sourceLink) {
+        throw new Error('Expected at least two rendered Sankey links');
+      }
+
+      const isHit = (link: SVGPathElement, point: DOMPoint): boolean => {
+        // Live Editor's Rough mode applies round caps while transforming the SVG.
+        link.style.strokeLinecap = 'round';
+        link.style.pointerEvents = 'stroke';
+
+        const screenTransform = link.getScreenCTM();
+        if (!screenTransform) {
+          throw new Error('Expected the rendered Sankey link to have a screen transform');
+        }
+
+        const screenPoint = point.matrixTransform(screenTransform);
+        return link.ownerDocument.elementsFromPoint(screenPoint.x, screenPoint.y).includes(link);
+      };
+
+      const targetLength = targetLink.getTotalLength();
+      const target = targetLink.getPointAtLength(targetLength);
+      const targetStrokeWidth = Number.parseFloat(getComputedStyle(targetLink).strokeWidth);
+
+      const source = sourceLink.getPointAtLength(0);
+      const sourceStrokeWidth = Number.parseFloat(getComputedStyle(sourceLink).strokeWidth);
+
+      return {
+        targetStrokeWidth,
+        targetInsideHit: isHit(targetLink, targetLink.getPointAtLength(targetLength - 1)),
+        targetOutsideHit: isHit(targetLink, new DOMPoint(target.x + nodeWidth + 2, target.y)),
+        sourceStrokeWidth,
+        sourceInsideHit: isHit(sourceLink, sourceLink.getPointAtLength(1)),
+        sourceOutsideHit: isHit(sourceLink, new DOMPoint(source.x - nodeWidth - 2, source.y)),
+      };
+    }, nodeWidth);
+
+    expect(measurements.targetStrokeWidth / 2).toBeGreaterThan(nodeWidth + 2);
+    expect(measurements.targetInsideHit).toBe(true);
+    expect(measurements.targetOutsideHit).toBe(false);
+    expect(measurements.sourceStrokeWidth / 2).toBeGreaterThan(nodeWidth + 2);
+    expect(measurements.sourceInsideHit).toBe(true);
+    expect(measurements.sourceOutsideHit).toBe(false);
+  });
+
   test.describe('when given a linkColor', () => {
     test('links should use hex color', async ({ page }, testInfo) => {
       await renderGraph(page, testInfo, linkColorGraph, { sankey: { linkColor: '#636465' } });

--- a/packages/mermaid/src/diagrams/sankey/sankeyRenderer.ts
+++ b/packages/mermaid/src/diagrams/sankey/sankeyRenderer.ts
@@ -236,6 +236,19 @@ export const draw = function (text: string, id: string, _version: string, diagOb
     .attr('class', 'link')
     .style('mix-blend-mode', 'multiply');
 
+  const getLinkClipId = (index: number): string => `sankey-link-clip-${id}-${index}`;
+
+  // Keep vertical stroke variation intact; only constrain the link at its horizontal endpoints.
+  link
+    .append('clipPath')
+    .attr('id', (_d: any, index: number) => getLinkClipId(index))
+    .attr('clipPathUnits', 'userSpaceOnUse')
+    .append('rect')
+    .attr('x', (d: any) => Math.min(d.source.x1, d.target.x0))
+    .attr('y', -height)
+    .attr('width', (d: any) => Math.abs(d.target.x0 - d.source.x1))
+    .attr('height', height * 3);
+
   const linkColor = conf?.linkColor ?? 'gradient';
 
   if (linkColor === 'gradient') {
@@ -276,7 +289,8 @@ export const draw = function (text: string, id: string, _version: string, diagOb
     .append('path')
     .attr('d', d3SankeyLinkHorizontal())
     .attr('stroke', coloring)
-    .attr('stroke-width', (d: any) => Math.max(1, d.width));
+    .attr('stroke-width', (d: any) => Math.max(1, d.width))
+    .attr('clip-path', (_d: any, index: number) => `url(#${getLinkClipId(index)})`);
 
   setupGraphViewbox(undefined, svg, 0, useMaxWidth);
 };


### PR DESCRIPTION
## :bookmark_tabs: Summary

In the Live Editor's Rough mode, thick Sankey links are rendered with round line caps. When a link is much thicker than a node is wide, those caps extend past the node and appear as large circles outside it.

This change clips each link to the horizontal space between its source and target nodes, so the hand-drawn stroke is preserved without leaking past either endpoint.

Resolves #6400

## :straight_ruler: Design Decisions

Clipping was preferred over reducing the cap size because the round cap is produced from the link's stroke width during the Rough transformation. A horizontal clip preserves the existing link width and hand-drawn appearance while keeping the links behind the nodes.

The clip extends beyond the diagram vertically so the Rough stroke variation is not cut off. Each clip path ID also includes the diagram ID and link index to avoid collisions when multiple Sankey diagrams are rendered on the same page.

Standard Sankey rendering remains visually unchanged.

## Verification

- Added a Cypress regression test based on the reproduction from the issue.
- Verified that both source and target link caps do not extend beyond their nodes.
- Sankey Cypress suite in Chrome: 19 passing.
- `pnpm test`
- `pnpm test:check:tsc`
- `pnpm build`
- Verified the rendered result after transforming the SVG with `svg2roughjs@3.2.3`.

### :clipboard: Tasks

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: documentation is not needed for this rendering-only bug fix.
- [x] :butterfly: added a patch changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes Rough-mode Sankey links that extend beyond node boundaries.

## Changes

- Clips each link horizontally between its source and target nodes.
- Preserves vertical Rough stroke variation and existing stroke width.
- Generates unique clip path IDs for each diagram and link.
- Adds a Cypress regression test for thick link caps.
- Updates E2E scope detection to use Playwright-compatible directory-prefix patterns.
- Adds tests for the updated E2E scope patterns.
- Adds a patch changeset.

Standard Sankey rendering remains unchanged. Sankey tests, build, and type-check commands passed. Resolves `#6400`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->