### PR TITLE
test(e2e): grid-order deletion canary — removed tests must not re-tile

### DIFF
--- a/e2e/diagrams/pie/should-render-a-pie-diagram-with-showdata.mmd
+++ b/e2e/diagrams/pie/should-render-a-pie-diagram-with-showdata.mmd
@@ -1,3 +1,0 @@
-pie showData
-  "Dogs": 50
-  "Cats": 25

--- a/e2e/rendering/er/erDiagram-unified.spec.js
+++ b/e2e/rendering/er/erDiagram-unified.spec.js
@@ -838,34 +838,5 @@ test.describe('Entity Relationship Diagram Unified', () => {
         options
       );
     });
-
-    test(`${description}should render nested ER subgraphs with direction override`, async ({
-      page,
-    }, testInfo) => {
-      await imgSnapshotTest(
-        page,
-        testInfo,
-        `
-        erDiagram
-          direction LR
-
-          subgraph domain
-            direction TB
-
-            CUSTOMER
-
-            subgraph details
-              ORDER
-            end
-          end
-
-          PRODUCT
-
-          PRODUCT ||--o{ domain : links
-          CUSTOMER ||--o{ ORDER : places
-        `,
-        options
-      );
-    });
   });
 });


### PR DESCRIPTION
## :bookmark_tabs: Summary

Companion to the addition canary (#8096, passed with exactly the predicted 2 changed sheets): this PR removes one test from each ordering path to verify how the sheet grid handles **deletion**. Intended for verification — check the Argos build, then close.

## :straight_ruler: Design Decisions

Deletion has different semantics per path, so the two canaries predict different things:

- **Manifest-pinned group** — deletes `diagrams/pie/should-render-a-pie-diagram-with-showdata.mmd`, pinned **mid-manifest** (slot 8 of 13, in the middle of `pie-001`). The manifest must keep the removed tile's slot as a **blank cell**: no later tile shifts. Verified against the planner with the committed manifest: `pie-001` keeps every other tile in its exact cell with slot 8 blank, and `pie-002` is untouched. (The blank slot persists until the weekly "Refresh screenshot sheet order" workflow compacts it.)
- **Unpinned spec group** — deletes the **last-declared** test in `erDiagram-unified.spec.js` (`should render nested ER subgraphs with direction override`, which registers 3 screenshots via the options loop). Spec groups follow declaration order with no blank slots, so removing the tail leaves every earlier tile in place — only the group's **final sheet** changes (loses its last 3 tiles).

**Expected Argos result:** exactly 2 changed sheets — `diagrams/pie/pie-001` (one cell goes blank) and the last `rendering/er/erDiagram-unified.spec.js` sheet (3 tiles fewer at its end). `pie-002` and all earlier ER sheets untouched. A mid-group shift on either side means the deletion handling regressed.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests — this PR is itself the test; placement verified against the planner with the committed manifest.
- [x] :notebook: have added documentation — expectations documented here and in the commit message.
- [x] :butterfly: No changeset — e2e test removals only, no package changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhV5y9E2LTdbciNqy6V4bb

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhV5y9E2LTdbciNqy6V4bb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed the mid-manifest pie diagram E2E fixture to verify that its slot remains blank without shifting later tiles.
- Removed the final unified ER diagram snapshot test to verify that only the final sheet changes.
- No production code or changeset changes are included.
- Expected Argos changes: `diagrams/pie/pie-001` and the final unified ER diagram sheet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->