### PR TITLE
fix(gantt): stop a trailing comma from killing the render

### DIFF
--- a/.changeset/gantt-trailing-comma.md
+++ b/.changeset/gantt-trailing-comma.md
@@ -2,4 +2,4 @@
 'mermaid': patch
 ---
 
-fix: report a Gantt task with more comma separated fields than it can have, instead of crashing at render. A trailing comma or an extra field pushed the task past the three fields the parser handles and fell through an empty `default:`, leaving it with no start time and throwing "Cannot read properties of undefined (reading 'type')" at draw time. It now fails at parse with the offending definition quoted.
+fix: report a Gantt task with more comma-separated fields than it can have, instead of crashing at render. A trailing comma or an extra field pushed the task past the three fields the parser handles and fell through an empty `default:`, leaving it with no start time and throwing "Cannot read properties of undefined (reading 'type')" at draw time. It now fails at parse with the offending definition quoted.

--- a/.changeset/gantt-trailing-comma.md
+++ b/.changeset/gantt-trailing-comma.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: stop a trailing comma on a Gantt task line from killing the render. The empty field pushed the task past the three fields the parser handles and fell through an empty `default:`, leaving the task with no start time and throwing "Cannot read properties of undefined (reading 'type')" at draw time. A trailing comma is now ignored, and a task with genuinely too many fields fails at parse with the offending line named.

--- a/.changeset/gantt-trailing-comma.md
+++ b/.changeset/gantt-trailing-comma.md
@@ -2,4 +2,4 @@
 'mermaid': patch
 ---
 
-fix: stop a trailing comma on a Gantt task line from killing the render. The empty field pushed the task past the three fields the parser handles and fell through an empty `default:`, leaving the task with no start time and throwing "Cannot read properties of undefined (reading 'type')" at draw time. A trailing comma is now ignored, and a task with genuinely too many fields fails at parse with the offending line named.
+fix: report a Gantt task with more comma separated fields than it can have, instead of crashing at render. A trailing comma or an extra field pushed the task past the three fields the parser handles and fell through an empty `default:`, leaving it with no start time and throwing "Cannot read properties of undefined (reading 'type')" at draw time. It now fails at parse with the offending definition quoted.

