### PR TITLE
Order unpinned screenshots by test declaration instead of alphabetically

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -426,8 +426,11 @@ jobs:
       # Sheets are tiled in the committed order (e2e/sheet-order.json): new
       # screenshots append at their group's tail and removed ones leave a blank
       # cell, so adding/removing a test changes only that group's last/affected
-      # sheet instead of cascading. The manifest is compacted periodically by the
-      # "Refresh screenshot sheet order" workflow (opens a PR), not on every run.
+      # sheet instead of cascading. Groups the manifest doesn't cover yet are tiled
+      # in test-declaration order (read from the capture sidecars), so a test added
+      # at the end of its spec still appends instead of re-sorting the group. The
+      # manifest is compacted periodically by the "Refresh screenshot sheet order"
+      # workflow (opens a PR), not on every run.
       - name: Composite screenshots into per-spec sheets
         if: env.GROUP_ARGOS_IMAGES == 'true'
         run: pnpm run screenshots:sheets

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -428,9 +428,10 @@ jobs:
       # cell, so adding/removing a test changes only that group's last/affected
       # sheet instead of cascading. Groups the manifest doesn't cover yet are tiled
       # in test-declaration order (read from the capture sidecars), so a test added
-      # at the end of its spec still appends instead of re-sorting the group. The
-      # manifest is compacted periodically by the "Refresh screenshot sheet order"
-      # workflow (opens a PR), not on every run.
+      # at the end of its spec still appends instead of re-sorting the group; tiles
+      # whose sidecar is missing or unreadable fall back to source-path order at
+      # the group's tail. The manifest is compacted periodically by the "Refresh
+      # screenshot sheet order" workflow (opens a PR), not on every run.
       - name: Composite screenshots into per-spec sheets
         if: env.GROUP_ARGOS_IMAGES == 'true'
         run: pnpm run screenshots:sheets

--- a/e2e/helpers/argos-metadata.ts
+++ b/e2e/helpers/argos-metadata.ts
@@ -185,31 +185,34 @@ export function annotateTilePosition(
   };
 }
 
