### PR TITLE
fix(elk): build markers with the host instance's config

### DIFF
--- a/.changeset/elk-neo-marker-theme-config.md
+++ b/.changeset/elk-neo-marker-theme-config.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: neo-look arrowheads and crow's-foot markers no longer fall back to default theme colours/stroke widths on the first render with `layout: elk`. State diagram arrowheads stayed dark on dark themes, and ER / requirement markers were drawn at the default stroke width, because markers were created from the layout package's own bundled copy of mermaid, whose config had not been initialized yet.

--- a/docs/config/setup/mermaid/functions/clearLayoutRenderState.md
+++ b/docs/config/setup/mermaid/functions/clearLayoutRenderState.md
@@ -12,7 +12,7 @@
 
 > **clearLayoutRenderState**(): `void`
 
-Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:196](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L196)
+Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:206](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L206)
 
 ## Returns
 

--- a/docs/config/setup/mermaid/functions/defaultMeasureLayout.md
+++ b/docs/config/setup/mermaid/functions/defaultMeasureLayout.md
@@ -12,7 +12,7 @@
 
 > **defaultMeasureLayout**(`data4Layout`, `__namedParameters`): `Promise`<{ `graph`: `Graph`; `groups`: { `clusters`: `D3Selection`<`SVGGElement`>; `edgeLabels`: `D3Selection`<`SVGGElement`>; `edgePaths`: `D3Selection`<`SVGGElement`>; `nodes`: `D3Selection`<`SVGGElement`>; `rootGroups`: `D3Selection`<`SVGGElement`>; }; `nodeElements`: `Map`<`string`, `D3Selection`<`SVGElement` | `SVGGElement`>>; }>
 
-Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:203](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L203)
+Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:213](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L213)
 
 ## Parameters
 

--- a/docs/config/setup/mermaid/functions/paintLayoutData.md
+++ b/docs/config/setup/mermaid/functions/paintLayoutData.md
@@ -12,7 +12,7 @@
 
 > **paintLayoutData**(`data4Layout`, `context`, `options`): `Promise`<`void`>
 
-Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:210](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L210)
+Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:220](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L220)
 
 ## Parameters
 

