### PR TITLE
fix(c4): allow hash characters in titles

### DIFF
--- a/.changeset/c4-title-hash.md
+++ b/.changeset/c4-title-hash.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+Allow C4 diagram titles to include `#` characters without triggering a parser error.

--- a/.changeset/c4-title-hash.md
+++ b/.changeset/c4-title-hash.md
@@ -2,4 +2,4 @@
 'mermaid': patch
 ---
 
-Allow C4 diagram titles to include `#` characters without triggering a parser error.
+fix(c4): allow C4 diagram titles to include `#` characters without triggering a parser error.

--- a/packages/mermaid/src/diagrams/c4/parser/c4Diagram.jison
+++ b/packages/mermaid/src/diagrams/c4/parser/c4Diagram.jison
@@ -85,7 +85,7 @@
 
 
 "title"\s[^\n;]+                          return 'title';
-"accDescription"\s[^#\n;]+                return 'accDescription';
+"accDescription"\s[^\n;]+                 return 'accDescription';
 accTitle\s*":"\s*                         { this.begin("acc_title");return 'acc_title'; }
 <acc_title>(?!\n|;|#)*[^\n]*              { this.popState(); return "acc_title_value"; }
 accDescr\s*":"\s*                         { this.begin("acc_descr");return 'acc_descr'; }

--- a/packages/mermaid/src/diagrams/c4/parser/c4Diagram.jison
+++ b/packages/mermaid/src/diagrams/c4/parser/c4Diagram.jison
@@ -84,7 +84,7 @@
 .*direction\s+LR[^\n]*                    return 'direction_lr';
 
 
-"title"\s[^#\n;]+                         return 'title';
+"title"\s[^\n;]+                          return 'title';
 "accDescription"\s[^#\n;]+                return 'accDescription';
 accTitle\s*":"\s*                         { this.begin("acc_title");return 'acc_title'; }
 <acc_title>(?!\n|;|#)*[^\n]*              { this.popState(); return "acc_title_value"; }

--- a/packages/mermaid/src/diagrams/c4/parser/c4Diagram.spec.ts
+++ b/packages/mermaid/src/diagrams/c4/parser/c4Diagram.spec.ts
@@ -22,13 +22,25 @@ Person(customerA, "Banking Customer A", "A customer of the bank, with personal b
     expect(rendered).toBe(true);
   });
 
-  it('should allow # characters in the diagram title', function () {
+  it.each(['Sprint #3 architecture', 'Boundary (#4864)', 'issue#4864'])(
+    'should allow # characters in C4 titles like %s',
+    function (title: string) {
+      c4.parser.parse(`C4Context
+title ${title}
+Person(customer, "Customer", "A customer")`);
+
+      const yy = c4.parser.yy;
+      expect(yy.getTitle()).toBe(title);
+    }
+  );
+
+  it('should allow # characters in accDescription', function () {
     c4.parser.parse(`C4Context
-title Sprint #3 architecture
+accDescription Sprint #3 notes
 Person(customer, "Customer", "A customer")`);
 
     const yy = c4.parser.yy;
-    expect(yy.getTitle()).toBe('Sprint #3 architecture');
+    expect(yy.getAccDescription()).toBe('Sprint #3 notes');
   });
 
   it('should handle parameter names that are keywords', function () {

--- a/packages/mermaid/src/diagrams/c4/parser/c4Diagram.spec.ts
+++ b/packages/mermaid/src/diagrams/c4/parser/c4Diagram.spec.ts
@@ -22,6 +22,15 @@ Person(customerA, "Banking Customer A", "A customer of the bank, with personal b
     expect(rendered).toBe(true);
   });
 
+  it('should allow # characters in the diagram title', function () {
+    c4.parser.parse(`C4Context
+title Sprint #3 architecture
+Person(customer, "Customer", "A customer")`);
+
+    const yy = c4.parser.yy;
+    expect(yy.getTitle()).toBe('Sprint #3 architecture');
+  });
+
   it('should handle parameter names that are keywords', function () {
     c4.parser.parse(`C4Context
 title title


### PR DESCRIPTION
## :bookmark_tabs: Summary

Fixes #8030.

Allows C4 diagram titles to include `#` characters. Previously, the C4 lexer stopped `title` tokens at `#`, so titles like `Sprint #3 architecture` caused a parse error.

## :straight_ruler: Design Decisions

Only the `title` lexer rule is relaxed; comment handling and other metadata lexer rules are unchanged.

## :clipboard: Tasks

- [x] Add regression coverage for C4 titles containing `#`
- [x] Add a patch changeset

## :test_tube: How to test

```sh
pnpm exec vitest run packages/mermaid/src/diagrams/c4/parser/c4Diagram.spec.ts
pnpm lint:jison
pnpm exec prettier --check packages/mermaid/src/diagrams/c4/parser/c4Diagram.spec.ts .changeset/c4-title-hash.md
git diff --check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What's working well

- 🎉 [praise] The C4 lexer accepts `#` in titles and accumulated descriptions.
- 🎉 [praise] The lexer still stops these tokens at newlines and semicolons.
- 🎉 [praise] Regression tests cover multiple title formats, including `Boundary (`#4864`)` and `issue#4864`.
- 🎉 [praise] Comment-sensitive lexer rules remain unchanged.
- 🎉 [praise] The patch changeset uses the requested `fix(c4):` prefix.

## Security

- No XSS or injection issues identified.

## Review verdict

**APPROVE**
<!-- end of auto-generated comment: release notes by coderabbit.ai -->