### PR TITLE
fix: class diagram markers no longer scale with edge stroke-width

### DIFF
--- a/.changeset/tidy-markers-userspaceonuse.md
+++ b/.changeset/tidy-markers-userspaceonuse.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: class diagram relation markers (composition, aggregation, extension, dependency, lollipop) no longer scale with the edge stroke width, so they stay outside the class box boundary in themes that set `strokeWidth: 2` (`redux`, `redux-dark`, `redux-color`, `redux-dark-color`, `neo`, `neo-dark`) with the default `classic` look.

--- a/cypress/integration/rendering/class/classDiagram-neo.spec.js
+++ b/cypress/integration/rendering/class/classDiagram-neo.spec.js
@@ -183,3 +183,29 @@ describe('Class diagram — Neo look with new themes', () => {
     });
   });
 });
+
+// The neo/redux themes set `themeVariables.strokeWidth` to 2, which lands on `path.relation`.
+// Relation markers must not scale with it, otherwise they overshoot the line-end offset and end
+// up drawn behind the class box. The `look: 'neo'` cases above use the `-margin` marker variants,
+// so only the default `classic` look exercises the plain markers.
+describe('Class diagram — Classic look with new themes', () => {
+  themes.forEach(({ theme, label }) => {
+    it(`CLASSIC-1 [${label}]: should render relation markers outside the class box`, () => {
+      imgSnapshotTest(diagrams.allRelationships, {
+        logLevel: 1,
+        htmlLabels: true,
+        theme,
+      });
+    });
+  });
+
+  themes.forEach(({ theme, label }) => {
+    it(`CLASSIC-2 [${label}]: should render cardinality with classic look`, () => {
+      imgSnapshotTest(diagrams.cardinality, {
+        logLevel: 1,
+        htmlLabels: true,
+        theme,
+      });
+    });
+  });
+});

