### PR TITLE
fix(c4): send accTitle to the accessible title

### DIFF
--- a/.changeset/c4-acctitle.md
+++ b/.changeset/c4-acctitle.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix(c4): `accTitle` sets the accessible title instead of the visible one

--- a/packages/mermaid/src/diagrams/c4/parser/c4Diagram.jison
+++ b/packages/mermaid/src/diagrams/c4/parser/c4Diagram.jison
@@ -239,7 +239,7 @@ otherStatements
 otherStatement
     : title {yy.setTitle($1.substring(6));$$=$1.substring(6);}
     | accDescription {yy.setAccDescription($1.substring(15));$$=$1.substring(15);}
-    | acc_title acc_title_value  { $$=$2.trim();yy.setTitle($$); }
+    | acc_title acc_title_value  { $$=$2.trim();yy.setAccTitle($$); }
     | acc_descr acc_descr_value  { $$=$2.trim();yy.setAccDescription($$); }
     | acc_descr_multiline_value  { $$=$1.trim();yy.setAccDescription($$); }
     ;

--- a/packages/mermaid/src/diagrams/c4/parser/c4Diagram.spec.ts
+++ b/packages/mermaid/src/diagrams/c4/parser/c4Diagram.spec.ts
@@ -39,6 +39,16 @@ Person(Person, "Person", "Person")`);
     expect(onlyShape.label.text).toBe('Person');
   });
 
+  it('should send accTitle to the accessible title, not the visible one', function () {
+    c4.parser.parse(`C4Context
+accTitle: an accessible title
+Person(Person, "Person", "Person")`);
+
+    const yy = c4.parser.yy;
+    expect(yy.getAccTitle()).toBe('an accessible title');
+    expect(yy.getTitle()).toBe('');
+  });
+
   it('should allow default in the parameters', function () {
     c4.parser.parse(`C4Context
 Person(default, "default", "default")`);


### PR DESCRIPTION
## Problem

In a C4 diagram, `accTitle:` wrote the **visible** diagram title and left the accessible title empty. `setAccTitle` was imported and exposed by the C4 db but never reached from the grammar.

So a C4 diagram using `accTitle:` got no accessible title at all, and text intended only for screen readers was rendered as the diagram's visible heading.

Measured before the fix, parsing:

```
C4Context
accTitle: an accessible title
Person(Person, "Person", "Person")
```

| accessor | before | after |
| --- | --- | --- |
| `getTitle()` | `an accessible title` | empty |
| `getAccTitle()` | empty | `an accessible title` |

## Cause

In the `otherStatement` production of `c4Diagram.jison`:

```
    | acc_title acc_title_value  { $$=$2.trim();yy.setTitle($$); }
    | acc_descr acc_descr_value  { $$=$2.trim();yy.setAccDescription($$); }
```

The first line called `yy.setTitle` where it should call `yy.setAccTitle`. The `accDescr:` line directly below already calls its matching setter, which is what makes this look like a copy/paste slip.

## Change

One character of intent: `setTitle` -> `setAccTitle`, plus a parser test asserting both halves (the accessible title is set **and** the visible title is left alone), so a future regression in either direction fails.

Found while verifying the character-class fix in #8039; deliberately kept separate from it.

Fixes #8040


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixes C4 `accTitle:` parsing to call `setAccTitle`.
- Keeps the visible diagram title unchanged.
- Adds a parser test for accessible and visible titles.
- Adds a patch changeset for Mermaid.

## Testing

- Verifies that `getAccTitle()` returns the declared value.
- Verifies that `getTitle()` remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->