-/**
- * Declaration position of the test that captured a tile, read from its sidecar.
- * Undefined when the sidecar is missing or unreadable (e.g. artifacts captured
- * before sidecars were written).
- */
-export function readTileOrigin(inputDir: string, source: string): ArgosLocation | undefined {
-  const sidecarPath = join(inputDir, argosMetadataSidecarPath(source));
+/** Parse a capture's sidecar; undefined when it is missing or unreadable. */
+function readSidecarMetadata(
+  inputDir: string,
+  source: string
+): ArgosScreenshotMetadata | undefined {
   try {
-    const meta = JSON.parse(readFileSync(sidecarPath, 'utf8')) as ArgosScreenshotMetadata;
-    return meta.test?.location;
+    return JSON.parse(
+      readFileSync(join(inputDir, argosMetadataSidecarPath(source)), 'utf8')
+    ) as ArgosScreenshotMetadata;
   } catch {
     return undefined;
   }
 }
 
-/** Declaration positions for every source with a readable sidecar, keyed by source path. */
+/**
+ * Declaration position of each screenshot's test — `test.location` (spec file
+ * plus line/column of the `test()` call) from its capture sidecar — keyed by
+ * source path. Sources without a readable sidecar are omitted.
+ */
 export function readTileOrigins(
   inputDir: string,
   sources: readonly string[]
 ): Map<string, ArgosLocation> {
   const origins = new Map<string, ArgosLocation>();
   for (const source of sources) {
-    const origin = readTileOrigin(inputDir, source);
-    if (origin) {
-      origins.set(source, origin);
+    const location = readSidecarMetadata(inputDir, source)?.test?.location;
+    if (location) {
+      origins.set(source, location);
     }
   }
   return origins;
@@ -217,27 +220,21 @@ export function readTileOrigins(
 
 /** Read a tile's sidecar if present; otherwise infer from the PNG path. */
 export function readTileAnnotation(inputDir: string, source: string): ArgosTestAnnotation {
-  const sidecarPath = join(inputDir, argosMetadataSidecarPath(source));
-  try {
-    const meta = JSON.parse(readFileSync(sidecarPath, 'utf8')) as ArgosScreenshotMetadata;
-    const fixture = meta.test?.annotations?.find((a) => a.type === 'mmd-fixture');
-    if (fixture) {
-      return fixture;
-    }
-    const testAnnotation = meta.test?.annotations?.find((a) => a.type === 'test');
-    if (testAnnotation) {
-      return testAnnotation;
-    }
-    if (meta.test?.title) {
-      return {
-        type: 'test',
-        description: meta.test.titlePath?.join(' › ') ?? meta.test.title,
-        location: meta.test.location,
-      };
-    }
-  } catch {
-    // Fall back to path inference when no sidecar exists (older artifacts).
+  const meta = readSidecarMetadata(inputDir, source);
+  const annotation =
+    meta?.test?.annotations?.find((a) => a.type === 'mmd-fixture') ??
+    meta?.test?.annotations?.find((a) => a.type === 'test');
+  if (annotation) {
+    return annotation;
   }
+  if (meta?.test?.title) {
+    return {
+      type: 'test',
+      description: meta.test.titlePath?.join(' › ') ?? meta.test.title,
+      location: meta.test.location,
+    };
+  }
+  // Fall back to path inference when no sidecar exists (older artifacts).
   return annotationFromScreenshotRelPath(source);
 }
 

--- a/e2e/helpers/argos-metadata.ts
+++ b/e2e/helpers/argos-metadata.ts
@@ -185,6 +185,36 @@ export function annotateTilePosition(
   };
 }
 
+/**
+ * Declaration position of the test that captured a tile, read from its sidecar.
+ * Undefined when the sidecar is missing or unreadable (e.g. artifacts captured
+ * before sidecars were written).
+ */
+export function readTileOrigin(inputDir: string, source: string): ArgosLocation | undefined {
+  const sidecarPath = join(inputDir, argosMetadataSidecarPath(source));
+  try {
+    const meta = JSON.parse(readFileSync(sidecarPath, 'utf8')) as ArgosScreenshotMetadata;
+    return meta.test?.location;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Declaration positions for every source with a readable sidecar, keyed by source path. */
+export function readTileOrigins(
+  inputDir: string,
+  sources: readonly string[]
+): Map<string, ArgosLocation> {
+  const origins = new Map<string, ArgosLocation>();
+  for (const source of sources) {
+    const origin = readTileOrigin(inputDir, source);
+    if (origin) {
+      origins.set(source, origin);
+    }
+  }
+  return origins;
+}
+
 /** Read a tile's sidecar if present; otherwise infer from the PNG path. */
 export function readTileAnnotation(inputDir: string, source: string): ArgosTestAnnotation {
   const sidecarPath = join(inputDir, argosMetadataSidecarPath(source));

--- a/scripts/screenshot-order.ts
+++ b/scripts/screenshot-order.ts
@@ -17,6 +17,7 @@
 
 import { writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
+import { readTileOrigins } from '../e2e/helpers/argos-metadata.ts';
 import {
   collectScreenshots,
   findUnordered,
@@ -56,7 +57,9 @@ async function main(): Promise<void> {
     return;
   }
 
-  const next = updateOrder(relPaths, previous);
+  // Newly-seen screenshots are folded in in test-declaration order (from the
+  // capture sidecars), matching how the compositor appends them at runtime.
+  const next = updateOrder(relPaths, previous, readTileOrigins(screenshotDir, relPaths));
   await writeFile(orderFile, JSON.stringify(next, null, 2) + '\n');
   log(`wrote ${orderFile} (${countTiles(next)} tiles across ${Object.keys(next).length} groups).`);
 }

--- a/scripts/screenshot-order.ts
+++ b/scripts/screenshot-order.ts
@@ -57,8 +57,8 @@ async function main(): Promise<void> {
     return;
   }
 
-  // Newly-seen screenshots are folded in in test-declaration order (from the
-  // capture sidecars), matching how the compositor appends them at runtime.
+  // Newly-seen screenshots fold into the manifest in test-declaration order
+  // (from the capture sidecars), matching how the compositor appends them.
   const next = updateOrder(relPaths, previous, readTileOrigins(screenshotDir, relPaths));
   await writeFile(orderFile, JSON.stringify(next, null, 2) + '\n');
   log(`wrote ${orderFile} (${countTiles(next)} tiles across ${Object.keys(next).length} groups).`);

--- a/scripts/screenshot-sheets.spec.ts
+++ b/scripts/screenshot-sheets.spec.ts
@@ -5,6 +5,7 @@ import sharp from 'sharp';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
   argosMetadataSidecarPath,
+  readTileOrigins,
   writeArgosMetadataSidecar,
 } from '../e2e/helpers/argos-metadata.js';
 import {
@@ -440,6 +441,170 @@ describe('append-only tile order', () => {
     const empty = planSheets(paths, { tilesPerSheet: 12, cols: 3, order: {} });
     expect(fallback[0].tiles.map((t) => t.source)).toEqual(empty[0].tiles.map((t) => t.source));
     expect(fallback[0].tiles.map((t) => t.source)).toEqual([...paths].sort());
+  });
+});
+
+describe('declaration-order fallback for unpinned tiles', () => {
+  // Every *.spec.* group is missing from the committed manifest today (it only
+  // covers the mmd `diagrams/*` folders), so these groups take layoutGroup's
+  // fallback on every run. Alphabetical there means a new test can take cell 1
+  // and push every other tile one cell along; declaration order appends instead.
+  const SPEC_FILE = `e2e/${FC_MAIN}`;
+
+  /** Sources with their `test()` call line, as the capture sidecars record it. */
+  const declared = (entries: [string, number][]) => ({
+    sources: entries.map(([name]) => `${FC_MAIN}/${name}`),
+    origins: new Map(
+      entries.map(([name, line]) => [`${FC_MAIN}/${name}`, { file: SPEC_FILE, line, column: 3 }])
+    ),
+  });
+
+  const cells = (
+    sources: string[],
+    origins?: Map<string, { file: string; line: number; column: number }>
+  ) =>
+    planSheets(sources, { tilesPerSheet: 12, cols: 3, origins }).flatMap((sheet) =>
+      sheet.tiles.map((t) => t.name)
+    );
+
+  it('lays an unpinned group out in declaration order, not alphabetically', () => {
+    const { sources, origins } = declared([
+      ['zebra.png', 10],
+      ['apple.png', 20],
+      ['mango.png', 30],
+    ]);
+    expect(cells(sources, origins)).toEqual(['zebra', 'apple', 'mango']);
+    expect(cells(sources)).toEqual(['apple', 'mango', 'zebra']); // today's fallback
+  });
+
+  it('a test added at the end of its spec appends, leaving every other tile in place', () => {
+    const { sources, origins } = declared([
+      ['basic-er-diagram.png', 10],
+      ['crows-foot-notation.png', 20],
+      ['zzz-last-one.png', 30],
+    ]);
+    const before = cells(sources, origins);
+
+    // Alphabetically first, but declared last — the case that used to take cell 1.
+    const added = `${FC_MAIN}/aaa-newly-added-test.png`;
+    const after = cells(
+      [...sources, added],
+      new Map([...origins, [added, { file: SPEC_FILE, line: 40, column: 3 }]])
+    );
+
+    expect(after).toEqual([...before, 'aaa-newly-added-test']);
+    expect(after.slice(0, before.length)).toEqual(before); // nothing shifted
+  });
+
+  it('keeps earlier sheets byte-identical when a test is appended to a multi-sheet group', () => {
+    const entries: [string, number][] = Array.from({ length: 26 }, (_, i) => [
+      `t-${String(i).padStart(3, '0')}.png`,
+      (i + 1) * 10,
+    ]);
+    const { sources, origins } = declared(entries);
+    const sig = (paths: string[], o: typeof origins) =>
+      planSheets(paths, { tilesPerSheet: 12, cols: 3, origins: o }).map(
+        (sheet) => `${sheet.group}#${sheet.index}:${sheet.tiles.map((t) => t.source).join(',')}`
+      );
+
+    const before = sig(sources, origins);
+    const added = `${FC_MAIN}/aaa-appended.png`; // sorts first, declared last
+    const after = sig(
+      [...sources, added],
+      new Map([...origins, [added, { file: SPEC_FILE, line: 999, column: 3 }]])
+    );
+
+    expect(after[0]).toBe(before[0]);
+    expect(after[1]).toBe(before[1]);
+    expect(after).toHaveLength(before.length); // 27 tiles still fit in 3 sheets
+    expect(after[2]).toBe(`${before[2]},${added}`);
+  });
+
+  it('falls back to path order for tiles sharing one call site (loop-registered tests)', () => {
+    const { sources, origins } = declared([
+      ['loop-b.png', 12],
+      ['loop-a.png', 12],
+      ['later.png', 20],
+    ]);
+    expect(cells(sources, origins)).toEqual(['loop-a', 'loop-b', 'later']);
+  });
+
+  it('leaves mmd fixture groups on alphabetical order (one runner call site for all)', () => {
+    // mmd-snapshots.spec.ts registers every fixture from a single test() call, so
+    // all of its captures report the same declaration position and tie — the mmd
+    // `diagrams/*` groups (the only ones the committed manifest covers) keep the
+    // layout they have today.
+    const runner = { file: 'e2e/rendering/mmd-snapshots.spec.ts', line: 26, column: 5 };
+    const fixtures = ['diagrams/packet/zebra.png', 'diagrams/packet/apple.png'];
+    const origins = new Map(fixtures.map((f) => [f, runner]));
+    const tiles = planSheets(fixtures, { tilesPerSheet: 12, cols: 3, origins })[0].tiles;
+    expect(tiles.map((t) => t.source)).toEqual([...fixtures].sort());
+  });
+
+  it('sorts sidecar-less tiles after placed ones, alphabetically among themselves', () => {
+    const { sources, origins } = declared([['declared.png', 10]]);
+    const orphans = [`${FC_MAIN}/no-sidecar-b.png`, `${FC_MAIN}/no-sidecar-a.png`];
+    expect(cells([...orphans, ...sources], origins)).toEqual([
+      'declared',
+      'no-sidecar-a',
+      'no-sidecar-b',
+    ]);
+  });
+
+  it('appends the unpinned tail of a manifest-pinned group in declaration order too', () => {
+    const { sources, origins } = declared([
+      ['pinned-a.png', 10],
+      ['pinned-b.png', 20],
+      ['new-zebra.png', 30],
+      ['new-apple.png', 40],
+    ]);
+    const order = { [FC_MAIN]: ['pinned-a.png', 'pinned-b.png'] };
+    const [sheet] = planSheets(sources, { tilesPerSheet: 12, cols: 3, order, origins });
+    expect(sheet.tiles.map((t) => t.name)).toEqual([
+      'pinned-a',
+      'pinned-b',
+      'new-zebra', // declared before new-apple, so it appends first
+      'new-apple',
+    ]);
+  });
+
+  it('updateOrder folds newly-seen screenshots in declaration order', () => {
+    const { sources, origins } = declared([
+      ['kept.png', 10],
+      ['new-zebra.png', 20],
+      ['new-apple.png', 30],
+    ]);
+    const next = updateOrder(sources, { [FC_MAIN]: ['kept.png'] }, origins);
+    expect(next[FC_MAIN]).toEqual(['kept.png', 'new-zebra.png', 'new-apple.png']);
+    // Without origins the same input sorts the new pair alphabetically.
+    expect(updateOrder(sources, { [FC_MAIN]: ['kept.png'] })[FC_MAIN]).toEqual([
+      'kept.png',
+      'new-apple.png',
+      'new-zebra.png',
+    ]);
+  });
+
+  it('reads declaration positions from the capture sidecars on disk', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'argos-origins-'));
+    const source = `${FC_MAIN}/a.png`;
+    await mkdir(join(dir, FC_MAIN), { recursive: true });
+    await writeArgosMetadataSidecar(join(dir, source), {
+      $schema: 'https://api.argos-ci.com/v2/screenshot-metadata.json',
+      test: {
+        title: 'a',
+        location: { file: SPEC_FILE, line: 42, column: 3 },
+        annotations: [],
+      },
+      automationLibrary: { name: 'playwright', version: '1' },
+      sdk: { name: '@argos-ci/cli', version: '1' },
+    });
+    await writeFile(join(dir, FC_MAIN, 'b.png.argos.json'), 'not json');
+
+    const origins = readTileOrigins(dir, [source, `${FC_MAIN}/b.png`, `${FC_MAIN}/c.png`]);
+    expect(origins.get(source)).toEqual({ file: SPEC_FILE, line: 42, column: 3 });
+    expect(origins.has(`${FC_MAIN}/b.png`)).toBe(false); // corrupt sidecar
+    expect(origins.has(`${FC_MAIN}/c.png`)).toBe(false); // no sidecar
+    await rm(dir, { recursive: true, force: true });
   });
 });
 

--- a/scripts/screenshot-sheets.spec.ts
+++ b/scripts/screenshot-sheets.spec.ts
@@ -597,6 +597,17 @@ describe('declaration-order tail for unpinned tiles', () => {
     ]);
   });
 
+  it('round-trips a root-level screenshot without blanking or pruning it', () => {
+    // deriveGroupKey('tile.png') is the synthetic 'root' key; rebuilding sources
+    // must not prefix it back on, or the tile turns into a blank 'root/tile.png'
+    // cell and drops out of the refreshed manifest.
+    const order = extendOrder({}, ['tile.png']);
+    expect(order).toEqual({ root: ['tile.png'] });
+    const [sheet] = planSheets(['tile.png'], { tilesPerSheet: 12, cols: 3, order });
+    expect(sheet.tiles.map((t) => [t.source, t.missing ?? false])).toEqual([['tile.png', false]]);
+    expect(updateOrder(['tile.png'], order)).toEqual({ root: ['tile.png'] });
+  });
+
   it('reads declaration positions from the capture sidecars on disk', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'argos-origins-'));
     const source = `${FC_MAIN}/a.png`;

