### PR TITLE
fix(c4): validate UpdateElementStyle and UpdateRelStyle colours

### DIFF
--- a/.changeset/c4-validate-style-colors.md
+++ b/.changeset/c4-validate-style-colors.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix(c4): reject non-colour `UpdateElementStyle` and `UpdateRelStyle` values so they are not interpolated into CSS

--- a/packages/mermaid/src/diagrams/c4/c4Db.ts
+++ b/packages/mermaid/src/diagrams/c4/c4Db.ts
@@ -23,6 +23,41 @@ type ParserAttribute = string | Record<string, string>;
 const TEXT_FIELDS = new Set(['label', 'descr', 'techn', 'type']);
 
 /**
+ * An `UpdateElementStyle` / `UpdateRelStyle` colour, accepted only if it is a
+ * colour on its own. The value is interpolated into a CSS declaration, so one
+ * carrying `;` or a `url(...)` could append further declarations; `CSS.supports`
+ * rejects those, and anything it cannot judge (no CSS API, as in jsdom) falls
+ * back to a conservative pattern match.
+ */
+const asColor = (value: unknown): string | undefined => {
+  if (typeof value !== 'string' || value === '') {
+    return undefined;
+  }
+  const accepted =
+    typeof globalThis.CSS?.supports === 'function'
+      ? globalThis.CSS.supports('color', value)
+      : /^(#[\da-f]{3,8}|[a-z]+|rgba?\([\d\s%,./]+\)|hsla?\([\d\s%,./deg]+\))$/i.test(value);
+  return accepted ? value : undefined;
+};
+
+const COLOR_STYLE_KEYS = new Set(['bgColor', 'fontColor', 'borderColor', 'textColor', 'lineColor']);
+
+const assignAttributeValue = (
+  target: C4Shape | C4Boundary | C4Rel,
+  key: string,
+  value: string
+): void => {
+  if (COLOR_STYLE_KEYS.has(key)) {
+    const color = asColor(value);
+    if (color !== undefined) {
+      target[key] = color;
+    }
+    return;
+  }
+  target[key] = value;
+};
+
+/**
  * Apply optional C4 attributes to `bag` from the parser.
  *
  * Values may arrive as a raw positional value or a single `{ key: value }` named
@@ -516,31 +551,31 @@ export const updateElStyle = function (
   if (bgColor !== undefined && bgColor !== null) {
     if (typeof bgColor === 'object') {
       const [key, value] = Object.entries(bgColor)[0];
-      old[key] = value;
+      assignAttributeValue(old, key, value);
     } else {
-      old.bgColor = bgColor;
+      assignAttributeValue(old, 'bgColor', bgColor);
     }
   }
   if (fontColor !== undefined && fontColor !== null) {
     if (typeof fontColor === 'object') {
       const [key, value] = Object.entries(fontColor)[0];
-      old[key] = value;
+      assignAttributeValue(old, key, value);
     } else {
-      old.fontColor = fontColor;
+      assignAttributeValue(old, 'fontColor', fontColor);
     }
   }
   if (borderColor !== undefined && borderColor !== null) {
     if (typeof borderColor === 'object') {
       const [key, value] = Object.entries(borderColor)[0];
-      old[key] = value;
+      assignAttributeValue(old, key, value);
     } else {
-      old.borderColor = borderColor;
+      assignAttributeValue(old, 'borderColor', borderColor);
     }
   }
   if (shadowing !== undefined && shadowing !== null) {
     if (typeof shadowing === 'object') {
       const [key, value] = Object.entries(shadowing)[0];
-      old[key] = value;
+      assignAttributeValue(old, key, value);
     } else {
       old.shadowing = shadowing;
     }
@@ -548,7 +583,7 @@ export const updateElStyle = function (
   if (shape !== undefined && shape !== null) {
     if (typeof shape === 'object') {
       const [key, value] = Object.entries(shape)[0];
-      old[key] = value;
+      assignAttributeValue(old, key, value);
     } else {
       old.shape = shape;
     }
@@ -556,7 +591,7 @@ export const updateElStyle = function (
   if (sprite !== undefined && sprite !== null) {
     if (typeof sprite === 'object') {
       const [key, value] = Object.entries(sprite)[0];
-      old[key] = value;
+      assignAttributeValue(old, key, value);
     } else {
       old.sprite = sprite;
     }
@@ -564,7 +599,7 @@ export const updateElStyle = function (
   if (techn !== undefined && techn !== null) {
     if (typeof techn === 'object') {
       const [key, value] = Object.entries(techn)[0];
-      old[key] = value;
+      assignAttributeValue(old, key, value);
     } else {
       // The parser hands over a plain string here, even though `techn` is a
       // `{ text: string }` object everywhere else.
@@ -574,7 +609,7 @@ export const updateElStyle = function (
   if (legendText !== undefined && legendText !== null) {
     if (typeof legendText === 'object') {
       const [key, value] = Object.entries(legendText)[0];
-      old[key] = value;
+      assignAttributeValue(old, key, value);
     } else {
       old.legendText = legendText;
     }
@@ -582,7 +617,7 @@ export const updateElStyle = function (
   if (legendSprite !== undefined && legendSprite !== null) {
     if (typeof legendSprite === 'object') {
       const [key, value] = Object.entries(legendSprite)[0];
-      old[key] = value;
+      assignAttributeValue(old, key, value);
     } else {
       old.legendSprite = legendSprite;
     }
@@ -606,17 +641,17 @@ export const updateRelStyle = function (
   if (textColor !== undefined && textColor !== null) {
     if (typeof textColor === 'object') {
       const [key, value] = Object.entries(textColor)[0];
-      old[key] = value;
+      assignAttributeValue(old, key, value);
     } else {
-      old.textColor = textColor;
+      assignAttributeValue(old, 'textColor', textColor);
     }
   }
   if (lineColor !== undefined && lineColor !== null) {
     if (typeof lineColor === 'object') {
       const [key, value] = Object.entries(lineColor)[0];
-      old[key] = value;
+      assignAttributeValue(old, key, value);
     } else {
-      old.lineColor = lineColor;
+      assignAttributeValue(old, 'lineColor', lineColor);
     }
   }
   if (offsetX !== undefined && offsetX !== null) {

--- a/packages/mermaid/src/diagrams/c4/parser/c4Db.spec.ts
+++ b/packages/mermaid/src/diagrams/c4/parser/c4Db.spec.ts
@@ -59,7 +59,7 @@ System(SystemAA, "Internet Banking System")
 }
 UpdateElementStyle(b1, $bgColor="red;color:lime", $fontColor="red;color:lime", $borderColor="red;color:lime")`);
 
-    const boundary = c4.parser.yy.getBoundaries().find((item) => item.alias === 'b1');
+    const boundary = c4.parser.yy.getBoundaries()[1];
     expect(boundary).toBeDefined();
     expect(boundary.bgColor ?? '').not.toContain(';');
     expect(boundary.fontColor ?? '').not.toContain(';');

--- a/packages/mermaid/src/diagrams/c4/parser/c4Db.spec.ts
+++ b/packages/mermaid/src/diagrams/c4/parser/c4Db.spec.ts
@@ -1,0 +1,71 @@
+import c4Db from '../c4Db.js';
+// @ts-ignore: JISON doesn't support types
+import c4 from './c4Diagram.jison';
+import { setConfig } from '../../../config.js';
+
+setConfig({
+  securityLevel: 'strict',
+});
+
+describe('C4 style colour storage', function () {
+  beforeEach(function () {
+    c4.parser.yy = c4Db;
+    c4.parser.yy.clear();
+  });
+
+  it('should not store a raw semicolon-bearing UpdateElementStyle colour', function () {
+    c4.parser.parse(`C4Context
+Person(customerA, "Banking Customer A")
+UpdateElementStyle(customerA, $bgColor="red;color:lime", $fontColor="red;color:lime", $borderColor="red;color:lime")`);
+
+    const shape = c4.parser.yy.getC4ShapeArray()[0];
+    expect(shape.bgColor ?? '').not.toContain(';');
+    expect(shape.fontColor ?? '').not.toContain(';');
+    expect(shape.borderColor ?? '').not.toContain(';');
+    expect(shape.bgColor).not.toBe('red;color:lime');
+    expect(shape.fontColor).not.toBe('red;color:lime');
+    expect(shape.borderColor).not.toBe('red;color:lime');
+  });
+
+  it('should still store a valid UpdateElementStyle colour', function () {
+    c4.parser.parse(`C4Context
+Person(customerA, "Banking Customer A")
+UpdateElementStyle(customerA, $bgColor="grey", $fontColor="red", $borderColor="#00ff00")`);
+
+    const shape = c4.parser.yy.getC4ShapeArray()[0];
+    expect(shape.bgColor).toBe('grey');
+    expect(shape.fontColor).toBe('red');
+    expect(shape.borderColor).toBe('#00ff00');
+  });
+
+  it('should not store a raw semicolon-bearing UpdateRelStyle colour', function () {
+    c4.parser.parse(`C4Context
+Person(customerA, "Banking Customer A")
+System(bank, "Bank")
+Rel(customerA, bank, "Uses")
+UpdateRelStyle(customerA, bank, $textColor="red;color:lime", $lineColor="blue;background:url(https://example.invalid)")`);
+
+    const rel = c4.parser.yy.getRels()[0];
+    expect(rel.textColor ?? '').not.toContain(';');
+    expect(rel.lineColor ?? '').not.toContain(';');
+    expect(rel.textColor).not.toBe('red;color:lime');
+    expect(rel.lineColor).not.toBe('blue;background:url(https://example.invalid)');
+  });
+
+  it('should not store a raw semicolon-bearing UpdateElementStyle colour on a boundary', function () {
+    c4.parser.parse(`C4Context
+Boundary(b1, "BankBoundary") {
+System(SystemAA, "Internet Banking System")
+}
+UpdateElementStyle(b1, $bgColor="red;color:lime", $fontColor="red;color:lime", $borderColor="red;color:lime")`);
+
+    const boundary = c4.parser.yy.getBoundaries().find((item) => item.alias === 'b1');
+    expect(boundary).toBeDefined();
+    expect(boundary.bgColor ?? '').not.toContain(';');
+    expect(boundary.fontColor ?? '').not.toContain(';');
+    expect(boundary.borderColor ?? '').not.toContain(';');
+    expect(boundary.bgColor).not.toBe('red;color:lime');
+    expect(boundary.fontColor).not.toBe('red;color:lime');
+    expect(boundary.borderColor).not.toBe('red;color:lime');
+  });
+});


### PR DESCRIPTION
C4 `UpdateElementStyle` and `UpdateRelStyle` stored colour values without checking them, so a string like `red;color:lime` could be interpolated into CSS.

Reuse the existing `asColor` check and ignore values that are not a colour. Valid colours still store.

Fixes #8057

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds centralized `asColor` validation for C4 element, boundary, and relationship styles.
- Rejects invalid colours, including semicolon-bearing declarations and `url(...)` values.
- Preserves valid named and hexadecimal colours.
- Adds parser tests for element, boundary, and relationship style updates.
- Adds a patch changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->