### PR TITLE
fix(flowchart): make the linkStyle bounds check actually fire

### DIFF
--- a/.changeset/linkstyle-index-bounds.md
+++ b/.changeset/linkstyle-index-bounds.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: report an out-of-range `linkStyle` index with the intended "index out of bounds" message instead of a raw `TypeError`. The bounds check was guarded by `typeof pos === 'number'`, but the grammar supplies indices as strings, so it never ran — for `linkStyle … interpolate` there was no check at all.

--- a/packages/mermaid/src/diagrams/flowchart/flowDb.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.ts
@@ -372,14 +372,44 @@ You have to call mermaid.initialize.`
   }
 
   /**
-   * Updates a link's line interpolation algorithm
+   * Resolves a `linkStyle` position to `'default'` or an in-range edge index.
+   *
+   * The grammar hands positions over as raw lexemes, so an index arrives as a string
+   * (`'1'`, not `1`). The bounds check used to sit behind `typeof pos === 'number'` and
+   * therefore never ran: an out-of-range index fell through to `this.edges[pos]` and
+   * threw a bare `TypeError` instead of the message it means to give.
    */
-  public updateLinkInterpolate(positions: ('default' | number)[], interpolate: string) {
+  private resolveLinkPosition(pos: number | string): 'default' | number {
+    if (pos === 'default') {
+      return 'default';
+    }
+
+    const index = Number(pos);
+
+    if (!Number.isInteger(index) || index < 0 || index >= this.edges.length) {
+      throw new Error(
+        `The index ${pos} for linkStyle is out of bounds. Valid indices for linkStyle are between 0 and ${
+          this.edges.length - 1
+        }. (Help: Ensure that the index is within the range of existing edges.)`
+      );
+    }
+
+    return index;
+  }
+
+  /**
+   * Updates a link's line interpolation algorithm
+   *
+   * `positions` holds edge indices as the grammar produced them (strings), or the
+   * literal `'default'`.
+   */
+  public updateLinkInterpolate(positions: (number | string)[], interpolate: string) {
     positions.forEach((pos) => {
-      if (pos === 'default') {
+      const position = this.resolveLinkPosition(pos);
+      if (position === 'default') {
         this.edges.defaultInterpolate = interpolate;
       } else {
-        this.edges[pos].interpolate = interpolate;
+        this.edges[position].interpolate = interpolate;
       }
     });
   }
@@ -387,26 +417,22 @@ You have to call mermaid.initialize.`
   /**
    * Updates a link with a style
    *
+   * `positions` holds edge indices as the grammar produced them (strings), or the
+   * literal `'default'`.
    */