--- a/packages/mermaid/src/diagrams/gantt/ganttDb.js
+++ b/packages/mermaid/src/diagrams/gantt/ganttDb.js
@@ -446,31 +446,29 @@ const parseId = function (idStr) {
 // length
 
 /**
- * Trims a task's comma separated fields down to the forms the switches below handle.
+ * Rejects a task carrying more comma separated fields than the switches below handle.
  *
- * A trailing comma leaves an empty final field, which is a typo with only one sensible
- * reading, so it is dropped. Any other overflow cannot be guessed at and is reported
- * here — it used to fall through an empty `default:`, leaving the task with no
- * `startTime` and surfacing much later as "Cannot read properties of undefined
- * (reading 'type')" at render time, which says nothing about the line at fault.
+ * Those switches cover one, two and three fields and had an empty `default:`, so a task
+ * with more was built with neither a `startTime` nor an `endTime`. Nothing checked for
+ * that, and `compileTask` later read `.type` off the missing `startTime`, throwing
+ * "Cannot read properties of undefined (reading 'type')" at draw time — a render-time
+ * crash naming nothing that points back at the line at fault.
+ *
+ * Only the field *count* is checked. An empty field is meaningful inside the supported
+ * forms, where it marks an omitted value: `Milestone : vert, 01,` is a vert marker with
+ * a start and no end, and dropping its empty field would re-read the `01` as the end and
+ * move the marker.
  *
  * @param {string[]} data - The task's fields, already tag-stripped and trimmed.
  * @param {string} dataStr - The raw task definition, for the error message.
- * @returns {string[]} `data`, with any trailing empty field removed.
- * @throws {Error} If more fields remain than a task definition can have.
+ * @throws {Error} If there are more fields than a task definition can have.
  */
-const normalizeTaskData = function (data, dataStr) {
-  while (data.length > 1 && data[data.length - 1] === '') {
-    data.pop();
-  }
-
+const assertTaskFieldCount = function (data, dataStr) {
   if (data.length > 3) {
     throw new Error(
       `Invalid task definition "${dataStr}": a task takes at most 3 comma separated fields (id, start, end), but ${data.length} were given.`
     );
   }
-
-  return data;
 };
 
 const compileData = function (prevTask, dataStr) {
@@ -493,7 +491,7 @@ const compileData = function (prevTask, dataStr) {
     data[i] = data[i].trim();
   }
 
-  normalizeTaskData(data, dataStr);
+  assertTaskFieldCount(data, dataStr);
 
   let endTimeData = '';
   switch (data.length) {
@@ -543,7 +541,7 @@ const parseData = function (prevTaskId, dataStr) {
     data[i] = data[i].trim();
   }
 
-  normalizeTaskData(data, dataStr);
+  assertTaskFieldCount(data, dataStr);
 
   switch (data.length) {
     case 1:

--- a/packages/mermaid/src/diagrams/gantt/ganttDb.js
+++ b/packages/mermaid/src/diagrams/gantt/ganttDb.js
@@ -445,6 +445,34 @@ const parseId = function (idStr) {
 // endDate
 // length
 
+/**
+ * Trims a task's comma separated fields down to the forms the switches below handle.
+ *
+ * A trailing comma leaves an empty final field, which is a typo with only one sensible
+ * reading, so it is dropped. Any other overflow cannot be guessed at and is reported
+ * here — it used to fall through an empty `default:`, leaving the task with no
+ * `startTime` and surfacing much later as "Cannot read properties of undefined
+ * (reading 'type')" at render time, which says nothing about the line at fault.
+ *
+ * @param {string[]} data - The task's fields, already tag-stripped and trimmed.
+ * @param {string} dataStr - The raw task definition, for the error message.
+ * @returns {string[]} `data`, with any trailing empty field removed.
+ * @throws {Error} If more fields remain than a task definition can have.
+ */
+const normalizeTaskData = function (data, dataStr) {
+  while (data.length > 1 && data[data.length - 1] === '') {
+    data.pop();
+  }
+
+  if (data.length > 3) {
+    throw new Error(
+      `Invalid task definition "${dataStr}": a task takes at most 3 comma separated fields (id, start, end), but ${data.length} were given.`
+    );
+  }
+
+  return data;
+};
+
 const compileData = function (prevTask, dataStr) {
   let ds;
 
@@ -464,6 +492,8 @@ const compileData = function (prevTask, dataStr) {
   for (let i = 0; i < data.length; i++) {
     data[i] = data[i].trim();
   }
+
+  normalizeTaskData(data, dataStr);
 
   let endTimeData = '';
   switch (data.length) {
@@ -512,6 +542,8 @@ const parseData = function (prevTaskId, dataStr) {
   for (let i = 0; i < data.length; i++) {
     data[i] = data[i].trim();
   }
+
+  normalizeTaskData(data, dataStr);
 
   switch (data.length) {
     case 1:

--- a/packages/mermaid/src/diagrams/gantt/ganttDb.js
+++ b/packages/mermaid/src/diagrams/gantt/ganttDb.js
@@ -446,7 +446,7 @@ const parseId = function (idStr) {
 // length
 
 /**
- * Rejects a task carrying more comma separated fields than the switches below handle.
+ * Rejects a task carrying more comma-separated fields than the switches below handle.
  *
  * Those switches cover one, two and three fields and had an empty `default:`, so a task
  * with more was built with neither a `startTime` nor an `endTime`. Nothing checked for
@@ -466,7 +466,7 @@ const parseId = function (idStr) {
 const assertTaskFieldCount = function (data, dataStr) {
   if (data.length > 3) {
     throw new Error(
-      `Invalid task definition "${dataStr}": a task takes at most 3 comma separated fields (id, start, end), but ${data.length} were given.`
+      `Invalid task definition "${dataStr}": a task takes at most 3 comma-separated fields (id, start, end), but ${data.length} were given.`
     );
   }
 };

--- a/packages/mermaid/src/diagrams/gantt/parser/gantt.spec.js
+++ b/packages/mermaid/src/diagrams/gantt/parser/gantt.spec.js
@@ -137,6 +137,50 @@ describe('when parsing a gantt diagram it', function () {
     expect(tasks[0].id).toEqual('des1');
     expect(tasks[0].task).toEqual('Design jison grammar');
   });
+  it('should ignore a trailing comma on a task line', function () {
+    // The empty field left by the trailing comma pushed the field count past the three
+    // the parser handles, so the task was built without a startTime and only failed at
+    // render with "Cannot read properties of undefined (reading 'type')".
+    const str =
+      'gantt\n' + 'dateFormat YYYY-MM-DD\n' + 'section S\n' + 'Task A :a1, 2024-01-01, 30d,\n';
+
+    expect(parserFnConstructor(str)).not.toThrow();
+
+    const tasks = parser.yy.getTasks();
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].id).toEqual('a1');
+    expect(tasks[0].startTime).toEqual(new Date(2024, 0, 1));
+  });
+
+  it('should ignore a trailing comma after a tagged task', function () {
+    const str =
+      'gantt\n' +
+      'dateFormat YYYY-MM-DD\n' +
+      'section S\n' +
+      'Task A :crit, a1, 2024-01-01, 30d,\n';
+
+    expect(parserFnConstructor(str)).not.toThrow();
+
+    const tasks = parser.yy.getTasks();
+
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].id).toEqual('a1');
+    expect(tasks[0].crit).toBe(true);
+    expect(tasks[0].startTime).toEqual(new Date(2024, 0, 1));
+  });
+
+  it('should report a task carrying more fields than it can have', function () {
+    // Nothing sensible can be guessed here, so it fails with the line at fault named
+    // rather than falling through and crashing at render.
+    const str =
+      'gantt\n' + 'dateFormat YYYY-MM-DD\n' + 'section S\n' + 'Task A :a1, 2024-01-01, 30d, junk\n';
+
+    expect(parserFnConstructor(str)).toThrow(
+      'Invalid task definition ":a1, 2024-01-01, 30d, junk": a task takes at most 3 comma separated fields (id, start, end), but 4 were given.'
+    );
+  });
+
   it('should handle a task with start/end time relative to other tasks', function () {
     const str =
       'gantt\n' +

--- a/packages/mermaid/src/diagrams/gantt/parser/gantt.spec.js
+++ b/packages/mermaid/src/diagrams/gantt/parser/gantt.spec.js
@@ -137,48 +137,46 @@ describe('when parsing a gantt diagram it', function () {
     expect(tasks[0].id).toEqual('des1');
     expect(tasks[0].task).toEqual('Design jison grammar');
   });
-  it('should ignore a trailing comma on a task line', function () {
-    // The empty field left by the trailing comma pushed the field count past the three
-    // the parser handles, so the task was built without a startTime and only failed at
-    // render with "Cannot read properties of undefined (reading 'type')".
+  it('should report a trailing comma after a full task line', function () {
+    // The empty field left by the trailing comma pushes the count past the three the
+    // parser handles, so the task used to be built without a startTime and only failed
+    // at render with "Cannot read properties of undefined (reading 'type')".
     const str =
       'gantt\n' + 'dateFormat YYYY-MM-DD\n' + 'section S\n' + 'Task A :a1, 2024-01-01, 30d,\n';
 
-    expect(parserFnConstructor(str)).not.toThrow();
-
-    const tasks = parser.yy.getTasks();
-
-    expect(tasks).toHaveLength(1);
-    expect(tasks[0].id).toEqual('a1');
-    expect(tasks[0].startTime).toEqual(new Date(2024, 0, 1));
-  });
-
-  it('should ignore a trailing comma after a tagged task', function () {
-    const str =
-      'gantt\n' +
-      'dateFormat YYYY-MM-DD\n' +
-      'section S\n' +
-      'Task A :crit, a1, 2024-01-01, 30d,\n';
-
-    expect(parserFnConstructor(str)).not.toThrow();
-
-    const tasks = parser.yy.getTasks();
-
-    expect(tasks).toHaveLength(1);
-    expect(tasks[0].id).toEqual('a1');
-    expect(tasks[0].crit).toBe(true);
-    expect(tasks[0].startTime).toEqual(new Date(2024, 0, 1));
+    expect(parserFnConstructor(str)).toThrow(
+      'Invalid task definition ":a1, 2024-01-01, 30d,": a task takes at most 3 comma separated fields (id, start, end), but 4 were given.'
+    );
   });
 
   it('should report a task carrying more fields than it can have', function () {
-    // Nothing sensible can be guessed here, so it fails with the line at fault named
-    // rather than falling through and crashing at render.
     const str =
       'gantt\n' + 'dateFormat YYYY-MM-DD\n' + 'section S\n' + 'Task A :a1, 2024-01-01, 30d, junk\n';
 
     expect(parserFnConstructor(str)).toThrow(
       'Invalid task definition ":a1, 2024-01-01, 30d, junk": a task takes at most 3 comma separated fields (id, start, end), but 4 were given.'
     );
+  });
+
+  it('should keep the empty end field of a vert marker', function () {
+    // `vert, 01,` is two fields once the tag is stripped — a start with the end left
+    // empty — and is the form the vert-tag rendering fixture uses. Treating the empty
+    // field as a stray trailing comma and dropping it would re-read the `01` as the end
+    // and move the marker off its start.
+    const str =
+      'gantt\n' +
+      'dateFormat ss\n' +
+      'section S\n' +
+      'A task    : a1, 00, 6s\n' +
+      'Milestone : vert, 01,\n';
+
+    expect(parserFnConstructor(str)).not.toThrow();
+
+    const marker = parser.yy.getTasks()[1];
+
+    expect(marker.vert).toBe(true);
+    expect(marker.startTime).toEqual(marker.endTime);
+    expect(marker.startTime.getSeconds()).toEqual(1);
   });
 
   it('should handle a task with start/end time relative to other tasks', function () {

--- a/packages/mermaid/src/diagrams/gantt/parser/gantt.spec.js
+++ b/packages/mermaid/src/diagrams/gantt/parser/gantt.spec.js
@@ -145,7 +145,7 @@ describe('when parsing a gantt diagram it', function () {
       'gantt\n' + 'dateFormat YYYY-MM-DD\n' + 'section S\n' + 'Task A :a1, 2024-01-01, 30d,\n';
 
     expect(parserFnConstructor(str)).toThrow(
-      'Invalid task definition ":a1, 2024-01-01, 30d,": a task takes at most 3 comma separated fields (id, start, end), but 4 were given.'
+      'Invalid task definition ":a1, 2024-01-01, 30d,": a task takes at most 3 comma-separated fields (id, start, end), but 4 were given.'
     );
   });
 
@@ -154,7 +154,7 @@ describe('when parsing a gantt diagram it', function () {
       'gantt\n' + 'dateFormat YYYY-MM-DD\n' + 'section S\n' + 'Task A :a1, 2024-01-01, 30d, junk\n';
 
     expect(parserFnConstructor(str)).toThrow(
-      'Invalid task definition ":a1, 2024-01-01, 30d, junk": a task takes at most 3 comma separated fields (id, start, end), but 4 were given.'
+      'Invalid task definition ":a1, 2024-01-01, 30d, junk": a task takes at most 3 comma-separated fields (id, start, end), but 4 were given.'
     );
   });
 


### PR DESCRIPTION
Closes #8123.

## Problem

A task's fields are dispatched on `switch (data.length)` with cases for 1, 2 and 3 and an **empty `default:`**. Anything with more fields is built with neither a `startTime` nor an `endTime`. Nothing checks for that, and `compileTask` later reads `.type` off the missing `startTime`.

I probed the reported cases against `develop` before changing anything:

```
trailing (`30d,`)                 parse=ok   getTasks=TypeError: Cannot read properties of undefined (reading 'type')
extra    (`30d, junk`)            parse=ok   getTasks=TypeError: Cannot read properties of undefined (reading 'type')
doubled  (`a1, , 30d`)            parse=ok   getTasks=Error: Invalid date:
valid                             parse=ok   getTasks=ok(1)
```

Two notes on the issue's framing, from that output:

- The trigger is **any field count above three**, not an empty field as such — `:a1, 2024-01-01, 30d, junk` crashes identically with nothing empty in it.
- The **doubled comma** (`:a1, , 30d`) does *not* take this path. It stays at 3 fields, hits `case 3`, and fails with `Invalid date:` — already an error rather than a crash, so I left it alone rather than widen the scope.

## Fix

The field count is validated before the switch. A task with more fields than the grammar has meaning for fails at parse with the definition quoted:

```
Invalid task definition ":a1, 2024-01-01, 30d,": a task takes at most 3 comma separated fields (id, start, end), but 4 were given.
```

That is strictly better than today for every input that reaches it: all of them currently crash at render, pointing at nothing.

This is the second of the two outcomes the issue offered. **I first tried the first one** — dropping the empty field left by a trailing comma so the diagram renders — and it was wrong. An empty field is meaningful inside the supported forms, where it marks an omitted value. The vert-tag rendering fixture uses:

```
Milestone     : vert, 01,
```

which is two fields once the tag is stripped: a start of `01` with the end left empty. Dropping the empty field re-read the `01` as the end, so the marker moved off second 01 and came back with an end before its start:

| | Milestone `vert` marker |
| --- | --- |
| `develop` | start=01, end=01 — zero-width marker at second 01 |
| dropping the empty field | start=06, end=01 — moved, end before start |

Argos caught it as a changed snapshot. Only the count is checked now, and there is a test pinning the vert form so it cannot regress again.

`parseData` and `compileData` split fields identically and shared the same hole, so the check lives in one helper used by both. It runs after `getTaskTags` has stripped tags, so tagged tasks are counted correctly.

## Tests

- a trailing comma after a full three-field task reports the error
- a task with four real fields reports it too
- the vert marker keeps its empty end field, staying a zero-width marker at its start

The first two fail against `develop`; the third passes there by design — it guards behaviour that already worked.

```
vitest run packages/mermaid/src/diagrams/gantt
  -> 2 files passed, 79 passed | 1 skipped
eslint on both changed files -> no errors
```

Patch changeset included. Valid diagrams are unaffected, so no visual diff is expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes Gantt task parsing for unsupported comma-separated field counts.

- Rejects task definitions with more than three fields during parsing.
- Reports the malformed task definition and field count.
- Preserves empty fields in supported syntax, including vertical-tag tasks.
- Adds regression tests for trailing commas, excessive fields, and vertical-tag markers.
- Adds a patch changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->