### PR TITLE
feat(state): support transition link styles

### DIFF
--- a/.changeset/state-transition-link-styles.md
+++ b/.changeset/state-transition-link-styles.md
@@ -1,0 +1,5 @@
+---
+'mermaid': minor
+---
+
+feat(state): add default and indexed `linkStyle` support for transitions

--- a/cypress/integration/rendering/state/stateDiagram-v2.spec.js
+++ b/cypress/integration/rendering/state/stateDiagram-v2.spec.js
@@ -887,4 +887,18 @@ State9_____________ --> State10_____________   : Transition9_____
       {}
     );
   });
+
+  it('should render default and indexed transition styles', () => {
+    imgSnapshotTest(
+      `stateDiagram-v2
+        [*] --> Idle : boot
+        Idle --> Running : start
+        Running --> Idle : stop
+        Running --> [*] : shutdown
+
+        linkStyle default stroke:#2563eb,stroke-width:2px,color:#1e3a8a
+        linkStyle 1,3 stroke:#dc2626,stroke-width:4px,color:#dc2626`,
+      { fontFamily: 'courier' }
+    );
+  });
 });

--- a/docs/syntax/stateDiagram.md
+++ b/docs/syntax/stateDiagram.md
@@ -634,6 +634,50 @@ stateDiagram
    Crash:::badBadEvent --> [*]
 ```
 
+### Styling transitions with `linkStyle` (v\<MERMAID_RELEASE_VERSION>+)
+
+You can style one or more transitions with the `linkStyle` keyword. Transitions are numbered from `0` in the order
+they appear in the diagram, including transitions inside composite states. Connectors between notes and states are not
+included in this numbering.
+
+To style selected transitions, provide a comma-separated list of their indexes followed by one or more CSS properties:
+
+```txt
+linkStyle 1,3 stroke:#dc2626,stroke-width:4px,color:#dc2626
+```
+
+Use `default` instead of an index to apply a style to every transition:
+
+```txt
+linkStyle default stroke:#2563eb,stroke-width:2px,color:#1e3a8a
+```
+
+An indexed style is applied after the default style, so it can override individual properties. If the same default or
+index is declared more than once, the last declaration for that target is used. A `linkStyle` declaration may appear
+before or after the transitions it styles.
+
+```mermaid-example
+stateDiagram-v2
+    [*] --> Idle : boot
+    Idle --> Running : start
+    Running --> Idle : stop
+    Running --> [*] : shutdown
+
+    linkStyle default stroke:#2563eb,stroke-width:2px,color:#1e3a8a
+    linkStyle 1,3 stroke:#dc2626,stroke-width:4px,color:#dc2626
+```
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle : boot
+    Idle --> Running : start
+    Running --> Idle : stop
+    Running --> [*] : shutdown
+
+    linkStyle default stroke:#2563eb,stroke-width:2px,color:#1e3a8a
+    linkStyle 1,3 stroke:#dc2626,stroke-width:4px,color:#dc2626
+```
+
 ## Spaces in state names
 
 Spaces can be added to a state by first defining the state with an id and then referencing the id later.

--- a/docs/syntax/stateDiagram.md
+++ b/docs/syntax/stateDiagram.md
@@ -731,6 +731,12 @@ To style selected transitions, provide a comma-separated list of their indexes f
 linkStyle 1,3 stroke:#dc2626,stroke-width:4px,color:#dc2626
 ```
 
+Commas separate CSS properties. Escape a literal comma in a CSS value with a backslash:
+
+```txt
+linkStyle 0 stroke-dasharray:5\,5,stroke:#2563eb
+```
+
 Use `default` instead of an index to apply a style to every transition:
 
 ```txt

