### PR TITLE
feat(i18n): add locale config with Chinese (Simplified) support

### DIFF
--- a/.changeset/zh-cn-locale.md
+++ b/.changeset/zh-cn-locale.md
@@ -1,0 +1,13 @@
+---
+'mermaid': minor
+---
+
+feat(i18n): add a `locale` config option with Chinese (Simplified) support
+
+Mermaid's own built-in text can now be rendered in a language other than English.
+Set `locale: 'zh-CN'` via `mermaid.initialize` or a `%%{init: {"locale": "zh-CN"}}%%`
+directive to translate the syntax error diagram. Messages missing from a locale fall
+back to English.
+
+Diagram content is unaffected — labels you write are always rendered as authored — and
+errors thrown as exceptions remain in English so they stay stable and searchable.

--- a/docs/config/setup/mermaid/interfaces/MermaidConfig.md
+++ b/docs/config/setup/mermaid/interfaces/MermaidConfig.md
@@ -18,7 +18,7 @@ Defined in: [packages/mermaid/src/config.type.ts:66](https://github.com/mermaid-
 
 > `optional` **altFontFamily**: `string`
 
-Defined in: [packages/mermaid/src/config.type.ts:174](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L174)
+Defined in: [packages/mermaid/src/config.type.ts:186](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L186)
 
 ---
 
@@ -26,7 +26,7 @@ Defined in: [packages/mermaid/src/config.type.ts:174](https://github.com/mermaid
 
 > `optional` **architecture**: `ArchitectureDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:247](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L247)
+Defined in: [packages/mermaid/src/config.type.ts:259](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L259)
 
 ---
 
@@ -34,7 +34,7 @@ Defined in: [packages/mermaid/src/config.type.ts:247](https://github.com/mermaid
 
 > `optional` **arrowMarkerAbsolute**: `boolean`
 
-Defined in: [packages/mermaid/src/config.type.ts:193](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L193)
+Defined in: [packages/mermaid/src/config.type.ts:205](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L205)
 
 Controls whether or arrow markers in html code are absolute paths or anchors.
 This matters if you are using base tag settings.
@@ -45,7 +45,7 @@ This matters if you are using base tag settings.
 
 > `optional` **block**: `BlockDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:255](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L255)
+Defined in: [packages/mermaid/src/config.type.ts:267](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L267)
 
 ---
 
@@ -53,7 +53,7 @@ Defined in: [packages/mermaid/src/config.type.ts:255](https://github.com/mermaid
 
 > `optional` **c4**: `C4DiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:252](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L252)
+Defined in: [packages/mermaid/src/config.type.ts:264](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L264)
 
 ---
 
@@ -61,7 +61,7 @@ Defined in: [packages/mermaid/src/config.type.ts:252](https://github.com/mermaid
 
 > `optional` **class**: `ClassDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:240](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L240)
+Defined in: [packages/mermaid/src/config.type.ts:252](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L252)
 
 ---
 
@@ -69,7 +69,7 @@ Defined in: [packages/mermaid/src/config.type.ts:240](https://github.com/mermaid
 
 > `optional` **cynefin**: `CynefinDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:261](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L261)
+Defined in: [packages/mermaid/src/config.type.ts:273](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L273)
 
 ---
 
@@ -77,7 +77,7 @@ Defined in: [packages/mermaid/src/config.type.ts:261](https://github.com/mermaid
 
 > `optional` **darkMode**: `boolean`
 
-Defined in: [packages/mermaid/src/config.type.ts:158](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L158)
+Defined in: [packages/mermaid/src/config.type.ts:170](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L170)
 
 ---
 
@@ -85,7 +85,7 @@ Defined in: [packages/mermaid/src/config.type.ts:158](https://github.com/mermaid
 
 > `optional` **deterministicIds**: `boolean`
 
-Defined in: [packages/mermaid/src/config.type.ts:226](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L226)
+Defined in: [packages/mermaid/src/config.type.ts:238](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L238)
 
 This option controls if the generated ids of nodes in the SVG are
 generated randomly or based on a seed.
@@ -101,7 +101,7 @@ should not change unless content is changed.
 
 > `optional` **deterministicIDSeed**: `string`
 
-Defined in: [packages/mermaid/src/config.type.ts:233](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L233)
+Defined in: [packages/mermaid/src/config.type.ts:245](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L245)
 
 This option is the optional seed for deterministic ids.
 If set to `undefined` but deterministicIds is `true`, a simple number iterator is used.
@@ -113,7 +113,7 @@ You can set this attribute to base the seed on a static string.
 
 > `optional` **dompurifyConfig**: `Config`
 
-Defined in: [packages/mermaid/src/config.type.ts:263](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L263)
+Defined in: [packages/mermaid/src/config.type.ts:275](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L275)
 
 ---
 
@@ -121,7 +121,7 @@ Defined in: [packages/mermaid/src/config.type.ts:263](https://github.com/mermaid
 
 > `optional` **elk**: `object`
 
-Defined in: [packages/mermaid/src/config.type.ts:111](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L111)
+Defined in: [packages/mermaid/src/config.type.ts:123](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L123)
 
 #### considerModelOrder?
 
@@ -176,7 +176,7 @@ Elk specific option affecting how nodes are placed.
 
 > `optional` **er**: `ErDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:242](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L242)
+Defined in: [packages/mermaid/src/config.type.ts:254](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L254)
 
 ---
 
@@ -184,7 +184,7 @@ Defined in: [packages/mermaid/src/config.type.ts:242](https://github.com/mermaid
 
 > `optional` **eventmodeling**: `EventModelingDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:256](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L256)
+Defined in: [packages/mermaid/src/config.type.ts:268](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L268)
 
 ---
 
@@ -192,7 +192,7 @@ Defined in: [packages/mermaid/src/config.type.ts:256](https://github.com/mermaid
 
 > `optional` **flowchart**: `FlowchartDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:234](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L234)
+Defined in: [packages/mermaid/src/config.type.ts:246](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L246)
 
 ---
 
@@ -200,7 +200,7 @@ Defined in: [packages/mermaid/src/config.type.ts:234](https://github.com/mermaid
 
 > `optional` **fontFamily**: `string`
 
-Defined in: [packages/mermaid/src/config.type.ts:173](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L173)
+Defined in: [packages/mermaid/src/config.type.ts:185](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L185)
 
 Specifies the font to be used in the rendered diagrams.
 Can be any possible CSS `font-family`.
@@ -212,7 +212,7 @@ See <https://developer.mozilla.org/en-US/docs/Web/CSS/font-family>
 
 > `optional` **fontSize**: `number`
 
-Defined in: [packages/mermaid/src/config.type.ts:265](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L265)
+Defined in: [packages/mermaid/src/config.type.ts:277](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L277)
 
 ---
 
@@ -220,7 +220,7 @@ Defined in: [packages/mermaid/src/config.type.ts:265](https://github.com/mermaid
 
 > `optional` **forceLegacyMathML**: `boolean`
 
-Defined in: [packages/mermaid/src/config.type.ts:215](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L215)
+Defined in: [packages/mermaid/src/config.type.ts:227](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L227)
 
 This option forces Mermaid to rely on KaTeX's own stylesheet for rendering MathML. Due to differences between OS
 fonts and browser's MathML implementation, this option is recommended if consistent rendering is important.
@@ -232,7 +232,7 @@ If set to true, ignores legacyMathML.
 
 > `optional` **gantt**: `GanttDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:237](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L237)
+Defined in: [packages/mermaid/src/config.type.ts:249](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L249)
 
 ---
 
@@ -240,7 +240,7 @@ Defined in: [packages/mermaid/src/config.type.ts:237](https://github.com/mermaid
 
 > `optional` **gitGraph**: `GitGraphDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:251](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L251)
+Defined in: [packages/mermaid/src/config.type.ts:263](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L263)
 
 ---
 
@@ -248,7 +248,7 @@ Defined in: [packages/mermaid/src/config.type.ts:251](https://github.com/mermaid
 
 > `optional` **handDrawnSeed**: `number`
 
-Defined in: [packages/mermaid/src/config.type.ts:96](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L96)
+Defined in: [packages/mermaid/src/config.type.ts:108](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L108)
 
 Defines the seed to be used when using handDrawn look. This is important for the automated tests as they will always find differences without the seed. The default value is 0 which gives a random seed.
 
@@ -258,7 +258,7 @@ Defines the seed to be used when using handDrawn look. This is important for the
 
 > `optional` **htmlLabels**: `boolean`
 
-Defined in: [packages/mermaid/src/config.type.ts:166](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L166)
+Defined in: [packages/mermaid/src/config.type.ts:178](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L178)
 
 Flag for setting whether or not a html tag should be used for rendering labels on nodes and edges.
 **Note:** Diagram-specific `htmlLabels` settings (e.g., `flowchart.htmlLabels`) are deprecated.
@@ -271,7 +271,7 @@ over any diagram-specific settings.
 
 > `optional` **ishikawa**: `IshikawaDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:249](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L249)
+Defined in: [packages/mermaid/src/config.type.ts:261](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L261)
 
 ---
 
@@ -279,7 +279,7 @@ Defined in: [packages/mermaid/src/config.type.ts:249](https://github.com/mermaid
 
 > `optional` **journey**: `JourneyDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:238](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L238)
+Defined in: [packages/mermaid/src/config.type.ts:250](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L250)
 
 ---
 
@@ -287,7 +287,7 @@ Defined in: [packages/mermaid/src/config.type.ts:238](https://github.com/mermaid
 
 > `optional` **kanban**: `KanbanDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:250](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L250)
+Defined in: [packages/mermaid/src/config.type.ts:262](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L262)
 
 ---
 
@@ -295,7 +295,7 @@ Defined in: [packages/mermaid/src/config.type.ts:250](https://github.com/mermaid
 
 > `optional` **layout**: `string`
 
-Defined in: [packages/mermaid/src/config.type.ts:101](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L101)
+Defined in: [packages/mermaid/src/config.type.ts:113](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L113)
 
 Defines which layout algorithm to use for rendering the diagram.
 
@@ -305,7 +305,7 @@ Defines which layout algorithm to use for rendering the diagram.
 
 > `optional` **legacyMathML**: `boolean`
 
-Defined in: [packages/mermaid/src/config.type.ts:208](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L208)
+Defined in: [packages/mermaid/src/config.type.ts:220](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L220)
 
 This option specifies if Mermaid can expect the dependent to include KaTeX stylesheets for browsers
 without their own MathML implementation. If this option is disabled and MathML is not supported, the math
@@ -314,11 +314,28 @@ fall back to legacy rendering for KaTeX.
 
 ---
 
+### locale?
+
+> `optional` **locale**: `"en"` | `"zh-CN"`
+
+Defined in: [packages/mermaid/src/config.type.ts:103](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L103)
+
+Language used for mermaid's own built-in text, such as the syntax error
+message shown when a diagram fails to parse.
+
+This does not translate diagram content — labels you write in a diagram are
+always rendered as authored. Error messages thrown as exceptions also remain
+in English so that they stay stable and searchable.
+
+Any message missing from the selected locale falls back to English.
+
+---
+
 ### logLevel?
 
 > `optional` **logLevel**: `0` | `2` | `1` | `"trace"` | `"debug"` | `"info"` | `"warn"` | `"error"` | `"fatal"` | `3` | `4` | `5`
 
-Defined in: [packages/mermaid/src/config.type.ts:179](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L179)
+Defined in: [packages/mermaid/src/config.type.ts:191](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L191)
 
 This option decides the amount of logging to be used by mermaid.
 
@@ -338,7 +355,7 @@ Defines which main look to use for the diagram.
 
 > `optional` **markdownAutoWrap**: `boolean`
 
-Defined in: [packages/mermaid/src/config.type.ts:266](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L266)
+Defined in: [packages/mermaid/src/config.type.ts:278](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L278)
 
 ---
 
@@ -346,7 +363,7 @@ Defined in: [packages/mermaid/src/config.type.ts:266](https://github.com/mermaid
 
 > `optional` **maxEdges**: `number`
 
-Defined in: [packages/mermaid/src/config.type.ts:110](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L110)
+Defined in: [packages/mermaid/src/config.type.ts:122](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L122)
 
 Defines the maximum number of edges that can be drawn in a graph.
 
@@ -356,7 +373,7 @@ Defines the maximum number of edges that can be drawn in a graph.
 
 > `optional` **maxTextSize**: `number`
 
-Defined in: [packages/mermaid/src/config.type.ts:105](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L105)
+Defined in: [packages/mermaid/src/config.type.ts:117](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L117)
 
 The maximum allowed size of the users text diagram
 
@@ -366,7 +383,7 @@ The maximum allowed size of the users text diagram
 
 > `optional` **mindmap**: `MindmapDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:248](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L248)
+Defined in: [packages/mermaid/src/config.type.ts:260](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L260)
 
 ---
 
@@ -374,7 +391,7 @@ Defined in: [packages/mermaid/src/config.type.ts:248](https://github.com/mermaid
 
 > `optional` **packet**: `PacketDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:254](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L254)
+Defined in: [packages/mermaid/src/config.type.ts:266](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L266)
 
 ---
 
@@ -382,7 +399,7 @@ Defined in: [packages/mermaid/src/config.type.ts:254](https://github.com/mermaid
 
 > `optional` **pie**: `PieDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:243](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L243)
+Defined in: [packages/mermaid/src/config.type.ts:255](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L255)
 
 ---
 
@@ -390,7 +407,7 @@ Defined in: [packages/mermaid/src/config.type.ts:243](https://github.com/mermaid
 
 > `optional` **quadrantChart**: `QuadrantChartConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:244](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L244)
+Defined in: [packages/mermaid/src/config.type.ts:256](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L256)
 
 ---
 
@@ -398,7 +415,7 @@ Defined in: [packages/mermaid/src/config.type.ts:244](https://github.com/mermaid
 
 > `optional` **radar**: `RadarDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:258](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L258)
+Defined in: [packages/mermaid/src/config.type.ts:270](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L270)
 
 ---
 
@@ -406,7 +423,7 @@ Defined in: [packages/mermaid/src/config.type.ts:258](https://github.com/mermaid
 
 > `optional` **railroad**: `RailroadDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:262](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L262)
+Defined in: [packages/mermaid/src/config.type.ts:274](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L274)
 
 ---
 
@@ -414,7 +431,7 @@ Defined in: [packages/mermaid/src/config.type.ts:262](https://github.com/mermaid
 
 > `optional` **requirement**: `RequirementDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:246](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L246)
+Defined in: [packages/mermaid/src/config.type.ts:258](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L258)
 
 ---
 
@@ -422,7 +439,7 @@ Defined in: [packages/mermaid/src/config.type.ts:246](https://github.com/mermaid
 
 > `optional` **sankey**: `SankeyDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:253](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L253)
+Defined in: [packages/mermaid/src/config.type.ts:265](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L265)
 
 ---
 
@@ -430,7 +447,7 @@ Defined in: [packages/mermaid/src/config.type.ts:253](https://github.com/mermaid
 
 > `optional` **secure**: `string`\[]
 
-Defined in: [packages/mermaid/src/config.type.ts:200](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L200)
+Defined in: [packages/mermaid/src/config.type.ts:212](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L212)
 
 This option controls which `currentConfig` keys are considered secure and
 can only be changed via call to `mermaid.initialize`.
@@ -442,7 +459,7 @@ This prevents malicious graph directives from overriding a site's default securi
 
 > `optional` **securityLevel**: `"strict"` | `"loose"` | `"antiscript"` | `"sandbox"`
 
-Defined in: [packages/mermaid/src/config.type.ts:183](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L183)
+Defined in: [packages/mermaid/src/config.type.ts:195](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L195)
 
 Level of trust for parsed diagram
 
@@ -452,7 +469,7 @@ Level of trust for parsed diagram
 
 > `optional` **sequence**: `SequenceDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:236](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L236)
+Defined in: [packages/mermaid/src/config.type.ts:248](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L248)
 
 ---
 
@@ -460,7 +477,7 @@ Defined in: [packages/mermaid/src/config.type.ts:236](https://github.com/mermaid
 
 > `optional` **startOnLoad**: `boolean`
 
-Defined in: [packages/mermaid/src/config.type.ts:187](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L187)
+Defined in: [packages/mermaid/src/config.type.ts:199](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L199)
 
 Dictates whether mermaid starts on Page load
 
@@ -470,7 +487,7 @@ Dictates whether mermaid starts on Page load
 
 > `optional` **state**: `StateDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:241](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L241)
+Defined in: [packages/mermaid/src/config.type.ts:253](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L253)
 
 ---
 
@@ -478,7 +495,7 @@ Defined in: [packages/mermaid/src/config.type.ts:241](https://github.com/mermaid
 
 > `optional` **suppressErrorRendering**: `boolean`
 
-Defined in: [packages/mermaid/src/config.type.ts:272](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L272)
+Defined in: [packages/mermaid/src/config.type.ts:284](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L284)
 
 Suppresses inserting 'Syntax error' diagram in the DOM.
 This is useful when you want to control how to handle syntax errors in your application.
@@ -489,7 +506,7 @@ This is useful when you want to control how to handle syntax errors in your appl
 
 > `optional` **swimlane**: `SwimlaneDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:235](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L235)
+Defined in: [packages/mermaid/src/config.type.ts:247](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L247)
 
 ---
 
@@ -524,7 +541,7 @@ Defined in: [packages/mermaid/src/config.type.ts:85](https://github.com/mermaid-
 
 > `optional` **timeline**: `TimelineDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:239](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L239)
+Defined in: [packages/mermaid/src/config.type.ts:251](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L251)
 
 ---
 
@@ -532,7 +549,7 @@ Defined in: [packages/mermaid/src/config.type.ts:239](https://github.com/mermaid
 
 > `optional` **treeView**: `TreeViewDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:257](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L257)
+Defined in: [packages/mermaid/src/config.type.ts:269](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L269)
 
 ---
 
@@ -540,7 +557,7 @@ Defined in: [packages/mermaid/src/config.type.ts:257](https://github.com/mermaid
 
 > `optional` **venn**: `VennDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:259](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L259)
+Defined in: [packages/mermaid/src/config.type.ts:271](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L271)
 
 ---
 
@@ -548,7 +565,7 @@ Defined in: [packages/mermaid/src/config.type.ts:259](https://github.com/mermaid
 
 > `optional` **wardley-beta**: `WardleyDiagramConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:260](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L260)
+Defined in: [packages/mermaid/src/config.type.ts:272](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L272)
 
 ---
 
@@ -556,7 +573,7 @@ Defined in: [packages/mermaid/src/config.type.ts:260](https://github.com/mermaid
 
 > `optional` **wrap**: `boolean`
 
-Defined in: [packages/mermaid/src/config.type.ts:264](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L264)
+Defined in: [packages/mermaid/src/config.type.ts:276](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L276)
 
 ---
 
@@ -564,4 +581,4 @@ Defined in: [packages/mermaid/src/config.type.ts:264](https://github.com/mermaid
 
 > `optional` **xyChart**: `XYChartConfig`
 
-Defined in: [packages/mermaid/src/config.type.ts:245](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L245)
+Defined in: [packages/mermaid/src/config.type.ts:257](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/config.type.ts#L257)

--- a/packages/mermaid/src/config.type.ts
+++ b/packages/mermaid/src/config.type.ts
@@ -90,6 +90,18 @@ export interface MermaidConfig {
    */
   look?: 'classic' | 'handDrawn' | 'neo';
   /**
+   * Language used for mermaid's own built-in text, such as the syntax error
+   * message shown when a diagram fails to parse.
+   *
+   * This does not translate diagram content — labels you write in a diagram are
+   * always rendered as authored. Error messages thrown as exceptions also remain
+   * in English so that they stay stable and searchable.
+   *
+   * Any message missing from the selected locale falls back to English.
+   *
+   */
+  locale?: 'en' | 'zh-CN';
+  /**
    * Defines the seed to be used when using handDrawn look. This is important for the automated tests as they will always find differences without the seed. The default value is 0 which gives a random seed.
    *
    */

--- a/packages/mermaid/src/diagrams/error/errorRenderer.spec.ts
+++ b/packages/mermaid/src/diagrams/error/errorRenderer.spec.ts
@@ -1,0 +1,37 @@
+import * as configApi from '../../config.js';
+import { zhCN } from '../../i18n/zh-CN.js';
+import { draw } from './errorRenderer.js';
+
+const renderErrorSvg = (): string[] => {
+  document.body.innerHTML = '<svg id="error-diagram"></svg>';
+  draw('', 'error-diagram', '11.0.0');
+  return [...document.querySelectorAll('#error-diagram text')].map(
+    (node) => node.textContent ?? ''
+  );
+};
+
+describe('errorRenderer', () => {
+  beforeEach(() => {
+    configApi.reset();
+    configApi.setSiteConfig({});
+  });
+
+  it('should render English text by default', () => {
+    expect(renderErrorSvg()).toEqual(['Syntax error in text', 'mermaid version 11.0.0']);
+  });
+
+  it('should render Chinese text when the locale is zh-CN', () => {
+    configApi.setSiteConfig({ locale: 'zh-CN' });
+
+    const [syntaxError, version] = renderErrorSvg();
+    expect(syntaxError).toBe(zhCN['error.syntaxError']);
+    expect(version).toContain('11.0.0');
+  });
+
+  it('should keep the version out of the translated string', () => {
+    configApi.setSiteConfig({ locale: 'zh-CN' });
+
+    // The version is interpolated, not concatenated, so it must not leave a placeholder.
+    expect(renderErrorSvg().join(' ')).not.toContain('{version}');
+  });
+});

--- a/packages/mermaid/src/diagrams/error/errorRenderer.ts
+++ b/packages/mermaid/src/diagrams/error/errorRenderer.ts
@@ -1,4 +1,5 @@
 import type { SVG, SVGGroup } from '../../diagram-api/types.js';
+import { t } from '../../i18n/index.js';
 import { log } from '../../logger.js';
 import { selectSvgElement } from '../../rendering-util/selectSvgElement.js';
 import { configureSvgSize } from '../../setupGraphViewbox.js';
@@ -66,14 +67,14 @@ export const draw = (_text: string, id: string, version: string) => {
     .attr('y', 250)
     .attr('font-size', '150px')
     .style('text-anchor', 'middle')
-    .text('Syntax error in text');
+    .text(t('error.syntaxError'));
   g.append('text') // text label for the x axis
     .attr('class', 'error-text')
     .attr('x', 1250)
     .attr('y', 400)
     .attr('font-size', '100px')
     .style('text-anchor', 'middle')
-    .text(`mermaid version ${version}`);
+    .text(t('error.version', { version }));
 };
 
 export const renderer = { draw };

--- a/packages/mermaid/src/i18n/i18n.spec.ts
+++ b/packages/mermaid/src/i18n/i18n.spec.ts
@@ -1,0 +1,85 @@
+import * as configApi from '../config.js';
+import type { MermaidConfig } from '../config.type.js';
+import { t, isSupportedLocale, defaultLocale } from './index.js';
+import { en } from './messages.js';
+import { zhCN } from './zh-CN.js';
+
+describe('i18n', () => {
+  beforeEach(() => {
+    configApi.reset();
+    configApi.setSiteConfig({});
+  });
+
+  describe('catalogs', () => {
+    it('should translate every English key in every locale', () => {
+      // Guards against a locale drifting behind `en` as new messages are added.
+      expect(Object.keys(zhCN).sort()).toEqual(Object.keys(en).sort());
+    });
+
+    it('should not leave any message untranslated', () => {
+      for (const [key, value] of Object.entries(zhCN)) {
+        expect(value, `${key} is identical to the English message`).not.toBe(
+          en[key as keyof typeof en]
+        );
+      }
+    });
+
+    it('should keep placeholders consistent across locales', () => {
+      const placeholders = (message: string) => (message.match(/{(\w+)}/g) ?? []).sort();
+      for (const key of Object.keys(en) as (keyof typeof en)[]) {
+        expect(placeholders(zhCN[key]), `${key} has mismatched placeholders`).toEqual(
+          placeholders(en[key])
+        );
+      }
+    });
+  });
+
+  describe('isSupportedLocale', () => {
+    it.each(['en', 'zh-CN'])('should accept %s', (locale) => {
+      expect(isSupportedLocale(locale)).toBe(true);
+    });
+
+    it.each([undefined, '', 'fr', 'zh', 'ZH-CN', 'toString', 'constructor'])(
+      'should reject %o',
+      (locale) => {
+        expect(isSupportedLocale(locale)).toBe(false);
+      }
+    );
+  });
+
+  describe('t', () => {
+    it('should default to English', () => {
+      expect(defaultLocale).toBe('en');
+      expect(t('error.syntaxError')).toBe('Syntax error in text');
+    });
+
+    it('should resolve messages in the configured locale', () => {
+      configApi.setSiteConfig({ locale: 'zh-CN' });
+      expect(t('error.syntaxError')).toBe(zhCN['error.syntaxError']);
+    });
+
+    it('should fall back to English for an unknown locale', () => {
+      // Config is JSON at runtime, so an unsupported value can reach us.
+      configApi.setSiteConfig({ locale: 'fr' } as unknown as MermaidConfig);
+      expect(t('error.syntaxError')).toBe(en['error.syntaxError']);
+    });
+
+    it('should substitute placeholders', () => {
+      expect(t('error.version', { version: '11.0.0' })).toBe('mermaid version 11.0.0');
+    });
+
+    it('should substitute placeholders in the configured locale', () => {
+      configApi.setSiteConfig({ locale: 'zh-CN' });
+      expect(t('error.version', { version: '11.0.0' })).toContain('11.0.0');
+      expect(t('error.version', { version: '11.0.0' })).not.toContain('{version}');
+    });
+
+    it('should leave unknown placeholders untouched', () => {
+      expect(t('error.version', { unrelated: 'x' })).toBe('mermaid version {version}');
+    });
+
+    it('should accept numeric placeholder values', () => {
+      expect(t('error.version', { version: 11 })).toBe('mermaid version 11');
+    });
+  });
+});

--- a/packages/mermaid/src/i18n/index.ts
+++ b/packages/mermaid/src/i18n/index.ts
@@ -1,0 +1,46 @@
+import { getConfig } from '../config.js';
+import type { MessageCatalog, MessageKey } from './messages.js';
+import { en } from './messages.js';
+import { zhCN } from './zh-CN.js';
+
+const catalogs = {
+  en,
+  'zh-CN': zhCN,
+} satisfies Record<string, MessageCatalog>;
+
+export type Locale = keyof typeof catalogs;
+
+/** Locale used when none is configured, and whenever a message has no translation. */
+export const defaultLocale: Locale = 'en';
+
+/**
+ * Whether a locale has a catalog. Config can carry any string at runtime, so this is
+ * checked rather than assumed from the type.
+ *
+ * @param locale - Locale identifier to check.
+ * @returns True if messages are available for the locale.
+ */
+export const isSupportedLocale = (locale?: string): locale is Locale =>
+  locale !== undefined && Object.hasOwn(catalogs, locale);
+
+const interpolate = (message: string, params: Record<string, string | number>): string =>
+  message.replace(/{(\w+)}/g, (placeholder, name: string) =>
+    Object.hasOwn(params, name) ? String(params[name]) : placeholder
+  );
+
+/**
+ * Resolves a built-in message in the configured locale.
+ *
+ * Falls back to English when the locale is unknown or its catalog is missing the key,
+ * so an incomplete translation degrades to English rather than to nothing.
+ *
+ * @param key - Message key, as defined by the English catalog.
+ * @param params - Values substituted into `{placeholder}` slots in the message.
+ * @returns The resolved message.
+ */
+export const t = (key: MessageKey, params?: Record<string, string | number>): string => {
+  const { locale } = getConfig();
+  const message =
+    (isSupportedLocale(locale) ? catalogs[locale][key] : undefined) ?? catalogs[defaultLocale][key];
+  return params ? interpolate(message, params) : message;
+};

--- a/packages/mermaid/src/i18n/messages.ts
+++ b/packages/mermaid/src/i18n/messages.ts
@@ -1,0 +1,18 @@
+/**
+ * Catalog of mermaid's built-in, user-visible strings.
+ *
+ * `en` is the source of truth: it defines the set of valid message keys, so a locale
+ * that forgets one fails to type-check rather than silently rendering English.
+ *
+ * Only text that mermaid renders itself belongs here. Thrown `Error` messages are
+ * deliberately left untranslated — they are developer-facing, asserted in tests, and
+ * stay far more useful when they remain stable and searchable.
+ */
+export const en = {
+  'error.syntaxError': 'Syntax error in text',
+  'error.version': 'mermaid version {version}',
+} as const;
+
+export type MessageKey = keyof typeof en;
+
+export type MessageCatalog = Record<MessageKey, string>;

--- a/packages/mermaid/src/i18n/zh-CN.ts
+++ b/packages/mermaid/src/i18n/zh-CN.ts
@@ -1,0 +1,12 @@
+import type { MessageCatalog } from './messages.js';
+
+/**
+ * Chinese (Simplified) messages.
+ *
+ * Typed against {@link MessageCatalog} so that adding a key to the English catalog
+ * without translating it here is a compile error.
+ */
+export const zhCN: MessageCatalog = {
+  'error.syntaxError': '文本语法错误',
+  'error.version': 'mermaid 版本 {version}',
+};

--- a/packages/mermaid/src/schemas/config.schema.yaml
+++ b/packages/mermaid/src/schemas/config.schema.yaml
@@ -56,6 +56,7 @@ required:
   - block
   - treeView
   - look
+  - locale
   - eventmodeling
   - radar
   - venn
@@ -94,6 +95,24 @@ properties:
       - handDrawn
       - neo
     default: 'classic'
+  locale:
+    description: |
+      Language used for mermaid's own built-in text, such as the syntax error
+      message shown when a diagram fails to parse.
+
+      This does not translate diagram content — labels you write in a diagram are
+      always rendered as authored. Error messages thrown as exceptions also remain
+      in English so that they stay stable and searchable.
+
+      Any message missing from the selected locale falls back to English.
+    type: string
+    enum:
+      - en
+      - zh-CN
+    meta:enum:
+      en: English
+      zh-CN: Chinese (Simplified) / 简体中文
+    default: 'en'
   handDrawnSeed:
     description: |
       Defines the seed to be used when using handDrawn look. This is important for the automated tests as they will always find differences without the seed. The default value is 0 which gives a random seed.


### PR DESCRIPTION
## 📑 Summary

Adds a `locale` config option and a minimal message catalog, with Chinese (Simplified) as the first translation. The syntax error diagram is the first — and for now only — consumer.

Refs #7757.

This is deliberately a **foundation PR**. Mermaid has no i18n infrastructure today, so the goal here is to establish a pattern small enough to review in one sitting, rather than to translate everything at once. If the approach looks right, additional strings and locales are cheap follow-ups.

## 📏 Design decisions

A few choices worth calling out, since they narrow the scope from what the issue asks for:

**English is the source of truth.** `messages.ts` defines the key set via `as const`, and every other locale is typed `Record<MessageKey, string>`. Adding a message without translating it is a compile error, not a silent English fallback at runtime.

**Only rendered text is translated. Thrown `Error` messages stay English.** `UnknownDiagramError` and `MermaidParseError` are developer-facing: they're asserted in inline snapshots, surfaced to integrators, and are what people paste into search engines and issue reports. Translating them costs debuggability and gains little, since they aren't what an end user reads. `MermaidParseError` is also only partly ours — its inner text comes from Chevrotain, so localizing it properly would mean a custom `errorMessageProvider` per Langium grammar. Happy to revisit if maintainers disagree.

**Missing translations fall back to English** rather than rendering an empty label, so a partial locale degrades gracefully.

**No new dependency.** An i18n library would be a lot of weight for a two-string catalog; `t()` is ~20 lines including `{placeholder}` interpolation.

**`locale` is not a `secure` key**, so it can be set per-diagram with `%%{init: {"locale": "zh-CN"}}%%` as well as globally via `mermaid.initialize`. This works on the error path because directives are applied before parsing is attempted. It carries no security weight.

## 🔧 Usage

```js
mermaid.initialize({ locale: 'zh-CN' });
```

A diagram that fails to parse then renders `文本语法错误` instead of `Syntax error in text`.

## 🚫 Explicitly out of scope

I inventoried mermaid's hardcoded English strings while scoping this. There are fewer than the issue implies — nearly all diagram text is user-supplied — but these are the real remaining candidates, all deferred:

- **Cynefin** domain labels and descriptions (`cynefinRenderer.ts`)
- **Gantt** date axis — d3's English month/weekday names, which would want a `d3.timeFormatLocale`
- **Requirement diagram** type/risk/verification labels — these double as semantic data values and typed string unions, so display text has to be decoupled from the value first

Each is a self-contained follow-up once the pattern here is agreed.

## ✅ Testing

- `i18n.spec.ts` — catalog completeness (every locale covers every English key), placeholder consistency across locales, fallback for unknown locales, and interpolation
- `errorRenderer.spec.ts` — new file; renders the error diagram under both locales and asserts the emitted SVG text

The catalog-completeness test is the one that matters long-term: it's what stops a locale silently drifting behind English as messages are added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds configurable internationalization support with Simplified Chinese (`zh-CN`) as the first additional locale.

## Changes

- Adds the optional `locale` configuration property.
- Supports global and per-diagram locale configuration.
- Adds English and Simplified Chinese message catalogs.
- Translates syntax-error labels and Mermaid version text.
- Falls back to English for unsupported locales and missing translations.
- Keeps diagram-authored labels and developer-facing exceptions in English.
- Updates configuration schema and generated documentation.
- Adds tests for catalog completeness, placeholders, fallback behavior, interpolation, and localized syntax-error rendering.
- Adds a minor changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->