-  public updateLink(positions: ('default' | number)[], style: string[]) {
+  public updateLink(positions: (number | string)[], style: string[]) {
     positions.forEach((pos) => {
-      if (typeof pos === 'number' && pos >= this.edges.length) {
-        throw new Error(
-          `The index ${pos} for linkStyle is out of bounds. Valid indices for linkStyle are between 0 and ${
-            this.edges.length - 1
-          }. (Help: Ensure that the index is within the range of existing edges.)`
-        );
-      }
-      if (pos === 'default') {
+      const position = this.resolveLinkPosition(pos);
+      if (position === 'default') {
         this.edges.defaultStyle = style;
       } else {
-        this.edges[pos].style = style;
-        // if edges[pos].style does have fill not set, set it to none
+        this.edges[position].style = style;
+        // if edges[position].style does have fill not set, set it to none
         if (
-          (this.edges[pos]?.style?.length ?? 0) > 0 &&
-          !this.edges[pos]?.style?.some((s) => s?.startsWith('fill'))
+          (this.edges[position]?.style?.length ?? 0) > 0 &&
+          !this.edges[position]?.style?.some((s) => s?.startsWith('fill'))
         ) {
-          this.edges[pos]?.style?.push('fill:none');
+          this.edges[position]?.style?.push('fill:none');
         }
       }
     });

--- a/packages/mermaid/src/diagrams/flowchart/parser/flow-style.spec.js
+++ b/packages/mermaid/src/diagrams/flowchart/parser/flow-style.spec.js
@@ -286,18 +286,47 @@ describe('[Style] when parsing', () => {
     expect(edges[0].type).toBe('arrow_point');
   });
 
-  it('should handle style definitions within number of edges', function () {
+  it('should throw a descriptive error for a linkStyle index past the last edge', function () {
+    // `.toThrow` used to be chained onto `parse()` inside the arrow rather than onto the
+    // `expect`, so this asserted nothing and the raw TypeError below went unnoticed.
     expect(() =>
-      flow.parser
-        .parse(
-          `graph TD
+      flow.parser.parse(`graph TD
     A-->B
-    linkStyle 1 stroke-width:1px;`
-        )
-        .toThrow(
-          'The index 1 for linkStyle is out of bounds. Valid indices for linkStyle are between 0 and 0. (Help: Ensure that the index is within the range of existing edges.)'
-        )
+    linkStyle 1 stroke-width:1px;`)
+    ).toThrow(
+      'The index 1 for linkStyle is out of bounds. Valid indices for linkStyle are between 0 and 0. (Help: Ensure that the index is within the range of existing edges.)'
     );
+  });
+
+  it('should throw a descriptive error for an out-of-bounds linkStyle interpolate index', function () {
+    expect(() =>
+      flow.parser.parse(`graph TD
+    A-->B
+    linkStyle 1 interpolate basis`)
+    ).toThrow(
+      'The index 1 for linkStyle is out of bounds. Valid indices for linkStyle are between 0 and 0. (Help: Ensure that the index is within the range of existing edges.)'
+    );
+  });
+
+  it('should name the offending index when several are given', function () {
+    // The whole statement fails on the first bad index rather than styling the good ones.
+    expect(() =>
+      flow.parser.parse(`graph TD
+    A-->B
+    A-->C
+    linkStyle 0,5 stroke-width:1px;`)
+    ).toThrow('The index 5 for linkStyle is out of bounds');
+  });
+
+  it('should still accept the last valid index', function () {
+    flow.parser.parse(`graph TD
+    A-->B
+    A-->C
+    linkStyle 1 stroke-width:1px;`);
+
+    const edges = flow.parser.yy.getEdges();
+
+    expect(edges[1].style[0]).toBe('stroke-width:1px');
   });
 
   it('should handle style definitions within number of edges', function () {


### PR DESCRIPTION
Closes #8122.

## Problem

`FlowDB.updateLink` already contains the error this should produce:

```js
if (typeof pos === 'number' && pos >= this.edges.length) {
  throw new Error(`The index ${pos} for linkStyle is out of bounds. …`);
}
```

but the jison grammar builds `numList` straight from the `NUM` lexeme, so positions arrive as **strings** — `linkStyle 1` gives `"1"`. `typeof "1" === 'number'` is false, the guard is skipped, and `this.edges["1"].style = …` runs against an undefined edge.

I confirmed all three facts against `develop` before changing anything:

```
UPDATE_LINK_ERROR:  TypeError | Cannot set properties of undefined (setting 'style')
INTERPOLATE_ERROR:  TypeError | Cannot set properties of undefined (setting 'interpolate')
POSITIONS_TYPES:    [["string:\"0\""]]
```

That second line is a bug the issue doesn't mention: `updateLinkInterpolate` reads the same positions and has **no** bounds check at all, so `linkStyle 1 interpolate basis` fails the same way. Fixing only `updateLink` would have left it.

## Why it was never caught

The existing test intends to assert exactly this message, but the `.toThrow()` is chained onto `parse()` *inside* the arrow function instead of onto the `expect`:

```js
expect(() =>
  flow.parser.parse(`…`).toThrow('The index 1 for linkStyle is out of bounds. …')
);
```

`expect(fn)` with no matcher asserts nothing, so the test passed no matter what `parse` did. That is why the raw `TypeError` survived.

## Fix

Both entry points now resolve a position through one `resolveLinkPosition` helper that coerces the index and raises the message the guard always meant to give. Behaviour for `default`, for valid indices, and for multi-index statements (`linkStyle 0,1 …`) is unchanged.

The signatures said `('default' | number)[]`, which was never true at runtime; they now say `(number | string)[]` with the `'default'` sentinel documented. (`'default' | number | string` would be the clearer spelling, but `@typescript-eslint/no-redundant-type-constituents` rejects it as redundant.)

## Tests

The broken test now asserts, plus three more in `flow-style.spec.js`:

- an out-of-bounds index on `linkStyle … stroke-width` (the reported case)
- the same on `linkStyle … interpolate` (the unreported one)
- a multi-index statement naming the offending index
- the last valid index still applies, so the new bound isn't off by one

Reverting `flowDb.ts` fails exactly the three new negative cases; the fourth passes either way by design.

```
vitest run packages/mermaid/src/diagrams/flowchart
  -> 18 passed | 1 skipped, 986 tests passed | 3 skipped
eslint on both changed files -> no errors
```

`tsc -p packages/mermaid` reports only the pre-existing `Cannot find module '@mermaid-js/parser'` errors from the unbuilt workspace package — none in `flowDb.ts`.

## Notes

No rendering change, so no visual diff is expected. Patch changeset included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What's working well

- 🎉 Fixes the root cause by coercing grammar-produced string indices before bounds checks.
- 🎉 Applies the shared validation logic to both `updateLink` and `updateLinkInterpolate`.
- 🎉 Adds focused tests for invalid indices, multiple indices, interpolation, styling, and the last valid index.
- 🎉 Includes a patch changeset with a clear explanation of the user-visible fix.

## Security

No XSS or injection issues identified. The changes only validate flowchart link indices and do not modify SVG output or sanitization paths.

## Verdict

APPROVE

<!-- end of auto-generated comment: release notes by coderabbit.ai -->