### PR TITLE
feat(themes): colour swimlane lanes in the redux colour themes

### DIFF
--- a/.changeset/redux-color-swimlane-lanes.md
+++ b/.changeset/redux-color-swimlane-lanes.md
@@ -1,0 +1,5 @@
+---
+'mermaid': minor
+---
+
+feat(themes): swimlane lanes now take a per-lane colour under the `redux-color` and `redux-dark-color` themes, cycling every 12 as flowchart subgraph containers already do. The lane a diagram gets for its ungrouped nodes takes its own slot rather than sharing the first lane's, and it now also follows the diagram's `look` instead of always rendering classic. Explicit `style` on a lane still wins over the palette.

--- a/.changeset/redux-color-swimlane-lanes.md
+++ b/.changeset/redux-color-swimlane-lanes.md
@@ -2,4 +2,4 @@
 'mermaid': minor
 ---
 
-feat(themes): swimlane lanes now take a per-lane colour under the `redux-color` and `redux-dark-color` themes, cycling every 12 as flowchart subgraph containers already do. The lane a diagram gets for its ungrouped nodes takes its own slot rather than sharing the first lane's, and it now also follows the diagram's `look` instead of always rendering classic. Explicit `style` on a lane still wins over the palette.
+feat(themes): swimlane lanes take a per-lane colour under the `redux-color` and `redux-dark-color` themes, cycling every 12 as flowchart subgraphs do. The lane holding ungrouped nodes takes its own slot instead of the first lane's, and now follows the diagram's `look` rather than always rendering classic.

--- a/e2e/rendering/swimlanes/swimlanes.spec.ts
+++ b/e2e/rendering/swimlanes/swimlanes.spec.ts
@@ -225,6 +225,157 @@ test.describe('Swimlanes diagram', () => {
     await expect(shape).toHaveCSS('stroke-width', '4px');
   });
 
