### PR TITLE
fix(c4): stop wrapping non-text named attributes that land in a text slot

### DIFF
--- a/.changeset/c4-named-attr-text-slot.md
+++ b/.changeset/c4-named-attr-text-slot.md
@@ -1,0 +1,10 @@
+---
+'mermaid': patch
+---
+
+fix(c4): stop wrapping non-text named attributes that land in a text slot
+
+A named attribute such as `$tags` or `$sprite` can arrive in the positional
+slot of a text field when the argument before it is omitted. It was then
+stored as `{ text: value }` rather than a string, so `$tags` given without a
+description crashed rendering.

--- a/packages/mermaid/src/diagrams/c4/c4Db.ts
+++ b/packages/mermaid/src/diagrams/c4/c4Db.ts
@@ -16,6 +16,13 @@ import type { C4Boundary, C4Rel, C4Shape } from './c4Types.js';
 type ParserAttribute = string | Record<string, string>;
 
 /**
+ * The fields a C4 element, boundary or relationship stores as `{ text }`. Everything else
+ * a named attribute can set - `$tags`, `$sprite`, `$link`, colours, `$shape` - is a plain
+ * string.
+ */
+const TEXT_FIELDS = new Set(['label', 'descr', 'techn', 'type']);
+
+/**
  * Apply optional C4 attributes to `bag` from the parser.
  *
  * Values may arrive as a raw positional value or a single `{ key: value }` named
@@ -114,7 +121,7 @@ export const addRel = function (
   } else {
     if (typeof techn === 'object') {
       const [key, value] = Object.entries(techn)[0];
-      rel[key] = { text: value };
+      rel[key] = TEXT_FIELDS.has(key) ? { text: value } : value;
     } else {
       rel.techn = { text: techn };
     }
@@ -125,7 +132,7 @@ export const addRel = function (
   } else {
     if (typeof descr === 'object') {
       const [key, value] = Object.entries(descr)[0];
-      rel[key] = { text: value };
+      rel[key] = TEXT_FIELDS.has(key) ? { text: value } : value;
     } else {
       rel.descr = { text: descr };
     }
@@ -171,7 +178,7 @@ export const addPersonOrSystem = function (
   } else {
     if (typeof descr === 'object') {
       const [key, value] = Object.entries(descr)[0];
-      personOrSystem[key] = { text: value };
+      personOrSystem[key] = TEXT_FIELDS.has(key) ? { text: value } : value;
     } else {
       personOrSystem.descr = { text: descr };
     }
@@ -220,7 +227,7 @@ export const addContainer = function (
   } else {
     if (typeof techn === 'object') {
       const [key, value] = Object.entries(techn)[0];
-      container[key] = { text: value };
+      container[key] = TEXT_FIELDS.has(key) ? { text: value } : value;
     } else {
       container.techn = { text: techn };
     }
@@ -231,7 +238,7 @@ export const addContainer = function (
   } else {
     if (typeof descr === 'object') {
       const [key, value] = Object.entries(descr)[0];
-      container[key] = { text: value };
+      container[key] = TEXT_FIELDS.has(key) ? { text: value } : value;
     } else {
       container.descr = { text: descr };
     }
@@ -280,7 +287,7 @@ export const addComponent = function (
   } else {
     if (typeof techn === 'object') {
       const [key, value] = Object.entries(techn)[0];
-      component[key] = { text: value };
+      component[key] = TEXT_FIELDS.has(key) ? { text: value } : value;
     } else {
       component.techn = { text: techn };
     }
@@ -291,7 +298,7 @@ export const addComponent = function (
   } else {
     if (typeof descr === 'object') {
       const [key, value] = Object.entries(descr)[0];
-      component[key] = { text: value };
+      component[key] = TEXT_FIELDS.has(key) ? { text: value } : value;
     } else {
       component.descr = { text: descr };
     }
@@ -339,7 +346,7 @@ export const addPersonOrSystemBoundary = function (
   } else {
     if (typeof type === 'object') {
       const [key, value] = Object.entries(type)[0];
-      boundary[key] = { text: value };
+      boundary[key] = TEXT_FIELDS.has(key) ? { text: value } : value;
     } else {
       boundary.type = { text: type };
     }
@@ -390,7 +397,7 @@ export const addContainerBoundary = function (
   } else {
     if (typeof type === 'object') {
       const [key, value] = Object.entries(type)[0];
-      boundary[key] = { text: value };
+      boundary[key] = TEXT_FIELDS.has(key) ? { text: value } : value;
     } else {
       boundary.type = { text: type };
     }
@@ -444,7 +451,7 @@ export const addDeploymentNode = function (
   } else {
     if (typeof type === 'object') {
       const [key, value] = Object.entries(type)[0];
-      boundary[key] = { text: value };
+      boundary[key] = TEXT_FIELDS.has(key) ? { text: value } : value;
     } else {
       boundary.type = { text: type };
     }
@@ -455,7 +462,7 @@ export const addDeploymentNode = function (
   } else {
     if (typeof descr === 'object') {
       const [key, value] = Object.entries(descr)[0];
-      boundary[key] = { text: value };
+      boundary[key] = TEXT_FIELDS.has(key) ? { text: value } : value;
     } else {
       boundary.descr = { text: descr };
     }

--- a/packages/mermaid/src/diagrams/c4/c4Db.ts
+++ b/packages/mermaid/src/diagrams/c4/c4Db.ts
@@ -38,7 +38,12 @@ const assignAttributes = <Bag extends C4Shape | C4Boundary | C4Rel>(
     }
     if (typeof value === 'object') {
       const [key, val] = Object.entries(value)[0];
-      bag[key] = val;
+      // Same rule as the positional text slots: a text field is stored as `{ text }`
+      // whichever slot it arrived through. `System_Boundary` and friends splice their
+      // kind in as a positional argument, so an explicit `$type` shifts along into this
+      // one and would otherwise land here as a bare string and overwrite the wrapped
+      // value the type slot just set.
+      bag[key] = TEXT_FIELDS.has(key) ? { text: val } : val;
     } else {
       bag[field] = value;
     }

--- a/packages/mermaid/src/diagrams/c4/c4Db.ts
+++ b/packages/mermaid/src/diagrams/c4/c4Db.ts
@@ -117,7 +117,7 @@ export const addRel = function (
   rel.label = { text: label };
 
   if (techn === undefined || techn === null) {
-    rel.techn = { text: '' };
+    rel.techn ??= { text: '' };
   } else {
     if (typeof techn === 'object') {
       const [key, value] = Object.entries(techn)[0];
@@ -128,7 +128,7 @@ export const addRel = function (
   }
 
   if (descr === undefined || descr === null) {
-    rel.descr = { text: '' };
+    rel.descr ??= { text: '' };
   } else {
     if (typeof descr === 'object') {
       const [key, value] = Object.entries(descr)[0];
@@ -174,7 +174,7 @@ export const addPersonOrSystem = function (
   }
 
   if (descr === undefined || descr === null) {
-    personOrSystem.descr = { text: '' };
+    personOrSystem.descr ??= { text: '' };
   } else {
     if (typeof descr === 'object') {
       const [key, value] = Object.entries(descr)[0];
@@ -223,7 +223,7 @@ export const addContainer = function (
   }
 
   if (techn === undefined || techn === null) {
-    container.techn = { text: '' };
+    container.techn ??= { text: '' };
   } else {
     if (typeof techn === 'object') {
       const [key, value] = Object.entries(techn)[0];
@@ -234,7 +234,7 @@ export const addContainer = function (
   }
 
   if (descr === undefined || descr === null) {
-    container.descr = { text: '' };
+    container.descr ??= { text: '' };
   } else {
     if (typeof descr === 'object') {
       const [key, value] = Object.entries(descr)[0];
@@ -283,7 +283,7 @@ export const addComponent = function (
   }
 
   if (techn === undefined || techn === null) {
-    component.techn = { text: '' };
+    component.techn ??= { text: '' };
   } else {
     if (typeof techn === 'object') {
       const [key, value] = Object.entries(techn)[0];
@@ -294,7 +294,7 @@ export const addComponent = function (
   }
 
   if (descr === undefined || descr === null) {
-    component.descr = { text: '' };
+    component.descr ??= { text: '' };
   } else {
     if (typeof descr === 'object') {
       const [key, value] = Object.entries(descr)[0];
@@ -458,7 +458,7 @@ export const addDeploymentNode = function (
   }
 
   if (descr === undefined || descr === null) {
-    boundary.descr = { text: '' };
+    boundary.descr ??= { text: '' };
   } else {
     if (typeof descr === 'object') {
       const [key, value] = Object.entries(descr)[0];

--- a/packages/mermaid/src/diagrams/c4/parser/c4NamedAttributes.spec.ts
+++ b/packages/mermaid/src/diagrams/c4/parser/c4NamedAttributes.spec.ts
@@ -52,4 +52,31 @@ Rel(a, b, "uses", $tags="async")`);
 
     expect(c4.parser.yy.getRels()[0].tags).toBe('async');
   });
+
+  // `Container` takes `techn` before `descr`, so a named `$descr` here lands in the
+  // `techn` slot. The techn handler assigned it correctly, and then the descr handler's
+  // "argument absent" branch overwrote it with an empty default - the description was
+  // silently lost rather than misshaped.
+  it('keeps a named $descr that lands in an earlier slot', function () {
+    c4.parser.parse(`C4Container\nContainer(c, "C", $descr="a description")`);
+
+    expect(c4.parser.yy.getC4ShapeArray()[0].descr.text).toBe('a description');
+  });
+
+  it('still defaults descr to empty when it is genuinely absent', function () {
+    c4.parser.parse(`C4Container\nContainer(c, "C", $techn="Java")`);
+
+    const [shape] = c4.parser.yy.getC4ShapeArray();
+    expect(shape.techn.text).toBe('Java');
+    expect(shape.descr.text).toBe('');
+  });
+
+  it('keeps a named $descr on a relationship, where techn also comes first', function () {
+    c4.parser.parse(`C4Context
+Person(a, "A")
+Person(b, "B")
+Rel(a, b, "uses", $descr="how it is used")`);
+
+    expect(c4.parser.yy.getRels()[0].descr.text).toBe('how it is used');
+  });
 });

--- a/packages/mermaid/src/diagrams/c4/parser/c4NamedAttributes.spec.ts
+++ b/packages/mermaid/src/diagrams/c4/parser/c4NamedAttributes.spec.ts
@@ -79,4 +79,68 @@ Rel(a, b, "uses", $descr="how it is used")`);
 
     expect(c4.parser.yy.getRels()[0].descr.text).toBe('how it is used');
   });
+
+  /**
+   * Every kind of declaration, given exactly one named attribute so that it lands in the
+   * first optional slot - which is rarely its own. Each bug found in this area so far
+   * only showed up for one such combination, so they are enumerated rather than sampled.
+   *
+   * `descr`, `techn` and `type` are stored as `{ text }`; `tags`, `sprite` and `link` are
+   * plain strings. Which slot the value travelled through must not change that.
+   */
+  describe('one named attribute, whichever slot it lands in', function () {
+    const TEXT_FIELDS = new Set(['descr', 'techn', 'type']);
+
+    const expectField = (subject: Record<string, unknown>, field: string) => {
+      if (TEXT_FIELDS.has(field)) {
+        expect(subject[field]).toEqual({ text: 'V' });
+      } else {
+        expect(subject[field]).toBe('V');
+      }
+    };
+
+    const shape = () => c4.parser.yy.getC4ShapeArray()[0];
+    const boundary = () =>
+      c4.parser.yy.getBoundaries().find((b: { alias: string }) => b.alias !== 'global');
+
+    const elements: [string, string, string[]][] = [
+      ['C4Context', 'System(x, "L", $F="V")', ['descr', 'tags', 'sprite', 'link']],
+      ['C4Context', 'Person(x, "L", $F="V")', ['descr', 'tags', 'sprite', 'link']],
+      ['C4Container', 'Container(x, "L", $F="V")', ['descr', 'techn', 'tags', 'sprite', 'link']],
+      ['C4Component', 'Component(x, "L", $F="V")', ['descr', 'techn', 'tags', 'sprite', 'link']],
+    ];
+    for (const [header, template, fields] of elements) {
+      it.each(fields)(`${template.replace('$F', '$%s')}`, function (field) {
+        c4.parser.parse(`${header}\n${template.replace('$F', `$${field}`)}`);
+        expectField(shape(), field);
+      });
+    }
+
+    // `System_Boundary` and `Container_Boundary` splice their kind in as a positional
+    // argument, so an explicit `$type` shifts one slot along into `tags`.
+    const boundaries: [string, string, string[]][] = [
+      ['C4Context', 'System_Boundary(x, "L", $F="V")', ['type', 'tags', 'link']],
+      ['C4Container', 'Container_Boundary(x, "L", $F="V")', ['type', 'tags', 'link']],
+      ['C4Deployment', 'Node(x, "L", $F="V")', ['type', 'descr', 'tags', 'sprite', 'link']],
+    ];
+    for (const [header, template, fields] of boundaries) {
+      it.each(fields)(`${template.replace('$F', '$%s')}`, function (field) {
+        c4.parser.parse(
+          `${header}\n${template.replace('$F', `$${field}`)} {\nContainer(i, "I")\n}`
+        );
+        expectField(boundary(), field);
+      });
+    }
+
+    it.each(['techn', 'descr', 'tags', 'sprite', 'link'])(
+      'Rel(a, b, "uses", $%s="V")',
+      function (field) {
+        c4.parser.parse(`C4Context
+Person(a, "A")
+Person(b, "B")
+Rel(a, b, "uses", $${field}="V")`);
+        expectField(c4.parser.yy.getRels()[0], field);
+      }
+    );
+  });
 });

