### PR TITLE
fix: stop relying on fastdom's UMD export detection

### DIFF
--- a/packages/mermaid/src/rendering-util/fastdom.spec.ts
+++ b/packages/mermaid/src/rendering-util/fastdom.spec.ts
@@ -12,36 +12,44 @@ import { createFastdomWrapper } from './fastdom.js';
 // depend on the equally affected `fastdom-promised` UMD export at all.
 
 describe('fastdom wrapper', () => {
-	it('works with a healthy module default export', async () => {
-		const fastdom = createFastdomWrapper({ default: fastdomRaw });
-		expect(typeof fastdom.measure).toBe('function');
-		expect(typeof fastdom.mutate).toBe('function');
-		await expect(fastdom.measure(() => 42)).resolves.toBe(42);
-	});
+  it('works with a healthy module default export', async () => {
+    const fastdom = createFastdomWrapper({ default: fastdomRaw });
+    expect(typeof fastdom.measure).toBe('function');
+    expect(typeof fastdom.mutate).toBe('function');
+    await expect(fastdom.measure(() => 42)).resolves.toBe(42);
+  });
 
-	it('recovers via the window.fastdom singleton when the interop default is empty', async () => {
-		// Simulates the AMD branch having swallowed `module.exports`.
-		const globalScope = { fastdom: fastdomRaw };
-		const fastdom = createFastdomWrapper({}, globalScope);
-		expect(typeof fastdom.measure).toBe('function');
-		expect(typeof fastdom.mutate).toBe('function');
-		await expect(fastdom.measure(() => 'ok')).resolves.toBe('ok');
-	});
+  it('recovers via the window.fastdom singleton when the interop default is empty', async () => {
+    // Simulates the AMD branch having swallowed `module.exports`.
+    const globalScope = { fastdom: fastdomRaw };
+    const fastdom = createFastdomWrapper({}, globalScope);
+    expect(typeof fastdom.measure).toBe('function');
+    expect(typeof fastdom.mutate).toBe('function');
+    await expect(fastdom.measure(() => 'ok')).resolves.toBe('ok');
+  });
 
-	it('applies the promised extension even when the extension module export is lost', async () => {
-		// The promised extension is vendored, so a broken UMD export for it
-		// cannot affect the wrapper - verified by measure/mutate returning
-		// promises on the recovered instance.
-		const globalScope = { fastdom: fastdomRaw };
-		const fastdom = createFastdomWrapper(undefined, globalScope);
-		await expect(fastdom.measure(() => null)).resolves.toBeNull();
-		await expect(fastdom.mutate(() => null)).resolves.toBeNull();
-	});
+  it('applies the promised extension even when the extension module export is lost', async () => {
+    // The promised extension is vendored, so a broken UMD export for it
+    // cannot affect the wrapper - verified by measure/mutate returning
+    // promises on the recovered instance.
+    const globalScope = { fastdom: fastdomRaw };
+    const fastdom = createFastdomWrapper(undefined, globalScope);
+    await expect(fastdom.measure(() => null)).resolves.toBeNull();
+    await expect(fastdom.mutate(() => null)).resolves.toBeNull();
+  });
 
-	it('the real module-level wrapper exposes the promisified API', async () => {
-		vi.resetModules();
-		const { default: fastdom } = await import('./fastdom.js');
-		expect(typeof fastdom.measure).toBe('function');
-		await expect(fastdom.measure(() => 1)).resolves.toBe(1);
-	});
+  it('falls back to a local core when neither the module nor the global provides one', async () => {
+    // e.g. Node SSR during the docs build, where neither export shape
+    // carries the singleton.
+    const fastdom = createFastdomWrapper(undefined, {});
+    await expect(fastdom.measure(() => 'fallback')).resolves.toBe('fallback');
+    await expect(fastdom.mutate(() => 'done')).resolves.toBe('done');
+  });
+
+  it('the real module-level wrapper exposes the promisified API', async () => {
+    vi.resetModules();
+    const { default: fastdom } = await import('./fastdom.js');
+    expect(typeof fastdom.measure).toBe('function');
+    await expect(fastdom.measure(() => 1)).resolves.toBe(1);
+  });
 });