--- a/docs/syntax/stateDiagram.md
+++ b/docs/syntax/stateDiagram.md
@@ -719,6 +719,50 @@ stateDiagram
    Crash:::badBadEvent --> [*]
 ```
 
+### Styling transitions with `linkStyle` (v\<MERMAID_RELEASE_VERSION>+)
+
+You can style one or more transitions with the `linkStyle` keyword. Transitions are numbered from `0` in the order
+they appear in the diagram, including transitions inside composite states. Connectors between notes and states are not
+included in this numbering.
+
+To style selected transitions, provide a comma-separated list of their indexes followed by one or more CSS properties:
+
+```txt
+linkStyle 1,3 stroke:#dc2626,stroke-width:4px,color:#dc2626
+```
+
+Use `default` instead of an index to apply a style to every transition:
+
+```txt
+linkStyle default stroke:#2563eb,stroke-width:2px,color:#1e3a8a
+```
+
+An indexed style is applied after the default style, so it can override individual properties. If the same default or
+index is declared more than once, the last declaration for that target is used. A `linkStyle` declaration may appear
+before or after the transitions it styles.
+
+```mermaid-example
+stateDiagram-v2
+    [*] --> Idle : boot
+    Idle --> Running : start
+    Running --> Idle : stop
+    Running --> [*] : shutdown
+
+    linkStyle default stroke:#2563eb,stroke-width:2px,color:#1e3a8a
+    linkStyle 1,3 stroke:#dc2626,stroke-width:4px,color:#dc2626
+```
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle : boot
+    Idle --> Running : start
+    Running --> Idle : stop
+    Running --> [*] : shutdown
+
+    linkStyle default stroke:#2563eb,stroke-width:2px,color:#1e3a8a
+    linkStyle 1,3 stroke:#dc2626,stroke-width:4px,color:#dc2626
+```
+
 ## Spaces in state names
 
 Spaces can be added to a state by first defining the state with an id and then referencing the id later.

--- a/e2e/diagrams/state-diagram-v2/should-style-transitions-with-linkstyle.mmd
+++ b/e2e/diagrams/state-diagram-v2/should-style-transitions-with-linkstyle.mmd
@@ -9,4 +9,4 @@ stateDiagram-v2
   Running --> [*] : shutdown
 
   linkStyle default stroke:#2563eb,stroke-width:2px,color:#1e3a8a
-  linkStyle 1,3 stroke:#dc2626,stroke-width:4px,color:#dc2626
+  linkStyle 1,3 stroke:#dc2626,stroke-width:4px,stroke-dasharray:5\,5,color:#dc2626

--- a/e2e/diagrams/state-diagram-v2/should-style-transitions-with-linkstyle.mmd
+++ b/e2e/diagrams/state-diagram-v2/should-style-transitions-with-linkstyle.mmd
@@ -1,0 +1,12 @@
+---
+config:
+  fontFamily: courier
+---
+stateDiagram-v2
+  [*] --> Idle : boot
+  Idle --> Running : start
+  Running --> Idle : stop
+  Running --> [*] : shutdown
+
+  linkStyle default stroke:#2563eb,stroke-width:2px,color:#1e3a8a
+  linkStyle 1,3 stroke:#dc2626,stroke-width:4px,color:#dc2626

--- a/packages/mermaid/src/diagrams/state/parser/state-style.spec.js
+++ b/packages/mermaid/src/diagrams/state/parser/state-style.spec.js
@@ -396,4 +396,159 @@ describe('ClassDefs and classes when parsing a State diagram', () => {
       });
     });
   });