--- a/packages/mermaid/src/diagrams/c4/parser/c4NamedAttributes.spec.ts
+++ b/packages/mermaid/src/diagrams/c4/parser/c4NamedAttributes.spec.ts
@@ -1,0 +1,55 @@
+import c4Db from '../c4Db.js';
+// @ts-ignore: JISON doesn't support types
+import c4 from './c4Diagram.jison';
+import { setConfig } from '../../../config.js';
+
+setConfig({ securityLevel: 'strict' });
+
+/**
+ * A named attribute can land in a positional slot when the argument before it is omitted.
+ * Only the slot's own field is text, so the value must not be wrapped in `{ text }` just
+ * because it arrived through a text slot - consumers read `$tags` and `$sprite` as strings.
+ */
+describe('named attributes arriving in a positional text slot', function () {
+  beforeEach(function () {
+    c4.parser.yy = c4Db;
+    c4.parser.yy.clear();
+  });
+
+  it('keeps $tags a string when the description is omitted', function () {
+    c4.parser.parse(`C4Context\nSystem(s, "S", $tags="cylinder")`);
+
+    expect(c4.parser.yy.getC4ShapeArray()[0].tags).toBe('cylinder');
+  });
+
+  it('keeps $tags a string when the description is given', function () {
+    c4.parser.parse(`C4Context\nSystem(s, "S", "desc", $tags="cylinder")`);
+
+    const [shape] = c4.parser.yy.getC4ShapeArray();
+    expect(shape.tags).toBe('cylinder');
+    expect(shape.descr.text).toBe('desc');
+  });
+
+  it('still stores the description as text when it is the one named', function () {
+    c4.parser.parse(`C4Context\nSystem(s, "S", $descr="a description")`);
+
+    expect(c4.parser.yy.getC4ShapeArray()[0].descr.text).toBe('a description');
+  });
+
+  it('keeps $sprite and $link strings on a container', function () {
+    c4.parser.parse(`C4Container\nContainer(c, "C", $sprite="browser", $link="https://x.test")`);
+
+    const [shape] = c4.parser.yy.getC4ShapeArray();
+    expect(shape.sprite).toBe('browser');
+    expect(shape.link).toBe('https://x.test');
+  });
+
+  it('keeps a relationship $tags a string when techn and descr are omitted', function () {
+    c4.parser.parse(`C4Context
+Person(a, "A")
+Person(b, "B")
+Rel(a, b, "uses", $tags="async")`);
+
+    expect(c4.parser.yy.getRels()[0].tags).toBe('async');
+  });
+});