--- a/packages/mermaid/src/rendering-util/fastdom.spec.ts
+++ b/packages/mermaid/src/rendering-util/fastdom.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- fixture needs the raw singleton
+import fastdomRaw from 'fastdom';
+import { createFastdomWrapper } from './fastdom.js';
+
+// https://github.com/mermaid-js/mermaid/issues/8095
+// fastdom's UMD tail prefers an AMD `define` over CommonJS
+// `module.exports`. On pages that define a global `define` function, the
+// bundled copy takes the AMD branch and the bundler's interop default export
+// arrives empty, which used to crash `.extend`. The wrapper must recover via
+// the `window.fastdom` singleton fastdom always publishes, and must not
+// depend on the equally affected `fastdom-promised` UMD export at all.
+
+const asCore = (value: unknown) => value as Parameters<typeof createFastdomWrapper>[0];
+
+describe('fastdom wrapper', () => {
+	it('works with a healthy module default export', () => {
+		const fastdom = createFastdomWrapper(asCore({ default: fastdomRaw }));
+		expect(typeof fastdom.measure).toBe('function');
+		expect(typeof fastdom.mutate).toBe('function');
+		const result = fastdom.measure(() => 42) as unknown as Promise<number>;
+		expect(result).toBeInstanceOf(Promise);
+		return (result as Promise<number>).then((value) => expect(value).toBe(42));
+	});
+
+	it('recovers via the window.fastdom singleton when the interop default is empty', () => {
+		// Simulates the AMD branch having swallowed `module.exports`.
+		const globalScope = { fastdom: fastdomRaw as unknown as Record<string, never> };
+		const fastdom = createFastdomWrapper(asCore({}), globalScope);
+		expect(typeof fastdom.measure).toBe('function');
+		expect(typeof fastdom.mutate).toBe('function');
+		return Promise.resolve(fastdom.measure(() => 'ok') as unknown as Promise<string>).then((value) =>
+			expect(value).toBe('ok'),
+		);
+	});
+
+	it('applies the promised extension even when the extension module export is lost', () => {
+		// The promised extension is vendored, so a broken UMD export for it
+		// cannot affect the wrapper - verified by measure/mutate returning
+		// promises on the recovered instance.
+		const globalScope = { fastdom: fastdomRaw as unknown as Record<string, never> };
+		const fastdom = createFastdomWrapper(asCore(undefined), globalScope);
+		expect(fastdom.measure(() => null)).toBeInstanceOf(Promise);
+		expect(fastdom.mutate(() => null)).toBeInstanceOf(Promise);
+	});
+
+	it('the real module-level wrapper exposes the promisified API', async () => {
+		vi.resetModules();
+		const { default: fastdom } = await import('./fastdom.js');
+		expect(typeof fastdom.measure).toBe('function');
+		expect(fastdom.measure(() => 1)).toBeInstanceOf(Promise);
+	});
+});

--- a/packages/mermaid/src/rendering-util/fastdom.spec.ts
+++ b/packages/mermaid/src/rendering-util/fastdom.spec.ts
@@ -11,43 +11,37 @@ import { createFastdomWrapper } from './fastdom.js';
 // the `window.fastdom` singleton fastdom always publishes, and must not
 // depend on the equally affected `fastdom-promised` UMD export at all.
 
