### PR TITLE
fix(parser): pin langium to 4.2.1 to keep chevrotain v11 and Node 20 support

### DIFF
--- a/.changeset/pin-langium-chevrotain-11-node20.md
+++ b/.changeset/pin-langium-chevrotain-11-node20.md
@@ -3,13 +3,3 @@
 ---
 
 fix(parser): pin langium to 4.2.1 to keep chevrotain v11 and restore Node 20 support
-
-langium 4.2.2+ switched to chevrotain v12, which requires Node >= 22 and calls
-`Object.groupBy` (a Node 21+ API) during grammar validation. Since chevrotain is
-bundled into the published parser, this could throw
-`TypeError: Object.groupBy is not a function` for consumers running mermaid on
-Node 20, and it broke `langium generate` for contributors on Node 20.
-
-Pinning langium to 4.2.1 (the last release on chevrotain ~11.1.1) and aligning
-the parser's own `chevrotain`/`@chevrotain/types` pins on ~11.1.2 keeps a single
-chevrotain version in the tree and keeps the published bundle Node 20 compatible.

--- a/.changeset/pin-langium-chevrotain-11-node20.md
+++ b/.changeset/pin-langium-chevrotain-11-node20.md
@@ -1,0 +1,15 @@
+---
+'@mermaid-js/parser': patch
+---
+
+fix(parser): pin langium to 4.2.1 to keep chevrotain v11 and restore Node 20 support
+
+langium 4.2.2+ switched to chevrotain v12, which requires Node >= 22 and calls
+`Object.groupBy` (a Node 21+ API) during grammar validation. Since chevrotain is
+bundled into the published parser, this could throw
+`TypeError: Object.groupBy is not a function` for consumers running mermaid on
+Node 20, and it broke `langium generate` for contributors on Node 20.
+
+Pinning langium to 4.2.1 (the last release on chevrotain ~11.1.1) and aligning
+the parser's own `chevrotain`/`@chevrotain/types` pins on ~11.1.2 keeps a single
+chevrotain version in the tree and keeps the published bundle Node 20 compatible.

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "jison": "^0.4.18",
     "js-yaml": "^4.3.0",
     "jsdom": "^26.1.0",
-    "langium-cli": "^4.2.1",
+    "langium-cli": "~4.2.1",
     "lint-staged": "^16.1.6",
     "lit": "^3.3.3",
     "markdown-table": "^3.0.4",