### PR DESCRIPTION
Closes #8099.

## The bug

A C4 element with `$tags` and no description fails to render:

```
C4Context
System(s, "S", $tags="cylinder")
```

```
TypeError: shape.tags.split is not a function
```

Adding a description makes it work again, which is the confusing part:

```
C4Context
System(s, "S", "desc", $tags="cylinder")
```

## Cause

A named attribute lands in a positional slot when the argument before it is omitted. The handlers for the text slots (`label`, `descr`, `techn`, `type`) wrapped whatever arrived in `{ text: value }`, regardless of which field the value was actually for:

```ts
if (typeof descr === 'object') {
  const [key, value] = Object.entries(descr)[0];
  personOrSystem[key] = { text: value };
}
```

With the description omitted, `$tags="cylinder"` arrives in that slot and `tags` is stored as `{ text: 'cylinder' }` instead of a string. `resolveNodeShape` then calls `.split(',')` on it and throws, failing the whole render.

`assignAttributes`, used for attributes that arrive in their own slots, already assigns raw values - so the two paths disagreed about the same field.

## The fix

Only a text field belongs in a `{ text }` wrapper. The eleven slot handlers now consult one set of field names and assign anything else raw, which is what `assignAttributes` already did.

This also corrects `$sprite` and `$link` arriving through a text slot. They do not throw today because nothing calls a string method on them, but they were stored in the wrong shape.