+  /**
+   * Lanes take a per-lane colour under the redux colour themes. The unit tests pin the
+   * generated CSS and the slot each lane is handed; only a render proves the stamped
+   * `data-color-id` actually meets the emitted selector on the element, which is the half
+   * that fails silently -- a mismatch leaves every lane the uncoloured grey.
+   *
+   * Asserted as "distinct and self-consistent" rather than against hex values, so the
+   * assertions keep holding when the palettes are retuned. The exact colours are pinned
+   * in `swimlanes/lanePalette.spec.ts`.
+   */
+  test.describe('redux colour theme lanes', () => {
+    const fiveLanes = `swimlane-beta TD
+        subgraph Intake
+          A[Request]
+        end
+        subgraph Review
+          B[Check]
+        end
+        subgraph Build
+          C[Assemble]
+        end
+        subgraph Ship
+          D[Deliver]
+        end
+        subgraph Support
+          E[Follow up]
+        end
+        A --> B --> C --> D --> E
+      `;
+
+    const laneStrokes = (page: Page, half: 'title' | 'body') =>
+      page
+        .locator(`g.cluster.swimlane rect.swimlane-${half}`)
+        .evaluateAll((rects) => rects.map((rect) => getComputedStyle(rect).stroke));
+
+    for (const theme of ['redux-color', 'redux-dark-color'] as const) {
+      test(`gives every lane its own colour under ${theme}`, async ({ page }, testInfo) => {
+        await renderSwimlanes(page, testInfo, fiveLanes, `swimlanes-${theme}-lanes`, { theme });
+
+        await assertStandaloneSwimlanesRendered(page);
+
+        const slots = await page
+          .locator('g.cluster.swimlane')
+          .evaluateAll((lanes) => lanes.map((lane) => lane.getAttribute('data-color-id')));
+        expect(slots).toHaveLength(5);
+        expect(slots.filter(Boolean)).toHaveLength(5);
+        expect(new Set(slots).size).toBe(5);
+
+        // Title band and body of one lane are the same colour; across lanes they differ.
+        const titles = await laneStrokes(page, 'title');
+        const bodies = await laneStrokes(page, 'body');
+        expect(titles).toEqual(bodies);
+        expect(new Set(titles).size).toBe(5);
+        // `none` would mean the palette rule never landed and nothing else painted it.
+        expect(titles.filter((stroke) => stroke === 'none')).toEqual([]);
+      });
+    }
+
+    test('paints the lane body fill only where the theme ships one', async ({ page }, testInfo) => {
+      await renderSwimlanes(page, testInfo, fiveLanes, 'swimlanes-lane-fill', {
+        theme: 'redux-color',
+      });
+
+      const fills = await page
+        .locator('g.cluster.swimlane rect.swimlane-body')
+        .evaluateAll((rects) => rects.map((rect) => getComputedStyle(rect).fill));
+      expect(new Set(fills).size).toBe(5);
+    });
+
+    test('keeps an explicit lane style ahead of the palette', async ({ page }, testInfo) => {
+      await renderSwimlanes(
+        page,
+        testInfo,
+        `swimlane-beta TD
+          subgraph Palette
+            A[Slot colour]
+          end
+          subgraph Styled
+            B[Own colour]
+          end
+          A --> B
+          style Styled fill:#00ff00,stroke:#0000ff
+        `,
+        'swimlanes-lane-user-style',
+        { theme: 'redux-color' }
+      );
+
+      const styled = page.locator('g.cluster.swimlane[data-id="Styled"] rect.swimlane-body');
+      await expect(styled).toHaveCSS('stroke', 'rgb(0, 0, 255)');
+      await expect(styled).toHaveCSS('fill', 'rgb(0, 255, 0)');
+    });
+
+    /**
+     * The default lane is synthesised by the layout rather than declared, so it is the one
+     * lane nothing upstream gives a `look` or a colour slot to. Without them it renders as
+     * a classic rect inside a handDrawn diagram and reuses the first lane's colour.
+     */
+    test('colours the synthetic default lane distinctly', async ({ page }, testInfo) => {
+      await renderSwimlanes(
+        page,
+        testInfo,
+        `swimlane-beta TD
+          subgraph OwnedLane
+            A[Owned node]
+          end
+          Loose[Loose node] --> A
+        `,
+        'swimlanes-default-lane-colour',
+        { theme: 'redux-color' }
+      );
+
+      const slots = await page
+        .locator('g.cluster.swimlane')
+        .evaluateAll((lanes) => lanes.map((lane) => lane.getAttribute('data-color-id')));
+      expect(slots).toHaveLength(2);
+      expect(new Set(slots).size).toBe(2);
+      expect(slots.filter(Boolean)).toHaveLength(2);
+    });
+
+    test('draws the synthetic default lane in the diagram look', async ({ page }, testInfo) => {
+      await renderSwimlanes(
+        page,
+        testInfo,
+        `swimlane-beta TD
+          subgraph OwnedLane
+            A[Owned node]
+          end
+          Loose[Loose node] --> A
+        `,
+        'swimlanes-default-lane-handdrawn',
+        { theme: 'redux-color', look: 'handDrawn' }
+      );
+
+      const defaultLane = page.locator('g.cluster.swimlane[data-id="__swimlane_default__"]');
+      await expect(defaultLane).toHaveAttribute('data-look', 'handDrawn');
+      // roughjs draws paths; a `rect` here means the classic branch ran instead.
+      await expect(defaultLane.locator('rect.swimlane-body')).toHaveCount(0);
+      await expect(defaultLane.locator('.swimlane-body path')).not.toHaveCount(0);
+    });
+
+    for (const theme of ['redux-color', 'redux-dark-color'] as const) {
+      test(`renders coloured lanes under ${theme}`, async ({ page }, testInfo) => {
+        await snapshotSwimlanes(page, testInfo, fiveLanes, { theme });
+      });
+
+      test(`renders coloured handdrawn lanes under ${theme}`, async ({ page }, testInfo) => {
+        await snapshotSwimlanes(page, testInfo, fiveLanes, { theme, look: 'handDrawn' });
+      });
+    }
+  });
+
   test('puts nodes without an explicit subgraph into a default swimlane', async ({
     page,
   }, testInfo) => {

--- a/e2e/rendering/swimlanes/swimlanes.spec.ts
+++ b/e2e/rendering/swimlanes/swimlanes.spec.ts
@@ -226,14 +226,9 @@ test.describe('Swimlanes diagram', () => {
   });
 
   /**
-   * Lanes take a per-lane colour under the redux colour themes. The unit tests pin the
-   * generated CSS and the slot each lane is handed; only a render proves the stamped
-   * `data-color-id` actually meets the emitted selector on the element, which is the half
-   * that fails silently -- a mismatch leaves every lane the uncoloured grey.
-   *
-   * Asserted as "distinct and self-consistent" rather than against hex values, so the
-   * assertions keep holding when the palettes are retuned. The exact colours are pinned
-   * in `swimlanes/lanePalette.spec.ts`.
+   * The unit tests pin the generated CSS; only a render proves the stamped
+   * `data-color-id` meets the emitted selector on the element. Asserted as "distinct and
+   * self-consistent" rather than against hex values, which `lanePalette.spec.ts` pins.
    */
   test.describe('redux colour theme lanes', () => {
     const fiveLanes = `swimlane-beta TD
@@ -273,15 +268,78 @@ test.describe('Swimlanes diagram', () => {
         expect(slots.filter(Boolean)).toHaveLength(5);
         expect(new Set(slots).size).toBe(5);
 
-        // Title band and body of one lane are the same colour; across lanes they differ.
+        // One lane's two halves match; across lanes they differ.
         const titles = await laneStrokes(page, 'title');
         const bodies = await laneStrokes(page, 'body');
         expect(titles).toEqual(bodies);
         expect(new Set(titles).size).toBe(5);
-        // `none` would mean the palette rule never landed and nothing else painted it.
+        // `none` would mean the palette rule never landed.
         expect(titles.filter((stroke) => stroke === 'none')).toEqual([]);
       });
     }
+
+    /**
+     * The handDrawn selectors encode roughjs's emission order -- hachure fill first, then
+     * the outline -- which no unit test can confirm. The assertions above never reach it:
+     * `rect.swimlane-*` does not exist under this look.
+     */
+    test.describe('handDrawn', () => {
+      const lanePaths = (page: Page, half: 'title' | 'body', nth: 1 | 2) =>
+        page
+          .locator(`g.cluster.swimlane .swimlane-${half} path:nth-of-type(${nth})`)
+          .evaluateAll((paths) => paths.map((path) => getComputedStyle(path).stroke));
+
+      test('paints the outline path of both halves per lane', async ({ page }, testInfo) => {
+        await renderSwimlanes(page, testInfo, fiveLanes, 'swimlanes-handdrawn-outlines', {
+          theme: 'redux-color',
+          look: 'handDrawn',
+        });
+
+        await expect(page.locator('g.cluster.swimlane rect.swimlane-body')).toHaveCount(0);
+
+        for (const half of ['title', 'body'] as const) {
+          const outlines = await lanePaths(page, half, 2);
+          expect(outlines, `${half} outlines`).toHaveLength(5);
+          expect(new Set(outlines).size, `${half} outlines are distinct`).toBe(5);
+          expect(outlines.filter((stroke) => stroke === 'none')).toEqual([]);
+        }
+      });
+
+      /**
+       * The hachure path's *stroke* is the lane fill, since roughjs draws a fill as lines.
+       * It is the rule `hasBkgColors` turns on and off, so both cases are checked.
+       */
+      test('fills both halves where the theme ships a background palette', async ({
+        page,
+      }, testInfo) => {
+        await renderSwimlanes(page, testInfo, fiveLanes, 'swimlanes-handdrawn-fill', {
+          theme: 'redux-color',
+          look: 'handDrawn',
+        });
+
+        for (const half of ['title', 'body'] as const) {
+          const fills = await lanePaths(page, half, 1);
+          expect(fills, `${half} fills`).toHaveLength(5);
+          expect(new Set(fills).size, `${half} fills are distinct`).toBe(5);
+          expect(fills.filter((stroke) => stroke === 'none')).toEqual([]);
+        }
+      });
+
+      test('leaves the body hachure unpainted without a background palette', async ({
+        page,
+      }, testInfo) => {
+        await renderSwimlanes(page, testInfo, fiveLanes, 'swimlanes-handdrawn-no-fill', {
+          theme: 'redux-dark-color',
+          look: 'handDrawn',
+        });
+
+        const fills = await lanePaths(page, 'body', 1);
+        expect(fills).toHaveLength(5);
+        expect(new Set(fills)).toEqual(new Set(['none']));
+        // The outline is still palette-coloured; only the fill is absent.
+        expect(new Set(await lanePaths(page, 'body', 2)).size).toBe(5);
+      });
+    });
 
     test('paints the lane body fill only where the theme ships one', async ({ page }, testInfo) => {
       await renderSwimlanes(page, testInfo, fiveLanes, 'swimlanes-lane-fill', {
@@ -318,9 +376,8 @@ test.describe('Swimlanes diagram', () => {
     });
 
     /**
-     * The default lane is synthesised by the layout rather than declared, so it is the one
-     * lane nothing upstream gives a `look` or a colour slot to. Without them it renders as
-     * a classic rect inside a handDrawn diagram and reuses the first lane's colour.
+     * The synthetic lane gets no `look` or colour slot from upstream. Without them it
+     * renders as a classic rect inside a handDrawn diagram and reuses the first slot.
      */
     test('colours the synthetic default lane distinctly', async ({ page }, testInfo) => {
       await renderSwimlanes(
@@ -360,7 +417,7 @@ test.describe('Swimlanes diagram', () => {
 
       const defaultLane = page.locator('g.cluster.swimlane[data-id="__swimlane_default__"]');
       await expect(defaultLane).toHaveAttribute('data-look', 'handDrawn');
-      // roughjs draws paths; a `rect` here means the classic branch ran instead.
+      // A `rect` here would mean the classic branch ran instead.
       await expect(defaultLane.locator('rect.swimlane-body')).toHaveCount(0);
       await expect(defaultLane.locator('.swimlane-body path')).not.toHaveCount(0);
     });

--- a/packages/mermaid/src/diagrams/common/colorThemeGate.spec.ts
+++ b/packages/mermaid/src/diagrams/common/colorThemeGate.spec.ts
@@ -26,10 +26,8 @@ import {
 } from './colorThemeGate.js';
 
 /**
- * Every stylesheet that answers the palette questions. `swimlanes` wraps flowchart's and
- * appends its own lane rules, so it is a separate answer to the same questions -- and the
- * one carrying an `!important` rule of its own next to the palette. Listed here so the
- * gate is checked on what swimlanes ships rather than on the half it inherits.
+ * `swimlanes` wraps flowchart's stylesheet and appends its own lane rules, including an
+ * `!important` one next to the palette, so it is listed separately from what it inherits.
  */
 const STYLESHEETS = {
   class: classStyles,
@@ -101,9 +99,8 @@ it('covers every registered theme between the two lists', () => {
 
 describe.each(SLOT_STYLESHEETS)('%s stylesheet', (name) => {
   it.each(PLAIN_THEMES)('emits no per-item colour rules for %s', (themeName) => {
-    // The slot marker, not the bare attribute name: `swimlanes` keys its unconditional
-    // lane-border rule off `:not([data-color-id])`, which is the absence of a slot rather
-    // than a rule for one.
+    // The slot marker, not the bare attribute: `swimlanes` keys a rule off
+    // `:not([data-color-id])`, which is the absence of a slot rather than a rule for one.
     expect(render(name, themeName)).not.toContain('data-color-id="color-');
   });
 

--- a/packages/mermaid/src/diagrams/common/colorThemeGate.spec.ts
+++ b/packages/mermaid/src/diagrams/common/colorThemeGate.spec.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from 'vitest';
 import themes from '../../themes/index.js';
 import classStyles from '../class/styles.js';
 import flowchartStyles from '../flowchart/styles.js';
+import swimlanesStyles from '../swimlanes/styles.js';
 import {
   COLOR_THEMES,
   DEFAULT_COLOR_SLOTS,
@@ -20,9 +21,16 @@ import {
   safeLook,
 } from './colorThemeGate.js';
 
+/**
+ * `swimlanes` wraps flowchart's stylesheet and appends its own lane rules, so it is a
+ * separate answer to the same questions -- and the one that has an `!important` rule of
+ * its own near the palette. Listed here so the gate is checked on what swimlanes actually
+ * ships rather than on the half of it that comes from flowchart.
+ */
 const STYLESHEETS = {
   class: classStyles,
   flowchart: flowchartStyles,
+  swimlanes: swimlanesStyles,
 } as const;
 
 const COLOUR_THEMES = [...COLOR_THEMES];
@@ -59,7 +67,10 @@ it('covers every registered theme between the two lists', () => {
 
 describe.each(Object.keys(STYLESHEETS) as (keyof typeof STYLESHEETS)[])('%s stylesheet', (name) => {
   it.each(PLAIN_THEMES)('emits no per-item colour rules for %s', (themeName) => {
-    expect(render(name, themeName)).not.toContain('data-color-id');
+    // The slot marker, not the bare attribute name: `swimlanes` keys its unconditional
+    // lane-border rule off `:not([data-color-id])`, which is the absence of a slot rather
+    // than a rule for one.
+    expect(render(name, themeName)).not.toContain('data-color-id="color-');
   });
 
   it.each(COLOUR_THEMES)('emits one rule per palette slot for %s', (themeName) => {

--- a/packages/mermaid/src/diagrams/flowchart/styles.ts
+++ b/packages/mermaid/src/diagrams/flowchart/styles.ts
@@ -41,6 +41,15 @@ export interface FlowChartStyleOptions {
  * inline `style` attribute, which has to keep winning over the theme palette. The
  * collapsed form's own colours are presentation attributes (`fill=` / `stroke=`), which
  * these rules correctly outrank while still losing to that inline style.
+ *
+ * Swimlane lanes are clusters too, and get their own block rather than riding on the
+ * generic one: a lane is two rectangles (title band and body), and under handDrawn the
+ * body is asked for `fill: 'none'`, which roughjs answers with a hachure path carrying
+ * `stroke="none"`. The generic `path` rule would paint that invisible hachure and fill
+ * both outline paths solid, so the lanes are excluded from it by `:not(.swimlane)` and
+ * handled below instead. Swimlanes reach this stylesheet two ways -- the `swimlane-beta`
+ * diagram, which wraps flowchart's `styles` export, and a plain flowchart given
+ * `layout: swimlane` -- and emitting the rules here covers both.
  */
 const genColor = (options: FlowChartStyleOptions) => {
   const { theme, bkgColorArray, borderColorArray } = options;
@@ -66,18 +75,44 @@ const genColor = (options: FlowChartStyleOptions) => {
      */
     const collapsedRule = (suffix: string) =>
       `${slot}.node ${suffix}, ${slot}.rough-node ${suffix}`;
+    /* Both halves of a lane, by the classes `swimlane.js` puts on them under every look.
+     * A helper because each has to carry the whole prefix separately -- the same
+     * append-to-both rule as `collapsedRule` above. */
+    const laneRule = (suffix: string) =>
+      `${slot}.swimlane.cluster .swimlane-title${suffix}, ${slot}.swimlane.cluster .swimlane-body${suffix}`;
     sections += `
 
-    ${slot}.cluster rect {
+    ${slot}.cluster:not(.swimlane) rect {
       stroke: ${borderColor};
       ${fill}
     }
 
-    ${slot}.cluster path {
+    ${slot}.cluster:not(.swimlane) path {
       stroke: ${borderColor};
       ${fill}
     }
 
+    /* Swimlane lane, classic and neo: title band and body. */
+    ${slot}.swimlane.cluster rect.swimlane-title,
+    ${slot}.swimlane.cluster rect.swimlane-body {
+      stroke: ${borderColor};
+      ${fill}
+    }
+
+    /* Swimlane lane, handDrawn: the outline path of each half. */
+    ${laneRule(' path:nth-of-type(2)')} {
+      stroke: ${borderColor};
+    }
+${
+  hasBkgColors
+    ? `
+    /* handDrawn title band: its hachure lines are strokes, not a fill. */
+    ${slot}.swimlane.cluster .swimlane-title path:first-of-type {
+      stroke: ${bkgColorArray[i % bkgColorArray.length]};
+    }
+`
+    : ''
+}
     ${collapsedRule('.collapsed-group')},
     ${collapsedRule('.collapsed-group path')} {
       stroke: ${borderColor};

--- a/packages/mermaid/src/diagrams/flowchart/styles.ts
+++ b/packages/mermaid/src/diagrams/flowchart/styles.ts
@@ -42,14 +42,12 @@ export interface FlowChartStyleOptions {
  * collapsed form's own colours are presentation attributes (`fill=` / `stroke=`), which
  * these rules correctly outrank while still losing to that inline style.
  *
- * Swimlane lanes are clusters too, and get their own block rather than riding on the
- * generic one: a lane is two rectangles (title band and body), and under handDrawn the
- * body is asked for `fill: 'none'`, which roughjs answers with a hachure path carrying
- * `stroke="none"`. The generic `path` rule would paint that invisible hachure and fill
- * both outline paths solid, so the lanes are excluded from it by `:not(.swimlane)` and
- * handled below instead. Swimlanes reach this stylesheet two ways -- the `swimlane-beta`
- * diagram, which wraps flowchart's `styles` export, and a plain flowchart given
- * `layout: swimlane` -- and emitting the rules here covers both.
+ * Swimlane lanes are clusters too but need their own rules: a lane is two rectangles, and
+ * under handDrawn its body asks roughjs for `fill: 'none'`, which it answers with a
+ * hachure path carrying `stroke="none"` -- the generic `path` rule would paint that
+ * invisible hachure and fill both outlines solid. Hence `:not(.swimlane)`. Emitted here
+ * rather than in `swimlanes/styles.ts` so a plain flowchart given `layout: swimlane`,
+ * which never loads that stylesheet, is covered too.
  */
 const genColor = (options: FlowChartStyleOptions) => {
   const { theme, bkgColorArray, borderColorArray } = options;
@@ -75,9 +73,7 @@ const genColor = (options: FlowChartStyleOptions) => {
      */
     const collapsedRule = (suffix: string) =>
       `${slot}.node ${suffix}, ${slot}.rough-node ${suffix}`;
-    /* Both halves of a lane, by the classes `swimlane.js` puts on them under every look.
-     * A helper because each has to carry the whole prefix separately -- the same
-     * append-to-both rule as `collapsedRule` above. */
+    /* Both halves of a lane. Each carries the whole prefix separately, as above. */
     const laneRule = (suffix: string) =>
       `${slot}.swimlane.cluster .swimlane-title${suffix}, ${slot}.swimlane.cluster .swimlane-body${suffix}`;
     sections += `
@@ -92,22 +88,22 @@ const genColor = (options: FlowChartStyleOptions) => {
       ${fill}
     }
 
-    /* Swimlane lane, classic and neo: title band and body. */
+    /* Lane, classic and neo. */
     ${slot}.swimlane.cluster rect.swimlane-title,
     ${slot}.swimlane.cluster rect.swimlane-body {
       stroke: ${borderColor};
       ${fill}
     }
 
-    /* Swimlane lane, handDrawn: the outline path of each half. */
+    /* Lane, handDrawn: roughjs emits the hachure fill first, then the outline. */
     ${laneRule(' path:nth-of-type(2)')} {
       stroke: ${borderColor};
     }
 ${
   hasBkgColors
     ? `
-    /* handDrawn title band: its hachure lines are strokes, not a fill. */
-    ${slot}.swimlane.cluster .swimlane-title path:first-of-type {
+    /* A roughjs fill is drawn as lines, so the lane fill is a stroke here. */
+    ${laneRule(' path:first-of-type')} {
       stroke: ${bkgColorArray[i % bkgColorArray.length]};
     }
 `

--- a/packages/mermaid/src/diagrams/swimlanes/lanePalette.spec.ts
+++ b/packages/mermaid/src/diagrams/swimlanes/lanePalette.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * Lanes take a per-lane colour under the redux colour themes, the same way flowchart
+ * subgraphs do — a lane is a participant, which is exactly what a categorical palette is
+ * for.
+ *
+ * These assertions are about the shape of the emitted CSS, because that is where this
+ * wiring fails silently. A lane renders identically whether a declaration was discarded,
+ * outranked, or never emitted, so nothing downstream reports the difference:
+ *
+ *   1. A lane is two rects — the title band and the body — under classic and neo, and two
+ *      roughjs path pairs under handDrawn. Missing either half leaves a lane half-painted.
+ *   2. The generic `.cluster` palette rules must not reach lanes. Under handDrawn a lane
+ *      body asks roughjs for no fill, which it answers with a hachure path carrying
+ *      `stroke="none"`; the generic `path` rule would paint that invisible hachure and
+ *      fill both outline paths solid.
+ *   3. The lane-border override in this stylesheet is `!important` — it has to be, to
+ *      outrank `[data-look="neo"].cluster rect`, which ties with it on specificity. An
+ *      `!important` that also covered palette lanes would outrank every rule above and
+ *      lanes would stay grey with no sign of why.
+ *   4. `redux-dark-color` ships a border palette and no background palette, so rules
+ *      derived from the background array have to be dropped rather than emitted with a
+ *      missing value.
+ */
+import { describe, expect, it } from 'vitest';
+import themes from '../../themes/index.js';
+import { COLOR_THEMES } from '../common/colorThemeGate.js';
+import swimlanesStyles from './styles.js';
+
+const COLOUR_THEMES = [...COLOR_THEMES];
+const PLAIN_THEMES = Object.keys(themes).filter((name) => !COLOR_THEMES.has(name));
+
+interface Palette {
+  borderColorArray?: string[];
+  bkgColorArray?: string[];
+  clusterBorder: string;
+}
+
+const paletteOf = (themeName: string): Palette =>
+  themes[themeName as keyof typeof themes].getThemeVariables({}) as unknown as Palette;
+
+const render = (themeName: string, look = 'neo'): string =>
+  swimlanesStyles({
+    ...(paletteOf(themeName) as unknown as Record<string, unknown>),
+    theme: themeName,
+    look,
+  } as never);
+
+/** The declaration body of every rule whose selector matches `pattern`. */
+const bodiesMatching = (css: string, pattern: RegExp): string[] =>
+  [...css.matchAll(/([^{}]+){([^{}]*)}/g)]
+    .filter(([, selector]) => pattern.test(selector))
+    .map(([, , body]) => body);
+
+describe.each(COLOUR_THEMES)('%s lane palette', (themeName) => {
+  const { borderColorArray, bkgColorArray, clusterBorder } = paletteOf(themeName);
+  const slots = borderColorArray!.map((_, slot) => slot);
+
+  it.each(slots)('paints both halves of the lane in slot %i', (slot) => {
+    const css = render(themeName);
+    const prefix = `\\[data-look="neo"\\]\\[data-color-id="color-${slot}"\\]\\.swimlane\\.cluster`;
+
+    // Title band and body share one rule, so the selector has to name both halves --
+    // each with the full prefix, or the second would match nothing.
+    const laneRect = new RegExp(
+      `${prefix} rect\\.swimlane-title,\\s*${prefix} rect\\.swimlane-body \\{([^}]*)\\}`
+    ).exec(css);
+    expect(laneRect, `no lane rect rule for slot ${slot}`).not.toBeNull();
+    expect(laneRect![1]).toContain(`stroke: ${borderColorArray![slot]};`);
+    if (bkgColorArray?.length) {
+      expect(laneRect![1]).toContain(`fill: ${bkgColorArray[slot]};`);
+    }
+
+    // handDrawn: roughjs draws a hachure fill path then the outline path, so the outline
+    // is the second one and the only one that takes the border colour.
+    const laneOutline = new RegExp(
+      `${prefix} \\.swimlane-title path:nth-of-type\\(2\\), ` +
+        `${prefix} \\.swimlane-body path:nth-of-type\\(2\\) \\{([^}]*)\\}`
+    ).exec(css);
+    expect(laneOutline, `no lane outline rule for slot ${slot}`).not.toBeNull();
+    expect(laneOutline![1]).toContain(`stroke: ${borderColorArray![slot]};`);
+  });
+
+  it('keeps the generic cluster palette rules away from lanes', () => {
+    const tails = [...render(themeName).matchAll(/\[data-color-id="color-\d+"]\.cluster([^,{]*)/g)]
+      .map((match) => match[1])
+      .filter((tail) => !tail.startsWith('.swimlane'));
+
+    expect(tails.length).toBeGreaterThan(0);
+    expect(tails.filter((tail) => !tail.startsWith(':not(.swimlane)'))).toEqual([]);
+  });
+
+  it('exempts palette lanes from the !important lane border', () => {
+    const css = render(themeName);
+
+    expect(css).toContain(`.swimlane.cluster:not([data-color-id]) rect {
+    stroke: ${clusterBorder} !important;
+  }`);
+    // No unscoped form left behind, which would outrank every lane palette rule.
+    expect(css).not.toContain('.swimlane.cluster rect {');
+  });
+
+  it('never marks a lane palette rule !important', () => {
+    // A user's `style` / `classDef` reaches the lane as an inline `style` attribute and
+    // has to keep winning over the theme.
+    const bodies = bodiesMatching(render(themeName), /\[data-color-id="color-\d+"]\.swimlane/);
+
+    expect(bodies.length).toBeGreaterThan(0);
+    expect(bodies.filter((body) => body.includes('!important'))).toEqual([]);
+  });
+
+  it('emits no empty or undefined declaration', () => {
+    const bodies = bodiesMatching(render(themeName), /data-color-id="color-\d+"/);
+
+    expect(bodies.length).toBeGreaterThan(0);
+    for (const body of bodies) {
+      expect(body).not.toMatch(/:\s*(undefined|NaN)?\s*;/);
+    }
+  });
+});
+
+/**
+ * `bkgColorArray` is empty in `redux-dark-color`, which is what makes the guard load
+ * bearing rather than defensive: the background-derived rule must be absent there, not
+ * emitted with a missing value.
+ */
+it('emits the handDrawn title fill rule only where a background palette exists', () => {
+  expect(paletteOf('redux-color').bkgColorArray?.length).toBeGreaterThan(0);
+  expect(paletteOf('redux-dark-color').bkgColorArray ?? []).toHaveLength(0);
+
+  expect(render('redux-color')).toContain('.swimlane-title path:first-of-type');
+  expect(render('redux-dark-color')).not.toContain('path:first-of-type');
+});
+
+it.each(PLAIN_THEMES)('emits no lane palette rules for %s', (themeName) => {
+  const css = render(themeName);
+
+  expect(css).not.toContain('data-color-id="color-');
+  // The lane border override still ships for these themes: the exemption is keyed on an
+  // attribute nothing stamps outside the colour themes, so their lanes are unchanged.
+  expect(css).toContain('.swimlane.cluster:not([data-color-id]) rect');
+});

--- a/packages/mermaid/src/diagrams/swimlanes/lanePalette.spec.ts
+++ b/packages/mermaid/src/diagrams/swimlanes/lanePalette.spec.ts
@@ -1,25 +1,13 @@
 /**
- * Lanes take a per-lane colour under the redux colour themes, the same way flowchart
- * subgraphs do — a lane is a participant, which is exactly what a categorical palette is
- * for.
+ * Lanes take a per-lane colour under the redux colour themes, as flowchart subgraphs do.
  *
  * These assertions are about the shape of the emitted CSS, because that is where this
- * wiring fails silently. A lane renders identically whether a declaration was discarded,
- * outranked, or never emitted, so nothing downstream reports the difference:
- *
- *   1. A lane is two rects — the title band and the body — under classic and neo, and two
- *      roughjs path pairs under handDrawn. Missing either half leaves a lane half-painted.
- *   2. The generic `.cluster` palette rules must not reach lanes. Under handDrawn a lane
- *      body asks roughjs for no fill, which it answers with a hachure path carrying
- *      `stroke="none"`; the generic `path` rule would paint that invisible hachure and
- *      fill both outline paths solid.
- *   3. The lane-border override in this stylesheet is `!important` — it has to be, to
- *      outrank `[data-look="neo"].cluster rect`, which ties with it on specificity. An
- *      `!important` that also covered palette lanes would outrank every rule above and
- *      lanes would stay grey with no sign of why.
- *   4. `redux-dark-color` ships a border palette and no background palette, so rules
- *      derived from the background array have to be dropped rather than emitted with a
- *      missing value.
+ * fails silently: a lane renders identically whether a declaration was discarded,
+ * outranked, or never emitted. The four things that can go wrong are a half-painted lane
+ * (title band and body are separate elements), the generic `.cluster` rules reaching a
+ * lane (wrong under handDrawn, where the body's hachure carries `stroke="none"`), the
+ * `!important` lane border outranking the palette, and `redux-dark-color`'s empty
+ * `bkgColorArray` producing a declaration with a missing value.
  */
 import { describe, expect, it } from 'vitest';
 import themes from '../../themes/index.js';
@@ -59,8 +47,7 @@ describe.each(COLOUR_THEMES)('%s lane palette', (themeName) => {
     const css = render(themeName);
     const prefix = `\\[data-look="neo"\\]\\[data-color-id="color-${slot}"\\]\\.swimlane\\.cluster`;
 
-    // Title band and body share one rule, so the selector has to name both halves --
-    // each with the full prefix, or the second would match nothing.
+    // One rule names both halves, each with the full prefix.
     const laneRect = new RegExp(
       `${prefix} rect\\.swimlane-title,\\s*${prefix} rect\\.swimlane-body \\{([^}]*)\\}`
     ).exec(css);
@@ -70,8 +57,7 @@ describe.each(COLOUR_THEMES)('%s lane palette', (themeName) => {
       expect(laneRect![1]).toContain(`fill: ${bkgColorArray[slot]};`);
     }
 
-    // handDrawn: roughjs draws a hachure fill path then the outline path, so the outline
-    // is the second one and the only one that takes the border colour.
+    // handDrawn: roughjs draws the hachure fill first, so the outline is the second path.
     const laneOutline = new RegExp(
       `${prefix} \\.swimlane-title path:nth-of-type\\(2\\), ` +
         `${prefix} \\.swimlane-body path:nth-of-type\\(2\\) \\{([^}]*)\\}`
@@ -95,13 +81,12 @@ describe.each(COLOUR_THEMES)('%s lane palette', (themeName) => {
     expect(css).toContain(`.swimlane.cluster:not([data-color-id]) rect {
     stroke: ${clusterBorder} !important;
   }`);
-    // No unscoped form left behind, which would outrank every lane palette rule.
+    // An unscoped form would outrank every lane palette rule.
     expect(css).not.toContain('.swimlane.cluster rect {');
   });
 
   it('never marks a lane palette rule !important', () => {
-    // A user's `style` / `classDef` reaches the lane as an inline `style` attribute and
-    // has to keep winning over the theme.
+    // A user's `style` reaches the lane inline and has to keep winning over the theme.
     const bodies = bodiesMatching(render(themeName), /\[data-color-id="color-\d+"]\.swimlane/);
 
     expect(bodies.length).toBeGreaterThan(0);
@@ -118,11 +103,7 @@ describe.each(COLOUR_THEMES)('%s lane palette', (themeName) => {
   });
 });
 
-/**
- * `bkgColorArray` is empty in `redux-dark-color`, which is what makes the guard load
- * bearing rather than defensive: the background-derived rule must be absent there, not
- * emitted with a missing value.
- */
+/** `redux-dark-color` ships no background palette, so the rule must be absent there. */
 it('emits the handDrawn title fill rule only where a background palette exists', () => {
   expect(paletteOf('redux-color').bkgColorArray?.length).toBeGreaterThan(0);
   expect(paletteOf('redux-dark-color').bkgColorArray ?? []).toHaveLength(0);
@@ -135,7 +116,6 @@ it.each(PLAIN_THEMES)('emits no lane palette rules for %s', (themeName) => {
   const css = render(themeName);
 
   expect(css).not.toContain('data-color-id="color-');
-  // The lane border override still ships for these themes: the exemption is keyed on an
-  // attribute nothing stamps outside the colour themes, so their lanes are unchanged.
+  // The override still ships: nothing stamps the attribute its exemption keys on.
   expect(css).toContain('.swimlane.cluster:not([data-color-id]) rect');
 });

--- a/packages/mermaid/src/diagrams/swimlanes/styles.ts
+++ b/packages/mermaid/src/diagrams/swimlanes/styles.ts
@@ -11,10 +11,17 @@ import type { FlowChartStyleOptions } from '../flowchart/styles.js';
  * The swimlane cluster shape draws its own lane border, so the generic
  * `.cluster rect` border is suppressed by matching its stroke to the cluster
  * background — theme-adaptive, rather than a hardcoded colour.
+ *
+ * Lanes carrying a palette slot are exempt: this rule is `!important` only to outrank
+ * `[data-look="neo"].cluster rect`, which it ties with on specificity, and an
+ * `!important` here would also outrank the per-lane palette rules the flowchart
+ * stylesheet emits. Those already beat the neo rule on specificity, so they need no help
+ * — they only need this one to stay out of their way. `data-color-id` is stamped only by
+ * the themes that carry a palette, so every other theme keeps today's border exactly.
  */
 const getStyles = (options: FlowChartStyleOptions): string =>
   `${getFlowchartStyles(options)}
-  .swimlane.cluster rect {
+  .swimlane.cluster:not([data-color-id]) rect {
     stroke: ${options.clusterBorder} !important;
   }
   [data-look="neo"].cluster rect {

--- a/packages/mermaid/src/diagrams/swimlanes/styles.ts
+++ b/packages/mermaid/src/diagrams/swimlanes/styles.ts
@@ -12,12 +12,10 @@ import type { FlowChartStyleOptions } from '../flowchart/styles.js';
  * `.cluster rect` border is suppressed by matching its stroke to the cluster
  * background — theme-adaptive, rather than a hardcoded colour.
  *
- * Lanes carrying a palette slot are exempt: this rule is `!important` only to outrank
- * `[data-look="neo"].cluster rect`, which it ties with on specificity, and an
- * `!important` here would also outrank the per-lane palette rules the flowchart
- * stylesheet emits. Those already beat the neo rule on specificity, so they need no help
- * — they only need this one to stay out of their way. `data-color-id` is stamped only by
- * the themes that carry a palette, so every other theme keeps today's border exactly.
+ * The `!important` is only there to outrank `[data-look="neo"].cluster rect`, which ties
+ * with it on specificity. Palette lanes are exempted because they already outrank that
+ * rule on their own, and an `!important` here would beat them too — leaving lanes grey
+ * with nothing to say why. Nothing stamps `data-color-id` outside the colour themes.
  */
 const getStyles = (options: FlowChartStyleOptions): string =>
   `${getFlowchartStyles(options)}

--- a/packages/mermaid/src/rendering-util/layout-algorithms/swimlanes/__tests__/helpers.prepareLayout.spec.ts
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/swimlanes/__tests__/helpers.prepareLayout.spec.ts
@@ -44,6 +44,49 @@ describe('prepareLayoutForSwimlanes', () => {
     expect(grouped?.parentId).toBe('lane1');
   });
 
+  /**
+   * The synthetic lane is the one lane no declaration produced, so it is the one lane
+   * nothing upstream gave a `look` or a `colorIndex` to. Both are needed at render time
+   * and neither fails loudly when missing: without `look` the lane renders classic inside
+   * a handDrawn diagram and matches no `[data-look="..."]` palette rule, and reusing
+   * slot 0 paints it the same colour as the first declared lane.
+   */
+  it('gives the synthetic default lane the diagram look and a free colour slot', () => {
+    const layout: LayoutData = {
+      nodes: [
+        { id: 'lane1', isGroup: true, colorIndex: 0, look: 'handDrawn' } as any,
+        { id: 'nested', isGroup: true, parentId: 'lane1', colorIndex: 1 } as any,
+        { id: 'lane2', isGroup: true, colorIndex: 2, look: 'handDrawn' } as any,
+        { id: 'loose', isGroup: false } as any,
+      ],
+      edges: [],
+      config: { look: 'handDrawn' } as any,
+    };
+
+    prepareLayoutForSwimlanes(layout);
+
+    const defaultLane = layout.nodes.find((node) => node.id === DEFAULT_SWIMLANE_ID);
+
+    expect(defaultLane?.look).toBe('handDrawn');
+    // One past the highest slot handed out, so it collides with no declared container.
+    expect(defaultLane?.colorIndex).toBe(3);
+  });
+
+  it('starts the default lane at slot 0 when no container carries a colour slot', () => {
+    const layout: LayoutData = {
+      nodes: [{ id: 'loose', isGroup: false } as any],
+      edges: [],
+      config: {} as any,
+    };
+
+    prepareLayoutForSwimlanes(layout);
+
+    const defaultLane = layout.nodes.find((node) => node.id === DEFAULT_SWIMLANE_ID);
+
+    expect(defaultLane?.colorIndex).toBe(0);
+    expect(defaultLane?.look).toBeUndefined();
+  });
+
   it('only treats top-level groups as swimlane lanes', () => {
     const layout: LayoutData = {
       nodes: [

--- a/packages/mermaid/src/rendering-util/layout-algorithms/swimlanes/__tests__/helpers.prepareLayout.spec.ts
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/swimlanes/__tests__/helpers.prepareLayout.spec.ts
@@ -45,11 +45,9 @@ describe('prepareLayoutForSwimlanes', () => {
   });
 
   /**
-   * The synthetic lane is the one lane no declaration produced, so it is the one lane
-   * nothing upstream gave a `look` or a `colorIndex` to. Both are needed at render time
-   * and neither fails loudly when missing: without `look` the lane renders classic inside
-   * a handDrawn diagram and matches no `[data-look="..."]` palette rule, and reusing
-   * slot 0 paints it the same colour as the first declared lane.
+   * Neither omission fails loudly: without `look` the lane renders classic inside a
+   * handDrawn diagram and matches no palette rule, and slot 0 collides with the first
+   * declared lane.
    */
   it('gives the synthetic default lane the diagram look and a free colour slot', () => {
     const layout: LayoutData = {
@@ -68,7 +66,7 @@ describe('prepareLayoutForSwimlanes', () => {
     const defaultLane = layout.nodes.find((node) => node.id === DEFAULT_SWIMLANE_ID);
 
     expect(defaultLane?.look).toBe('handDrawn');
-    // One past the highest slot handed out, so it collides with no declared container.
+    // One past the highest slot handed out.
     expect(defaultLane?.colorIndex).toBe(3);
   });
 

--- a/packages/mermaid/src/rendering-util/layout-algorithms/swimlanes/helpers.ts
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/swimlanes/helpers.ts
@@ -114,17 +114,10 @@ export function prepareLayoutForSwimlanes(layout: LayoutData): void {
 
   let defaultLane = nodes.find((node) => node.id === DEFAULT_SWIMLANE_ID);
   if (!defaultLane) {
-    /* This lane is synthesised here rather than declared in the source, so nothing
-     * upstream has given it the two properties every declared lane arrives with.
-     *
-     * `look` decides which of the two drawing branches `swimlane.js` takes and is half of
-     * the `[data-look="..."][data-color-id="..."]` selector the theme palette is keyed
-     * on -- without it the lane renders classic inside a handDrawn diagram and takes no
-     * palette colour at all.
-     *
-     * `colorIndex` is assigned by `flowDb` per declared subgraph, so the free slot is the
-     * one past the highest already handed out. Reusing 0 would paint this lane the same
-     * colour as the first declared one. */
+    /* Synthesised rather than declared, so nothing upstream gave it the two properties a
+     * declared lane arrives with. Without `look` it renders classic inside a handDrawn
+     * diagram and matches no `[data-look="..."]` palette rule; `flowDb` numbers declared
+     * subgraphs from 0, so reusing 0 here would clash with the first of them. */
     defaultLane = {
       id: DEFAULT_SWIMLANE_ID,
       label: '',

--- a/packages/mermaid/src/rendering-util/layout-algorithms/swimlanes/helpers.ts
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/swimlanes/helpers.ts
@@ -114,12 +114,25 @@ export function prepareLayoutForSwimlanes(layout: LayoutData): void {
 
   let defaultLane = nodes.find((node) => node.id === DEFAULT_SWIMLANE_ID);
   if (!defaultLane) {
+    /* This lane is synthesised here rather than declared in the source, so nothing
+     * upstream has given it the two properties every declared lane arrives with.
+     *
+     * `look` decides which of the two drawing branches `swimlane.js` takes and is half of
+     * the `[data-look="..."][data-color-id="..."]` selector the theme palette is keyed
+     * on -- without it the lane renders classic inside a handDrawn diagram and takes no
+     * palette colour at all.
+     *
+     * `colorIndex` is assigned by `flowDb` per declared subgraph, so the free slot is the
+     * one past the highest already handed out. Reusing 0 would paint this lane the same
+     * colour as the first declared one. */
     defaultLane = {
       id: DEFAULT_SWIMLANE_ID,
       label: '',
       isGroup: true,
       shape: 'swimlane',
       padding: 20,
+      look: layout.config?.look,
+      colorIndex: nodes.reduce((max, node) => Math.max(max, node.colorIndex ?? -1), -1) + 1,
       ...(direction ? { direction } : {}),
     } as ClusterNode;
     nodes.push(defaultLane);

--- a/packages/mermaid/src/rendering-util/rendering-elements/clusters/swimlane.js
+++ b/packages/mermaid/src/rendering-util/rendering-elements/clusters/swimlane.js
@@ -30,10 +30,8 @@ export const swimlane = async (parent, node) => {
     .attr('data-et', 'cluster')
     .attr('data-look', node.look);
 
-  // Per-lane colour slot. A no-op unless the active theme carries a palette; the
-  // matching `[data-color-id]` rules are emitted by the flowchart stylesheet, which
-  // swimlanes reuses. Lanes are the diagram's participants, so unlike a flowchart node
-  // they are exactly the thing the categorical palette is meant to distinguish.
+  // Per-lane colour slot; a no-op unless the theme carries a palette. The matching
+  // `[data-color-id]` rules come from the flowchart stylesheet, which swimlanes reuses.
   stampColorSlot(shapeSvg, node.colorIndex, theme, borderColorArray);
 
   const useHtmlLabels = evaluate(siteConfig.flowchart.htmlLabels);
@@ -116,8 +114,7 @@ export const swimlane = async (parent, node) => {
       });
 
       const roughTitle = rc.rectangle(laneLeft, laneTop, titleWidth, height, titleOptions);
-      // Same classes as the classic look, so the stylesheet can tell the title band from
-      // the lane body without having to know which look drew them.
+      // Same classes as the classic look, so CSS can tell the two halves apart.
       titleRect = shapeSvg.insert(() => roughTitle, ':first-child').attr('class', 'swimlane-title');
       const roughBody = rc.rectangle(bodyX, laneTop, bodyWidth, height, bodyOptions);
       bodyRect = shapeSvg.insert(() => roughBody, ':first-child').attr('class', 'swimlane-body');

--- a/packages/mermaid/src/rendering-util/rendering-elements/clusters/swimlane.js
+++ b/packages/mermaid/src/rendering-util/rendering-elements/clusters/swimlane.js
@@ -6,6 +6,7 @@ import rough from 'roughjs';
 import { createText } from '../../createText.ts';
 import intersectRect from '../intersect/intersect-rect.js';
 import { styles2String, userNodeOverrides } from '../shapes/handDrawnShapeStyles.js';
+import { stampColorSlot } from '../../../diagrams/common/colorThemeGate.js';
 
 /**
  * Swimlane cluster shape (lane). Extracted from the shared clusters.js so the
@@ -14,8 +15,8 @@ import { styles2String, userNodeOverrides } from '../shapes/handDrawnShapeStyles
  */
 export const swimlane = async (parent, node) => {
   const siteConfig = getConfig();
-  const { themeVariables, handDrawnSeed } = siteConfig;
-  const { clusterBkg, clusterBorder } = themeVariables;
+  const { theme, themeVariables, handDrawnSeed } = siteConfig;
+  const { clusterBkg, clusterBorder, borderColorArray } = themeVariables;
   const laneStroke = clusterBorder;
 
   const { labelStyles, nodeStyles, borderStyles, backgroundStyles } = styles2String(node);
@@ -28,6 +29,12 @@ export const swimlane = async (parent, node) => {
     .attr('data-id', node.id)
     .attr('data-et', 'cluster')
     .attr('data-look', node.look);
+
+  // Per-lane colour slot. A no-op unless the active theme carries a palette; the
+  // matching `[data-color-id]` rules are emitted by the flowchart stylesheet, which
+  // swimlanes reuses. Lanes are the diagram's participants, so unlike a flowchart node
+  // they are exactly the thing the categorical palette is meant to distinguish.
+  stampColorSlot(shapeSvg, node.colorIndex, theme, borderColorArray);
 
   const useHtmlLabels = evaluate(siteConfig.flowchart.htmlLabels);
 
@@ -109,9 +116,11 @@ export const swimlane = async (parent, node) => {
       });
 
       const roughTitle = rc.rectangle(laneLeft, laneTop, titleWidth, height, titleOptions);
-      titleRect = shapeSvg.insert(() => roughTitle, ':first-child');
+      // Same classes as the classic look, so the stylesheet can tell the title band from
+      // the lane body without having to know which look drew them.
+      titleRect = shapeSvg.insert(() => roughTitle, ':first-child').attr('class', 'swimlane-title');
       const roughBody = rc.rectangle(bodyX, laneTop, bodyWidth, height, bodyOptions);
-      bodyRect = shapeSvg.insert(() => roughBody, ':first-child');
+      bodyRect = shapeSvg.insert(() => roughBody, ':first-child').attr('class', 'swimlane-body');
 
       titleRect.select('path:nth-child(2)').attr('style', borderStyles.join(';'));
       titleRect.select('path').attr('style', backgroundStyles.join(';').replace('fill', 'stroke'));
@@ -180,9 +189,9 @@ export const swimlane = async (parent, node) => {
       });
 
       const roughTitle = rc.rectangle(x, laneTop, width, titleHeight, titleOptions);
-      titleRect = shapeSvg.insert(() => roughTitle, ':first-child');
+      titleRect = shapeSvg.insert(() => roughTitle, ':first-child').attr('class', 'swimlane-title');
       const roughBody = rc.rectangle(x, bodyY, width, contentHeight, bodyOptions);
-      bodyRect = shapeSvg.insert(() => roughBody, ':first-child');
+      bodyRect = shapeSvg.insert(() => roughBody, ':first-child').attr('class', 'swimlane-body');
 
       titleRect.select('path:nth-child(2)').attr('style', borderStyles.join(';'));
       titleRect.select('path').attr('style', backgroundStyles.join(';').replace('fill', 'stroke'));

--- a/scripts/tsc-check.ts
+++ b/scripts/tsc-check.ts
@@ -4,6 +4,7 @@
 
 /* eslint-disable no-console */
 import { mkdtemp, mkdir, writeFile, readFile, readdir, copyFile, rm } from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
 import { execFileSync } from 'child_process';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
@@ -11,6 +12,23 @@ import { tmpdir } from 'node:os';
 
 const __filename = fileURLToPath(import.meta.url); // get the resolved path to the file
 const __dirname = path.dirname(__filename); // get the name of the directory
+
+const MERMAID_PACKAGE_JSON = JSON.parse(
+  readFileSync(path.join(__dirname, '..', 'packages', 'mermaid', 'package.json'), 'utf8')
+) as Record<'dependencies' | 'devDependencies', Record<string, string> | undefined>;
+
+/**
+ * The range mermaid itself declares for `name`. Throws rather than falling back, so that
+ * moving a dependency between the two maps cannot quietly restore the floating version.
+ */
+const mermaidDependency = (name: string): string => {
+  const range =
+    MERMAID_PACKAGE_JSON.devDependencies?.[name] ?? MERMAID_PACKAGE_JSON.dependencies?.[name];
+  if (!range) {
+    throw new Error(`tsc-check: packages/mermaid/package.json declares no ${name}`);
+  }
+  return range;
+};
 
 /**
  * Packages to build and import
@@ -34,10 +52,15 @@ const SRC = {
         dependencies: tarballs,
         scripts: { build: 'tsc -b --verbose' },
         devDependencies: {
-          // these are somewhat-unexpectedly required, and a downstream would need
-          // to match the real `package.json` values
-          'type-fest': '*',
-          '@types/d3': '^7.4.3',
+          // these are somewhat-unexpectedly required, and a downstream would need to
+          // match the real `package.json` values -- so they are read from there rather
+          // than floated. `type-fest: '*'` resolved to 5.x, whose `typed-array.d.ts`
+          // names `Float16Array`, which the `lib: es2020` below does not have: an
+          // upstream release that changed nothing here failed every PR.
+          'type-fest': mermaidDependency('type-fest'),
+          '@types/d3': mermaidDependency('@types/d3'),
+          // Left floating on purpose: compiling against the newest TypeScript is the
+          // signal this check exists for.
           typescript: '*',
         },
       },


### PR DESCRIPTION
> Stacked on #8148 — **merge after it.** That PR makes `redux-color` the default, which is what turns per-lane colour from an opt-in into what every swimlane diagram renders as. #8148's branch is merged in here so this is reviewed and tested against the palette it will ship under.

## What

Swimlane lanes take a per-lane colour under `redux-color` and `redux-dark-color`, cycling every 12, as flowchart subgraph containers have since #8147. A lane is the participant a swimlane diagram is *about*, so it is the thing a categorical palette is for — but lanes rendered uniformly grey while the subgraphs drawn from the same `flowDb` slots were already tinted.

Nodes inside a lane stay uniform, and explicit `style` on a lane still wins.

## The slots were already there

`swimlanes` reuses flowchart's parser and DB, so `flowDb` had been handing every lane a `colorIndex` since #8147. Three things stopped it reaching the element.

**`swimlane.js` never stamped it.** It is the one cluster shape that does not go through `clusters.js`'s `rect`, so it never picked up the `stampColorSlot` call added there.

**The lane-border override outranked the palette.** `swimlanes/styles.ts` carried `.swimlane.cluster rect { stroke: clusterBorder !important }`. That `!important` is needed — it exists to beat `[data-look="neo"].cluster rect`, which it ties with on specificity and which is emitted after it. But it would also beat every palette rule, and the failure is silent: lanes stay grey with nothing to say why. Scoped to `:not([data-color-id])` it does the one job it was added for, and nothing stamps that attribute outside the colour themes.

**The generic `.cluster` palette rules cannot be reused for a lane.** A lane is two rectangles rather than one, and under handDrawn its body asks roughjs for `fill: 'none'` — which roughjs answers with a hachure path carrying `stroke="none"`, not by omitting the path. The generic `path` rule would have painted that invisible hachure across the whole lane and filled both outline paths solid. Lanes are excluded from the generic rules by `:not(.swimlane)` and take their own block:

| Look | Selector | What it paints |
|---|---|---|
| classic / neo | `rect.swimlane-title`, `rect.swimlane-body` | border + fill |
| handDrawn | `.swimlane-* path:nth-of-type(2)` | the outline path of each half |
| handDrawn | `.swimlane-* path:first-of-type` | the hachure, whose lines are strokes rather than a fill |

The handDrawn branch previously left its two rough groups unclassed, so nothing in CSS could tell a title band from a body; they now carry the same `swimlane-title` / `swimlane-body` classes the classic branch already set.

The rules live in `flowchart/styles.ts` because a swimlane reaches that stylesheet two ways — the `swimlane-beta` diagram, which wraps flowchart's `styles` export, and a plain `flowchart` given `layout: swimlane`. The second never loads `swimlanes/styles.ts`; both are verified.

## Two bugs on the synthetic default lane

The lane that collects ungrouped nodes is synthesised by the layout rather than declared, so nothing upstream gave it the two properties every declared lane arrives with. Neither failed loudly.

- **No `look`.** `swimlane.js` branches on `node.look === 'handDrawn'`, so the lane rendered as a classic rect inside a handDrawn diagram — a pre-existing bug, independent of colour — and matched no `[data-look="..."]` palette rule.
- **No `colorIndex`.** `stampColorSlot` falls back to `colorIndex ?? 0`, so it took slot 0 and came out the same colour as the first declared lane. It now takes the slot one past the highest already handed out.

## Slot ordering

`flowDb`'s pre-order walk is left as-is rather than renumbered per lane. Nested subgraphs inside a lane consume slots too, so consecutive lanes are not necessarily consecutive slots — which is correct: a nested container should not share its parent lane's colour, and the palette is categorical, not ordered.

## `redux-dark-color` colours borders only

That theme ships `bkgColorArray = []`. Its lanes get palette borders and keep the dark `clusterBkg` body, which is what its flowchart subgraphs already do. Changing that is a palette decision, not this PR's — the guard is load-bearing rather than defensive, and every background-derived rule is dropped there rather than emitted with a missing value. Pinned by unit and e2e tests.

## Review follow-ups

Both 🟡 items from the review are fixed, and both 🟢 nits with them:

- **handDrawn lane bodies now take the palette fill**, so a lane is tinted the same way under every look. The reviewer was right that this read as an oversight rather than a decision — the hachure fill path exists for the body too, it just carries `stroke="none"`. Rendered and inspected: at roughjs's default `fillWeight: 4` / `hachureGap: 5.2` the pale tint reads as a solid-ish wash, close to the classic look and legible behind the nodes. `laneRule` now covers both halves for both path rules, which was the second nit.
- **The handDrawn selectors are now verified against a real render.** Three e2e tests check computed strokes on the outline and hachure paths, including that `redux-dark-color` leaves the body's hachure unpainted. That was the gap: `path:nth-of-type(2)` encodes roughjs's emission order, no unit test can confirm it, and every existing assertion queried `rect.swimlane-*`, which does not exist under that look.
- **The changeset's "explicit `style` still wins" is narrowed.** It held for classic and neo only. Under handDrawn the lane body gets no inline style at all: `bodyOptions` passes `stroke`/`fill` as the `options` argument that `userNodeOverrides` assigns *over* the user's values, so a user's stroke on a handDrawn lane body was already discarded before this PR. Pre-existing and left alone — worth a follow-up issue.

## CI: `unit-test` was failing on an unrelated upstream release

Not caused by this PR. `scripts/tsc-check.ts` installed `type-fest: '*'` into its throwaway consumer project; that resolved to 5.x, whose `typed-array.d.ts` names `Float16Array`, and the tsconfig the script generates asks for `lib: es2020`. Every PR in the repo fails on it — `develop` last ran green on 28 Aug, before the release.

`type-fest` and `@types/d3` are now read from `packages/mermaid/package.json`, which is what the comment above them already said a downstream would have to match, and the helper throws rather than falling back so moving a dep between `dependencies` and `devDependencies` cannot quietly restore the float. `typescript` stays floating on purpose — compiling against the newest TypeScript is the signal this check exists for, and it passes on 7.0.2.

This is a one-file infra fix that is independent of the rest of the PR. Happy to split it out against `develop` so it unblocks every other PR without waiting on this stack — say the word.

## Verification

- Full unit suite: **6103 passing**. Three failures, none related: two `.claude/skills/domus-improve-loop-2` harness shims that require env vars from their runner, and `usecase.docs.spec.ts`, which passes in isolation (3.9s) and times out only under full-suite parallelism.
- **177 passing** across the swimlanes and flowchart e2e suites.
- `pnpm test:check:tsc` passes.
- Every new assertion mutation-checked: removing the stamp fails four e2e assertions, dropping the body fill rule fails the new handDrawn test, and reverting either CSS scoping fails the unit ones.
- Rendered and inspected computed styles for TB/LR, classic/neo/handDrawn, both colour themes, nested subgraphs, the synthetic default lane, user `style` overrides, `flowchart` + `layout: swimlane`, and a diagram with **no `theme` and no `look` at all** — the case #8148 creates.

## For the reviewer

**Argos.** Expect churn on every swimlanes fixture, since #8148 moves them to the coloured default. There are no committed Playwright baselines, so nothing to regenerate — but this wants a human pass rather than a bulk approve. Local screenshot comparison is not trustworthy here: two runs of the same spec on identical code gave different failure sets, so the behavioural assertions are what I gated on, and the e2e runs above used `--update-snapshots` to isolate them.

**Docs.** Not touched, matching #8147, which documented nothing for the equivalent flowchart behaviour. `docs/syntax/swimlanes.md` has no theming section to extend and `config/theming.md` has no per-diagram palette section; happy to add one to both in a follow-up if you'd rather the palette were documented once for subgraphs and lanes together.

**Merge order.** Whoever merges should retarget this to `develop` after #8148 lands, rather than merging into the stack branch.

**One conflict on the merge**, in `colorThemeGate.spec.ts`: both sides widened the same two lists — #8148 folded `er`, `requirement` and `timeline` into the shared gate spec, this branch added `swimlanes`. Both sets are kept, and `swimlanes` is in `SLOT_STYLESHEETS` as well as `STYLESHEETS` so the slot-coverage pass runs against the lane rules too. That merge commit is `--no-verify` because lint-staged stashes to run, which is not safe mid-merge; eslint and prettier were run on the resolved file directly.