--- a/scripts/screenshot-sheets.spec.ts
+++ b/scripts/screenshot-sheets.spec.ts
@@ -15,6 +15,7 @@ import {
   DEFAULT_TILE_WIDTH,
   deriveGroupKey,
   ensureSheetMetadataSidecars,
+  extendOrder,
   findUnordered,
   formatTileTitle,
   LABEL_HEIGHT,
@@ -22,6 +23,7 @@ import {
   updateOrder,
   writeSheets,
 } from './screenshot-sheets.js';
+import type { OrderManifest, TileOrigins } from './screenshot-sheets.js';
 
 const SLOT_WIDTH = 40;
 const SLOT_HEIGHT = 30;
@@ -444,14 +446,16 @@ describe('append-only tile order', () => {
   });
 });
 
-describe('declaration-order fallback for unpinned tiles', () => {
+describe('declaration-order tail for unpinned tiles', () => {
   // Every *.spec.* group is missing from the committed manifest today (it only
-  // covers the mmd `diagrams/*` folders), so these groups take layoutGroup's
-  // fallback on every run. Alphabetical there means a new test can take cell 1
-  // and push every other tile one cell along; declaration order appends instead.
+  // covers the mmd `diagrams/*` folders), so alphabetical layout let a new test
+  // whose slug sorts early take cell 1 and shift every other tile. The CLI now
+  // extends the manifest over all captured screenshots before planning
+  // (extendOrder): unpinned tiles are pinned in test-declaration order, so a
+  // test added at the end of its spec appends at its group's tail.
   const SPEC_FILE = `e2e/${FC_MAIN}`;
 
-  /** Sources with their `test()` call line, as the capture sidecars record it. */
+  /** Sources with the `test()` call line their capture sidecars would record. */
   const declared = (entries: [string, number][]) => ({
     sources: entries.map(([name]) => `${FC_MAIN}/${name}`),
     origins: new Map(
@@ -459,13 +463,13 @@ describe('declaration-order fallback for unpinned tiles', () => {
     ),
   });
 
-  const cells = (
-    sources: string[],
-    origins?: Map<string, { file: string; line: number; column: number }>
-  ) =>
-    planSheets(sources, { tilesPerSheet: 12, cols: 3, origins }).flatMap((sheet) =>
-      sheet.tiles.map((t) => t.name)
-    );
+  /** Tile names as the CLI lays them out: manifest extended, then planned. */
+  const cells = (sources: string[], origins?: TileOrigins, previous: OrderManifest = {}) =>
+    planSheets(sources, {
+      tilesPerSheet: 12,
+      cols: 3,
+      order: extendOrder(previous, sources, origins),
+    }).flatMap((sheet) => sheet.tiles.map((t) => t.name));
 
   it('lays an unpinned group out in declaration order, not alphabetically', () => {
     const { sources, origins } = declared([
@@ -474,7 +478,9 @@ describe('declaration-order fallback for unpinned tiles', () => {
       ['mango.png', 30],
     ]);
     expect(cells(sources, origins)).toEqual(['zebra', 'apple', 'mango']);
-    expect(cells(sources)).toEqual(['apple', 'mango', 'zebra']); // today's fallback
+    // Without the extend pass the same group re-sorts alphabetically.
+    const [bare] = planSheets(sources, { tilesPerSheet: 12, cols: 3 });
+    expect(bare.tiles.map((t) => t.name)).toEqual(['apple', 'mango', 'zebra']);
   });
 
   it('a test added at the end of its spec appends, leaving every other tile in place', () => {
@@ -493,7 +499,6 @@ describe('declaration-order fallback for unpinned tiles', () => {
     );
 
     expect(after).toEqual([...before, 'aaa-newly-added-test']);
-    expect(after.slice(0, before.length)).toEqual(before); // nothing shifted
   });
 
   it('keeps earlier sheets byte-identical when a test is appended to a multi-sheet group', () => {
@@ -502,8 +507,8 @@ describe('declaration-order fallback for unpinned tiles', () => {
       (i + 1) * 10,
     ]);
     const { sources, origins } = declared(entries);
-    const sig = (paths: string[], o: typeof origins) =>
-      planSheets(paths, { tilesPerSheet: 12, cols: 3, origins: o }).map(
+    const sig = (paths: string[], o: TileOrigins) =>
+      planSheets(paths, { tilesPerSheet: 12, cols: 3, order: extendOrder({}, paths, o) }).map(
         (sheet) => `${sheet.group}#${sheet.index}:${sheet.tiles.map((t) => t.source).join(',')}`
       );
 
@@ -520,64 +525,72 @@ describe('declaration-order fallback for unpinned tiles', () => {
     expect(after[2]).toBe(`${before[2]},${added}`);
   });
 
-  it('falls back to path order for tiles sharing one call site (loop-registered tests)', () => {
+  it('breaks call-site ties (loop-registered tests) and sidecar-less tiles by path order', () => {
     const { sources, origins } = declared([
       ['loop-b.png', 12],
-      ['loop-a.png', 12],
+      ['loop-a.png', 12], // same test() line as loop-b
       ['later.png', 20],
     ]);
-    expect(cells(sources, origins)).toEqual(['loop-a', 'loop-b', 'later']);
-  });
-
-  it('leaves mmd fixture groups on alphabetical order (one runner call site for all)', () => {
-    // mmd-snapshots.spec.ts registers every fixture from a single test() call, so
-    // all of its captures report the same declaration position and tie — the mmd
-    // `diagrams/*` groups (the only ones the committed manifest covers) keep the
-    // layout they have today.
-    const runner = { file: 'e2e/rendering/mmd-snapshots.spec.ts', line: 26, column: 5 };
-    const fixtures = ['diagrams/packet/zebra.png', 'diagrams/packet/apple.png'];
-    const origins = new Map(fixtures.map((f) => [f, runner]));
-    const tiles = planSheets(fixtures, { tilesPerSheet: 12, cols: 3, origins })[0].tiles;
-    expect(tiles.map((t) => t.source)).toEqual([...fixtures].sort());
-  });
-
-  it('sorts sidecar-less tiles after placed ones, alphabetically among themselves', () => {
-    const { sources, origins } = declared([['declared.png', 10]]);
     const orphans = [`${FC_MAIN}/no-sidecar-b.png`, `${FC_MAIN}/no-sidecar-a.png`];
     expect(cells([...orphans, ...sources], origins)).toEqual([
-      'declared',
-      'no-sidecar-a',
+      'loop-a',
+      'loop-b',
+      'later',
+      'no-sidecar-a', // sidecar-less tiles sort after located ones
       'no-sidecar-b',
     ]);
   });
 
-  it('appends the unpinned tail of a manifest-pinned group in declaration order too', () => {
+  it('leaves mmd fixture groups alphabetical (one runner call site registers all)', () => {
+    // mmd-snapshots.spec.ts registers every fixture from a single test() call, so
+    // all of its captures tie on declaration position — the mmd `diagrams/*`
+    // groups (the only ones the committed manifest covers) keep today's layout.
+    const runner = { file: 'e2e/rendering/mmd-snapshots.spec.ts', line: 26, column: 5 };
+    const fixtures = ['diagrams/packet/zebra.png', 'diagrams/packet/apple.png'];
+    const origins = new Map(fixtures.map((f) => [f, runner]));
+    expect(extendOrder({}, fixtures, origins)['diagrams/packet']).toEqual([
+      'apple.png',
+      'zebra.png',
+    ]);
+  });
+
+  it('extendOrder keeps committed entries verbatim, appending only unpinned tiles', () => {
     const { sources, origins } = declared([
       ['pinned-a.png', 10],
-      ['pinned-b.png', 20],
       ['new-zebra.png', 30],
       ['new-apple.png', 40],
     ]);
-    const order = { [FC_MAIN]: ['pinned-a.png', 'pinned-b.png'] };
-    const [sheet] = planSheets(sources, { tilesPerSheet: 12, cols: 3, order, origins });
-    expect(sheet.tiles.map((t) => t.name)).toEqual([
+    // pinned-b has no capture this run: its entry (and thus its blank slot) stays.
+    const previous = { [FC_MAIN]: ['pinned-a.png', 'pinned-b.png'] };
+    expect(extendOrder(previous, sources, origins)[FC_MAIN]).toEqual([
+      'pinned-a.png',
+      'pinned-b.png',
+      'new-zebra.png', // declared before new-apple, so it appends first
+      'new-apple.png',
+    ]);
+    expect(cells(sources, origins, previous)).toEqual([
       'pinned-a',
-      'pinned-b',
-      'new-zebra', // declared before new-apple, so it appends first
+      'pinned-b', // blank cell — slot kept
+      'new-zebra',
       'new-apple',
     ]);
   });
 
-  it('updateOrder folds newly-seen screenshots in declaration order', () => {
+  it('updateOrder folds newly-seen screenshots in declaration order and prunes removals', () => {
     const { sources, origins } = declared([
       ['kept.png', 10],
       ['new-zebra.png', 20],
       ['new-apple.png', 30],
     ]);
-    const next = updateOrder(sources, { [FC_MAIN]: ['kept.png'] }, origins);
-    expect(next[FC_MAIN]).toEqual(['kept.png', 'new-zebra.png', 'new-apple.png']);
-    // Without origins the same input sorts the new pair alphabetically.
-    expect(updateOrder(sources, { [FC_MAIN]: ['kept.png'] })[FC_MAIN]).toEqual([
+    const previous = {
+      [FC_MAIN]: ['removed.png', 'kept.png'],
+      'gone/entirely.spec.js': ['x.png'],
+    };
+    expect(updateOrder(sources, previous, origins)).toEqual({
+      [FC_MAIN]: ['kept.png', 'new-zebra.png', 'new-apple.png'],
+    });
+    // Without origins the new pair falls back to alphabetical order.
+    expect(updateOrder(sources, previous)[FC_MAIN]).toEqual([
       'kept.png',
       'new-apple.png',
       'new-zebra.png',

--- a/scripts/screenshot-sheets.ts
+++ b/scripts/screenshot-sheets.ts
@@ -240,6 +240,15 @@ function groupRelative(source: string, groupKey: string): string {
   return groupKey && source.startsWith(`${groupKey}/`) ? source.slice(groupKey.length + 1) : source;
 }
 
+/**
+ * Inverse of {@link groupRelative}: the full source path for a manifest entry.
+ * `root` is {@link deriveGroupKey}'s synthetic key for top-level screenshots, not
+ * a real path segment, so it must not be prefixed back on.
+ */
+function groupSource(groupKey: string, rel: string): string {
+  return groupKey === 'root' ? rel : `${groupKey}/${rel}`;
+}
+
 /** A slot in a group's layout: a captured screenshot, or a blank placeholder. */
 interface TileSlot {
   source: string;
@@ -277,7 +286,7 @@ function layoutGroup(sources: string[], groupKey: string, order?: OrderManifest)
   const presentSet = new Set(sources);
   const canonicalSet = new Set(canonical);
   const slots: TileSlot[] = canonical.map((rel) => {
-    const source = `${groupKey}/${rel}`;
+    const source = groupSource(groupKey, rel);
     return { source, missing: !presentSet.has(source) };
   });
   const appended = sources
@@ -363,7 +372,7 @@ export function updateOrder(
   const present = new Set(relPaths);
   const next: OrderManifest = {};
   for (const [key, rels] of Object.entries(extendOrder(previous, relPaths, origins))) {
-    const kept = rels.filter((rel) => present.has(`${key}/${rel}`));
+    const kept = rels.filter((rel) => present.has(groupSource(key, rel)));
     if (kept.length > 0) {
       next[key] = kept;
     }

--- a/scripts/screenshot-sheets.ts
+++ b/scripts/screenshot-sheets.ts
@@ -22,10 +22,12 @@ import {
   formatTileTitle,
   listRelativeFiles,
   readTileAnnotation,
+  readTileOrigins,
   verifyArgosMetadataSidecars,
   writeArgosMetadataSidecar,
 } from '../e2e/helpers/argos-metadata.ts';
 import type {
+  ArgosLocation,
   ArgosScreenshotMetadata,
   ArgosTestAnnotation,
 } from '../e2e/helpers/argos-metadata.ts';
@@ -192,6 +194,8 @@ export interface PlanSheetsOptions {
   cols?: number;
   /** Canonical per-group tile order. Sources absent here sort to the tail. */
   order?: OrderManifest;
+  /** Declaration position per source, used to order tiles the manifest doesn't pin. */
+  origins?: TileOrigins;
 }
 
 export interface ComposeSheetOptions {
@@ -245,12 +249,61 @@ interface TileSlot {
 }
 
 /**
+ * Where each screenshot's test is declared, keyed by screenshot source path.
+ * Read from the capture sidecars ({@link readTileOrigins}) — `test.location` is
+ * the spec file plus the line/column of the `test()` call.
+ */
+export type TileOrigins = ReadonlyMap<string, ArgosLocation>;
+
+/**
+ * Orders tiles the manifest doesn't pin. Sorting them alphabetically re-sorts the
+ * whole group on every insertion: a new test whose slug sorts early takes cell 1
+ * and shifts every later tile, across sheet boundaries — exactly the churn the
+ * manifest exists to prevent, and what every group missing a manifest entry (all
+ * spec-file groups, plus any newly added diagram folder) gets today.
+ *
+ * Declaration position appends instead. A test written at the end of its spec is
+ * declared last, so its tile lands in the last cell and the tiles before it stay
+ * put. Tiles sharing one call site (loop-registered tests, or several screenshots
+ * from one test) and tiles whose sidecar is unreadable tie, and fall back to path
+ * order — so the layout is always deterministic, and a group with no sidecars at
+ * all keeps the previous alphabetical behavior.
+ */
+function compareTileOrder(a: string, b: string, origins?: TileOrigins): number {
+  const originA = origins?.get(a);
+  const originB = origins?.get(b);
+  if (originA && originB) {
+    if (originA.file !== originB.file) {
+      return originA.file < originB.file ? -1 : 1;
+    }
+    if (originA.line !== originB.line) {
+      return originA.line - originB.line;
+    }
+    if (originA.column !== originB.column) {
+      return originA.column - originB.column;
+    }
+  } else if (originA) {
+    // Sidecar-less tiles sort after placed ones rather than interleaving.
+    return -1;
+  } else if (originB) {
+    return 1;
+  }
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/** Sorts sources into canonical tail order (see {@link compareTileOrder}). */
+function sortTiles(sources: readonly string[], origins?: TileOrigins): string[] {
+  return [...sources].sort((a, b) => compareTileOrder(a, b, origins));
+}
+
+/**
  * Lays out a group's tiles in committed-manifest order:
  *  - manifest sources still present keep their slot;
  *  - manifest sources now absent keep their slot as a blank placeholder, so
  *    removing a test doesn't shift later tiles across sheets;
- *  - present sources not in the manifest append at the tail, sorted.
- * Without a manifest entry for the group, falls back to plain alphabetical order.
+ *  - present sources not in the manifest append at the tail, in declaration order.
+ * Without a manifest entry for the group, every source is laid out in declaration
+ * order (see {@link compareTileOrder}), so a newly added test still appends.
  *
  * Unlike the upstream coarse-grouped batcher, our group key {@link deriveGroupKey}
  * IS the scoping unit (a whole spec file or diagram folder), and planSheets only
@@ -258,10 +311,15 @@ interface TileSlot {
  * group an absent manifest tile always means a removed test — never a scoped-out
  * one — and needs no per-spec "did it run?" check.
  */
-function layoutGroup(sources: string[], groupKey: string, order?: OrderManifest): TileSlot[] {
+function layoutGroup(
+  sources: string[],
+  groupKey: string,
+  order?: OrderManifest,
+  origins?: TileOrigins
+): TileSlot[] {
   const canonical = order?.[groupKey];
   if (!canonical) {
-    return [...sources].sort().map((source) => ({ source, missing: false }));
+    return sortTiles(sources, origins).map((source) => ({ source, missing: false }));
   }
   const presentSet = new Set(sources);
   const canonicalSet = new Set(canonical);
@@ -269,30 +327,44 @@ function layoutGroup(sources: string[], groupKey: string, order?: OrderManifest)
     const source = `${groupKey}/${rel}`;
     return { source, missing: !presentSet.has(source) };
   });
-  const appended = sources
-    .filter((s) => !canonicalSet.has(groupRelative(s, groupKey)))
-    .sort()
-    .map((source) => ({ source, missing: false }));
+  const appended = sortTiles(
+    sources.filter((s) => !canonicalSet.has(groupRelative(s, groupKey))),
+    origins
+  ).map((source) => ({ source, missing: false }));
   return [...slots, ...appended];
 }
 
 /**
  * Recomputes the manifest from the screenshots currently present: each group
  * keeps its committed order (for sources still present) then appends newly-seen
- * sources, sorted. Removed sources drop out. Pure and deterministic.
+ * sources in declaration order. Removed sources drop out. Pure and deterministic.
  */
-export function updateOrder(relPaths: string[], previous: OrderManifest = {}): OrderManifest {
-  const present = new Map<string, string[]>();
+export function updateOrder(
+  relPaths: string[],
+  previous: OrderManifest = {},
+  origins?: TileOrigins
+): OrderManifest {
+  // Full source paths per group (origins are keyed by source), plus their
+  // group-relative names for matching against the committed manifest.
+  const present = new Map<string, { sources: string[]; rels: Set<string> }>();
   for (const p of relPaths) {
     const key = deriveGroupKey(p);
-    (present.get(key) ?? present.set(key, []).get(key)!).push(groupRelative(p, key));
+    let bucket = present.get(key);
+    if (!bucket) {
+      bucket = { sources: [], rels: new Set() };
+      present.set(key, bucket);
+    }
+    bucket.sources.push(p);
+    bucket.rels.add(groupRelative(p, key));
   }
   const next: OrderManifest = {};
   for (const key of [...present.keys()].sort()) {
-    const here = new Set(present.get(key));
-    const kept = (previous[key] ?? []).filter((rel) => here.has(rel));
+    const here = present.get(key)!;
+    const kept = (previous[key] ?? []).filter((rel) => here.rels.has(rel));
     const keptSet = new Set(kept);
-    const added = [...here].filter((rel) => !keptSet.has(rel)).sort();
+    const added = sortTiles(here.sources, origins)
+      .map((source) => groupRelative(source, key))
+      .filter((rel) => !keptSet.has(rel));
     next[key] = [...kept, ...added];
   }
   return next;
@@ -345,7 +417,7 @@ export function planSheets(relPaths: string[], options: PlanSheetsOptions = {}):
 
   const sheets: Sheet[] = [];
   for (const key of [...groups.keys()].sort()) {
-    const slots = layoutGroup(groups.get(key) ?? [], key, options.order);
+    const slots = layoutGroup(groups.get(key) ?? [], key, options.order, options.origins);
     const basename = (key.split('/').pop() ?? 'sheet').replace(SPEC_SEGMENT_RE, '');
     for (let start = 0; start < slots.length; start += tilesPerSheet) {
       const chunk = slots.slice(start, start + tilesPerSheet);
@@ -610,13 +682,21 @@ async function main(): Promise<void> {
   log(
     orderedGroups > 0
       ? `loaded committed tile order for ${orderedGroups} groups from ${orderFile}`
-      : `no committed tile order at ${orderFile} — groups fall back to alphabetical`
+      : `no committed tile order at ${orderFile} — groups fall back to declaration order`
   );
 
   const relPaths = await collectScreenshots(inputDir);
   log(`collected ${relPaths.length} screenshots from ${inputDir}`);
 
-  const plans = planSheets(relPaths, { tilesPerSheet, cols, order });
+  // Tiles the manifest doesn't pin are laid out in test-declaration order, so a
+  // newly added test appends instead of re-sorting its group alphabetically.
+  const origins = readTileOrigins(inputDir, relPaths);
+  log(
+    `resolved test declaration order for ${origins.size}/${relPaths.length} screenshots ` +
+      `(unpinned tiles append in that order)`
+  );
+
+  const plans = planSheets(relPaths, { tilesPerSheet, cols, order, origins });
   const groupCount = new Set(plans.map((p) => p.group)).size;
   if (plans.length === 0) {
     log('no screenshots found — nothing to composite');

--- a/scripts/screenshot-sheets.ts
+++ b/scripts/screenshot-sheets.ts
@@ -194,8 +194,6 @@ export interface PlanSheetsOptions {
   cols?: number;
   /** Canonical per-group tile order. Sources absent here sort to the tail. */
   order?: OrderManifest;
-  /** Declaration position per source, used to order tiles the manifest doesn't pin. */
-  origins?: TileOrigins;
 }
 
 export interface ComposeSheetOptions {
@@ -249,61 +247,21 @@ interface TileSlot {
 }
 
 /**
- * Where each screenshot's test is declared, keyed by screenshot source path.
- * Read from the capture sidecars ({@link readTileOrigins}) — `test.location` is
- * the spec file plus the line/column of the `test()` call.
+ * Where each screenshot's test is declared (its sidecar's `test.location`: spec
+ * file plus line/column of the `test()` call), keyed by screenshot source path.
+ * Produced by {@link readTileOrigins}.
  */
 export type TileOrigins = ReadonlyMap<string, ArgosLocation>;
-
-/**
- * Orders tiles the manifest doesn't pin. Sorting them alphabetically re-sorts the
- * whole group on every insertion: a new test whose slug sorts early takes cell 1
- * and shifts every later tile, across sheet boundaries — exactly the churn the
- * manifest exists to prevent, and what every group missing a manifest entry (all
- * spec-file groups, plus any newly added diagram folder) gets today.
- *
- * Declaration position appends instead. A test written at the end of its spec is
- * declared last, so its tile lands in the last cell and the tiles before it stay
- * put. Tiles sharing one call site (loop-registered tests, or several screenshots
- * from one test) and tiles whose sidecar is unreadable tie, and fall back to path
- * order — so the layout is always deterministic, and a group with no sidecars at
- * all keeps the previous alphabetical behavior.
- */
-function compareTileOrder(a: string, b: string, origins?: TileOrigins): number {
-  const originA = origins?.get(a);
-  const originB = origins?.get(b);
-  if (originA && originB) {
-    if (originA.file !== originB.file) {
-      return originA.file < originB.file ? -1 : 1;
-    }
-    if (originA.line !== originB.line) {
-      return originA.line - originB.line;
-    }
-    if (originA.column !== originB.column) {
-      return originA.column - originB.column;
-    }
-  } else if (originA) {
-    // Sidecar-less tiles sort after placed ones rather than interleaving.
-    return -1;
-  } else if (originB) {
-    return 1;
-  }
-  return a < b ? -1 : a > b ? 1 : 0;
-}
-
-/** Sorts sources into canonical tail order (see {@link compareTileOrder}). */
-function sortTiles(sources: readonly string[], origins?: TileOrigins): string[] {
-  return [...sources].sort((a, b) => compareTileOrder(a, b, origins));
-}
 
 /**
  * Lays out a group's tiles in committed-manifest order:
  *  - manifest sources still present keep their slot;
  *  - manifest sources now absent keep their slot as a blank placeholder, so
  *    removing a test doesn't shift later tiles across sheets;
- *  - present sources not in the manifest append at the tail, in declaration order.
- * Without a manifest entry for the group, every source is laid out in declaration
- * order (see {@link compareTileOrder}), so a newly added test still appends.
+ *  - present sources not in the manifest append at the tail, sorted.
+ * Without a manifest entry for the group, falls back to plain alphabetical order.
+ * (The CLI pins every captured tile up front via {@link extendOrder}, so these
+ * fallbacks matter only for direct callers.)
  *
  * Unlike the upstream coarse-grouped batcher, our group key {@link deriveGroupKey}
  * IS the scoping unit (a whole spec file or diagram folder), and planSheets only
@@ -311,15 +269,10 @@ function sortTiles(sources: readonly string[], origins?: TileOrigins): string[] 
  * group an absent manifest tile always means a removed test — never a scoped-out
  * one — and needs no per-spec "did it run?" check.
  */
-function layoutGroup(
-  sources: string[],
-  groupKey: string,
-  order?: OrderManifest,
-  origins?: TileOrigins
-): TileSlot[] {
+function layoutGroup(sources: string[], groupKey: string, order?: OrderManifest): TileSlot[] {
   const canonical = order?.[groupKey];
   if (!canonical) {
-    return sortTiles(sources, origins).map((source) => ({ source, missing: false }));
+    return [...sources].sort().map((source) => ({ source, missing: false }));
   }
   const presentSet = new Set(sources);
   const canonicalSet = new Set(canonical);
@@ -327,45 +280,93 @@ function layoutGroup(
     const source = `${groupKey}/${rel}`;
     return { source, missing: !presentSet.has(source) };
   });
-  const appended = sortTiles(
-    sources.filter((s) => !canonicalSet.has(groupRelative(s, groupKey))),
-    origins
-  ).map((source) => ({ source, missing: false }));
+  const appended = sources
+    .filter((s) => !canonicalSet.has(groupRelative(s, groupKey)))
+    .sort()
+    .map((source) => ({ source, missing: false }));
   return [...slots, ...appended];
 }
 
 /**
+ * Tail order for tiles the committed manifest doesn't pin. Alphabetical order
+ * would re-sort a group on every insertion — a new test whose slug sorts early
+ * takes the first cell and shifts every later tile across sheet boundaries.
+ * Declaration order appends instead: a test added at the end of its spec sorts
+ * last, so the tiles before it keep their cells. Tiles sharing one call site
+ * (e.g. the mmd runner registers every fixture from a single test() call) or
+ * lacking a readable sidecar tie, and fall back to path order — deterministic,
+ * and identical to the old alphabetical layout when no origins are known.
+ */
+function byDeclaration(origins?: TileOrigins) {
+  return (a: string, b: string): number => {
+    const originA = origins?.get(a);
+    const originB = origins?.get(b);
+    if (originA && originB) {
+      if (originA.file !== originB.file) {
+        return originA.file < originB.file ? -1 : 1;
+      }
+      if (originA.line !== originB.line) {
+        return originA.line - originB.line;
+      }
+      if (originA.column !== originB.column) {
+        return originA.column - originB.column;
+      }
+    } else if (originA || originB) {
+      // Sidecar-less tiles sort after located ones rather than interleaving.
+      return originA ? -1 : 1;
+    }
+    return a < b ? -1 : a > b ? 1 : 0;
+  };
+}
+
+/**
+ * The committed order extended to place every captured screenshot: each group's
+ * committed entries are kept verbatim (so a removed test keeps its blank slot)
+ * and captured tiles the manifest doesn't pin append at their group's tail in
+ * declaration order. The CLI feeds the result to {@link planSheets}, which
+ * therefore never has to invent an order of its own.
+ */
+export function extendOrder(
+  previous: OrderManifest,
+  relPaths: string[],
+  origins?: TileOrigins
+): OrderManifest {
+  const captured = new Map<string, string[]>();
+  for (const p of relPaths) {
+    const key = deriveGroupKey(p);
+    (captured.get(key) ?? captured.set(key, []).get(key)!).push(p);
+  }
+  const next: OrderManifest = {};
+  for (const key of [...new Set([...Object.keys(previous), ...captured.keys()])].sort()) {
+    const pinned = previous[key] ?? [];
+    const pinnedSet = new Set(pinned);
+    const appended = (captured.get(key) ?? [])
+      .filter((source) => !pinnedSet.has(groupRelative(source, key)))
+      .sort(byDeclaration(origins))
+      .map((source) => groupRelative(source, key));
+    next[key] = [...pinned, ...appended];
+  }
+  return next;
+}
+
+/**
  * Recomputes the manifest from the screenshots currently present: each group
- * keeps its committed order (for sources still present) then appends newly-seen
- * sources in declaration order. Removed sources drop out. Pure and deterministic.
+ * keeps its committed order for tiles still captured, newly-seen tiles append
+ * in declaration order, and removed tiles and groups drop out. Pure and
+ * deterministic — {@link extendOrder} with the leftovers pruned.
  */
 export function updateOrder(
   relPaths: string[],
   previous: OrderManifest = {},
   origins?: TileOrigins
 ): OrderManifest {
-  // Full source paths per group (origins are keyed by source), plus their
-  // group-relative names for matching against the committed manifest.
-  const present = new Map<string, { sources: string[]; rels: Set<string> }>();
-  for (const p of relPaths) {
-    const key = deriveGroupKey(p);
-    let bucket = present.get(key);
-    if (!bucket) {
-      bucket = { sources: [], rels: new Set() };
-      present.set(key, bucket);
-    }
-    bucket.sources.push(p);
-    bucket.rels.add(groupRelative(p, key));
-  }
+  const present = new Set(relPaths);
   const next: OrderManifest = {};
-  for (const key of [...present.keys()].sort()) {
-    const here = present.get(key)!;
-    const kept = (previous[key] ?? []).filter((rel) => here.rels.has(rel));
-    const keptSet = new Set(kept);
-    const added = sortTiles(here.sources, origins)
-      .map((source) => groupRelative(source, key))
-      .filter((rel) => !keptSet.has(rel));
-    next[key] = [...kept, ...added];
+  for (const [key, rels] of Object.entries(extendOrder(previous, relPaths, origins))) {
+    const kept = rels.filter((rel) => present.has(`${key}/${rel}`));
+    if (kept.length > 0) {
+      next[key] = kept;
+    }
   }
   return next;
 }
@@ -417,7 +418,7 @@ export function planSheets(relPaths: string[], options: PlanSheetsOptions = {}):
 
   const sheets: Sheet[] = [];
   for (const key of [...groups.keys()].sort()) {
-    const slots = layoutGroup(groups.get(key) ?? [], key, options.order, options.origins);
+    const slots = layoutGroup(groups.get(key) ?? [], key, options.order);
     const basename = (key.split('/').pop() ?? 'sheet').replace(SPEC_SEGMENT_RE, '');
     for (let start = 0; start < slots.length; start += tilesPerSheet) {
       const chunk = slots.slice(start, start + tilesPerSheet);
@@ -688,15 +689,14 @@ async function main(): Promise<void> {
   const relPaths = await collectScreenshots(inputDir);
   log(`collected ${relPaths.length} screenshots from ${inputDir}`);
 
-  // Tiles the manifest doesn't pin are laid out in test-declaration order, so a
-  // newly added test appends instead of re-sorting its group alphabetically.
+  // Extend the committed order over every captured screenshot: tiles it doesn't
+  // pin (new tests, groups it doesn't cover) append at their group's tail in
+  // test-declaration order, read from the capture sidecars.
   const origins = readTileOrigins(inputDir, relPaths);
-  log(
-    `resolved test declaration order for ${origins.size}/${relPaths.length} screenshots ` +
-      `(unpinned tiles append in that order)`
-  );
+  const effectiveOrder = extendOrder(order, relPaths, origins);
+  log(`declaration order known for ${origins.size}/${relPaths.length} screenshots`);
 
-  const plans = planSheets(relPaths, { tilesPerSheet, cols, order, origins });
+  const plans = planSheets(relPaths, { tilesPerSheet, cols, order: effectiveOrder });
   const groupCount = new Set(plans.map((p) => p.group)).size;
   if (plans.length === 0) {
     log('no screenshots found — nothing to composite');


### PR DESCRIPTION
## :bookmark_tabs: Summary

Changes screenshot sheet layout to use test-declaration order (from capture sidecars) instead of alphabetical order for tiles not pinned in the committed manifest. This prevents new tests from re-sorting their group: a test added at the end of its spec now appends at the tail rather than shifting earlier tiles when its slug sorts early.

## :straight_ruler: Design Decisions

**Declaration order for unpinned tiles:** The committed manifest (`e2e/sheet-order.json`) pins tiles to prevent cascading layout changes when tests are added/removed. However, groups not yet in the manifest fell back to alphabetical order, causing a new test with an early-sorting slug to take the first cell and shift every other tile.

The fix reads test declaration positions (`test.location`: spec file + line/column) from capture sidecars and sorts unpinned tiles by:
1. Declaration file and line/column (primary)
2. Path order for ties (loop-registered tests, missing sidecars)

This matches how tests are declared in spec files, so appending a test at the end of its spec appends it to the layout instead of re-sorting.

**Key functions:**
- `readTileOrigins()`: Extracts `test.location` from capture sidecars into a `TileOrigins` map
- `byDeclaration()`: Comparator implementing the sort order above
- `extendOrder()`: Extends the committed manifest over all captured screenshots, appending unpinned tiles in declaration order (replaces the old `updateOrder` behavior)
- `updateOrder()`: Now prunes `extendOrder()` results to only captured tiles, for manifest compaction

**Backward compatibility:** Groups with all tiles in the committed manifest are unaffected. Groups with no sidecars fall back to path order (identical to old alphabetical layout when no origins are known). The mmd fixture groups (all registered from one call site) remain alphabetical since they tie on declaration position.

## :clipboard: Tasks

- [x] :computer: Added comprehensive test suite covering declaration order, multi-sheet stability, tie-breaking, and sidecar reading
- [x] :book: Updated workflow documentation to explain declaration-order fallback for uncovered groups
- [x] :butterfly: Changes are internal refactoring of screenshot ordering logic with no user-facing API changes

https://claude.ai/code/session_01LhV5y9E2LTdbciNqy6V4bb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Changed unpinned screenshot ordering from alphabetical order to test-declaration order.
- Added shared sidecar metadata reading with `readTileOrigins()`.
- Added `extendOrder()` to preserve pinned entries and append new tiles by declaration location.
- Added path-order fallback for missing or unreadable sidecars.
- Updated manifest compaction to retain only captured tiles.
- Added tests for ordering, tie-breaking, sidecar handling, manifest behavior, and multi-sheet stability.
- Updated Argos sheet-order documentation.

No user-facing API changes were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->