### PR TITLE
fix(flowchart): group whitespace runs into a single SPACE token

### DIFF
--- a/.changeset/flowchart-lexer-whitespace.md
+++ b/.changeset/flowchart-lexer-whitespace.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: group runs of whitespace into a single token in the flowchart lexer, which made parsing time grow quadratically with the length of the run

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow-huge.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow-huge.spec.js
@@ -29,7 +29,7 @@ describe('[Text] when parsing', () => {
     it('should handle a long run of whitespace', function () {
       // The lexer used to emit one SPACE token per whitespace character, which made
       // parsing quadratic in the length of the run: 24 KiB of them took over 5 seconds.
-      const run = ' \t'.repeat(12_000);
+      const run = ' \t\r'.repeat(8_000);
       const text = `graph LR;A-->B;\n${run}`;
 
       // The invariant behind the fix: the whole run reaches the parser as a single
@@ -46,6 +46,15 @@ describe('[Text] when parsing', () => {
       expect(spaces).toEqual([run]);
 
       flow.parser.parse(text);
+
+      expect(flow.parser.yy.getEdges().length).toBe(1);
+      expect(flow.parser.yy.getVertices().size).toBe(2);
+    });
+
+    it('should treat a lone carriage return as whitespace', function () {
+      // `\s` used to cover it. The SPACE rule excludes `\n` only, so CR-only line
+      // endings keep lexing as whitespace instead of raising an unmatched-input error.
+      flow.parser.parse('graph LR;\rA-->B;');
 
       expect(flow.parser.yy.getEdges().length).toBe(1);
       expect(flow.parser.yy.getVertices().size).toBe(2);

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow-huge.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow-huge.spec.js
@@ -50,14 +50,24 @@ describe('[Text] when parsing', () => {
       expect(flow.parser.yy.getEdges().length).toBe(1);
       expect(flow.parser.yy.getVertices().size).toBe(2);
     });
+  });
 
+  describe('it should lex whitespace without disturbing line endings', function () {
     it('should treat a lone carriage return as whitespace', function () {
-      // `\s` used to cover it. The SPACE rule excludes `\n` only, so CR-only line
-      // endings keep lexing as whitespace instead of raising an unmatched-input error.
+      // `\s` used to cover it, so the SPACE rule keeps matching a `\r` that is not
+      // part of a CRLF, rather than raising an unmatched-input error.
       flow.parser.parse('graph LR;\rA-->B;');
 
       expect(flow.parser.yy.getEdges().length).toBe(1);
       expect(flow.parser.yy.getVertices().size).toBe(2);
+    });
+
+    it('should leave the carriage return of a CRLF to the newline rule', function () {
+      // Whitespace before a CRLF must not swallow the `\r`: SPACE is accepted by
+      // `styleComponent`, so it would end up inside the parsed style.
+      flow.parser.parse('graph LR;\r\nA-->B;\r\nstyle A fill:#f9f \r\n');
+
+      expect(flow.parser.yy.getVertices().get('A').styles).toEqual(['fill:#f9f ']);
     });
   });
 });

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow-huge.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow-huge.spec.js
@@ -25,5 +25,30 @@ describe('[Text] when parsing', () => {
       expect(edges.length).toBe(47917);
       expect(vert.size).toBe(2);
     });
+
+    it('should handle a long run of whitespace', function () {
+      // The lexer used to emit one SPACE token per whitespace character, which made
+      // parsing quadratic in the length of the run: 24 KiB of them took over 5 seconds.
+      const run = ' \t'.repeat(12_000);
+      const text = `graph LR;A-->B;\n${run}`;
+
+      // The invariant behind the fix: the whole run reaches the parser as a single
+      // SPACE token instead of one per character. The lexer gets its own FlowDB
+      // because the `graph` rules consume `yy.firstGraph()`.
+      const { lexer, symbols_ } = flow.parser;
+      lexer.setInput(text, new FlowDB());
+      const spaces = [];
+      for (let token = lexer.lex(); token !== symbols_.EOF; token = lexer.lex()) {
+        if (token === symbols_.SPACE) {
+          spaces.push(lexer.yytext);
+        }
+      }
+      expect(spaces).toEqual([run]);
+
+      flow.parser.parse(text);
+
+      expect(flow.parser.yy.getEdges().length).toBe(1);
+      expect(flow.parser.yy.getVertices().size).toBe(2);
+    });
   });
 });

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
@@ -286,7 +286,7 @@ that id.
 
 "\""                  return 'QUOTE';
 (\r?\n)+              return 'NEWLINE';