## Why CI did not catch it

The characterization case for `$tags` supplies a description first:

```
Person(p, "Person", "desc", $tags="v1.0")
```

which is the form that works, so the broken form was never exercised. This PR adds a parser spec covering both.

## Tests

`c4NamedAttributes.spec.ts` covers both forms of `$tags`, a named `$descr` (which must still be wrapped), `$sprite`/`$link` on a container, and a relationship `$tags`. Three of the five fail without the change; the other two are there so a future fix cannot quietly break the working form.

132 C4 unit tests pass; `tsc`, eslint and Prettier clean.

## Scope

Independent of the C4 renderer series in #7849 - it is a db-layer fix and applies to `develop` as it stands. Found while building `AddElementTag` support, where the broken form is the natural one to write.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What's working well

- 🎉 [praise] The fix preserves raw values for `$tags`, `$sprite`, and `$link`.
- 🎉 [praise] Text fields remain wrapped as `{ text: value }` through `TEXT_FIELDS`.
- 🎉 [praise] Default values no longer overwrite named attributes assigned by earlier handlers.
- 🎉 [praise] Regression tests cover elements, relationships, omitted descriptions, and named `$descr`.
- 🎉 [praise] The changeset documents the patch release impact.

## Review verdict

**APPROVE**

## Self-check

- [x] Praise included
- [x] No blocking or important findings
- [x] Tests cover the reported regression
- [x] Verdict matches the findings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Update: widened after review

The review point on the first commit turned out to describe a live bug, not a test gap, and enumerating the area found a third. This PR is now three commits against one defect seen from three angles - a named attribute landing in a positional slot that is not its own:

1. `30325d498` - the value was wrapped in `{ text }` whichever field it was for, so `$tags` became an object and `resolveNodeShape` threw.
2. `0e3ce32a9` - a later slot's "argument absent" branch overwrote what an earlier slot had just assigned, so `Container(c, "C", $descr="desc")` silently lost the description.
3. `eb9ec8ad7` - `assignAttributes` stored text fields raw, so an explicit `$type` on `System_Boundary` (whose kind is spliced in as a positional argument, shifting `$type` into the `tags` slot) overwrote the wrapped value with a bare string, and the type vanished.

Each appeared for exactly one declaration kind and one attribute, which is why they were not found together. The tests now enumerate every declaration kind against every attribute that can reach its first optional slot - 34 combinations - and assert the stored shape, so the next one of these fails loudly instead of waiting to be tripped over.
