### PR TITLE
fix: bump layout-elk version

### DIFF
--- a/.changeset/elk-keep-entry-node-on-top.md
+++ b/.changeset/elk-keep-entry-node-on-top.md
@@ -1,5 +1,5 @@
 ---
-'@mermaid-js/layout-elk': minor
+'@mermaid-js/layout-elk': patch
 'mermaid': minor
 ---
 

--- a/.changeset/elk-node-placement-alignment.md
+++ b/.changeset/elk-node-placement-alignment.md
@@ -1,6 +1,6 @@
 ---
 'mermaid': minor
-'@mermaid-js/layout-elk': minor
+'@mermaid-js/layout-elk': patch
 ---
 
 feat(elk): add `elk.nodePlacementAlignment` config option


### PR DESCRIPTION
## :bookmark_tabs: Summary

Since layout elk is currently 0.2.2, making a minor bump to 0.3.0 would be a breaking change, since in NPM, versions starting with 0. are treated differently.

To handle that an update of the elk changesets to use patch instead of minor.

Resolves #<your issue id here>

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

### :clipboard: Tasks

Make sure you

- [ ] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
