### PR TITLE
fix(e2e): emit regex spec patterns, not globs, from the scope detector

### DIFF
--- a/scripts/e2e-diagram-scope.mjs
+++ b/scripts/e2e-diagram-scope.mjs
@@ -20,10 +20,19 @@
  * Module usage:
  *   import { detectScope } from './e2e-diagram-scope.mjs';
  *   const spec = detectScope(['packages/mermaid/src/diagrams/flowchart/flowchart.ts']);
- *   // => 'e2e/rendering/flowchart/**'
+ *   // => 'e2e/rendering/flowchart/'
  */
 
 import { createInterface } from 'readline';
+
+/*
+ * Patterns are matched by Playwright as REGULAR EXPRESSIONS against each test
+ * file's path, not as globs - `playwright test <pattern>` compiles its
+ * positional arguments with `new RegExp()`. A glob such as `.../c4/**` is not a
+ * valid regex ("Nothing to repeat") and aborts the run before any test starts,
+ * so a directory pattern ends at the separator and matches every file beneath
+ * it by virtue of being a substring match.
+ */
 import { existsSync, readdirSync } from 'fs';
 import { fileURLToPath } from 'url';
 
@@ -223,7 +232,7 @@ export function detectScope(files, options = {}) {
 
       // File inside a diagram subfolder → scope to that subfolder.
       const subFolder = rest.slice(0, slashIdx);
-      directlyChangedSpecs.push(`${specFolderPrefix}${subFolder}/**`);
+      directlyChangedSpecs.push(`${specFolderPrefix}${subFolder}/`);
       continue;
     }
 
