### PR TITLE
fix: stop sanitizeDirective from stripping treeView/packet/state/git theme variables

### DIFF
--- a/.changeset/theme-variables-stripped-by-sanitize-directive.md
+++ b/.changeset/theme-variables-stripped-by-sanitize-directive.md
@@ -1,0 +1,11 @@
+---
+'mermaid': patch
+---
+
+fix: several documented theme variables set through frontmatter or `%%{init}%%` were silently dropped before reaching the renderer, even though the identical variable worked fine when passed to `mermaid.initialize({ themeVariables: ... })`.
+
+`sanitizeDirective` only keeps a key if its bare name shows up somewhere in `configKeys`, a flat set built from `defaultConfig`. `defaultConfig.themeVariables` comes from the default theme's `getThemeVariables()`, which never defined `treeView.iconColor`, `treeView.descriptionColor`, `treeView.highlightBg`, `treeView.highlightStroke`, `packet.startByteColor`, `packet.endByteColor`, `packet.blockStrokeColor`, `packet.blockFillColor`, `stateBorder`, or `commitLineColor` (those only exist on the redux themes). Frontmatter setting any of them was stripped before the theme was calculated, while the exact same key worked through site config.
+
+The default theme now defines all of these, matching the hardcoded fallback values each diagram's own styles already used, so the default rendering is unchanged and the frontmatter path now works the same as `initialize()`.
+
+`requirementEdgeLabelBackground` from the same report is left for a follow-up: besides supplying a background color, its mere presence also flips a styling condition in `requirementBox.ts`, so giving it a default value would change more than just frontmatter support and needs a closer look first.

--- a/packages/mermaid/src/themes/theme-default.js
+++ b/packages/mermaid/src/themes/theme-default.js
@@ -242,6 +242,7 @@ class Theme {
     this.compositeBorder = this.compositeBorder || this.nodeBorder;
     this.innerEndBackground = this.nodeBorder;
     this.specialStateColor = this.lineColor;
+    this.stateBorder = this.stateBorder || this.nodeBorder;
 
     this.errorBkgColor = this.errorBkgColor || this.tertiaryColor;
     this.errorTextColor = this.errorTextColor || this.tertiaryTextColor;
@@ -389,6 +390,26 @@ class Theme {
         '#ECECFF,#8493A6,#FFC3A0,#DCDDE1,#B8E994,#D1A36F,#C3CDE6,#FFB6C1,#496078,#F8F3E3',
     };
 
+    /* treeView */
+    this.treeView = {
+      labelColor: this.treeView?.labelColor || 'black',
+      lineColor: this.treeView?.lineColor || 'black',
+      iconColor: this.treeView?.iconColor || '#546e7a',
+      descriptionColor: this.treeView?.descriptionColor || '#6a9955',
+      highlightBg: this.treeView?.highlightBg || 'rgba(255, 193, 7, 0.15)',
+      highlightStroke: this.treeView?.highlightStroke || '#ffc107',
+    };
+
+    /* packet */
+    this.packet = {
+      startByteColor: this.packet?.startByteColor || 'black',
+      endByteColor: this.packet?.endByteColor || 'black',
+      labelColor: this.packet?.labelColor || 'black',
+      titleColor: this.packet?.titleColor || 'black',
+      blockStrokeColor: this.packet?.blockStrokeColor || 'black',
+      blockFillColor: this.packet?.blockFillColor || '#efefef',
+    };
+
     /* requirement-diagram */
     this.requirementBackground = this.requirementBackground || this.primaryColor;
     this.requirementBorderColor = this.requirementBorderColor || this.primaryBorderColor;
@@ -450,6 +471,7 @@ class Theme {
     this.commitLabelColor = this.commitLabelColor || this.secondaryTextColor;
     this.commitLabelBackground = this.commitLabelBackground || this.secondaryColor;
     this.commitLabelFontSize = this.commitLabelFontSize || '10px';
+    this.commitLineColor = this.commitLineColor ?? this.lineColor;
 
     /* -------------------------------------------------- */
     /* Event Modeling diagrams                             */

--- a/packages/mermaid/src/utils/sanitizeDirective.spec.ts
+++ b/packages/mermaid/src/utils/sanitizeDirective.spec.ts
@@ -62,6 +62,32 @@ describe('sanitizeDirective', () => {
         commitLineColor: '#ff0000',
       });
     });
