### PR TITLE
fix(flowchart): preserve subgraph direction for clusters with external edges (#8066)

### DIFF
--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/mermaid-graphlib.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/mermaid-graphlib.js
@@ -342,6 +342,40 @@ export const extractor = (graph, depth) => {
     if (!clusterDb.has(node)) {
       log.debug('Not a cluster', node, depth);
     } else if (
+      clusterDb.get(node)?.clusterData?.dir &&
+      graph.children(node) &&
+      graph.children(node).length > 0
+    ) {
+      // Cluster with an explicit direction keyword — always create a subgraph,
+      // even when it has external connections (fixes issue #4648 / #8066).
+      log.debug('Cluster with explicit dir, creating subgraph for children', node, depth);
+
+      const dir = clusterDb.get(node).clusterData.dir;
+      const clusterGraph = new graphlib.Graph({
+        multigraph: true,
+        compound: true,
+      })
+        .setGraph({
+          rankdir: dir,
+          nodesep: 50,
+          ranksep: 50,
+          marginx: 8,
+          marginy: 8,
+        })
+        .setDefaultEdgeLabel(function () {
+          return {};
+        });
+
+      copy(node, graph, clusterGraph, node);
+      graph.setNode(node, {
+        clusterNode: true,
+        id: node,
+        clusterData: clusterDb.get(node).clusterData,
+        label: clusterDb.get(node).label,
+        graph: clusterGraph,
+      });
+      log.debug('Subgraph for cluster with explicit dir created:', node);
+    } else if (
       !clusterDb.get(node).externalConnections &&
       graph.children(node) &&
       graph.children(node).length > 0

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/mermaid-graphlib.spec.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/mermaid-graphlib.spec.js
@@ -247,6 +247,43 @@ describe('Graphlib decorations', () => {
       expect(g.nodes().length).toBe(1);
     });
 
+    it('extracts cluster with explicit direction even when it has external connections (#8066)', function () {
+      /*
+      flowchart LR
+      subgraph Branches
+        dev --> uat
+      end
+      subgraph Orgs
+        direction TB
+        org1
+        org2
+      end
+      dev --> org1
+      uat --> org2
+      */
+      g.setNode('Branches', { data: 'branches' });
+      g.setNode('dev', { data: 'dev' });
+      g.setNode('uat', { data: 'uat' });
+      g.setParent('dev', 'Branches');
+      g.setParent('uat', 'Branches');
+      g.setEdge('dev', 'uat', { data: 'internal' }, '1');
+
+      g.setNode('Orgs', { data: 'orgs', dir: 'TB' });
+      g.setNode('org1', { data: 'org1' });
+      g.setNode('org2', { data: 'org2' });
+      g.setParent('org1', 'Orgs');
+      g.setParent('org2', 'Orgs');
+
+      g.setEdge('dev', 'org1', { data: 'ext1' }, '2');
+      g.setEdge('uat', 'org2', { data: 'ext2' }, '3');
+
+      adjustClustersAndEdges(g, 0);
+
+      // Orgs should be extracted into a clusterNode with rankdir: 'TB'
+      expect(g.node('Orgs').clusterNode).toBe(true);
+      expect(g.node('Orgs').graph.graph().rankdir).toBe('TB');
+    });
+
     it('adjustClustersAndEdges the extracted graphs shall contain the correct data GLB11', function () {
       /*
     subgraph A


### PR DESCRIPTION
Fixes #8066

### Summary
When subgraphs contained explicit direction overrides (such as \direction LR\), clusters with external connections were bypassing cluster extraction in Dagre layout, causing inner nodes to revert to top-level layout direction.

### Solution
- Restored explicit cluster extraction branching in \packages/mermaid/src/rendering-util/layout-algorithms/dagre/mermaid-graphlib.js\ when \clusterData.dir\ is specified.
- Added test coverage in \mermaid-graphlib.spec.js\.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What's working well

- 🎉 Fixes `#8066` by preserving explicit subgraph directions for clusters with external edges.
- 🎉 Restores cluster extraction when `clusterData.dir` is defined.
- 🎉 Adds regression coverage for `TB` direction and incoming external connections.

## Review

No blocking or important issues identified.

## Verdict

**APPROVE**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->