@@ -173,6 +173,7 @@
   },
   "pnpm": {
     "overrides": {
+      "langium": "4.2.1",
       "dependency-tree": "11.4.3",
       "@isaacs/brace-expansion": "^5.0.1",
       "minimatch@10": "^10.2.6"

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.57.8",
     "chevrotain": "~11.1.2",
-    "langium": "^4.2.4"
+    "langium": "4.2.1"
   },
   "files": [
     "dist/"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  langium: 4.2.1
   dependency-tree: 11.4.3
   '@isaacs/brace-expansion': ^5.0.1
   minimatch@10: ^10.2.6
@@ -202,7 +203,7 @@ importers:
         specifier: ^26.1.0
         version: 26.1.0(canvas@3.2.3)
       langium-cli:
-        specifier: ^4.2.1
+        specifier: ~4.2.1
         version: 4.2.1
       lint-staged:
         specifier: ^16.1.6
@@ -607,8 +608,8 @@ importers:
         specifier: ~11.1.2
         version: 11.1.2
       langium:
-        specifier: ^4.2.4
-        version: 4.2.4
+        specifier: 4.2.1
+        version: 4.2.1
 
   packages/tiny: {}
 
@@ -1652,32 +1653,17 @@ packages:
   '@chevrotain/cst-dts-gen@11.1.2':
     resolution: {integrity: sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==}
 
-  '@chevrotain/cst-dts-gen@12.0.0':
-    resolution: {integrity: sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==}
-
   '@chevrotain/gast@11.1.2':
     resolution: {integrity: sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g==}
-
-  '@chevrotain/gast@12.0.0':
-    resolution: {integrity: sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==}
 
   '@chevrotain/regexp-to-ast@11.1.2':
     resolution: {integrity: sha512-nMU3Uj8naWer7xpZTYJdxbAs6RIv/dxYzkYU8GSwgUtcAAlzjcPfX1w+RKRcYG8POlzMeayOQ/znfwxEGo5ulw==}
 
-  '@chevrotain/regexp-to-ast@12.0.0':
-    resolution: {integrity: sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==}
-
   '@chevrotain/types@11.1.2':
     resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
-  '@chevrotain/types@12.0.0':
-    resolution: {integrity: sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==}
-
   '@chevrotain/utils@11.1.2':
     resolution: {integrity: sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==}
-
-  '@chevrotain/utils@12.0.0':
-    resolution: {integrity: sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==}
 
   '@codemirror/commands@6.10.4':
     resolution: {integrity: sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==}
@@ -5309,17 +5295,13 @@ packages:
     resolution: {integrity: sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==}
     engines: {node: '>= 0.8.0'}
 
-  chevrotain-allstar@0.4.3:
-    resolution: {integrity: sha512-2X4mkroolSMKqW+H22pyPMUVDqYZzPhephTmg/NODKb1IGYPHfxfhcW0EjS7wcPJNbze2i4vBWT7zT5FKF2lrQ==}
+  chevrotain-allstar@0.3.1:
+    resolution: {integrity: sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==}
     peerDependencies:
-      chevrotain: ^12.0.0
+      chevrotain: ^11.0.0
 
   chevrotain@11.1.2:
     resolution: {integrity: sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==}
-
-  chevrotain@12.0.0:
-    resolution: {integrity: sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==}
-    engines: {node: '>=22.0.0'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -6921,10 +6903,6 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
-  fs-extra@11.3.2:
-    resolution: {integrity: sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==}
-    engines: {node: '>=14.14'}
-
   fs-extra@11.3.4:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
     engines: {node: '>=14.14'}
@@ -8073,8 +8051,8 @@ packages:
   langium-railroad@4.2.0:
     resolution: {integrity: sha512-LYR22GV14iz0GTUtR91pZY6yNImYRk1HbAuHBP8k8GESMcSkCJh+iewJooH9k8H8dJOteXvvI7aFkz6rfU9oLQ==}
 
-  langium@4.2.4:
-    resolution: {integrity: sha512-J0M9BkTOZ9Izee2YL0eXkUKFdWhrmTYYVLgiZTz6Z3KvK03ooM+vjVrfphKcdGVPWmM2cFYtDnNyIsIIZPrHNA==}
+  langium@4.2.1:
+    resolution: {integrity: sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==}
     engines: {node: '>=20.10.0', npm: '>=10.2.3'}
 
   latest-version@9.0.0:
@@ -12948,31 +12926,16 @@ snapshots:
       '@chevrotain/types': 11.1.2
       lodash-es: 4.17.23
 
-  '@chevrotain/cst-dts-gen@12.0.0':
-    dependencies:
-      '@chevrotain/gast': 12.0.0
-      '@chevrotain/types': 12.0.0
-
   '@chevrotain/gast@11.1.2':
     dependencies:
       '@chevrotain/types': 11.1.2
       lodash-es: 4.17.23
 
-  '@chevrotain/gast@12.0.0':
-    dependencies:
-      '@chevrotain/types': 12.0.0
-
   '@chevrotain/regexp-to-ast@11.1.2': {}
-
-  '@chevrotain/regexp-to-ast@12.0.0': {}
 
   '@chevrotain/types@11.1.2': {}
 
-  '@chevrotain/types@12.0.0': {}
-
   '@chevrotain/utils@11.1.2': {}
-
-  '@chevrotain/utils@12.0.0': {}
 
   '@codemirror/commands@6.10.4':
     dependencies:
@@ -14642,7 +14605,7 @@ snapshots:
       ajv: 8.18.0
       ajv-draft-04: 1.0.0(ajv@8.18.0)
       ajv-formats: 3.0.1(ajv@8.18.0)
-      fs-extra: 11.3.2
+      fs-extra: 11.3.4
       import-lazy: 4.0.0
       jju: 1.4.0
       resolve: 1.22.12
@@ -16713,9 +16676,9 @@ snapshots:
 
   check-more-types@2.24.0: {}
 
-  chevrotain-allstar@0.4.3(chevrotain@12.0.0):
+  chevrotain-allstar@0.3.1(chevrotain@11.1.2):
     dependencies:
-      chevrotain: 12.0.0
+      chevrotain: 11.1.2
       lodash-es: 4.18.1
 
   chevrotain@11.1.2:
@@ -16726,14 +16689,6 @@ snapshots:
       '@chevrotain/types': 11.1.2
       '@chevrotain/utils': 11.1.2
       lodash-es: 4.17.23
-
-  chevrotain@12.0.0:
-    dependencies:
-      '@chevrotain/cst-dts-gen': 12.0.0
-      '@chevrotain/gast': 12.0.0
-      '@chevrotain/regexp-to-ast': 12.0.0
-      '@chevrotain/types': 12.0.0
-      '@chevrotain/utils': 12.0.0
 
   chokidar@3.6.0:
     dependencies:
@@ -18723,12 +18678,6 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
-  fs-extra@11.3.2:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.2.0
-      universalify: 2.0.1
-
   fs-extra@11.3.4:
     dependencies:
       graceful-fs: 4.2.11
@@ -20061,28 +20010,24 @@ snapshots:
   langium-cli@4.2.1:
     dependencies:
       chalk: 5.6.2
-      commander: 14.0.2
-      fs-extra: 11.3.2
+      commander: 14.0.3
+      fs-extra: 11.3.4
       jsonschema: 1.5.0
-      langium: 4.2.4
+      langium: 4.2.1
       langium-railroad: 4.2.0
       lodash: 4.18.1
 
   langium-railroad@4.2.0:
     dependencies:
-      langium: 4.2.4
+      langium: 4.2.1
       railroad-diagrams: 1.0.0
 
-  langium@4.2.4:
+  langium@4.2.1:
     dependencies:
-      '@chevrotain/regexp-to-ast': 12.0.0
-      chevrotain: 12.0.0
-      chevrotain-allstar: 0.4.3(chevrotain@12.0.0)
-      vscode-jsonrpc: 8.2.0
+      chevrotain: 11.1.2
+      chevrotain-allstar: 0.3.1(chevrotain@11.1.2)
       vscode-languageserver: 9.0.1
-      vscode-languageserver-protocol: 3.17.5
       vscode-languageserver-textdocument: 1.0.12
-      vscode-languageserver-types: 3.17.5
       vscode-uri: 3.1.0
 
   latest-version@9.0.0:

--- a/renovate.json
+++ b/renovate.json
@@ -51,6 +51,11 @@
     {
       "matchPackageNames": ["chokidar"],
       "enabled": false
+    },
+    {
+      "description": "langium >=4.2.2 depends on chevrotain v12, which requires Node >=22 (uses Object.groupBy). Pinned to 4.2.1 / chevrotain v11 to keep Node 20 support — bump manually and in sync when Node 20 support is dropped.",
+      "matchPackageNames": ["langium", "langium-cli", "chevrotain", "@chevrotain/types"],
+      "enabled": false
     }
   ],
   "dependencyDashboard": false,


### PR DESCRIPTION
Resolves #8027

## The problem

langium 4.2.2+ switched from chevrotain v11 to **chevrotain v12**, which:

- declares `engines: { node: ">=22.0.0" }`
- calls `Object.groupBy` — a **Node 21+ API** — in `lib/src/parse/grammar/checks.js` during grammar validation

Since #7907 chevrotain is **bundled into the published `@mermaid-js/parser`**, so after the renovate patch-bump of langium `^4.0.3 → ^4.2.4` (#7916 era), the published parser bundle contained Node 22-only code. Consumers running mermaid on Node 20 could hit `TypeError: Object.groupBy is not a function`, and `langium generate` crashed for contributors on Node 20 with the same error.

The langium/chevrotain version map:

| langium | chevrotain | Node support |
| --- | --- | --- |
| ≤ 4.2.1 | ~11.1.1 | no engines restriction |
| ≥ 4.2.2 | ~12.0.0 | `>=22.0.0`, uses `Object.groupBy` |

## The fix

- Pin `langium` to **4.2.1** (the last release on chevrotain v11) in `packages/parser`, and via a **pnpm override** — the override is required because `langium-cli`'s own dependency range (`~4.2.0`) would otherwise still resolve its internal langium to 4.2.4 → chevrotain 12, keeping `langium generate` broken on Node 20
- Pin `langium-cli` to `~4.2.1` (4.3.0 tracks langium 4.3 / chevrotain 12)
- Add a renovate `packageRules` entry disabling updates for `langium`, `langium-cli`, `chevrotain`, and `@chevrotain/types`, with a description documenting when to lift the pin — this drift was originally introduced by an automated renovate bump, so without this rule the pin would be silently re-broken on the next patch sweep
- This also collapses the dependency tree back to a **single chevrotain version** (11.1.2); previously chevrotain 11 (parser pins) and 12 (via langium) were both resolved

## Trade-off

Staying on chevrotain v11 keeps its pinned `lodash-es@4.17.23` (the CVE-flagged version that motivated bundling in #7907). Exposure is limited since it's bundled rather than a published dependency, but lockfile scanners may still flag it. To be revisited when Node 20 support is dropped — the renovate rule description marks the spot.

## Verification (all on Node 20.12.0)

- ✅ `pnpm install` + full `pnpm build` (previously failed in `prepare`)
- ✅ `pnpm --filter parser langium:generate` (previously: `TypeError: Object.groupBy is not a function`)
- ✅ Parser unit tests: 691/691
- ✅ `tsc --emitDeclarationOnly` on the parser package
- ✅ Built `mermaid-parser.core.mjs` imports and parses a pie diagram on Node 20; `grep Object.groupBy` across all dist chunks: zero hits
- ✅ `renovate-config-validator` passes (same command as the config-lint workflow)
- ✅ api-extractor rollup (`prepack`) — run on Node 22, as `scripts/prepack.ts` itself requires `--experimental-strip-types` (publish-time-only path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Pin `langium` and `langium-cli` to 4.2.1 for Chevrotain 11 and Node 20 compatibility.
- Add a pnpm override to prevent newer Langium versions from resolving.
- Disable Renovate updates for Langium, Langium CLI, Chevrotain, and `@chevrotain/types`.
- Add a patch changeset for `@mermaid-js/parser`.
- Verify installation, build, Langium generation, parser tests, declaration generation, bundled parser behavior, distribution contents, and Renovate configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->