### PR TITLE
docs(c4): say that the example's red styling is a demonstration

### DIFF
--- a/docs/syntax/c4.md
+++ b/docs/syntax/c4.md
@@ -104,6 +104,8 @@ Mermaid's C4 diagram syntax is compatible with plantUML. See example below:
 
 ```
 
+The colours in this example are a demonstration of custom styling, not the defaults. `UpdateElementStyle` turns "Banking Customer A" red, and the `UpdateRelStyle` statements beside it recolour four relationships - three blue, including the one leaving "Banking Customer A", and the one arriving from the e-mail system red. Remove those statements and every element and relationship renders in the standard C4 palette.
+
 For an example, see the source code demos/index.html
 
 5 types of C4 charts are supported.
@@ -317,6 +319,8 @@ config:
       UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
 
 ```
+
+As above, "Banking Customer A" is red because the example restyles it with `UpdateElementStyle`, not because that is the default appearance of a `Person`.
 
 ## C4 Container diagram (C4Container)
 

--- a/packages/mermaid/src/docs/syntax/c4.md
+++ b/packages/mermaid/src/docs/syntax/c4.md
@@ -51,6 +51,8 @@ Mermaid's C4 diagram syntax is compatible with plantUML. See example below:
 
 ```
 
+The colours in this example are a demonstration of custom styling, not the defaults. `UpdateElementStyle` turns "Banking Customer A" red, and the `UpdateRelStyle` statements beside it recolour four relationships - three blue, including the one leaving "Banking Customer A", and the one arriving from the e-mail system red. Remove those statements and every element and relationship renders in the standard C4 palette.
+
 For an example, see the source code demos/index.html
 
 5 types of C4 charts are supported.
@@ -215,6 +217,8 @@ config:
       UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
 
 ```
+
+As above, "Banking Customer A" is red because the example restyles it with `UpdateElementStyle`, not because that is the default appearance of a `Person`.
 
 ## C4 Container diagram (C4Container)
 


### PR DESCRIPTION
Fixes #7491.

The canonical `C4Context` example in the docs doubles as a styling demonstration:

```
UpdateElementStyle(customerA, $fontColor="red", $bgColor="grey", $borderColor="red")
UpdateRelStyle(customerA, SystemAA, $textColor="blue", $lineColor="blue", $offsetX="5")
```

Nothing near the example says so, so a reader reasonably takes the result as the default appearance and concludes that the first `Person` renders differently from the others. That is exactly how it was reported: red border, red title, red description, red relationship arrows - every symptom traceable to those two statements, and none of them present when the same source is rendered without them.

This adds a note under the example rather than changing it, so the demonstration stays where it is. The example appears twice on the page (the intro and the `C4Context` section), so there is a note under each.

@pbrolin47 confirmed on the issue that a minor documentation update is a fine resolution here. The generated `docs/syntax/c4.md` is regenerated from the source page in the same commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Review plan

| Tier | Count | Files |
|---|---:|---|
| Tier 1 | 0 | — |
| Tier 2 | 0 | — |
| Tier 3 | 2 | `docs/syntax/c4.md`, `packages/mermaid/src/docs/syntax/c4.md` |
| Skip | 0 | — |

The PR updates C4 documentation only. No runtime code, public API, parser, renderer, or test files changed.

## What's working well

- 🎉 The documentation explains that the red styling is intentional.
- 🎉 The note identifies `UpdateElementStyle` and `UpdateRelStyle` as the source of the styling.
- 🎉 The clarification distinguishes the blue outgoing relationship from the red incoming relationship.
- 🎉 The change addresses issue `#7491` without changing rendering behavior.
- 🎉 Both documentation copies were updated consistently.

## Security

No XSS or injection issues identified.

## Findings

No blocking or important issues found.

## Verdict

**APPROVE**

Severity tally: 0 blocking / 0 important / 0 nit / 0 suggestion / 5 praise
<!-- end of auto-generated comment: release notes by coderabbit.ai -->