### PR TITLE
fix(c4): allow '#' in title and accDescription

### DIFF
--- a/.changeset/c4-title-hash.md
+++ b/.changeset/c4-title-hash.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix(c4): allow `#` in a C4 `title` and `accDescription`

--- a/packages/mermaid/src/diagrams/c4/parser/c4Diagram.jison
+++ b/packages/mermaid/src/diagrams/c4/parser/c4Diagram.jison
@@ -84,8 +84,8 @@
 .*direction\s+LR[^\n]*                    return 'direction_lr';
 
 
-"title"\s[^#\n;]+                         return 'title';
-"accDescription"\s[^#\n;]+                return 'accDescription';
+"title"\s[^\n;]+                          return 'title';
+"accDescription"\s[^\n;]+                 return 'accDescription';
 accTitle\s*":"\s*                         { this.begin("acc_title");return 'acc_title'; }
 <acc_title>(?!\n|;|#)*[^\n]*              { this.popState(); return "acc_title_value"; }
 accDescr\s*":"\s*                         { this.begin("acc_descr");return 'acc_descr'; }

--- a/packages/mermaid/src/diagrams/c4/parser/c4Diagram.spec.ts
+++ b/packages/mermaid/src/diagrams/c4/parser/c4Diagram.spec.ts
@@ -39,6 +39,22 @@ Person(Person, "Person", "Person")`);
     expect(onlyShape.label.text).toBe('Person');
   });
 
+  it('should allow a # in the title', function () {
+    c4.parser.parse(`C4Context
+title Relationship to a boundary (#4864)
+Person(Person, "Person", "Person")`);
+
+    expect(c4.parser.yy.getTitle()).toBe('Relationship to a boundary (#4864)');
+  });
+
+  it('should allow a # in the accDescription', function () {
+    c4.parser.parse(`C4Context
+accDescription Context diagram for issue #4864
+Person(Person, "Person", "Person")`);
+
+    expect(c4.parser.yy.getAccDescription()).toBe('Context diagram for issue #4864');
+  });
+
   it('should allow default in the parameters', function () {
     c4.parser.parse(`C4Context
 Person(default, "default", "default")`);


### PR DESCRIPTION
## Problem

A `#` anywhere in a C4 `title` breaks the whole diagram:

```
C4Context
title Relationship to a boundary (#4864)
Person(customerA, "Banking Customer A")
```

```
Lexical error on line 2. Unrecognized text.
```

`accDescription` has the same defect.

## Cause

`c4Diagram.jison` matched both values with `[^#\n;]+`:

```
"title"\s[^#\n;]+                         return 'title';
"accDescription"\s[^#\n;]+                return 'accDescription';
```

The `#` in the character class ends the token early, and the remainder of the line then fails to lex. C4's comment syntax is `%%`, with its own `\%\%` lexer rules, and the grammar has no `#` comment rule at all, so nothing depends on that exclusion.

Verified through `mermaid.parse`, so the same preprocessing as the render path:

| input | before | after |
| --- | --- | --- |
| `title Relationship to a boundary (#4864)` | Lexical error | parses |
| `title Relationship to a boundary` | parses | parses |
| `accDescription covers issue #4864` | Lexical error | parses |
| `accTitle: covers #4864` | parses | parses |

`accTitle:` / `accDescr:` use different lexer rules and were already unaffected. This also looks C4-specific: `sequenceDiagram` accepts a `#` in its title despite carrying a similar-looking exclusion.

## Change

Drop `#` from the two character classes. `\n` and `;` still terminate the value, so nothing else about the rules changes. Two parser tests cover a `#` in each.

Found while adding the Cypress case @pbrolin47 asked for in #7874, where a `(#4864)` in the test's own `title` was what made that test fail.

Fixes #8030


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Allow `#` characters in C4 `title` and `accDescription` values.
- Preserve newline and semicolon termination behavior.
- Add parser tests for both value types.
- Add a Mermaid patch changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->