### PR TITLE
fix(kanban): support accTitle and accDescr accessibility directives

### DIFF
--- a/packages/mermaid/src/diagrams/kanban/kanban.spec.ts
+++ b/packages/mermaid/src/diagrams/kanban/kanban.spec.ts
@@ -542,7 +542,9 @@ describe('accessibility directives (issue #8120)', function () {
 `;
     kanban.parse(str);
     expect(kanban.yy.getAccTitle()).toEqual('Multi-line board');
-    expect(kanban.yy.getAccDescription()).toEqual('Line 1\n    Line 2'.replace(/^    /gm, '').trimEnd());
+    expect(kanban.yy.getAccDescription()).toEqual(
+      'Line 1\n    Line 2'.replace(/^ {4}/gm, '').trimEnd()
+    );
 
     const sections = kanban.yy.getSections();
     expect(sections.length).toEqual(1);

--- a/packages/mermaid/src/diagrams/kanban/kanban.spec.ts
+++ b/packages/mermaid/src/diagrams/kanban/kanban.spec.ts
@@ -492,3 +492,75 @@ describe('item data data', function () {
     expect(sections[0].ticket).toEqual('MC-1234');
   });
 });
+
+describe('accessibility directives (issue #8120)', function () {
+  beforeEach(function () {
+    kanban.yy = kanbanDB;
+    kanban.yy.clear();
+  });
+
+  it('should support accTitle and not treat it as a column node', function () {
+    const str = `kanban
+  accTitle: My Kanban Board
+  id1[Todo]
+    task1[Buy milk]
+`;
+    kanban.parse(str);
+    expect(kanban.yy.getAccTitle()).toEqual('My Kanban Board');
+
+    const sections = kanban.yy.getSections();
+    expect(sections.length).toEqual(1);
+    expect(sections[0].id).toEqual('id1');
+    expect(sections[0].label).toEqual('Todo');
+  });
+
+  it('should support single-line accDescr and not treat it as a column node', function () {
+    const str = `kanban
+  accTitle: Project Board
+  accDescr: Simple board describing project tasks
+  col1[In Progress]
+    task1[Write docs]
+`;
+    kanban.parse(str);
+    expect(kanban.yy.getAccTitle()).toEqual('Project Board');
+    expect(kanban.yy.getAccDescription()).toEqual('Simple board describing project tasks');
+
+    const sections = kanban.yy.getSections();
+    expect(sections.length).toEqual(1);
+    expect(sections[0].id).toEqual('col1');
+  });
+
+  it('should support multi-line accDescr block', function () {
+    const str = `kanban
+  accTitle: Multi-line board
+  accDescr {
+    Line 1
+    Line 2
+  }
+  col1[Done]
+    task1[Finished]
+`;
+    kanban.parse(str);
+    expect(kanban.yy.getAccTitle()).toEqual('Multi-line board');
+    expect(kanban.yy.getAccDescription()).toEqual('Line 1\n    Line 2'.replace(/^    /gm, '').trimEnd());
+
+    const sections = kanban.yy.getSections();
+    expect(sections.length).toEqual(1);
+    expect(sections[0].id).toEqual('col1');
+  });
+
+  it('should clear accessibility state on clear()', function () {
+    const str = `kanban
+  accTitle: Board Title
+  accDescr: Board Description
+  col1[Backlog]
+`;
+    kanban.parse(str);
+    expect(kanban.yy.getAccTitle()).toEqual('Board Title');
+    expect(kanban.yy.getAccDescription()).toEqual('Board Description');
+
+    kanban.yy.clear();
+    expect(kanban.yy.getAccTitle()).toEqual('');
+    expect(kanban.yy.getAccDescription()).toEqual('');
+  });
+});

--- a/packages/mermaid/src/diagrams/kanban/kanbanDb.ts
+++ b/packages/mermaid/src/diagrams/kanban/kanbanDb.ts
@@ -1,6 +1,13 @@
 import { getConfig } from '../../diagram-api/diagramAPI.js';
 import type { D3Element } from '../../types.js';
 import { sanitizeText } from '../../diagrams/common/common.js';
+import {
+  setAccTitle,
+  getAccTitle,
+  setAccDescription,
+  getAccDescription,
+  clear as clearCommon,
+} from '../../diagrams/common/commonDb.js';
 import { log } from '../../logger.js';
 import type { Edge, KanbanNode } from '../../rendering-util/types.js';
 import defaultConfig from '../../defaultConfig.js';
@@ -17,6 +24,7 @@ const clear = () => {
   sections = [];
   cnt = 0;
   elements = {};
+  clearCommon();
 };
 /*
  * if your level is the section level return null - then you do not belong to a level
@@ -250,6 +258,10 @@ const db = {
   type2Str,
   getLogger,
   getElementById,
+  setAccTitle,
+  getAccTitle,
+  setAccDescription,
+  getAccDescription,
 } as const;
 
 export default db;

--- a/packages/mermaid/src/diagrams/kanban/parser/kanban.jison
+++ b/packages/mermaid/src/diagrams/kanban/parser/kanban.jison
@@ -18,6 +18,9 @@
 %x shapeData
 %x shapeDataStr
 %x shapeDataEndBracket
+%x acc_title
+%x acc_descr
+%x acc_descr_multiline
 
 %%
 
@@ -48,6 +51,13 @@
 \s*\%\%.*          {yy.getLogger().trace('Found comment',yytext); return 'SPACELINE';}
 // \%\%[^\n]*\n                             /* skip comments */
 "kanban"		       {return 'KANBAN';}
+accTitle\s*":"\s*                               { this.begin("acc_title");return 'acc_title'; }
+<acc_title>(?!\n|;|#)*[^\n]*                    { this.popState(); return "acc_title_value"; }
+accDescr\s*":"\s*                               { this.begin("acc_descr");return 'acc_descr'; }
+<acc_descr>(?!\n|;|#)*[^\n]*                    { this.popState(); return "acc_descr_value"; }
+accDescr\s*"{"\s*                               { this.begin("acc_descr_multiline");}
+<acc_descr_multiline>[\}]                       { this.popState(); }
+<acc_descr_multiline>[^\}]*                     return "acc_descr_multiline_value";
 ":::"              { this.begin('CLASS'); }
 <CLASS>.+			     { this.popState();return 'CLASS'; }
 <CLASS>\n				   { this.popState();}
@@ -134,6 +144,12 @@ statement
 	| ICON                 { yy.decorateNode({icon: $1}); }
 	| CLASS                { yy.decorateNode({class: $1}); }
   | SPACELIST
+  | acc_title acc_title_value  { $$=$2.trim();yy.setAccTitle($$); }
+  | acc_descr acc_descr_value  { $$=$2.trim();yy.setAccDescription($$); }
+  | acc_descr_multiline_value { $$=$1.trim();yy.setAccDescription($$); }
+  | SPACELIST acc_title acc_title_value  { $$=$3.trim();yy.setAccTitle($$); }
+  | SPACELIST acc_descr acc_descr_value  { $$=$3.trim();yy.setAccDescription($$); }
+  | SPACELIST acc_descr_multiline_value { $$=$2.trim();yy.setAccDescription($$); }
 	;
 
 


### PR DESCRIPTION
## Summary

Fixes #8120 - Kanban diagrams had no support for the standard accTitle/accDescr accessibility directives. Two failure modes existed:

- Inline form (accTitle: My board) was silently parsed as a board column, producing a spurious node.
- Block form (accDescr { ... }) crashed with a lex error (unexpected character: ->{<-).

The result: every kanban SVG was shipped with no <title> or <desc> element.

## Changes

### kanbanDb.ts
- Import setAccTitle, getAccTitle, setAccDescription, getAccDescription, and clear as clearCommon from commonDb.js.
- Call clearCommon() inside clear() so accessibility state resets between renders.
- Expose all four accessors on the exported db object.

### kanban.jison
- Declare %x acc_title, %x acc_descr, %x acc_descr_multiline lexer states.
- Add lex rules for accTitle:, accDescr:, and the accDescr { } block form before the NODE_ID catch-all.
- Wire grammar statement alternatives to call yy.setAccTitle / yy.setAccDescription.

### kanban.spec.ts
Added accessibility directives (issue #8120) describe block with 4 tests:
1. accTitle: sets title and produces no spurious column node.
2. Single-line accDescr: sets description and produces no spurious column node.
3. Multi-line accDescr block sets description.
4. clear() resets both title and description.

All 34 kanban tests pass (30 pre-existing + 4 new).

## Testing

pnpm vitest run packages/mermaid/src/diagrams/kanban/kanban.spec.ts
Test Files  1 passed (1)
Tests  34 passed (34)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What's working well

- 🎉 Adds `accTitle` and `accDescr` support for Kanban diagrams.
- 🎉 Prevents directives from becoming column nodes.
- 🎉 Clears accessibility state through `clear()`.
- 🎉 Adds tests for titles, descriptions, multiline descriptions, and state reset.
- 🎉 Reuses shared accessibility database helpers.

## Security

No XSS or injection issues identified.

## Things to address

- 🟡 **[important]** Add a rendering test that verifies Kanban SVG output contains `<title>` and `<desc>` elements. The current tests verify parser and database state only.

## Self-check

- [x] Includes praise.
- [x] No duplicate findings.
- [x] Severity tally: 0 blocking / 1 important / 0 nit / 0 suggestion / 5 praise.
- [x] Verdict matches criteria: COMMENT.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->