+
+  describe('linkStyle statement for transitions', () => {
+    it('applies an indexed style to the selected transition and its label', () => {
+      stateDiagram.parser.parse(`stateDiagram-v2
+        A --> B: first
+        B --> C: second
+        linkStyle 1 stroke:#f00,stroke-width:4px,color:blue`);
+
+      const data4Layout = stateDiagram.parser.yy.getData();
+
+      expect(data4Layout.edges[0].style).toBe('fill:none');
+      expect(data4Layout.edges[1].style).toEqual([
+        'fill:none',
+        'stroke:#f00',
+        'stroke-width:4px',
+        'color:blue',
+      ]);
+      expect(data4Layout.edges[1].labelStyle).toEqual([
+        'stroke:#f00',
+        'stroke-width:4px',
+        'color:blue',
+      ]);
+    });
+
+    it('applies a default style to transitions without styling internal note edges', () => {
+      stateDiagram.parser.parse(`stateDiagram-v2
+        A --> B: first
+        note right of B: context
+        B --> C: second
+        linkStyle default stroke:#999,stroke-width:2px,color:#333`);
+
+      const data4Layout = stateDiagram.parser.yy.getData();
+      const transitions = data4Layout.edges.filter((edge) => edge.classes === 'transition');
+      const noteEdge = data4Layout.edges.find((edge) => edge.classes.includes('note-edge'));
+
+      expect(transitions).toHaveLength(2);
+      for (const transition of transitions) {
+        expect(transition.style).toEqual([
+          'fill:none',
+          'stroke:#999',
+          'stroke-width:2px',
+          'color:#333',
+        ]);
+        expect(transition.labelStyle).toEqual(['stroke:#999', 'stroke-width:2px', 'color:#333']);
+      }
+      expect(noteEdge.style).toBe('fill:none');
+      expect(noteEdge.labelStyle).toBe('');
+    });
+
+    it('uses the last default and indexed declarations while keeping indexed styles most specific', () => {
+      stateDiagram.parser.parse(`stateDiagram-v2
+        A --> B
+        B --> C
+        C --> D
+        linkStyle 0,2 stroke:#f80,stroke-width:2px
+        linkStyle default stroke:#999,color:gray
+        linkStyle 2 stroke:#00f,color:blue
+        linkStyle default stroke:#333,color:black`);
+
+      const { edges } = stateDiagram.parser.yy.getData();
+
+      expect(edges[0].style).toEqual([
+        'fill:none',
+        'color:black',
+        'stroke:#f80',
+        'stroke-width:2px',
+      ]);
+      expect(edges[1].style).toEqual(['fill:none', 'stroke:#333', 'color:black']);
+      expect(edges[2].style).toEqual(['fill:none', 'stroke:#00f', 'color:blue']);
+      expect(edges[2].labelStyle).toEqual(['stroke:#00f', 'color:blue']);
+    });
+
+    it('numbers nested transitions in deterministic source order and accepts declarations before edges', () => {
+      stateDiagram.parser.parse(`stateDiagram-v2
+        linkStyle 0,2 stroke:#c00
+        A --> B: outer first
+        state Group {
+          C --> D: nested
+        }
+        B --> Group: outer last`);
+
+      const transitions = stateDiagram.parser.yy
+        .getData()
+        .edges.filter((edge) => edge.classes === 'transition');
+
+      expect(transitions.map(({ start, end }) => [start, end])).toEqual([
+        ['A', 'B'],
+        ['C', 'D'],
+        ['B', 'Group'],
+      ]);
+      expect(transitions[0].style).toEqual(['fill:none', 'stroke:#c00']);
+      expect(transitions[1].style).toBe('fill:none');
+      expect(transitions[2].style).toEqual(['fill:none', 'stroke:#c00']);
+    });
+
+    it('does not count note connector edges in indexed link styles', () => {
+      stateDiagram.parser.parse(`stateDiagram-v2
+        A
+        note right of A: context
+        A --> B
+        B --> C
+        linkStyle 1 stroke:#0a0`);
+
+      const { edges } = stateDiagram.parser.yy.getData();
+      const transitions = edges.filter((edge) => edge.classes === 'transition');
+      const noteEdge = edges.find((edge) => edge.classes.includes('note-edge'));
+
+      expect(transitions[0].style).toBe('fill:none');
+      expect(transitions[1].style).toEqual(['fill:none', 'stroke:#0a0']);
+      expect(noteEdge.style).toBe('fill:none');
+    });
+
+    it('supports escaped commas in CSS values and an optional trailing semicolon', () => {
+      stateDiagram.parser.parse(`stateDiagram-v2
+        A --> B
+        linkStyle 0 stroke-dasharray:5\\,5,font-family:Arial\\,sans-serif;`);
+
+      const { edges } = stateDiagram.parser.yy.getData();
+
+      expect(edges[0].style).toEqual([
+        'fill:none',
+        'stroke-dasharray:5,5',
+        'font-family:Arial,sans-serif',
+      ]);
+    });
+
+    it('requires the targets and styles to stay on the linkStyle line', () => {
+      expect(() =>
+        stateDiagram.parser.parse(`stateDiagram-v2
+          A --> B
+          linkStyle 0
+          B --> C`)
+      ).toThrow();
+    });
+
+    it('reports indexed styles that are outside the transition range', () => {
+      expect(() =>
+        stateDiagram.parser.parse(`stateDiagram-v2
+          A --> B
+          linkStyle 1 stroke:#f00`)
+      ).toThrow(
+        'The index 1 for linkStyle is out of bounds. Valid indices for linkStyle are between 0 and 0. (Help: Ensure that the index is within the range of existing transitions.)'
+      );
+    });
+
+    it('reports indexed styles when the diagram has no transitions', () => {
+      expect(() =>
+        stateDiagram.parser.parse(`stateDiagram-v2
+          A
+          linkStyle 0 stroke:#f00`)
+      ).toThrow(
+        'The index 0 for linkStyle is out of bounds because the state diagram has no transitions.'
+      );
+    });
+  });
 });