--- a/packages/mermaid/src/rendering-util/rendering-elements/markers.js
+++ b/packages/mermaid/src/rendering-util/rendering-elements/markers.js
@@ -35,6 +35,7 @@ const extension = (elem, type, id) => {
     .attr('markerWidth', 20)
     .attr('markerHeight', 28)
     .attr('orient', 'auto')
+    .attr('markerUnits', 'userSpaceOnUse')
     .append('path')
     .attr('d', 'M 1,1 V 13 L18,7 Z'); // this is actual shape for arrowhead
 
@@ -83,6 +84,7 @@ const composition = (elem, type, id) => {
     .attr('markerWidth', 190)
     .attr('markerHeight', 240)
     .attr('orient', 'auto')
+    .attr('markerUnits', 'userSpaceOnUse')
     .append('path')
     .attr('d', 'M 18,7 L9,13 L1,7 L9,1 Z');
 
@@ -96,6 +98,7 @@ const composition = (elem, type, id) => {
     .attr('markerWidth', 20)
     .attr('markerHeight', 28)
     .attr('orient', 'auto')
+    .attr('markerUnits', 'userSpaceOnUse')
     .append('path')
     .attr('d', 'M 18,7 L9,13 L1,7 L9,1 Z');
 
@@ -141,6 +144,7 @@ const aggregation = (elem, type, id) => {
     .attr('markerWidth', 190)
     .attr('markerHeight', 240)
     .attr('orient', 'auto')
+    .attr('markerUnits', 'userSpaceOnUse')
     .append('path')
     .attr('d', 'M 18,7 L9,13 L1,7 L9,1 Z');
 
@@ -154,6 +158,7 @@ const aggregation = (elem, type, id) => {
     .attr('markerWidth', 20)
     .attr('markerHeight', 28)
     .attr('orient', 'auto')
+    .attr('markerUnits', 'userSpaceOnUse')
     .append('path')
     .attr('d', 'M 18,7 L9,13 L1,7 L9,1 Z');
 
@@ -198,6 +203,7 @@ const dependency = (elem, type, id) => {
     .attr('markerWidth', 190)
     .attr('markerHeight', 240)
     .attr('orient', 'auto')
+    .attr('markerUnits', 'userSpaceOnUse')
     .append('path')
     .attr('d', 'M 5,7 L9,13 L1,7 L9,1 Z');
 
@@ -211,6 +217,7 @@ const dependency = (elem, type, id) => {
     .attr('markerWidth', 20)
     .attr('markerHeight', 28)
     .attr('orient', 'auto')
+    .attr('markerUnits', 'userSpaceOnUse')
     .append('path')
     .attr('d', 'M 18,7 L9,13 L14,7 L9,1 Z');
   elem
@@ -254,6 +261,7 @@ const lollipop = (elem, type, id) => {
     .attr('markerWidth', 190)
     .attr('markerHeight', 240)
     .attr('orient', 'auto')
+    .attr('markerUnits', 'userSpaceOnUse')
     .append('circle')
     .attr('fill', 'transparent')
     .attr('cx', 7)
@@ -270,6 +278,7 @@ const lollipop = (elem, type, id) => {
     .attr('markerWidth', 190)
     .attr('markerHeight', 240)
     .attr('orient', 'auto')
+    .attr('markerUnits', 'userSpaceOnUse')
     .append('circle')
     .attr('fill', 'transparent')
     .attr('cx', 7)

--- a/packages/mermaid/src/rendering-util/rendering-elements/markers.spec.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/markers.spec.ts
@@ -1,0 +1,33 @@
+import { select } from 'd3';
+import { describe, expect, it } from 'vitest';
+import insertMarkers from './markers.js';
+
+/**
+ * The class diagram relation markers must not scale with the edge's stroke-width.
+ *
+ * Themes such as `redux`/`neo` set `themeVariables.strokeWidth` to 2, which becomes the
+ * `stroke-width` of `path.relation`. Markers default to `markerUnits="strokeWidth"`, so any
+ * marker missing an explicit `markerUnits` gets drawn at twice its size and overshoots the
+ * line-end offset from `markerOffsets`, ending up hidden behind the class box.
+ */
+const classDiagramMarkers = ['aggregation', 'extension', 'composition', 'dependency', 'lollipop'];
+
+const renderMarkers = () => {
+  const svg = select(document.body).append('svg');
+  insertMarkers(svg, classDiagramMarkers, 'classDiagram', 'test');
+  return svg;
+};
+
+describe('class diagram markers', () => {
+  it('sets markerUnits="userSpaceOnUse" on every marker so size is independent of stroke-width', () => {
+    const svg = renderMarkers();
+
+    const offenders = svg
+      .selectAll('marker')
+      .nodes()
+      .filter((marker) => (marker as Element).getAttribute('markerUnits') !== 'userSpaceOnUse')
+      .map((marker) => (marker as Element).id);
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

In the `redux` themes, class diagram relation markers are drawn oversized and end up hidden behind the class box instead of touching its boundary. Some markers on the same diagram look correct, which made the failure look arbitrary.

| Before (`theme: redux`, default look) | After |
|---|---|
| Composition/aggregation diamonds clipped in half by the box edge; extension triangles flush against the border | All markers full size, sitting outside the boundary |

## Root cause

The five class diagram marker families (`composition`, `aggregation`, `extension`, `dependency`, `lollipop`) never set `markerUnits`, so they fell back to the SVG default of `strokeWidth` — meaning marker geometry is multiplied by the referencing path's stroke width.

`class/styles.js` applies `stroke-width: ${options.strokeWidth}` to `path.relation` **unconditionally**, so every theme that sets `themeVariables.strokeWidth: 2` drew these markers at 2x. At double size they overshoot the line-end offset from `markerOffsets` (17.25 for composition/aggregation/extension) and land inside the node.

Affected themes: `redux`, `redux-dark`, `redux-color`, `redux-dark-color`, `neo`, `neo-dark`.

Only the default `classic` look was affected, which explains the partial symptom:

| Marker | `markerUnits` before | Result at `strokeWidth: 2` |
|---|---|---|
| `extensionStart` | already `userSpaceOnUse` | correct — why `<\|--` looked fine |
| all `-margin` variants (`look: neo`) | already `userSpaceOnUse` | correct — why `look: neo` worked |
| `extensionEnd`, `composition*`, `aggregation*`, `dependency*`, `lollipop*` | **missing** | 2x, clipped behind the box |

## Fix

Set `markerUnits="userSpaceOnUse"` on the nine markers that lacked it, matching what the `-margin` variants and `extensionStart` already did. Marker size now depends only on the marker definition, not on the edge stroke width.

## Scope

`markers.js` is shared, but these five marker families are requested only by [`classRenderer-v3-unified.ts`](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/diagrams/class/classRenderer-v3-unified.ts#L64) — no other diagram type consumes them, so no cross-diagram impact.

The equivalent plain markers for ER and requirement diagrams also lack `markerUnits`, but they are **not** affected by any built-in theme/look combination: both diagrams gate `.relationshipLine`'s stroke-width on `look === 'neo'`, which is the same condition that selects their `*_neo` markers (which already set `markerUnits`). Verified across the theme/look matrix — measured `1px` in classic, `2px` with `userSpaceOnUse` in neo. Left out of this hotfix deliberately.

## Testing

- **New unit test** `markers.spec.ts` asserts every class diagram marker sets `markerUnits="userSpaceOnUse"`. Confirmed failing first, listing exactly those nine markers, then passing.
- **New e2e cases** `CLASSIC-1` / `CLASSIC-2` in `classDiagram-neo.spec.js` across `neo`, `neo-dark`, `redux`, `redux-dark`. The existing suite only exercised `look: 'neo'`, which uses the `-margin` markers and therefore never covered the broken path.
- **Visual verification**: redux with the default look now matches redux + `look: neo`. `handDrawn` unaffected. `default` theme output unchanged — its `strokeWidth` is already 1, so the scale factor was always 1.

## Changeset

`patch` — rendering fix, no API change.
