### PR TITLE
fix: draw a marker for single-point xychart line series

### DIFF
--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/linePlot.spec.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/linePlot.spec.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import type { Axis } from '../axis/index.js';
+import type { LinePlotData } from '../../interfaces.js';
+import { LinePlot } from './linePlot.js';
+
+function createAxis(scale: (value: string | number) => number): Axis {
+  return { getScaleValue: scale } as Axis;
+}
+
+function linePlotData(data: LinePlotData['data'], strokeFill = '#f00'): LinePlotData {
+  return {
+    type: 'line',
+    title: 'series',
+    strokeFill,
+    strokeWidth: 2,
+    data,
+  };
+}
+
+describe('LinePlot', () => {
+  it('emits a point marker for a single-datum series', () => {
+    const xAxis = createAxis((value) => (value === 'Total' ? 100 : Number(value)));
+    const yAxis = createAxis((value) => Number(value) * 2);
+    const plot = new LinePlot(
+      linePlotData([['Total', 42]], '#ECECFF'),
+      xAxis,
+      yAxis,
+      'vertical',
+      0
+    );
+
+    const drawables = plot.getDrawableElement();
+
+    expect(drawables).toHaveLength(2);
+    expect(drawables[0]).toMatchObject({
+      groupTexts: ['plot', 'line-plot-0'],
+      type: 'path',
+      data: [{ strokeFill: '#ECECFF', strokeWidth: 2 }],
+    });
+    expect(drawables[1]).toEqual({
+      groupTexts: ['plot', 'line-plot-0'],
+      type: 'circle',
+      data: [
+        {
+          x: 100,
+          y: 84,
+          radius: 3,
+          fill: '#ECECFF',
+        },
+      ],
+    });
+  });
+
+  it('swaps coordinates for a single-datum horizontal series', () => {
+    const xAxis = createAxis((value) => (value === 'Total' ? 100 : Number(value)));
+    const yAxis = createAxis((value) => Number(value) * 2);
+    const plot = new LinePlot(linePlotData([['Total', 42]]), xAxis, yAxis, 'horizontal', 0);
+
+    const drawables = plot.getDrawableElement();
+    const marker = drawables.find((drawable) => drawable.type === 'circle');
+
+    expect(marker).toEqual({
+      groupTexts: ['plot', 'line-plot-0'],
+      type: 'circle',
+      data: [
+        {
+          x: 84,
+          y: 100,
+          radius: 3,
+          fill: '#f00',
+        },
+      ],
+    });
+  });
+
+  it('does not emit a point marker for a multi-datum series', () => {
+    const xAxis = createAxis((value) => (value === 'A' ? 0 : 1));
+    const yAxis = createAxis((value) => Number(value));
+    const plot = new LinePlot(
+      linePlotData([
+        ['A', 10],
+        ['B', 20],
+      ]),
+      xAxis,
+      yAxis,
+      'vertical',
+      0
+    );
+
+    const drawables = plot.getDrawableElement();
+
+    expect(drawables).toHaveLength(1);
+    expect(drawables[0].type).toBe('path');
+    expect(drawables.some((drawable) => drawable.type === 'circle')).toBe(false);
+  });
+});

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/linePlot.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/components/plot/linePlot.ts
@@ -45,6 +45,23 @@ export class LinePlot {
       },
     ];
 
+    // A single datum produces a zero-length M...Z path that paints nothing.
+    if (finalData.length === 1) {
+      const [px, py] = finalData[0];
+      elements.push({
+        groupTexts: ['plot', `line-plot-${this.plotIndex}`],
+        type: 'circle',
+        data: [
+          {
+            x: this.orientation === 'horizontal' ? py : px,
+            y: this.orientation === 'horizontal' ? px : py,
+            radius: Math.max(3, this.plotData.strokeWidth),
+            fill: this.plotData.strokeFill,
+          },
+        ],
+      });
+    }
+
     if (this.plotData.pointLabels && this.plotData.pointLabels.length > 0) {
       const labelOffset = 10;
       const fontSize = 12;

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/interfaces.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/interfaces.ts
@@ -162,6 +162,11 @@ export interface PathElem {
   strokeFill: string;
 }
 
+export interface CircleElem extends Point {
+  radius: number;
+  fill: string;
+}
+
 export type DrawableElem =
   | {
       groupTexts: string[];
@@ -177,4 +182,9 @@ export type DrawableElem =
       groupTexts: string[];
       type: 'path';
       data: PathElem[];
+    }
+  | {
+      groupTexts: string[];
+      type: 'circle';
+      data: CircleElem[];
     };

--- a/packages/mermaid/src/diagrams/xychart/xychartRenderer.ts
+++ b/packages/mermaid/src/diagrams/xychart/xychartRenderer.ts
@@ -253,6 +253,17 @@ export const draw = (txt: string, id: string, _version: string, diagObj: Diagram
           .attr('stroke', (data) => data.strokeFill)
           .attr('stroke-width', (data) => data.strokeWidth);
         break;
+      case 'circle':
+        shapeGroup
+          .selectAll('circle')
+          .data(shape.data)
+          .enter()
+          .append('circle')
+          .attr('cx', (data) => data.x)
+          .attr('cy', (data) => data.y)
+          .attr('r', (data) => data.radius)
+          .attr('fill', (data) => data.fill);
+        break;
     }
   }
 };


### PR DESCRIPTION
Fixes #8153

A one-point xychart-beta line series emitted a zero-length path and no marker, so the plot was blank. Draw a filled circle at the scaled point in the series color. Multi-point series unchanged.

Adds linePlot.spec.ts. 70 xychart unit tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Review

### What's working well

- 🎉 Fixes the zero-length SVG path case with a visible filled circle.
- 🎉 Preserves existing multi-point line rendering.
- 🎉 Handles horizontal plots by swapping marker coordinates.
- 🎉 Adds focused unit tests for single-point and multi-point series.
- 🎉 Keeps marker styling aligned with the series stroke color.

### Things to address

- 🟡 **[important] Renderer coverage:** `linePlot.spec.ts` verifies drawable data, but the renderer now has a new `circle` SVG branch. Please add an E2E rendering test using `imgSnapshotTest()` to verify that the marker appears in the final SVG and remains correct across chart orientations and themes.

### Security

No XSS or injection issues identified. The change only adds numeric SVG attributes and a series-derived fill value through the existing renderer path.

### Verdict

**COMMENT**

### Self-check

- [x] At least one 🎉 praise item exists.
- [x] No duplicate findings.
- [x] Severity tally: 0 blocking / 1 important / 0 nit / 0 suggestion / 5 praise.
- [x] Verdict matches the findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->