--- a/packages/mermaid/src/diagrams/state/parser/stateDiagram.jison
+++ b/packages/mermaid/src/diagrams/state/parser/stateDiagram.jison
@@ -33,6 +33,8 @@
 %x STYLE_IDS
 %x STYLEDEF_STYLES
 %x STYLEDEF_STYLEOPTS
+%x LINKSTYLE
+%x LINKSTYLE_STYLE
 
 %x NOTE
 %x NOTE_ID
@@ -106,6 +108,11 @@ accDescr\s*"{"\s*                                { this.begin("acc_descr_multili
 <INITIAL,struct>"style"\s+   { this.pushState('STYLE'); return 'style'; }
 <STYLE>[\w,]+\s+                 { this.popState(); this.pushState('STYLEDEF_STYLES'); return 'STYLE_IDS' }
 <STYLEDEF_STYLES>[^\n]*              { this.popState(); return 'STYLEDEF_STYLEOPTS' }
+
+<INITIAL,struct>"linkStyle"[ \t]+       { this.pushState('LINKSTYLE'); return 'linkStyle'; }
+<LINKSTYLE>"default"[ \t]+               { this.popState(); this.pushState('LINKSTYLE_STYLE'); return 'LINKSTYLE_DEFAULT'; }
+<LINKSTYLE>\d+([ \t]*","[ \t]*\d+)*[ \t]+     { this.popState(); this.pushState('LINKSTYLE_STYLE'); return 'LINKSTYLE_IDS'; }
+<LINKSTYLE_STYLE>[^\n]+                { this.popState(); return 'LINKSTYLE_STYLEOPTS'; }
 
 "scale"\s+            { this.pushState('SCALE'); /* console.log('Got scale', yytext);*/ return 'scale'; }
 <SCALE>\d+            return 'WIDTH';
@@ -201,6 +208,7 @@ line
 statement
 	: classDefStatement
     | styleStatement
+    | linkStyleStatement
     | cssClassStatement
 	| idStatement { /* console.log('got id', $1); */
             $$=$1;
@@ -300,6 +308,19 @@ classDefStatement
 styleStatement
     : style STYLE_IDS STYLEDEF_STYLEOPTS {
         $$ = { stmt: 'style', id: $2.trim(), styleClass: $3.trim() };
+        }
+    ;
+
+linkStyleStatement
+    : linkStyle LINKSTYLE_DEFAULT LINKSTYLE_STYLEOPTS {
+        $$ = { stmt: 'linkStyle', targets: 'default', style: $3.trim() };
+        }
+    | linkStyle LINKSTYLE_IDS LINKSTYLE_STYLEOPTS {
+        $$ = {
+            stmt: 'linkStyle',
+            targets: $2.trim().split(',').map(function (index) { return Number(index.trim()); }),
+            style: $3.trim()
+        };
         }
     ;
 

--- a/packages/mermaid/src/diagrams/state/stateCommon.ts
+++ b/packages/mermaid/src/diagrams/state/stateCommon.ts
@@ -22,6 +22,7 @@ export const STMT_RELATION = 'relation';
 // parsed statement type for a classDef
 export const STMT_CLASSDEF = 'classDef';
 export const STMT_STYLEDEF = 'style';
+export const STMT_LINKSTYLE = 'linkStyle';
 // parsed statement type for applyClass
 export const STMT_APPLYCLASS = 'applyClass';
 
@@ -73,6 +74,7 @@ export default {
   STMT_RELATION,
   STMT_CLASSDEF,
   STMT_STYLEDEF,
+  STMT_LINKSTYLE,
   STMT_APPLYCLASS,
   DEFAULT_STATE_TYPE,
   DIVIDER_TYPE,

--- a/packages/mermaid/src/diagrams/state/stateDb.ts
+++ b/packages/mermaid/src/diagrams/state/stateDb.ts
@@ -17,14 +17,17 @@ import { createTooltip } from '../common/svgDrawCommon.js';
 import { dataFetcher, reset as resetDataFetcher } from './dataFetcher.js';
 import { getDir } from './stateRenderer-v3-unified.js';
 import {
+  CSS_EDGE,
   DEFAULT_DIAGRAM_DIRECTION,
   DEFAULT_STATE_TYPE,
   DIVIDER_TYPE,
+  G_EDGE_STYLE,
   STMT_APPLYCLASS,
   STMT_CLASSDEF,
+  STMT_DIRECTION,
+  STMT_LINKSTYLE,
   STMT_RELATION,
   STMT_ROOT,
-  STMT_DIRECTION,
   STMT_STATE,
   STMT_STYLEDEF,
 } from './stateCommon.js';
@@ -49,6 +52,7 @@ interface BaseStmt {
     | 'relation'
     | 'state'
     | 'style'
+    | 'linkStyle'
     | 'root'
     | 'default'
     | 'click';
@@ -98,6 +102,12 @@ interface StyleStmt extends BaseStmt {
   styleClass: string;
 }
 
+interface LinkStyleStmt extends BaseStmt {
+  stmt: 'linkStyle';
+  targets: 'default' | number[];
+  style: string;
+}
+
 export interface RootStmt {
   id: 'root';
   stmt: 'root';
@@ -123,6 +133,7 @@ export type Stmt =
   | RelationStmt
   | StateStmt
   | StyleStmt
+  | LinkStyleStmt
   | RootStmt
   | ClickStmt;
 
@@ -173,8 +184,8 @@ export interface Edge {
   end: string;
   arrowhead: string;
   arrowTypeEnd: string;
-  style: string;
-  labelStyle: string;
+  style: string | string[];
+  labelStyle: string | string[];
   label?: string;
   arrowheadStyle: string;
   labelpos: string;
@@ -262,10 +273,12 @@ export class StateDB {
     const diagramStates = this.getStates();
     const config = getConfig();
 
+    const rootDoc = this.getRootDocV2() as StateStmt;
+
     resetDataFetcher();
     dataFetcher(
       undefined,
-      this.getRootDocV2() as StateStmt,
+      rootDoc,
       diagramStates,
       this.nodes,
       this.edges,
@@ -273,6 +286,7 @@ export class StateDB {
       config.look,
       this.classes
     );
+    this.applyLinkStyles(rootDoc.doc ?? []);
 
     // Process node labels
     for (const node of this.nodes) {
@@ -305,6 +319,88 @@ export class StateDB {
         state.styles = styles.map((s) => s.replace(/;/g, '')?.trim());
       }
     }
+  }
+
+  private applyLinkStyles(statements: Stmt[]) {
+    const directives: LinkStyleStmt[] = [];
+
+    const collectDirectives = (doc: Stmt[]) => {
+      for (const statement of doc) {
+        if (statement.stmt === STMT_LINKSTYLE) {
+          directives.push(statement);
+        } else if (statement.stmt === STMT_STATE && statement.doc) {
+          collectDirectives(statement.doc);
+        }
+      }
+    };
+
+    collectDirectives(statements);
+    if (directives.length === 0) {
+      return;
+    }
+
+    const transitions = this.edges.filter((edge) => edge.classes === CSS_EDGE);
+    let defaultStyles: string[] = [];
+    const indexedStyles = new Map<number, string[]>();
+
+    for (const directive of directives) {
+      const styles = this.parseLinkStyle(directive.style);
+      if (directive.targets === 'default') {
+        defaultStyles = styles;
+        continue;
+      }
+
+      for (const index of directive.targets) {
+        if (index >= transitions.length) {
+          if (transitions.length === 0) {
+            throw new Error(
+              `The index ${index} for linkStyle is out of bounds because the state diagram has no transitions.`
+            );
+          }
+          throw new Error(
+            `The index ${index} for linkStyle is out of bounds. Valid indices for linkStyle are between 0 and ${
+              transitions.length - 1
+            }. (Help: Ensure that the index is within the range of existing transitions.)`
+          );
+        }
+        indexedStyles.set(index, styles);
+      }
+    }
+
+    transitions.forEach((edge, index) => {
+      const styles = this.mergeLinkStyles(defaultStyles, indexedStyles.get(index) ?? []);
+      if (styles.length === 0) {
+        return;
+      }
+      edge.style = [G_EDGE_STYLE, ...styles];
+      edge.labelStyle = styles;
+    });
+  }
+
+  private parseLinkStyle(style: string): string[] {
+    return style
+      .replace(/\\,/g, '§§§')
+      .split(',')
+      .map((part) =>
+        part
+          .replace(/§§§/g, ',')
+          .replace(/;+\s*$/, '')
+          .trim()
+      )
+      .filter(Boolean);
+  }
+
+  private mergeLinkStyles(...styleGroups: string[][]): string[] {
+    const stylesByProperty = new Map<string, string>();
+
+    for (const style of styleGroups.flat()) {
+      const separator = style.indexOf(':');
+      const property = separator === -1 ? style : style.slice(0, separator).trim();
+      stylesByProperty.delete(property);
+      stylesByProperty.set(property, style);
+    }
+
+    return [...stylesByProperty.values()];
   }
 
   setRootDoc(o: Stmt[]) {

--- a/packages/mermaid/src/diagrams/state/stateDb.ts
+++ b/packages/mermaid/src/diagrams/state/stateDb.ts
@@ -17,14 +17,17 @@ import { createTooltip } from '../common/svgDrawCommon.js';
 import { dataFetcher, reset as resetDataFetcher } from './dataFetcher.js';
 import { getDir } from './stateRenderer-v3-unified.js';
 import {
+  CSS_EDGE,
   DEFAULT_DIAGRAM_DIRECTION,
   DEFAULT_STATE_TYPE,
   DIVIDER_TYPE,
+  G_EDGE_STYLE,
   STMT_APPLYCLASS,
   STMT_CLASSDEF,
+  STMT_DIRECTION,
+  STMT_LINKSTYLE,
   STMT_RELATION,
   STMT_ROOT,
-  STMT_DIRECTION,
   STMT_STATE,
   STMT_STYLEDEF,
 } from './stateCommon.js';
@@ -49,6 +52,7 @@ interface BaseStmt {
     | 'relation'
     | 'state'
     | 'style'
+    | 'linkStyle'
     | 'root'
     | 'default'
     | 'click';
@@ -98,6 +102,12 @@ interface StyleStmt extends BaseStmt {
   styleClass: string;
 }
 
+interface LinkStyleStmt extends BaseStmt {
+  stmt: 'linkStyle';
+  targets: 'default' | number[];
+  style: string;
+}
+
 export interface RootStmt {
   id: 'root';
   stmt: 'root';
@@ -123,6 +133,7 @@ export type Stmt =
   | RelationStmt
   | StateStmt
   | StyleStmt
+  | LinkStyleStmt
   | RootStmt
   | ClickStmt;
 
@@ -175,8 +186,8 @@ export interface Edge {
   end: string;
   arrowhead: string;
   arrowTypeEnd: string;
-  style: string;
-  labelStyle: string;
+  style: string | string[];
+  labelStyle: string | string[];
   label?: string;
   arrowheadStyle: string;
   labelpos: string;
@@ -269,10 +280,12 @@ export class StateDB {
     const diagramStates = this.getStates();
     const config = getConfig();
 
+    const rootDoc = this.getRootDocV2() as StateStmt;
+
     resetDataFetcher();
     dataFetcher(
       undefined,
-      this.getRootDocV2() as StateStmt,
+      rootDoc,
       diagramStates,
       this.nodes,
       this.edges,
@@ -280,6 +293,7 @@ export class StateDB {
       config.look,
       this.classes
     );
+    this.applyLinkStyles(rootDoc.doc ?? []);
 
     // Process node labels
     for (const node of this.nodes) {
@@ -312,6 +326,88 @@ export class StateDB {
         state.styles = styles.map((s) => s.replace(/;/g, '')?.trim());
       }
     }
+  }
+
+  private applyLinkStyles(statements: Stmt[]) {
+    const directives: LinkStyleStmt[] = [];
+
+    const collectDirectives = (doc: Stmt[]) => {
+      for (const statement of doc) {
+        if (statement.stmt === STMT_LINKSTYLE) {
+          directives.push(statement);
+        } else if (statement.stmt === STMT_STATE && statement.doc) {
+          collectDirectives(statement.doc);
+        }
+      }
+    };
+
+    collectDirectives(statements);
+    if (directives.length === 0) {
+      return;
+    }
+
+    const transitions = this.edges.filter((edge) => edge.classes === CSS_EDGE);
+    let defaultStyles: string[] = [];
+    const indexedStyles = new Map<number, string[]>();
+
+    for (const directive of directives) {
+      const styles = this.parseLinkStyle(directive.style);
+      if (directive.targets === 'default') {
+        defaultStyles = styles;
+        continue;
+      }
+
+      for (const index of directive.targets) {
+        if (index >= transitions.length) {
+          if (transitions.length === 0) {
+            throw new Error(
+              `The index ${index} for linkStyle is out of bounds because the state diagram has no transitions.`
+            );
+          }
+          throw new Error(
+            `The index ${index} for linkStyle is out of bounds. Valid indices for linkStyle are between 0 and ${
+              transitions.length - 1
+            }. (Help: Ensure that the index is within the range of existing transitions.)`
+          );
+        }
+        indexedStyles.set(index, styles);
+      }
+    }
+
+    transitions.forEach((edge, index) => {
+      const styles = this.mergeLinkStyles(defaultStyles, indexedStyles.get(index) ?? []);
+      if (styles.length === 0) {
+        return;
+      }
+      edge.style = [G_EDGE_STYLE, ...styles];
+      edge.labelStyle = styles;
+    });
+  }
+
+  private parseLinkStyle(style: string): string[] {
+    return style
+      .replace(/\\,/g, '§§§')
+      .split(',')
+      .map((part) =>
+        part
+          .replace(/§§§/g, ',')
+          .replace(/;+\s*$/, '')
+          .trim()
+      )
+      .filter(Boolean);
+  }
+
+  private mergeLinkStyles(...styleGroups: string[][]): string[] {
+    const stylesByProperty = new Map<string, string>();
+
+    for (const style of styleGroups.flat()) {
+      const separator = style.indexOf(':');
+      const property = separator === -1 ? style : style.slice(0, separator).trim();
+      stylesByProperty.delete(property);
+      stylesByProperty.set(property, style);
+    }
+
+    return [...stylesByProperty.values()];
   }
 
   setRootDoc(o: Stmt[]) {

--- a/packages/mermaid/src/docs/syntax/stateDiagram.md
+++ b/packages/mermaid/src/docs/syntax/stateDiagram.md
@@ -396,6 +396,39 @@ stateDiagram
    Crash:::badBadEvent --> [*]
 ```
 
+### Styling transitions with `linkStyle` (v<MERMAID_RELEASE_VERSION>+)
+
+You can style one or more transitions with the `linkStyle` keyword. Transitions are numbered from `0` in the order
+they appear in the diagram, including transitions inside composite states. Connectors between notes and states are not
+included in this numbering.
+
+To style selected transitions, provide a comma-separated list of their indexes followed by one or more CSS properties:
+
+```txt
+linkStyle 1,3 stroke:#dc2626,stroke-width:4px,color:#dc2626
+```
+
+Use `default` instead of an index to apply a style to every transition:
+
+```txt
+linkStyle default stroke:#2563eb,stroke-width:2px,color:#1e3a8a
+```
+
+An indexed style is applied after the default style, so it can override individual properties. If the same default or
+index is declared more than once, the last declaration for that target is used. A `linkStyle` declaration may appear
+before or after the transitions it styles.
+
+```mermaid-example
+stateDiagram-v2
+    [*] --> Idle : boot
+    Idle --> Running : start
+    Running --> Idle : stop
+    Running --> [*] : shutdown
+
+    linkStyle default stroke:#2563eb,stroke-width:2px,color:#1e3a8a
+    linkStyle 1,3 stroke:#dc2626,stroke-width:4px,color:#dc2626
+```
+
 ## Spaces in state names
 
 Spaces can be added to a state by first defining the state with an id and then referencing the id later.

--- a/packages/mermaid/src/docs/syntax/stateDiagram.md
+++ b/packages/mermaid/src/docs/syntax/stateDiagram.md
@@ -460,6 +460,12 @@ To style selected transitions, provide a comma-separated list of their indexes f
 linkStyle 1,3 stroke:#dc2626,stroke-width:4px,color:#dc2626
 ```
 
+Commas separate CSS properties. Escape a literal comma in a CSS value with a backslash:
+
+```txt
+linkStyle 0 stroke-dasharray:5\,5,stroke:#2563eb
+```
+
 Use `default` instead of an index to apply a style to every transition:
 
 ```txt

--- a/packages/mermaid/src/docs/syntax/stateDiagram.md
+++ b/packages/mermaid/src/docs/syntax/stateDiagram.md
@@ -448,6 +448,39 @@ stateDiagram
    Crash:::badBadEvent --> [*]
 ```
 
+### Styling transitions with `linkStyle` (v<MERMAID_RELEASE_VERSION>+)
+
+You can style one or more transitions with the `linkStyle` keyword. Transitions are numbered from `0` in the order
+they appear in the diagram, including transitions inside composite states. Connectors between notes and states are not
+included in this numbering.
+
+To style selected transitions, provide a comma-separated list of their indexes followed by one or more CSS properties:
+
+```txt
+linkStyle 1,3 stroke:#dc2626,stroke-width:4px,color:#dc2626
+```
+
+Use `default` instead of an index to apply a style to every transition:
+
+```txt
+linkStyle default stroke:#2563eb,stroke-width:2px,color:#1e3a8a
+```
+
+An indexed style is applied after the default style, so it can override individual properties. If the same default or
+index is declared more than once, the last declaration for that target is used. A `linkStyle` declaration may appear
+before or after the transitions it styles.
+
+```mermaid-example
+stateDiagram-v2
+    [*] --> Idle : boot
+    Idle --> Running : start
+    Running --> Idle : stop
+    Running --> [*] : shutdown
+
+    linkStyle default stroke:#2563eb,stroke-width:2px,color:#1e3a8a
+    linkStyle 1,3 stroke:#dc2626,stroke-width:4px,color:#dc2626
+```
+
 ## Spaces in state names
 
 Spaces can be added to a state by first defining the state with an id and then referencing the id later.


### PR DESCRIPTION
## :bookmark_tabs: Summary

State diagrams can now style transitions with the same `linkStyle` syntax used by flowcharts:

- `linkStyle default ...` applies a baseline style to every transition.
- `linkStyle 0,2 ...` targets transitions by their source-order index.
- Indexed styles override individual default properties, while later declarations replace earlier declarations for the same target.
- Nested transitions participate in deterministic source order; internal note connector edges do not.
- Invalid indices report the valid transition range instead of failing later during rendering.

The change includes parser and database coverage, a browser rendering case, user documentation, and a minor changeset.

Resolves #1352

## :straight_ruler: Design Decisions

The parser records `linkStyle` declarations in the state AST instead of mutating edges immediately. State diagrams can contain nested documents and declarations may precede the transitions they target, so the database applies the declarations only after `dataFetcher` has materialized the complete edge list.

Directive collection follows the source document recursively. Transition selection uses the existing exact `transition` class, which deliberately excludes note connector edges. Default and indexed declarations are resolved independently with last-declaration-wins semantics, then merged by CSS property so an indexed override produces one effective value. This also keeps the rendered path and its arrow marker on the same effective stroke color.

Escaped commas remain available inside CSS values, and both edge and label styles flow through Mermaid's existing rendering style pipeline.

### Validation

- `CI=true pnpm exec vitest run packages/mermaid/src/diagrams/state` — 7 files passed; 119 tests passed and 1 existing test skipped.
- `pnpm exec eslint --quiet <changed JS/TS files>` — passed.
- `pnpm lint:jison` — passed for all Jison grammars.
- `pnpm exec prettier --check <changed supported files>` — passed.
- `CI=true pnpm build:types` — passed for all packages and examples.
- `CI=true pnpm build:esbuild` — passed for all parser and package variants.
- Chrome Cypress `stateDiagram-v2.spec.js` — 48 tests passed, including the new default/indexed rendering case.

### :clipboard: Tasks

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation using `MERMAID_RELEASE_VERSION`.
- [x] :butterfly: have added a minor `mermaid` changeset with a `feat:` message.

### AI assistance disclosure

OpenAI Codex was used for issue research, implementation and review assistance, and running the validation described above. I reviewed and understand the complete change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What's working well

- 🎉 [praise] Adds indexed and default `linkStyle` support for state transitions.
- 🎉 [praise] Covers precedence, ordering, nested transitions, note connectors, escaped commas, and invalid indices.
- 🎉 [praise] Includes parser tests, rendering coverage, documentation, and a changeset.
- 🎉 [praise] Reuses the existing edge and label styling pipeline.

## Security

No XSS or injection issues identified.

## Things to address

No blocking or important issues identified.

## Review notes

The repository review configuration was not available at `.claude/repo.yaml`, so repository-specific tone and review-state settings could not be verified.

## Verdict

**APPROVE**

Checklist:
- [x] Praise included
- [x] No duplicate findings
- [x] Severity tally: 0 blocking / 0 important / 0 nit / 0 suggestion / 4 praise
- [x] Verdict matches findings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->