-const asCore = (value: unknown) => value as Parameters<typeof createFastdomWrapper>[0];
-
 describe('fastdom wrapper', () => {
-	it('works with a healthy module default export', () => {
-		const fastdom = createFastdomWrapper(asCore({ default: fastdomRaw }));
+	it('works with a healthy module default export', async () => {
+		const fastdom = createFastdomWrapper({ default: fastdomRaw });
 		expect(typeof fastdom.measure).toBe('function');
 		expect(typeof fastdom.mutate).toBe('function');
-		const result = fastdom.measure(() => 42) as unknown as Promise<number>;
-		expect(result).toBeInstanceOf(Promise);
-		return (result as Promise<number>).then((value) => expect(value).toBe(42));
+		await expect(fastdom.measure(() => 42)).resolves.toBe(42);
 	});
 
-	it('recovers via the window.fastdom singleton when the interop default is empty', () => {
+	it('recovers via the window.fastdom singleton when the interop default is empty', async () => {
 		// Simulates the AMD branch having swallowed `module.exports`.
-		const globalScope = { fastdom: fastdomRaw as unknown as Record<string, never> };
-		const fastdom = createFastdomWrapper(asCore({}), globalScope);
+		const globalScope = { fastdom: fastdomRaw };
+		const fastdom = createFastdomWrapper({}, globalScope);
 		expect(typeof fastdom.measure).toBe('function');
 		expect(typeof fastdom.mutate).toBe('function');
-		return Promise.resolve(fastdom.measure(() => 'ok') as unknown as Promise<string>).then((value) =>
-			expect(value).toBe('ok'),
-		);
+		await expect(fastdom.measure(() => 'ok')).resolves.toBe('ok');
 	});
 
-	it('applies the promised extension even when the extension module export is lost', () => {
+	it('applies the promised extension even when the extension module export is lost', async () => {
 		// The promised extension is vendored, so a broken UMD export for it
 		// cannot affect the wrapper - verified by measure/mutate returning
 		// promises on the recovered instance.
-		const globalScope = { fastdom: fastdomRaw as unknown as Record<string, never> };
-		const fastdom = createFastdomWrapper(asCore(undefined), globalScope);
-		expect(fastdom.measure(() => null)).toBeInstanceOf(Promise);
-		expect(fastdom.mutate(() => null)).toBeInstanceOf(Promise);
+		const globalScope = { fastdom: fastdomRaw };
+		const fastdom = createFastdomWrapper(undefined, globalScope);
+		await expect(fastdom.measure(() => null)).resolves.toBeNull();
+		await expect(fastdom.mutate(() => null)).resolves.toBeNull();
 	});
 
 	it('the real module-level wrapper exposes the promisified API', async () => {
 		vi.resetModules();
 		const { default: fastdom } = await import('./fastdom.js');
 		expect(typeof fastdom.measure).toBe('function');
-		expect(fastdom.measure(() => 1)).toBeInstanceOf(Promise);
+		await expect(fastdom.measure(() => 1)).resolves.toBe(1);
 	});
 });

--- a/packages/mermaid/src/rendering-util/fastdom.ts
+++ b/packages/mermaid/src/rendering-util/fastdom.ts
@@ -1,6 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports -- Only allowed to import `fastdom` in this file
 import fastdomModule from 'fastdom';
-import fastdomPromised from 'fastdom/extensions/fastdom-promised.js';
 
 /**
  * Promisified version of {@link fastdom} that uses `queueMicrotask` instead of `requestAnimationFrame` for faster execution.
@@ -10,8 +9,105 @@ import fastdomPromised from 'fastdom/extensions/fastdom-promised.js';
  * const bbox = await fastdom.measure(() => div.node()!.getBoundingClientRect());
  * ```
  */
-const fastdom = // @ts-expect-error -- fastdom types aren't yet ESM-compatible, we need this hack
-  (fastdomModule as typeof fastdomModule.default)
+
+type FastDomTask = { cancel(): void };
+
+type FastDomCore = {
+  extend(extension: Record<string, unknown>): FastDomCore;
+  measure<T>(fn: () => T, ctx?: unknown): FastDomTask | T;
+  mutate<T>(fn: () => T, ctx?: unknown): FastDomTask | T;
+  clear(task: FastDomTask): void;
+};
+
+// fastdom ships only a UMD build whose export tail prefers an AMD `define`
+// over CommonJS `module.exports`. When the host page defines a global
+// `define` function (legacy AMD loaders, analytics snippets, ...), the
+// bundled copy takes the AMD branch, never assigns `module.exports`, and the
+// bundler's interop default export comes through empty - crashing on
+// `.extend` (https://github.com/mermaid-js/mermaid/issues/8095).
+// fastdom always publishes its singleton on the global scope *before* that
+// branch (`window.fastdom`), so fall back to it when the module default does
+// not look like a FastDom instance.
+const resolveBase = (
+  module: unknown,
+  globalScope: Record<string, FastDomCore | undefined>,
+): FastDomCore => {
+  const fromModule = (module as { default?: FastDomCore } | undefined)?.default;
+  if (fromModule && typeof fromModule.extend === 'function') {
+    return fromModule;
+  }
+  const fromGlobal = globalScope.fastdom;
+  if (fromGlobal && typeof fromGlobal.extend === 'function') {
+    return fromGlobal;
+  }
+  throw new Error('Unable to initialize fastdom');
+};
+
+// The `fastdom/extensions/fastdom-promised.js` file has the same UMD problem,
+// and unlike the core it publishes its export only on the final `else`
+// branch, so it cannot be recovered from the global scope either. It is a
+// small, stable piece of MIT-licensed code (wilsonpage/fastdom), vendored
+// here so mermaid does not depend on either UMD tail at all.
+const createPromisedExtension = () => ({
+  initialize(this: { _tasks?: Map<Promise<unknown>, FastDomTask> }) {
+    this._tasks = new Map();
+  },
+
+  mutate<T>(
+    this: { _tasks: Map<Promise<T>, FastDomTask>; fastdom: FastDomCore },
+    fn: () => T,
+    ctx?: unknown,
+  ): Promise<T> {
+    return createPromisedTask(this, 'mutate', fn, ctx);
+  },
+
+  measure<T>(
+    this: { _tasks: Map<Promise<T>, FastDomTask>; fastdom: FastDomCore },
+    fn: () => T,
+    ctx?: unknown,
+  ): Promise<T> {
+    return createPromisedTask(this, 'measure', fn, ctx);
+  },
+
+  clear<T>(this: { _tasks: Map<Promise<T>, FastDomTask>; fastdom: FastDomCore }, promise: Promise<T>) {
+    const tasks = this._tasks;
+    const task = tasks.get(promise);
+    this.fastdom.clear(task!);
+    tasks.delete(promise);
+  },
+});
+
+function createPromisedTask<T>(
+  promised: { _tasks: Map<Promise<T>, FastDomTask>; fastdom: FastDomCore },
+  type: 'measure' | 'mutate',
+  fn: () => T,
+  ctx?: unknown,
+): Promise<T> {
+  const tasks = promised._tasks;
+  let task!: FastDomTask;
+
+  const promise = new Promise<T>((resolve, reject) => {
+    task = promised.fastdom[type](() => {
+      tasks.delete(promise);
+      try {
+        resolve(ctx ? (fn as (this: unknown) => T).call(ctx) : fn());
+      } catch (error) {
+        reject(error);
+      }
+    }, ctx) as FastDomTask;
+  });
+
+  tasks.set(promise, task);
+  return promise;
+}
+
+export const createFastdomWrapper = (
+  module: unknown = fastdomModule,
+  globalScope: Record<string, FastDomCore | undefined> = (typeof window !== 'undefined'
+    ? window
+    : globalThis) as unknown as Record<string, FastDomCore | undefined>,
+): FastDomCore & { clear(promise: Promise<unknown>): void } => {
+  return resolveBase(module, globalScope)
     .extend({
       /**
        * `requestAnimationFrame` is too slow compared to `queueMicrotask`.
@@ -24,6 +120,11 @@ const fastdom = // @ts-expect-error -- fastdom types aren't yet ESM-compatible, 
         }
       },
     })
-    .extend(fastdomPromised);
+    .extend(createPromisedExtension()) as FastDomCore & {
+    clear(promise: Promise<unknown>): void;
+  };
+};
+
+const fastdom = createFastdomWrapper();
 
 export default fastdom;

--- a/packages/mermaid/src/rendering-util/fastdom.ts
+++ b/packages/mermaid/src/rendering-util/fastdom.ts
@@ -10,21 +10,23 @@ import fastdomModule from 'fastdom';
  * ```
  */
 
-interface FastDomTask { cancelled?: boolean }
+interface FastDomTask {
+  cancelled?: boolean;
+}
 
 interface FastDomCore {
   extend(extension: Record<string, unknown>): FastDomCore;
   measure<T>(fn: () => T, ctx?: unknown): FastDomTask | T;
   mutate<T>(fn: () => T, ctx?: unknown): FastDomTask | T;
   clear(task: FastDomTask): void;
-};
+}
 
 /** The public API mermaid consumes: every scheduling call returns a promise. */
 export interface FastDomPromised {
   measure<T>(fn: () => T, ctx?: unknown): Promise<T>;
   mutate<T>(fn: () => T, ctx?: unknown): Promise<T>;
   clear(promise: Promise<unknown>): void;
-};
+}
 
 // Minimal drop-in replacement for fastdom's core singleton: batches measures
 // before mutates within one microtask and supports cancellation.
@@ -53,7 +55,11 @@ const createFallbackCore = (): FastDomCore => {
       schedule();
       batches![type].push(() => {
         if (!task.cancelled) {
-          if (ctx) { (fn as (this: unknown) => void).call(ctx); } else { fn(); }
+          if (ctx) {
+            (fn as (this: unknown) => void).call(ctx);
+          } else {
+            fn();
+          }
         }
       });
       return task;

--- a/packages/mermaid/src/rendering-util/fastdom.ts
+++ b/packages/mermaid/src/rendering-util/fastdom.ts
@@ -19,6 +19,13 @@ type FastDomCore = {
   clear(task: FastDomTask): void;
 };
 
+/** The public API mermaid consumes: every scheduling call returns a promise. */
+export type FastDomPromised = {
+  measure<T>(fn: () => T, ctx?: unknown): Promise<T>;
+  mutate<T>(fn: () => T, ctx?: unknown): Promise<T>;
+  clear(promise: Promise<unknown>): void;
+};
+
 // fastdom ships only a UMD build whose export tail prefers an AMD `define`
 // over CommonJS `module.exports`. When the host page defines a global
 // `define` function (legacy AMD loaders, analytics snippets, ...), the
@@ -30,13 +37,13 @@ type FastDomCore = {
 // not look like a FastDom instance.
 const resolveBase = (
   module: unknown,
-  globalScope: Record<string, FastDomCore | undefined>,
+  globalScope: Record<string, unknown>,
 ): FastDomCore => {
   const fromModule = (module as { default?: FastDomCore } | undefined)?.default;
   if (fromModule && typeof fromModule.extend === 'function') {
     return fromModule;
   }
-  const fromGlobal = globalScope.fastdom;
+  const fromGlobal = globalScope.fastdom as FastDomCore | undefined;
   if (fromGlobal && typeof fromGlobal.extend === 'function') {
     return fromGlobal;
   }
@@ -103,10 +110,10 @@ function createPromisedTask<T>(
 
 export const createFastdomWrapper = (
   module: unknown = fastdomModule,
-  globalScope: Record<string, FastDomCore | undefined> = (typeof window !== 'undefined'
+  globalScope: Record<string, unknown> = (typeof window !== 'undefined'
     ? window
-    : globalThis) as unknown as Record<string, FastDomCore | undefined>,
-): FastDomCore & { clear(promise: Promise<unknown>): void } => {
+    : globalThis) as unknown as Record<string, unknown>,
+): FastDomPromised => {
   return resolveBase(module, globalScope)
     .extend({
       /**
@@ -120,11 +127,9 @@ export const createFastdomWrapper = (
         }
       },
     })
-    .extend(createPromisedExtension()) as FastDomCore & {
-    clear(promise: Promise<unknown>): void;
-  };
+    .extend(createPromisedExtension()) as unknown as FastDomPromised;
 };
 
-const fastdom = createFastdomWrapper();
+const fastdom: FastDomPromised = createFastdomWrapper();
 
 export default fastdom;

--- a/packages/mermaid/src/rendering-util/fastdom.ts
+++ b/packages/mermaid/src/rendering-util/fastdom.ts
@@ -10,9 +10,9 @@ import fastdomModule from 'fastdom';
  * ```
  */
 
-type FastDomTask = { cancelled?: boolean };
+interface FastDomTask { cancelled?: boolean }
 
-type FastDomCore = {
+interface FastDomCore {
   extend(extension: Record<string, unknown>): FastDomCore;
   measure<T>(fn: () => T, ctx?: unknown): FastDomTask | T;
   mutate<T>(fn: () => T, ctx?: unknown): FastDomTask | T;
@@ -20,7 +20,7 @@ type FastDomCore = {
 };
 
 /** The public API mermaid consumes: every scheduling call returns a promise. */
-export type FastDomPromised = {
+export interface FastDomPromised {
   measure<T>(fn: () => T, ctx?: unknown): Promise<T>;
   mutate<T>(fn: () => T, ctx?: unknown): Promise<T>;
   clear(promise: Promise<unknown>): void;
@@ -29,7 +29,7 @@ export type FastDomPromised = {
 // Minimal drop-in replacement for fastdom's core singleton: batches measures
 // before mutates within one microtask and supports cancellation.
 const createFallbackCore = (): FastDomCore => {
-  let batches: { measure: Array<() => void>; mutate: Array<() => void> } | null = null;
+  let batches: { measure: (() => void)[]; mutate: (() => void)[] } | null = null;
   const schedule = () => {
     if (batches) {
       return;
@@ -53,7 +53,7 @@ const createFallbackCore = (): FastDomCore => {
       schedule();
       batches![type].push(() => {
         if (!task.cancelled) {
-          ctx ? (fn as (this: unknown) => void).call(ctx) : fn();
+          if (ctx) { (fn as (this: unknown) => void).call(ctx); } else { fn(); }
         }
       });
       return task;
@@ -105,7 +105,7 @@ const resolveBase = (module: unknown, globalScope: Record<string, unknown>): Fas
 // The `fastdom/extensions/fastdom-promised.js` file has the same UMD problem,
 // and unlike the core it publishes its export only on the final `else`
 // branch, so it cannot be recovered from the global scope either. It is a
-// small, stable piece of MIT-licensed code (wilsonpage/fastdom), vendored
+// small, stable piece of MIT-licensed code from the fastdom project, vendored
 // here so mermaid does not depend on either UMD tail at all.
 const createPromisedExtension = () => ({
   initialize(this: { _tasks?: Map<Promise<unknown>, FastDomTask> }) {
@@ -154,7 +154,7 @@ function createPromisedTask<T>(
       try {
         resolve(ctx ? (fn as (this: unknown) => T).call(ctx) : fn());
       } catch (error) {
-        reject(error);
+        reject(error instanceof Error ? error : new Error(String(error)));
       }
     }, ctx) as FastDomTask;
   });

--- a/packages/mermaid/src/rendering-util/fastdom.ts
+++ b/packages/mermaid/src/rendering-util/fastdom.ts
@@ -49,7 +49,7 @@ const createFallbackCore = (): FastDomCore => {
   const run =
     (type: 'measure' | 'mutate') =>
     (fn: () => void, ctx?: unknown): FastDomTask => {
-      const task: Task = { cancelled: false };
+      const task: { cancelled: boolean } = { cancelled: false };
       schedule();
       batches![type].push(() => {
         if (!task.cancelled) {

--- a/packages/mermaid/src/rendering-util/fastdom.ts
+++ b/packages/mermaid/src/rendering-util/fastdom.ts
@@ -10,7 +10,7 @@ import fastdomModule from 'fastdom';
  * ```
  */
 
-type FastDomTask = { cancel(): void };
+type FastDomTask = { cancelled?: boolean };
 
 type FastDomCore = {
   extend(extension: Record<string, unknown>): FastDomCore;
@@ -26,6 +26,53 @@ export type FastDomPromised = {
   clear(promise: Promise<unknown>): void;
 };
 
+// Minimal drop-in replacement for fastdom's core singleton: batches measures
+// before mutates within one microtask and supports cancellation.
+const createFallbackCore = (): FastDomCore => {
+  let batches: { measure: Array<() => void>; mutate: Array<() => void> } | null = null;
+  const schedule = () => {
+    if (batches) {
+      return;
+    }
+    batches = { measure: [], mutate: [] };
+    queueMicrotask(() => {
+      const current = batches!;
+      batches = null;
+      for (const fn of current.measure) {
+        fn();
+      }
+      for (const fn of current.mutate) {
+        fn();
+      }
+    });
+  };
+  const run =
+    (type: 'measure' | 'mutate') =>
+    (fn: () => void, ctx?: unknown): FastDomTask => {
+      const task: Task = { cancelled: false };
+      schedule();
+      batches![type].push(() => {
+        if (!task.cancelled) {
+          ctx ? (fn as (this: unknown) => void).call(ctx) : fn();
+        }
+      });
+      return task;
+    };
+  const core: FastDomCore = {
+    extend(extension: Record<string, unknown>): FastDomCore {
+      Object.assign(core, extension);
+      (extension as { initialize?: () => void }).initialize?.call(core);
+      return core;
+    },
+    measure: run('measure'),
+    mutate: run('mutate'),
+    clear(task: FastDomTask) {
+      task.cancelled = true;
+    },
+  };
+  return core;
+};
+
 // fastdom ships only a UMD build whose export tail prefers an AMD `define`
 // over CommonJS `module.exports`. When the host page defines a global
 // `define` function (legacy AMD loaders, analytics snippets, ...), the
@@ -34,20 +81,25 @@ export type FastDomPromised = {
 // `.extend` (https://github.com/mermaid-js/mermaid/issues/8095).
 // fastdom always publishes its singleton on the global scope *before* that
 // branch (`window.fastdom`), so fall back to it when the module default does
-// not look like a FastDom instance.
-const resolveBase = (
-  module: unknown,
-  globalScope: Record<string, unknown>,
-): FastDomCore => {
-  const fromModule = (module as { default?: FastDomCore } | undefined)?.default;
-  if (fromModule && typeof fromModule.extend === 'function') {
-    return fromModule;
+// not look like a FastDom instance, and to a locally built core as a last
+// resort (e.g. Node SSR, where neither export shape carries the singleton).
+const resolveBase = (module: unknown, globalScope: Record<string, unknown>): FastDomCore => {
+  const candidates = [
+    module,
+    (module as { default?: unknown } | undefined)?.default,
+    ((module as { default?: { default?: unknown } } | undefined)?.default as { default?: unknown })
+      ?.default,
+  ];
+  for (const candidate of candidates) {
+    if (candidate && typeof (candidate as FastDomCore).extend === 'function') {
+      return candidate as FastDomCore;
+    }
   }
   const fromGlobal = globalScope.fastdom as FastDomCore | undefined;
   if (fromGlobal && typeof fromGlobal.extend === 'function') {
     return fromGlobal;
   }
-  throw new Error('Unable to initialize fastdom');
+  return createFallbackCore();
 };
 
 // The `fastdom/extensions/fastdom-promised.js` file has the same UMD problem,
@@ -63,7 +115,7 @@ const createPromisedExtension = () => ({
   mutate<T>(
     this: { _tasks: Map<Promise<T>, FastDomTask>; fastdom: FastDomCore },
     fn: () => T,
-    ctx?: unknown,
+    ctx?: unknown
   ): Promise<T> {
     return createPromisedTask(this, 'mutate', fn, ctx);
   },
@@ -71,12 +123,15 @@ const createPromisedExtension = () => ({
   measure<T>(
     this: { _tasks: Map<Promise<T>, FastDomTask>; fastdom: FastDomCore },
     fn: () => T,
-    ctx?: unknown,
+    ctx?: unknown
   ): Promise<T> {
     return createPromisedTask(this, 'measure', fn, ctx);
   },
 
-  clear<T>(this: { _tasks: Map<Promise<T>, FastDomTask>; fastdom: FastDomCore }, promise: Promise<T>) {
+  clear<T>(
+    this: { _tasks: Map<Promise<T>, FastDomTask>; fastdom: FastDomCore },
+    promise: Promise<T>
+  ) {
     const tasks = this._tasks;
     const task = tasks.get(promise);
     this.fastdom.clear(task!);
@@ -88,7 +143,7 @@ function createPromisedTask<T>(
   promised: { _tasks: Map<Promise<T>, FastDomTask>; fastdom: FastDomCore },
   type: 'measure' | 'mutate',
   fn: () => T,
-  ctx?: unknown,
+  ctx?: unknown
 ): Promise<T> {
   const tasks = promised._tasks;
   let task!: FastDomTask;
@@ -112,7 +167,7 @@ export const createFastdomWrapper = (
   module: unknown = fastdomModule,
   globalScope: Record<string, unknown> = (typeof window !== 'undefined'
     ? window
-    : globalThis) as unknown as Record<string, unknown>,
+    : globalThis) as unknown as Record<string, unknown>
 ): FastDomPromised => {
   return resolveBase(module, globalScope)
     .extend({


### PR DESCRIPTION
## Summary

Fixes #8095.

Mermaid 11.17.0 fails to initialize on pages that define a global `define` function (`Uncaught TypeError: Wae.default.extend is not a function`, `window.mermaid` undefined). 11.16.1 worked because it didn't use fastdom at all — fastdom was introduced in b9fc2521.

**Root cause:** fastdom ships only a UMD build whose export tail prefers an AMD `define` over CommonJS:

```js
var exports = win.fastdom = (win.fastdom || new FastDom());
if ((typeof define) == 'function') define(function() { return exports; });
else if ((typeof module) == 'object') module.exports = exports;
```

When the page has a global `define` (legacy AMD loaders, analytics snippets, VS Code embedded browser), the bundled copy takes the AMD branch, never assigns `module.exports`, and the bundler's interop default export arrives empty — so `fastdomModule.default.extend` crashes.

**Fix:**

1. **Resilient core resolution**: if the interop default doesn't look like a FastDom instance, fall back to `window.fastdom` — which fastdom publishes *unconditionally before* its UMD branch, so it is always available.
2. **Vendor the promised extension**: `fastdom/extensions/fastdom-promised.js` has the same UMD problem, and unlike the core it only publishes its global in the final `else` branch, so it cannot be recovered from the global scope either. Its promise wrapper is small and stable (~40 lines, MIT, wilsonpage/fastdom), so it is vendored into `fastdom.ts` with attribution — mermaid no longer depends on either UMD tail.

## Testing

New `packages/mermaid/src/rendering-util/fastdom.spec.ts`:

- healthy default export → promisified API works end-to-end
- empty interop default + `window.fastdom` singleton → recovers, promises work
- lost extension export → measure/mutate still return promises (vendored extension)
- real module-level wrapper exposes the API

```
✓ packages/mermaid/src/rendering-util/fastdom.spec.ts (4 tests) 4ms
```

Full `src/rendering-util` suite: 75/76 files pass; the single failing file (`multi-diagram-id-uniqueness.spec.ts`) fails with `Failed to resolve entry for package "@mermaid-js/parser"` — an unbuilt workspace package in this checkout, unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes Mermaid initialization failures when a global `define` function causes FastDOM’s UMD export to resolve incorrectly.

- Resolves FastDOM from valid module exports, `window.fastdom`, or a local microtask-based fallback.
- Vendors the `fastdom-promised` wrapper locally.
- Adds the `FastDomPromised` interface with promise-based `measure` and `mutate` methods.
- Supports task cancellation and normalizes callback failures to `Error` objects.
- Adds tests for export recovery, singleton recovery, fallback behavior, promise APIs, and the module wrapper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->