+
+    it('blanks out hostile values nested under treeView and packet, same as top-level theme variables', () => {
+      const args = {
+        themeVariables: {
+          primaryColor: 'url(javascript:alert(1))',
+          treeView: {
+            iconColor: 'url(javascript:alert(1))',
+            descriptionColor: '#00ff00',
+          },
+          packet: {
+            startByteColor: '</style><script>alert(1)</script>',
+            endByteColor: 'black',
+          },
+        },
+      };
+      sanitizeDirective(args);
+      expect(args.themeVariables.primaryColor).toBe('');
+      expect(args.themeVariables.treeView).toEqual({
+        iconColor: '',
+        descriptionColor: '#00ff00',
+      });
+      expect(args.themeVariables.packet).toEqual({
+        startByteColor: '',
+        endByteColor: 'black',
+      });
+    });
   });
 
   describe('dictionary-style configs', () => {

--- a/packages/mermaid/src/utils/sanitizeDirective.spec.ts
+++ b/packages/mermaid/src/utils/sanitizeDirective.spec.ts
@@ -8,6 +8,62 @@ describe('sanitizeDirective', () => {
     expect(args).toEqual({ fontSize: 12 });
   });
 
+  describe('theme variables only the default theme is missing', () => {
+    it('keeps treeView theme variables that only the default theme lacked', () => {
+      const args = {
+        themeVariables: {
+          treeView: {
+            iconColor: '#ff0000',
+            descriptionColor: '#ff0000',
+            highlightBg: '#ff0000',
+            highlightStroke: '#ff0000',
+          },
+        },
+      };
+      sanitizeDirective(args);
+      expect(args.themeVariables.treeView).toEqual({
+        iconColor: '#ff0000',
+        descriptionColor: '#ff0000',
+        highlightBg: '#ff0000',
+        highlightStroke: '#ff0000',
+      });
+    });
+
+    it('keeps packet theme variables that only the default theme lacked', () => {
+      const args = {
+        themeVariables: {
+          packet: {
+            startByteColor: '#ff0000',
+            endByteColor: '#ff0000',
+            blockStrokeColor: '#ff0000',
+            blockFillColor: '#ff0000',
+          },
+        },
+      };
+      sanitizeDirective(args);
+      expect(args.themeVariables.packet).toEqual({
+        startByteColor: '#ff0000',
+        endByteColor: '#ff0000',
+        blockStrokeColor: '#ff0000',
+        blockFillColor: '#ff0000',
+      });
+    });
+
+    it('keeps stateBorder and commitLineColor, only defined by the redux themes', () => {
+      const args = {
+        themeVariables: {
+          stateBorder: '#ff0000',
+          commitLineColor: '#ff0000',
+        },
+      };
+      sanitizeDirective(args);
+      expect(args.themeVariables).toEqual({
+        stateBorder: '#ff0000',
+        commitLineColor: '#ff0000',
+      });
+    });
+  });
+
   describe('dictionary-style configs', () => {
     it('preserves treeView filenameIcons and extensionIcons entries', () => {
       const args = {

--- a/packages/mermaid/src/utils/sanitizeDirective.ts
+++ b/packages/mermaid/src/utils/sanitizeDirective.ts
@@ -30,6 +30,23 @@ const sanitizeDictionaryConfig = (dict: Record<string, unknown>, valuePattern: R
   }
 };
 
+const THEME_VARIABLE_VALUE_PATTERN = /^[\d "#%(),.;A-Za-z]+$/;
+
+// themeVariables can nest plain color leaves under a namespace object (treeView,
+// packet, ...), so this has to walk down into them instead of only checking the
+// top-level keys, or a nested leaf could carry a value the top-level check would
+// otherwise have blanked out.
+const sanitizeThemeVariables = (themeVariables: Record<string, unknown>): void => {
+  for (const key of Object.keys(themeVariables)) {
+    const value = themeVariables[key];
+    if (value && typeof value === 'object') {
+      sanitizeThemeVariables(value as Record<string, unknown>);
+    } else if (typeof value === 'string' && !THEME_VARIABLE_VALUE_PATTERN.test(value)) {
+      themeVariables[key] = '';
+    }
+  }
+};
+
 /**
  * Sanitizes directive objects
  *
@@ -87,12 +104,7 @@ export const sanitizeDirective = (args: any): void => {
   }
 
   if (args.themeVariables) {
-    for (const k of Object.keys(args.themeVariables)) {
-      const val = args.themeVariables[k];
-      if (val?.match && !val.match(/^[\d "#%(),.;A-Za-z]+$/)) {
-        args.themeVariables[k] = '';
-      }
-    }
+    sanitizeThemeVariables(args.themeVariables);
   }
   log.debug('After sanitization', args);
 };


### PR DESCRIPTION
Fixes #8170

`sanitizeDirective` keeps a key only if its bare name is somewhere in `configKeys`, a flat set built from `defaultConfig`. `defaultConfig.themeVariables` comes from the default theme's `getThemeVariables()`, which never defined:

- `treeView.iconColor`, `treeView.descriptionColor`, `treeView.highlightBg`, `treeView.highlightStroke`
- `packet.startByteColor`, `packet.endByteColor`, `packet.blockStrokeColor`, `packet.blockFillColor`
- `stateBorder`
- `commitLineColor`

(those only show up on the redux themes). So setting any of them through frontmatter or `%%{init}%%` got silently stripped before the theme was even calculated, while the identical key worked fine through `mermaid.initialize({ themeVariables: ... })`. `treeView.labelColor`/`treeView.lineColor` and `packet.labelColor`/`packet.titleColor` happened to survive only because those exact leaf names are used elsewhere in the config, which is what made the bug look inconsistent rather than fully broken.

The fix adds all of these to the default theme, using the same hardcoded values each diagram's own `styles.ts`/`styles.js` already falls back to (`treeView/styles.ts`, `packet/styles.ts`, `state/styles.js`'s `stateBorder || nodeBorder`, `git/styles.js`'s `commitLineColor ?? lineColor`), so default rendering is unchanged and only the frontmatter path starts working.

I deliberately left `requirementEdgeLabelBackground` out of this PR even though the issue lists it too. Besides supplying a background color in `requirement/styles.js`, its mere presence is also used as a boolean condition in `requirementBox.ts` (`requirementEdgeLabelBackground || borderColorArray?.length`) to decide whether to apply `nodeStyles` to the box's paths. Giving it a truthy default on the default theme would flip that condition for every requirement diagram using the default theme, which is a bigger behavior change than "make this overridable from frontmatter." That one probably needs its own look rather than being bundled in here.

## Testing

Added cases to `sanitizeDirective.spec.ts` covering the treeView, packet, and top-level (stateBorder/commitLineColor) keys. Confirmed they fail without the fix (the keys get deleted) and pass with it. Also ran the existing theme-related suites (`theme-redux-color-superset.spec.ts`, `config.spec.ts`, and the rest of `packages/mermaid/src/themes`) to make sure nothing about the redux/redux-dark theme comparisons regressed, since those are exactly the themes that already carried these variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds missing theme variables to the default theme so `sanitizeDirective` preserves them in frontmatter and `%%{init}%%` configuration.

### Changes

- Added default fallbacks for:
  - Tree view colors
  - Packet diagram colors
  - `stateBorder`
  - `commitLineColor`
- Added recursive sanitization for nested theme-variable values.
- Added tests for supported variables and hostile nested values.
- Added a changeset.
- Excluded `requirementEdgeLabelBackground` because its truthy default could change requirement diagram styling.

Default rendering remains unchanged because the new values match existing style fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->