### PR TITLE
fix: keep explicit line breaks in every wrapped label

### DIFF
--- a/.changeset/fix-wrap-label-line-breaks.md
+++ b/.changeset/fix-wrap-label-line-breaks.md
@@ -1,0 +1,9 @@
+---
+'mermaid': patch
+---
+
+fix: keep explicit `<br/>` line breaks in every wrapped label, not just the first one.
+`hasBreaks` and `wrapLabel` tested the shared, global `lineBreakRegex`, so each match
+left a `lastIndex` behind that made the next check start mid-string and miss the break.
+A label that came after another label containing a break was therefore re-wrapped,
+dropping the line break the diagram author had written.

--- a/packages/mermaid/src/diagrams/common/common.spec.ts
+++ b/packages/mermaid/src/diagrams/common/common.spec.ts
@@ -1,4 +1,10 @@
-import { sanitizeText, removeScript, parseGenericTypes, countOccurrence } from './common.js';
+import {
+  sanitizeText,
+  removeScript,
+  parseGenericTypes,
+  countOccurrence,
+  hasBreaks,
+} from './common.js';
 
 describe('when securityLevel is antiscript, all script must be removed', () => {
   /**
@@ -94,6 +100,21 @@ describe('Sanitize text', () => {
     expect(result).toContain('<p>');
     expect(result).toContain('Hello');
     expect(result).toContain('world');
+  });
+});
+
+describe('hasBreaks', () => {
+  it('should detect line breaks', () => {
+    expect(hasBreaks('a<br/>b')).toBe(true);
+    expect(hasBreaks('a<br>b')).toBe(true);
+    expect(hasBreaks('a<BR />b')).toBe(true);
+    expect(hasBreaks('no breaks here')).toBe(false);
+  });
+
+  it('should give the same answer on repeated calls', () => {
+    expect(hasBreaks('a<br/>b')).toBe(true);
+    expect(hasBreaks('a<br/>b')).toBe(true);
+    expect(hasBreaks('c<br/>d')).toBe(true);
   });
 });
 

--- a/packages/mermaid/src/diagrams/common/common.ts
+++ b/packages/mermaid/src/diagrams/common/common.ts
@@ -111,7 +111,9 @@ export const sanitizeTextOrArray = (
  * @returns Whether or not the text has breaks
  */
 export const hasBreaks = (text: string): boolean => {
-  return lineBreakRegex.test(text);
+  // `search` is used rather than `test` because `lineBreakRegex` is global,
+  // and `test` would carry its `lastIndex` over into the next call.
+  return text.search(lineBreakRegex) !== -1;
 };
 
 /**

--- a/packages/mermaid/src/utils.spec.ts
+++ b/packages/mermaid/src/utils.spec.ts
@@ -431,6 +431,23 @@ describe('when inserting titles', function () {
   });
 });
 
+describe('when wrapping labels', function () {
+  const wrapConfig = { fontSize: 12, fontWeight: 400, fontFamily: 'Arial', joinWith: '<br/>' };
+
+  jsdomIt('leaves a label that already has line breaks untouched', () => {
+    expect(utils.wrapLabel('first line<br/>second line', 100, wrapConfig)).toBe(
+      'first line<br/>second line'
+    );
+  });
+
+  jsdomIt('leaves every label with line breaks untouched, not just the first one', () => {
+    utils.wrapLabel('first line<br/>second line', 100, wrapConfig);
+    expect(utils.wrapLabel('third line<br/>fourth line', 100, wrapConfig)).toBe(
+      'third line<br/>fourth line'
+    );
+  });
+});
+
 describe('when parsing font sizes', function () {
   it('parses number inputs', function () {
     expect(utils.parseFontSize(14)).toEqual([14, '14px']);

--- a/packages/mermaid/src/utils.ts
+++ b/packages/mermaid/src/utils.ts
@@ -566,7 +566,7 @@ export const wrapLabel: (label: string, maxWidth: number, config: WrapLabelConfi
         { fontSize: 12, fontWeight: 400, fontFamily: 'Arial', joinWith: '<br/>' },
         config
       );
-      if (common.lineBreakRegex.test(label)) {
+      if (common.hasBreaks(label)) {
         return label;
       }
       const words = label.split(' ').filter(Boolean);


### PR DESCRIPTION
## :bookmark_tabs: Summary

Resolves #8037

`lineBreakRegex` is declared global (`/<br\s*\/?>/gi`) because `sanitizeText` and `splitBreaks` need it that way, but two call sites used it with `.test()`:

- `hasBreaks()` in `packages/mermaid/src/diagrams/common/common.ts`
- `wrapLabel()` in `packages/mermaid/src/utils.ts`, in the early return that leaves an already-broken label alone

`RegExp.prototype.test` on a global regex advances `lastIndex` and leaves it set. The next check then starts mid-string, so a `<br/>` sitting before that offset is not found, `wrapLabel` falls through to its word-wrapping branch, and it rewrites a label the author had already broken by hand.

In a sequence diagram this means the message *after* a message containing a `<br/>` loses its line break and is re-flowed:

```text
sequenceDiagram
  Alice->>Alice: wrap: aaa bbb ccc ddd eee fff ggg hhh iii jjj<br/>kkk
  Alice->>Alice: wrap: lll<br/>mmm nnn ooo ppp qqq rrr sss ttt uuu vvv
```

| | before | after |
| --- | --- | --- |
| message 1 | `aaa bbb ccc ddd eee fff ggg hhh iii jjj` / `kkk` | unchanged |
| message 2 | `lll` / `mmm nnn ooo ppp` / `qqq rrr sss ttt uuu` / `vvv` | `lll` / `mmm nnn ooo ppp qqq rrr sss ttt uuu vvv` |

## :straight_ruler: Design Decisions

`hasBreaks` now uses `String.prototype.search`, which ignores `lastIndex` and restores it, so the shared regex keeps working for the `replace`/`split` callers that rely on the global flag. `wrapLabel` calls `common.hasBreaks(label)` instead of reaching for the regex itself, so there is one place left that decides whether a label already has breaks.

The alternative — a second, non-global copy of the pattern — would put the `<br>` pattern in two places, and clearing `lastIndex` before each `test` would still leave it dirty for the next caller.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

Documentation is unchanged — this restores the documented behaviour of `<br/>` rather than adding to it.

Tests added, each failing on `develop` and passing here:

- `hasBreaks` gives the same answer on repeated calls (`common.spec.ts`)
- `wrapLabel` leaves *every* label with line breaks untouched, not just the first one (`utils.spec.ts`)

`vitest run` is green: 226 files, 5091 passed / 16 skipped / 2 todo. `pnpm lint` is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What's working well

- 🎉 Replaces stateful global-regex `.test()` calls with `search()` in `hasBreaks()`.
- 🎉 Makes `wrapLabel()` use `common.hasBreaks()`.
- 🎉 Adds regression tests for repeated detection and multiple labels with `<br/>` breaks.
- 🎉 Includes a patch changeset.

## Review result

✅ **Approve**

The fix addresses stale `lastIndex` state and preserves explicit breaks across wrapped labels. No API or documentation changes are introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->