### PR TITLE
test(e2e): grid-order canary — new tests must append, not re-tile

### DIFF
--- a/e2e/diagrams/pie/aaa-grid-order-canary.mmd
+++ b/e2e/diagrams/pie/aaa-grid-order-canary.mmd
@@ -1,0 +1,8 @@
+%% Grid-order canary: this fixture's name sorts alphabetically first in the
+%% pie folder. The committed sheet-order manifest (e2e/sheet-order.json) must
+%% keep it APPENDED at the group's tail, so Argos flags only diagrams/pie's
+%% last sheet (pie-002) — under plain alphabetical tiling it would have taken
+%% the first cell and re-tiled the whole group.
+pie title Grid order canary
+  "Pinned tiles": 13
+  "Appended tiles": 1

--- a/e2e/rendering/er/erDiagram-unified.spec.js
+++ b/e2e/rendering/er/erDiagram-unified.spec.js
@@ -868,4 +868,21 @@ test.describe('Entity Relationship Diagram Unified', () => {
       );
     });
   });
+
+  // Grid-order canary: declared last in this file but slugs alphabetically
+  // first in the group, so declaration-order tiling must APPEND it at the
+  // group's tail — Argos should flag only this group's last sheet. Under the
+  // old alphabetical layout it would have taken cell 1 and re-tiled every
+  // sheet of rendering/er/erDiagram-unified.spec.js.
+  test('aaa grid order canary appends at the group tail', async ({ page }, testInfo) => {
+    await imgSnapshotTest(
+      page,
+      testInfo,
+      `
+      erDiagram
+          CANARY ||--o{ TILE : appends
+        `,
+      { logLevel: 1 }
+    );
+  });
 });


### PR DESCRIPTION
## :bookmark_tabs: Summary

Verification PR for the sheet-order fix (#8093): adds one mmd fixture and one spec test that both deliberately sort **alphabetically first** in their groups. If the ordering fix works, each canary appends at its group's **tail**, and Argos flags only the last sheet of each group — no cascading re-tiling.

Intended for verification: check the Argos build, then close (or merge if the canaries are worth keeping as permanent regression sentinels).

## :straight_ruler: Design Decisions

Two canaries, one per ordering mechanism:

- **`e2e/diagrams/pie/aaa-grid-order-canary.mmd`** exercises the **committed manifest** path: `diagrams/pie`'s 13 existing tiles are pinned in `e2e/sheet-order.json`, so the new fixture must append as tile 14. Verified against the real planner with the committed manifest: `pie-001`'s tile list is unchanged, and `aaa-grid-order-canary` joins `simple-sports` on `pie-002`.
- **`aaa grid order canary appends at the group tail`** (appended at the end of `erDiagram-unified.spec.js`) exercises the **declaration-order** path: spec groups aren't in the manifest, so tiles follow `test.location` order. The canary is declared last in the file, so it must tile last — only that group's final sheet changes.

Under the pre-#8093 alphabetical layout, both canaries would have taken cell 1 of their groups and shifted every later tile across sheet boundaries.

**Expected Argos result:** exactly two changed sheets — `diagrams/pie/pie-002` and the last `rendering/er/erDiagram-unified.spec.js` sheet — each gaining one tile at the end, everything else untouched.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests — the additions are themselves e2e tests; placement was verified against the planner with the committed manifest.
- [x] :notebook: have added documentation — both canaries carry comments explaining what they verify.
- [x] :butterfly: No changeset — e2e test additions only, no package changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhV5y9E2LTdbciNqy6V4bb

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhV5y9E2LTdbciNqy6V4bb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added a pie fixture to verify manifest-based grid ordering.
- Added a final ER canary to verify declaration-order appending.
- Both canaries confirm that existing sheets are not re-tiled.
- Expected Argos changes are limited to `diagrams/pie/pie-002` and the final ER sheet.
- No package changes or changeset included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->