### PR TITLE
docs: add Line9 to community integrations

### DIFF
--- a/docs/ecosystem/integrations-community.md
+++ b/docs/ecosystem/integrations-community.md
@@ -272,6 +272,9 @@ Communication tools and platforms
 - [Codemia: A tool to practice system design problems](https://codemia.io) ✅
 - [ExDoc](https://github.com/elixir-lang/ex_doc)
   - [Rendering Mermaid graphs](https://github.com/elixir-lang/ex_doc#rendering-mermaid-graphs)
+- [Line9](https://line9.ai/) - alternative renderer for Mermaid: same syntax, rebuilt layout and typography
+  - [Web viewer](https://line9.ai/diagram) - paste Mermaid, get a Line9 render; no account required
+  - [CLI](https://line9.ai/cli) - `line9 render` for local and agent-driven workflows
 - [MarkChart: Preview Mermaid diagrams on macOS](https://markchart.app/)
 - [mermaid-isomorphic](https://github.com/remcohaszing/mermaid-isomorphic)
 - [mermaid-server: Generate diagrams using a HTTP request](https://github.com/TomWright/mermaid-server)

--- a/packages/mermaid/src/docs/ecosystem/integrations-community.md
+++ b/packages/mermaid/src/docs/ecosystem/integrations-community.md
@@ -267,6 +267,9 @@ Communication tools and platforms
 - [Codemia: A tool to practice system design problems](https://codemia.io) ✅
 - [ExDoc](https://github.com/elixir-lang/ex_doc)
   - [Rendering Mermaid graphs](https://github.com/elixir-lang/ex_doc#rendering-mermaid-graphs)
+- [Line9](https://line9.ai/) - alternative renderer for Mermaid: same syntax, rebuilt layout and typography
+  - [Web viewer](https://line9.ai/diagram) - paste Mermaid, get a Line9 render; no account required
+  - [CLI](https://line9.ai/cli) - `line9 render` for local and agent-driven workflows
 - [MarkChart: Preview Mermaid diagrams on macOS](https://markchart.app/)
 - [mermaid-isomorphic](https://github.com/remcohaszing/mermaid-isomorphic)
 - [mermaid-server: Generate diagrams using a HTTP request](https://github.com/TomWright/mermaid-server)


### PR DESCRIPTION
## :bookmark_tabs: Summary

Adds Line9 to Community Integrations → Other.

Line9 is an alternative renderer for Mermaid — it takes `.mmd` source unchanged and lays it out
with its own layout engine, aimed at flowcharts where the default layout stretches in a long aspect ratio.
It's a renderer, not a competing syntax: everything it reads is Mermaid, and everything it can't
lay out yet falls through to Mermaid's own output.

There's a free web viewer (no account) and a CLI. Disclosure: I built it. Happy to move the entry
or trim the wording if another section fits better.

## :straight_ruler: Design Decisions

- Edited `packages/mermaid/src/docs/ecosystem/integrations-community.md` only; the generated
  `docs/` copy is left for the automated docs build.
- Placed in **Other** rather than a platform-shaped section, since Line9 isn't a plugin for a
  host application.
- No ✅ — which marks native Mermaid support on a platform, which is not what this is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds Line9 to the **Community Integrations → Other** section.

Line9 provides a web viewer and CLI for rendering unchanged Mermaid `.mmd` files. It uses its own flowchart layout engine and falls back to Mermaid output for unsupported layouts.

Only the source documentation file was updated. The generated `docs/` copy remains unchanged for automated documentation builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->