--- a/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts
@@ -133,7 +133,17 @@ export function createCommonLayoutRenderer<
     options?: RenderOptions
   ): Promise<void> {
     const element = svg.select('g') as unknown as D3Selection<SVGElement>;
-    insertMarkers(element, data4Layout.markers, data4Layout.type, data4Layout.diagramId);
+    // Use the helper handed over by the host mermaid instance when there is one.
+    // External layout packages (elk, tidy-tree) are bundled with their own copy of
+    // these modules, and that copy's config module never sees `mermaid.initialize()`,
+    // so markers created through the statically imported `insertMarkers` read default
+    // theme variables instead of the diagram's.
+    (helpers?.insertMarkers ?? insertMarkers)(
+      element,
+      data4Layout.markers,
+      data4Layout.type,
+      data4Layout.diagramId
+    );
     clearLayoutRenderState();
 
     // Convenience struct containing everything you need to render


### PR DESCRIPTION
## Problem

With `look: 'neo'`, the **first** diagram rendered on a page with `layout: 'elk'` gets markers built from default theme variables instead of the diagram's:

- **state diagrams** — arrowheads stay dark on dark themes (`dark`, `redux-dark`, `neo-dark`) instead of taking the line colour
- **ER diagrams** — the crow's-foot markers (`only_one_neo`, `zero_or_one_neo`, `one_or_more_neo`, `zero_or_more_neo`) are drawn at the default stroke width instead of the theme's
- **requirement diagrams** — same for `requirement_arrow_neo` / `requirement_contains_neo`

`layout: 'dagre'` is unaffected. Renders after the first one on the same page are also fine, which is why this survives the e2e suite.

Rendering the same state diagram three times on one page (`theme: 'dark'`, `look: 'neo'`, `layout: 'elk'`) and reading the `fill` attribute that `barbNeo` writes onto the arrowhead path:

| render | marker fill | edge stroke |
| --- | --- | --- |
| #0 | `#333333` ❌ | `rgb(211, 211, 211)` |
| #1 | `lightgrey` ✅ | `rgb(211, 211, 211)` |
| #2 | `lightgrey` ✅ | `rgb(211, 211, 211)` |

`#333333` is the **default** theme's `transitionColor`.

## Cause

`@mermaid-js/layout-elk` is built with `mermaid` bundled in rather than external, so it runs its own copy of `config.ts` — a copy that never sees `mermaid.initialize()`. (`insertMarkers` and the marker definitions are compiled into the layout package's own chunks; you can confirm it by grepping the built `dist/chunks/mermaid-layout-elk.esm/*` for `barbNeo`.)

That copy's config is populated by `syncElkPackageConfig()` in `packages/mermaid-layout-elk/src/render.ts`, which calls `mermaid.mermaidAPI.setConfig(...)` — but it runs from `prepareLayout`, and `createCommonLayoutRenderer` calls `insertMarkers` as its **first** statement, before `prepareLayout`. So on the first render the marker functions read defaults; from the second render on the copy is warm.

Only the `*_neo` marker variants are affected, because they are the ones that bake theme values into presentation attributes at marker-creation time (`barbNeo` writes `fill: themeVariables.transitionColor`; the ER and requirement neo markers write `stroke-width: themeVariables.strokeWidth`). The classic markers leave their colour to the diagram stylesheet, which is generated by the host instance and therefore always correct.

## Fix

`createCommonLayoutRenderer` already receives the host instance's `internalHelpers` — `rendering-util/render.ts` passes it into every layout renderer — so prefer it over the statically imported binding:

```ts
(helpers?.insertMarkers ?? insertMarkers)(element, data4Layout.markers, data4Layout.type, data4Layout.diagramId);
```

Markers are then always created by the host instance, whose config is initialized, regardless of how a layout package was bundled. `mermaid-layout-tidy-tree` already takes `insertMarkers` from the helpers object this way. The `?? insertMarkers` fallback keeps the function working when it is called without helpers.

##Screenshots Before & After
<img width="1600" height="1950" alt="image" src="https://github.com/user-attachments/assets/e984325e-ea97-437a-bf12-6dcded3179ae" />


## Scope / follow-ups

Deliberately kept to `insertMarkers`, since that is what the reported rendering bug goes through. Two related items left out of this PR:

1. `insertNode`, `insertEdge`, `insertCluster` and `insertEdgeLabel` in the same function still use their static imports and carry the same exposure for anything they read from config at render time.
2. The underlying issues — layout packages bundling their own `mermaid`, and `syncElkPackageConfig()` running after `insertMarkers` — are still there. Either making `mermaid` external in the layout package builds, or syncing before markers are inserted, would remove this class of bug at the source.

Happy to fold either in if you would rather fix it there.

## Testing

- Built this branch and rendered state, ER and requirement diagrams × 10 themes (`mc`, `neo`, `dark`, `neo-dark`, `default`, `forest`, `base`, `neutral`, `redux`, `redux-dark`) × `dagre` / `elk`, one diagram per fresh page so every render is a first render, comparing each marker's `fill` and `stroke-width` between the two layouts: **50/50 match**. Before the patch the `elk` side differed on every theme whose `transitionColor` / `strokeWidth` is not the default — e.g. `redux-dark` ER `zeroOrMoreEnd` went from `fill: #ECECFF, stroke-width: 1` to `fill: #111113, stroke-width: 2`, and state `barbEnd-margin` on `dark` from `#333333` to `lightgrey`.
- The `dagre` values are unchanged by the patch, so no `dagre` visual baselines should move.
- Note for anyone writing a regression test: it has to render into a **fresh page / module graph**. A second render in the same page passes either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