@@ -277,7 +286,7 @@ export function detectScope(files, options = {}) {
   for (const name of diagramNames) {
     const folder = `${specBaseDir}/${name}`;
     if (existsSync(folder)) {
-      specs.add(`${folder}/**`);
+      specs.add(`${folder}/`);
     } else if (hasFixtures(name)) {
       // Fixtures-only diagram (no per-diagram spec subfolder) — the global mmd
       // snapshot runner exercises it.

--- a/scripts/e2e-diagram-scope.spec.ts
+++ b/scripts/e2e-diagram-scope.spec.ts
@@ -20,7 +20,7 @@ describe('detectScope', () => {
     ]);
     expect(result.split(',')).toEqual(
       expect.arrayContaining([
-        `${SPEC_BASE_DIR}/flowchart/**`,
+        `${SPEC_BASE_DIR}/flowchart/`,
         `${SPEC_BASE_DIR}/mmd-snapshots.spec.ts`,
       ])
     );
@@ -66,8 +66,8 @@ describe('detectScope', () => {
     ]);
     expect(result.split(',')).toEqual(
       expect.arrayContaining([
-        `${SPEC_BASE_DIR}/gantt/**`,
-        `${SPEC_BASE_DIR}/pie/**`,
+        `${SPEC_BASE_DIR}/gantt/`,
+        `${SPEC_BASE_DIR}/pie/`,
         `${SPEC_BASE_DIR}/mmd-snapshots.spec.ts`,
       ])
     );
@@ -85,7 +85,7 @@ describe('detectScope', () => {
     ]);
     expect(result.split(',')).toEqual(
       expect.arrayContaining([
-        `${SPEC_BASE_DIR}/flowchart/**`,
+        `${SPEC_BASE_DIR}/flowchart/`,
         `${SPEC_BASE_DIR}/mmd-snapshots.spec.ts`,
       ])
     );
@@ -112,10 +112,7 @@ describe('detectScope', () => {
   it('scopes to the subfolder when a spec file in that subfolder is modified', () => {
     const result = detectScope([`${SPEC_BASE_DIR}/gantt/gantt.spec.js`]);
     expect(result.split(',')).toEqual(
-      expect.arrayContaining([
-        `${SPEC_BASE_DIR}/gantt/**`,
-        `${SPEC_BASE_DIR}/mmd-snapshots.spec.ts`,
-      ])
+      expect.arrayContaining([`${SPEC_BASE_DIR}/gantt/`, `${SPEC_BASE_DIR}/mmd-snapshots.spec.ts`])
     );
   });
 
@@ -136,7 +133,7 @@ describe('detectScope', () => {
       `${SPEC_BASE_DIR}/gantt/gantt.spec.js`,
     ]);
     // Both point to the same subfolder — should deduplicate
-    expect(result.split(',').filter((s) => s === `${SPEC_BASE_DIR}/gantt/**`).length).toBe(1);
+    expect(result.split(',').filter((s) => s === `${SPEC_BASE_DIR}/gantt/`).length).toBe(1);
   });
 });
 
@@ -183,7 +180,7 @@ describe('ignorable files (docs-only, changesets, etc.)', () => {
     ]);
     expect(result.split(',')).toEqual(
       expect.arrayContaining([
-        `${SPEC_BASE_DIR}/flowchart/**`,
+        `${SPEC_BASE_DIR}/flowchart/`,
         `${SPEC_BASE_DIR}/mmd-snapshots.spec.ts`,
       ])
     );
@@ -196,7 +193,7 @@ describe('ignorable files (docs-only, changesets, etc.)', () => {
     ]);
     expect(result.split(',')).toEqual(
       expect.arrayContaining([
-        `${SPEC_BASE_DIR}/flowchart/**`,
+        `${SPEC_BASE_DIR}/flowchart/`,
         `${SPEC_BASE_DIR}/mmd-snapshots.spec.ts`,
       ])
     );
@@ -244,5 +241,44 @@ describe('diagram coverage', () => {
       missing,
       `Diagrams with no spec subfolder and no fixtures: ${missing.join(', ')}`
     ).toEqual([]);
+  });
+
+  // The patterns are handed to `playwright test` as positional arguments, which it
+  // compiles with `new RegExp()`. A glob such as `.../c4/**` is not a valid regex and
+  // aborts the whole run before any test starts, so every pattern this can return has
+  // to compile.
+  describe('every emitted pattern is a valid regular expression', () => {
+    const changeSets: [string, string[]][] = [
+      ['a single diagram', ['packages/mermaid/src/diagrams/c4/c4Db.ts']],
+      ['another diagram', ['packages/mermaid/src/diagrams/flowchart/flowchartDb.ts']],
+      [
+        'two diagrams',
+        [
+          'packages/mermaid/src/diagrams/gantt/ganttDb.js',
+          'packages/mermaid/src/diagrams/pie/pieDb.ts',
+        ],
+      ],
+      ['a spec file', [`${SPEC_BASE_DIR}/gantt/gantt.spec.js`]],
+      ['an mmd fixture', ['e2e/diagrams/c4/c4-1-should-render-a-simple-c4context-diagram.mmd']],
+    ];
+
+    it.each(changeSets)('compiles for %s', (_name, files) => {
+      const result = detectScope(files);
+      for (const pattern of result.split(',').filter(Boolean)) {
+        expect(() => new RegExp(pattern)).not.toThrow();
+      }
+    });
+
+    it('matches the files it is meant to scope to', () => {
+      const [pattern] = detectScope(['packages/mermaid/src/diagrams/c4/c4Db.ts']).split(',');
+
+      // a directory pattern still reaches every spec beneath it, as the glob did
+      expect(new RegExp(pattern).test(`${SPEC_BASE_DIR}/c4/c4-characterization.spec.js`)).toBe(
+        true
+      );
+      expect(new RegExp(pattern).test(`${SPEC_BASE_DIR}/c4/nested/deep.spec.js`)).toBe(true);
+      // and does not leak into a sibling folder with the same prefix
+      expect(new RegExp(pattern).test(`${SPEC_BASE_DIR}/c4-beta/other.spec.js`)).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
Closes #8102.

## The bug

Any PR whose changes scope to a single diagram fails `e2e` before running a test:

```
SyntaxError: Invalid regular expression: /e2e/rendering/c4/**/gi: Nothing to repeat
```

`e2e (1)` and `e2e-required` both go red, and no test has run.

## Cause

`detectScope` returns glob patterns:

```js
detectScope(['packages/mermaid/src/diagrams/c4/c4Db.ts'])
// => 'e2e/rendering/c4/**,e2e/rendering/mmd-snapshots.spec.ts'
```

Both consumers hand them to Playwright as positional arguments - `e2e.yml`:

```yaml
IFS=',' read -ra SPECS <<< "$SPEC_PATTERN"
pnpm exec playwright test "${SPECS[@]}" --shard="${SHARD}/${SHARD_TOTAL}"
```

and `scripts/run-e2e-scoped.ts` for local runs. Playwright compiles positional arguments with `new RegExp()` and matches them against each test file's path. `**` is not valid regex.

The globs were right for Cypress, whose `--spec` took a glob. The script was not updated when the runner changed.

## Why it has not broken every PR

A change that touches shared code falls back to the full suite and passes no pattern, so it never compiles one. The failure needs a change narrow enough to scope - which is to say, it fires on exactly the focused PRs the scoping feature exists to make faster.

It is not diagram-specific:

```js
detectScope(['packages/mermaid/src/diagrams/flowchart/flowchartDb.ts'])
// => 'e2e/rendering/flowchart/**,...'   same failure
```

## The fix

A directory pattern now ends at the separator. Playwright matches the expression anywhere in the path, so `e2e/rendering/c4/` reaches every spec beneath it exactly as `**` was meant to, including nested folders, and does not match a sibling like `e2e/rendering/c4-beta/` that merely shares the prefix - both asserted.

The existing expectations move with it. A new block asserts that every pattern `detectScope` can return compiles with `new RegExp()`, across single-diagram, multi-diagram, spec-file and `.mmd`-fixture changes. That block fails against the previous glob output, so it would have caught this.

## Verification

36 tests in `scripts/e2e-diagram-scope.spec.ts` pass; the new block fails if the globs are restored. eslint and Prettier clean.

I do not have a way to prove the CI path end to end from a fork without merging it, so the honest statement is: the pattern now compiles and matches the right files, which is what the job needed. If a maintainer wants to confirm on a branch first, this PR is itself a single-file-scoped change and should exercise the path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes scoped Playwright E2E runs by replacing invalid glob patterns such as `e2e/rendering/c4/**` with valid directory-ending regular-expression patterns.

## Tests

- Updated scope expectations.
- Verified every `detectScope` result compiles with `new RegExp()`.
- Confirmed nested specs match without matching sibling directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->