-[^\S\n\r]+            return 'SPACE';
+[^\S\n]+              return 'SPACE';
 <<EOF>>               return 'EOF';
 
 /lex

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
@@ -286,7 +286,7 @@ that id.
 
 "\""                  return 'QUOTE';
 (\r?\n)+              return 'NEWLINE';
-\s                    return 'SPACE';
+[^\S\n\r]+            return 'SPACE';
 <<EOF>>               return 'EOF';
 
 /lex

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow.jison
@@ -286,7 +286,7 @@ that id.
 
 "\""                  return 'QUOTE';
 (\r?\n)+              return 'NEWLINE';
-[^\S\n]+              return 'SPACE';
+(?:[^\S\r\n]|\r(?!\n))+   return 'SPACE';
 <<EOF>>               return 'EOF';
 
 /lex


### PR DESCRIPTION
Fixes #8127

The flowchart lexer emitted one `SPACE` token per whitespace character, while the rule directly above it already grouped newline runs:

    (\r?\n)+              return 'NEWLINE';
    \s                    return 'SPACE';

Since the jison lexer reassigns `this._input = this._input.slice(...)` on every token, each token copies the rest of the input, so parse time grew quadratically with the length of a whitespace run. A flowchart followed by 47 KiB of spaces took 21 s; the same length of `.` took 4 ms, because that lexes as a single token.

Grouping horizontal whitespace the same way newlines already are:

| input | before | after |
|---|---|---|
| 6 KiB of trailing spaces | 355 ms | 22 ms |
| 12 KiB | 1 379 ms | 77 ms |
| 23 KiB | 5 436 ms | 300 ms |
| 47 KiB | 21 486 ms | 1 253 ms |

Newlines keep their own rule, so `[^\S\n\r]+` cannot swallow them and line structure is unchanged.

The grammar already accommodates this: `spaceList: SPACE spaceList | SPACE` accepts a single token, and rules that expected exactly one `SPACE` become more permissive rather than less — `classDef  foo` with two spaces parses now, where it previously did not. All 984 flowchart tests pass.

### What this does not fix

The underlying cost is still O(n²) in token count, so this lowers the constant by about 17× without changing the complexity. A payload alternating one space and one newline still produces one token per character and takes ~15 s at 48 KiB, unchanged by this PR. That one lives in jison's lexer rather than in the grammar, and probably resolves itself with the parser migration already under way.

### Test

`flow-huge.spec.js` gets a case that lexes `graph LR;A-->B;` followed by 24 KiB of alternating spaces and tabs, and asserts the whole run arrives as a single `SPACE` token rather than one per character. That is the invariant this change establishes;
the speed follows from it. On `develop` the assertion reports 24 000 tokens instead of one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What's working well

- 🎉 [praise] Groups consecutive horizontal whitespace into one `SPACE` token.
- 🎉 [praise] Preserves separate `NEWLINE` handling.
- 🎉 [praise] Adds regression coverage for spaces, tabs, and carriage returns.
- 🎉 [praise] Improves parsing time for long trailing whitespace runs.
- 🎉 [praise] Includes a patch changeset.

## Things to address

No blocking or important issues identified.

## Security

No security-sensitive code paths changed.

## Verdict

**APPROVE**

Severity tally: 0 blocking / 0 important / 0 nit / 0 suggestion / 5 praise
<!-- end of auto-generated comment: release notes by coderabbit.ai -->