### PR TITLE
fix(ci): pin tsc-check's type dependencies to what mermaid declares

### DIFF
--- a/scripts/tsc-check.ts
+++ b/scripts/tsc-check.ts
@@ -8,9 +8,50 @@ import { execFileSync } from 'child_process';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { tmpdir } from 'node:os';
+import { createRequire } from 'node:module';
 
 const __filename = fileURLToPath(import.meta.url); // get the resolved path to the file
 const __dirname = path.dirname(__filename); // get the name of the directory
+
+const require_ = createRequire(import.meta.url);
+
+/**
+ * `mermaid`'s emitted `.d.ts` files reference `type-fest` and `@types/d3` directly, so the
+ * throwaway project has to install them itself. Their versions are not a free choice: the
+ * check compiles the *published* declarations, and those were built against exactly the
+ * ranges `packages/mermaid/package.json` declares.
+ *
+ * They used to be written as `'*'` and a hardcoded `'^7.4.3'`, which quietly meant "whatever
+ * the registry serves today". That resolved `type-fest` to a major mermaid has never been
+ * compiled against and broke this job at random -- 5.9.0 added `Float16Array` to its
+ * `TypedArray` union, which does not exist under the `es2020` lib below, and `skipLibCheck`
+ * is deliberately off here so third-party declarations are checked too. Two runs of the same
+ * commit seconds apart disagreed, depending on what npm resolved.
+ *
+ * Reading the ranges from the package under test is what makes this reproducible. It is also
+ * what the note below the field always asked for.
+ */
+const MERMAID_PKG = require_('../packages/mermaid/package.json') as {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+};
+
+/**
+ * Look in both sections: `type-fest` is a devDependency while `@types/d3` is a runtime one,
+ * and which section a type package sits in is not something this check should care about.
+ * Throw rather than emit `undefined` -- npm reads a missing range as "latest", which is the
+ * exact failure mode being fixed here, and it would come back silently.
+ */
+const typeDependency = (name: string): string => {
+  const range = MERMAID_PKG.dependencies?.[name] ?? MERMAID_PKG.devDependencies?.[name];
+  if (!range) {
+    throw new Error(
+      `tsc-check: packages/mermaid/package.json no longer declares '${name}'. ` +
+        `Update scripts/tsc-check.ts to match wherever it moved.`
+    );
+  }
+  return range;
+};
 
 /**
  * Packages to build and import
@@ -34,10 +75,15 @@ const SRC = {
         dependencies: tarballs,
         scripts: { build: 'tsc -b --verbose' },
         devDependencies: {
-          // these are somewhat-unexpectedly required, and a downstream would need
-          // to match the real `package.json` values
-          'type-fest': '*',
-          '@types/d3': '^7.4.3',
+          // these are somewhat-unexpectedly required, and a downstream needs to match the
+          // real `package.json` values -- see `typeDependency`
+          'type-fest': typeDependency('type-fest'),
+          '@types/d3': typeDependency('@types/d3'),
+          // Deliberately unpinned: a downstream picks its own compiler, so checking against
+          // the current release is the signal this job exists to give. Pinning it to the
+          // repo's own TypeScript additionally needs `"type": "module"` here, or the
+          // generated `src/index.ts` is treated as CommonJS under `moduleResolution:
+          // nodenext` and cannot import these ESM-only packages (TS1479).
           typescript: '*',
         },
       },
@@ -121,7 +167,9 @@ async function main() {
   for (const argv of COMMANDS) {
     console.warn('... in', cwd);
     console.warn('>>>', ...argv);
-    execFileSync(argv[0], argv.slice(1), { cwd });
+    // `stdio: 'inherit'`, or a failure prints the compiler output as `<Buffer 0a 3e ...>` and
+    // the actual diagnostic never reaches the log.
+    execFileSync(argv[0], argv.slice(1), { cwd, stdio: 'inherit' });
   }
 
   for (const lib of LIB) {


### PR DESCRIPTION
Fixes #8179

## Problem

`pnpm test:check:tsc` started failing on unrelated branches with:

```
node_modules/type-fest/source/typed-array.d.ts(14,4): error TS2304: Cannot find name 'Float16Array'.
```

`scripts/tsc-check.ts` generates its throwaway project with unpinned type dependencies:

```ts
'type-fest': '*',
'@types/d3': '^7.4.3',
```

`mermaid`'s emitted `.d.ts` files reference both directly, so the throwaway project has to install them — but their versions aren't a free choice. The check compiles the *published* declarations, and those were built against exactly the ranges `packages/mermaid/package.json` declares (`type-fest: ^4.41.0`). `'*'` resolved to **`type-fest@5.9.0`**, a major mermaid has never been compiled against.

`type-fest@5.9.0` was published **2026-08-30T23:58Z** and added `Float16Array` to its `TypedArray` union. The generated tsconfig sets `lib: ["dom", "es2020"]`, where that type doesn't exist, and deliberately leaves `skipLibCheck` off so third-party declarations get checked too.

Nothing in the repo changed. Two `Unit Tests` runs of the **same commit** `550394ad2`, started three seconds apart, disagreed purely on npm resolution:

| run | event | result |
| --- | --- | --- |
| [33385246996](https://github.com/mermaid-js/mermaid/actions/runs/33385246996) | `push` | ❌ failure |
| [33385250147](https://github.com/mermaid-js/mermaid/actions/runs/33385250147) | `pull_request` | ✅ success |

## Change

**Read both ranges from the package under test** rather than hardcoding them. This is what the note already sitting below the field asked for ("a downstream would need to match the real `package.json` values"). `typeDependency()` looks in both `dependencies` and `devDependencies`, since `type-fest` is a devDependency while `@types/d3` is a runtime one, and throws if either disappears — npm reads a missing range as "latest", which is the exact failure mode being fixed, and it would come back silently.

**`typescript` stays unpinned on purpose.** A downstream picks its own compiler, so checking against the current release is the signal this job exists to give. See the caveat below before changing that.

**`stdio: 'inherit'` on the build.** Without it `execFileSync` buffers the output and a failure prints:

```
stdout: <Buffer 0a 3e 20 62 75 69 6c 64 0a 3e 20 74 73 63 20 2d 62 ... 300 more bytes>,
stderr: <Buffer 6e 70 6d 20 77 61 72 6e 20 55 6e 6b 6e 6f 77 6e 20 ... 899 more bytes>
```

That hex dump is most of why this read as mysterious rather than as a version bump.

## Verification

Isolated by changing only the dependency, tarballs untouched:

| `type-fest` | `typescript` | result |
| --- | --- | --- |
| `5.9.0` | `7.0.2` | ❌ `Cannot find name 'Float16Array'` |
| `5.8.0` | `7.0.2` | ✅ passes |
| `^4.41.0` | `7.0.2` | ✅ passes |

`pnpm test:check:tsc` on this branch, against a fresh `pnpm build`: **`tsc-check OK`, 0 errors, exit 0.**

No changeset — nothing published changes.

## Two notes for reviewers

**Don't reach for `skipLibCheck: true`.** It silences this, but it skips *all* declaration files including `mermaid`'s own, which is the entire thing this check validates.

**Pinning `typescript` needs one more change.** I tried the repo's `~5.7.3` and got three `TS1479` errors: the generated `package.json` has no `"type": "module"`, so the harness's `src/index.ts` is treated as CommonJS under `moduleResolution: nodenext` and can't import these ESM-only packages. It passes today only because TS 7 changed that behaviour. Worth knowing before anyone pins it.

## Separate pre-existing bug, not fixed here

`packages/parser/scripts/prepack.ts` runs api-extractor over `dist/**/*.d.ts` and then **deletes those inputs**. So running `pnpm test:check:tsc` twice locally without an intervening rebuild makes the second run pack a degraded bundle — 289KB instead of 424KB — and fail with ~239 spurious `Cannot find name 'isAbstractElement'` errors from the langium re-exports. It cost me a detour; CI never hits it because each job starts from a fresh install. Happy to open a separate issue if that's wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes intermittent `pnpm test:check:tsc` failures by reading `type-fest` and `@types/d3` ranges from `packages/mermaid/package.json`.

Compiler output now streams directly to CI logs with `stdio: 'inherit'`. TypeScript remains unpinned intentionally to test current downstream compiler compatibility.

## Validation

- `pnpm test:check:tsc` passes with the declared dependency ranges.
- `skipLibCheck` remains disabled.
- No published package changes require a changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->