### PR TITLE
fix(themes): colour venn circles in the redux colour themes

### DIFF
--- a/.changeset/redux-color-venn.md
+++ b/.changeset/redux-color-venn.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix(themes): venn diagrams follow the `redux-color` and `redux-dark-color` palettes. Neither theme defined any `venn*` variable, so every circle fell back to a single `primaryColor` and the diagram rendered in one flat tone. The sets now take the same categorical palette as flowchart subgraphs, and an explicit `style` on a set still wins.

--- a/.changeset/redux-color-venn.md
+++ b/.changeset/redux-color-venn.md
@@ -2,4 +2,4 @@
 'mermaid': patch
 ---
 
-fix(themes): venn diagrams follow the `redux-color` and `redux-dark-color` palettes. Neither theme defined any `venn*` variable, so every circle fell back to a single `primaryColor` and the diagram rendered in one flat tone. The sets now take the same categorical palette as flowchart subgraphs, and an explicit `style` on a set still wins.
+fix(themes): venn circles follow the `redux-color` and `redux-dark-color` palettes. Neither theme defined any `venn*` variable, so every circle rendered in one flat colour.

--- a/e2e/rendering/venn/venn-redux-color.spec.ts
+++ b/e2e/rendering/venn/venn-redux-color.spec.ts
@@ -2,10 +2,8 @@ import { test, expect, type Page } from '@playwright/test';
 import { renderGraph } from '../../helpers/util.ts';
 
 /**
- * The venn fixtures under `e2e/diagrams/venn` give Argos its coverage of the colours.
- * These assert the thing a screenshot cannot state: that the circles are painted from the
- * theme palette and differ from each other, rather than all landing on the single
- * `primaryColor` fallback the renderer uses when a theme defines no `venn*` variables.
+ * What a screenshot cannot state: the circles differ from each other, rather than all
+ * landing on the single `primaryColor` fallback.
  */
 const threeSets = `venn-beta
   title Innovation

--- a/e2e/rendering/venn/venn-redux-color.spec.ts
+++ b/e2e/rendering/venn/venn-redux-color.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect, type Page } from '@playwright/test';
+import { renderGraph } from '../../helpers/util.ts';
+
+/**
+ * The venn fixtures under `e2e/diagrams/venn` give Argos its coverage of the colours.
+ * These assert the thing a screenshot cannot state: that the circles are painted from the
+ * theme palette and differ from each other, rather than all landing on the single
+ * `primaryColor` fallback the renderer uses when a theme defines no `venn*` variables.
+ */
+const threeSets = `venn-beta
+  title Innovation
+  set Desirable
+  set Feasible
+  set Viable
+  union Desirable,Feasible,Viable["Innovation"]
+`;
+
+const circleFills = (page: Page) =>
+  page
+    .locator('.venn-circle path')
+    .evaluateAll((paths) => paths.map((path) => getComputedStyle(path).fill));
+
+test.describe('Venn - redux colour themes', () => {
+  for (const theme of ['redux-color', 'redux-dark-color'] as const) {
+    test(`paints each set its own colour under ${theme}`, async ({ page }, testInfo) => {
+      await renderGraph(page, testInfo, threeSets, {
+        screenshot: false,
+        logLevel: 0,
+        name: `venn-${theme}`,
+        theme,
+      });
+
+      const fills = await circleFills(page);
+      expect(fills).toHaveLength(3);
+      expect(new Set(fills).size).toBe(3);
+      expect(fills.filter((fill) => fill === 'none' || fill === '')).toEqual([]);
+    });
+  }
+
+  test('keeps an explicit set style ahead of the palette', async ({ page }, testInfo) => {
+    await renderGraph(
+      page,
+      testInfo,
+      `venn-beta
+        set A
+        set B
+        union A, B
+        style A fill:#00ff00
+      `,
+      { screenshot: false, logLevel: 0, name: 'venn-user-style', theme: 'redux-color' }
+    );
+
+    const fills = await circleFills(page);
+    expect(fills).toContain('rgb(0, 255, 0)');
+  });
+});

--- a/packages/mermaid/src/diagrams/venn/vennPalette.spec.ts
+++ b/packages/mermaid/src/diagrams/venn/vennPalette.spec.ts
@@ -1,12 +1,6 @@
 /**
- * The renderer reads `venn1`..`venn8` off the theme and falls back to a single
- * `primaryColor` for any it does not find, so a theme that defines none renders every
- * circle in one flat tone. That is what `redux-color` and `redux-dark-color` shipped:
- * no `venn*` variables at all, and nothing to report it, since the fallback is a valid
- * colour and the diagram renders without complaint.
- *
- * Two halves are pinned here: the themes that should define the variables do, and the
- * renderer paints from them.
+ * A theme defining no `venn*` renders every circle in one flat `primaryColor`, which is
+ * what the redux colour themes shipped -- silently, since the fallback is a valid colour.
  */
 import { describe, expect, it, vi } from 'vitest';
 import * as configModule from '../../config.js';
@@ -14,7 +8,7 @@ import themes from '../../themes/index.js';
 import type { Diagram } from '../../Diagram.js';
 import { draw } from './vennRenderer.js';
 
-/** How many the renderer reads. Matches `theme-dark` and `theme-neutral`. */
+/** How many the renderer reads. */
 const VENN_SLOTS = 8;
 
 const slots = Array.from({ length: VENN_SLOTS }, (_, i) => i);
@@ -29,13 +23,8 @@ const vennColorsOf = (name: string) =>
   slots.map((i) => themeVariablesOf(name)[`venn${i + 1}`] as string | undefined);
 
 /**
- * The themes that deliberately ship no venn palette, so their circles stay one flat
- * `primaryColor`. Listed rather than derived: each carries a `cScale` that is unusable
- * here -- uniform grey in `redux`, near-black on a dark background in the other three --
- * so flat is the better of the two, and that is a decision rather than an omission.
- *
- * A new theme added without venn colours fails the exhaustiveness check below instead of
- * silently rendering flat.
+ * Deliberately flat: their `cScale` is uniform grey in `redux` and near-black in the
+ * others. Listed, so a new theme without venn colours fails the check below.
  */
 const NO_VENN_PALETTE = ['neo', 'neo-dark', 'redux', 'redux-dark'];
 
@@ -61,12 +50,7 @@ describe.each(NO_VENN_PALETTE)('%s venn colours', (name) => {
   });
 });
 
-/**
- * The colour themes take `borderColorArray` -- the same categorical palette flowchart
- * subgraphs and swimlane lanes are painted from -- so a venn reads as part of the theme
- * rather than as its own scheme. Asserted against the array rather than against hex, so
- * retuning the palette does not need this file edited.
- */
+/** Asserted against the array rather than hex, so retuning the palette needs no edit. */
 describe.each(['redux-color', 'redux-dark-color'])('%s venn palette', (name) => {
   it('takes the theme categorical palette', () => {
     const palette = themeVariablesOf(name).borderColorArray as string[];
@@ -123,8 +107,7 @@ describe('renderer palette fallback', () => {
   });
 
   it('falls back to one colour, not to undefined, without a palette', async () => {
-    // Pins the flat fallback itself, not how it is reached: the empty-palette guard in
-    // the renderer is a readability change and produces the same fills without it.
+    // Pins the fallback, not how it is reached: the renderer guard changes no output.
     const fills = (await drawWithTheme('redux')).filter(Boolean);
 
     expect(fills.length).toBeGreaterThanOrEqual(2);

--- a/packages/mermaid/src/diagrams/venn/vennPalette.spec.ts
+++ b/packages/mermaid/src/diagrams/venn/vennPalette.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * The renderer reads `venn1`..`venn8` off the theme and falls back to a single
+ * `primaryColor` for any it does not find, so a theme that defines none renders every
+ * circle in one flat tone. That is what `redux-color` and `redux-dark-color` shipped:
+ * no `venn*` variables at all, and nothing to report it, since the fallback is a valid
+ * colour and the diagram renders without complaint.
+ *
+ * Two halves are pinned here: the themes that should define the variables do, and the
+ * renderer paints from them.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import * as configModule from '../../config.js';
+import themes from '../../themes/index.js';
+import type { Diagram } from '../../Diagram.js';
+import { draw } from './vennRenderer.js';
+
+/** How many the renderer reads. Matches `theme-dark` and `theme-neutral`. */
+const VENN_SLOTS = 8;
+
+const slots = Array.from({ length: VENN_SLOTS }, (_, i) => i);
+
+const themeVariablesOf = (name: string): Record<string, string | string[] | undefined> =>
+  themes[name as keyof typeof themes].getThemeVariables({}) as unknown as Record<
+    string,
+    string | string[] | undefined
+  >;
+
+const vennColorsOf = (name: string) =>
+  slots.map((i) => themeVariablesOf(name)[`venn${i + 1}`] as string | undefined);
+
+/**
+ * The themes that deliberately ship no venn palette, so their circles stay one flat
+ * `primaryColor`. Listed rather than derived: each carries a `cScale` that is unusable
+ * here -- uniform grey in `redux`, near-black on a dark background in the other three --
+ * so flat is the better of the two, and that is a decision rather than an omission.
+ *
+ * A new theme added without venn colours fails the exhaustiveness check below instead of
+ * silently rendering flat.
+ */
+const NO_VENN_PALETTE = ['neo', 'neo-dark', 'redux', 'redux-dark'];
+
+const WITH_VENN_PALETTE = Object.keys(themes).filter((name) => !NO_VENN_PALETTE.includes(name));
+
+it('accounts for every registered theme', () => {
+  expect([...NO_VENN_PALETTE, ...WITH_VENN_PALETTE].sort()).toEqual(Object.keys(themes).sort());
+});
+
+describe.each(WITH_VENN_PALETTE)('%s venn colours', (name) => {
+  it('defines every slot the renderer reads', () => {
+    const colors = vennColorsOf(name);
+
+    expect(colors.filter((color) => typeof color === 'string' && color.length > 0)).toHaveLength(
+      VENN_SLOTS
+    );
+  });
+});
+
+describe.each(NO_VENN_PALETTE)('%s venn colours', (name) => {
+  it('defines none, and so renders flat by design', () => {
+    expect(vennColorsOf(name).filter(Boolean)).toEqual([]);
+  });
+});
+
+/**
+ * The colour themes take `borderColorArray` -- the same categorical palette flowchart
+ * subgraphs and swimlane lanes are painted from -- so a venn reads as part of the theme
+ * rather than as its own scheme. Asserted against the array rather than against hex, so
+ * retuning the palette does not need this file edited.
+ */
+describe.each(['redux-color', 'redux-dark-color'])('%s venn palette', (name) => {
+  it('takes the theme categorical palette', () => {
+    const palette = themeVariablesOf(name).borderColorArray as string[];
+
+    expect(palette.length).toBeGreaterThan(0);
+    expect(vennColorsOf(name)).toEqual(slots.map((i) => palette[i % palette.length]));
+  });
+
+  it('gives every slot a distinct colour', () => {
+    expect(new Set(vennColorsOf(name)).size).toBe(VENN_SLOTS);
+  });
+});
+
+describe('renderer palette fallback', () => {
+  const createDiagram = () =>
+    ({
+      db: {
+        getConfig: () => ({ padding: 15, useDebugLayout: false }),
+        getDiagramTitle: () => undefined,
+        getSubsetData: () => [
+          { sets: ['A'], size: 10, label: 'A' },
+          { sets: ['B'], size: 10, label: 'B' },
+          { sets: ['A', 'B'], size: 2.5, label: 'AB' },
+        ],
+        getTextData: () => [],
+        getStyleData: () => [],
+      },
+    }) as unknown as Diagram;
+
+  const drawWithTheme = async (themeName: string) => {
+    document.body.innerHTML = '<svg id="venn"></svg>';
+    const spy = vi.spyOn(configModule, 'getConfig');
+    spy.mockReturnValue({
+      ...configModule.getConfig(),
+      themeVariables: themeVariablesOf(themeName),
+    } as never);
+
+    try {
+      await draw('', 'venn', '1.0', createDiagram());
+    } finally {
+      spy.mockRestore();
+    }
+
+    return [...document.querySelectorAll('.venn-circle path')].map(
+      (path) => (path as SVGPathElement).style.fill
+    );
+  };
+
+  it('paints each circle its own colour under a palette theme', async () => {
+    const fills = (await drawWithTheme('redux-color')).filter(Boolean);
+
+    expect(fills.length).toBeGreaterThanOrEqual(2);
+    expect(new Set(fills).size).toBe(fills.length);
+  });
+
+  it('falls back to one colour, not to undefined, without a palette', async () => {
+    // Pins the flat fallback itself, not how it is reached: the empty-palette guard in
+    // the renderer is a readability change and produces the same fills without it.
+    const fills = (await drawWithTheme('redux')).filter(Boolean);
+
+    expect(fills.length).toBeGreaterThanOrEqual(2);
+    expect(new Set(fills).size).toBe(1);
+    expect(fills).not.toContain('undefined');
+  });
+});

--- a/packages/mermaid/src/diagrams/venn/vennRenderer.ts
+++ b/packages/mermaid/src/diagrams/venn/vennRenderer.ts
@@ -123,8 +123,12 @@ export const draw: DrawDefinition = (
     const data = d as VennData;
     const setsKey = stableSetsKey([...data.sets].sort());
     const customStyle = styleByKey.get(setsKey);
-    const baseColor =
-      customStyle?.fill || themeColors[i % themeColors.length] || themeVariables.primaryColor;
+    // `themeColors` is empty for the themes that define no `venn*` variables. Falling back
+    // to one flat `primaryColor` is intended for those, but the route there was `i % 0`
+    // being NaN and indexing to `undefined` -- same result, and no way to tell a theme
+    // that opted out from one that forgot. Spelled out so the next reader can.
+    const paletteColor = themeColors.length > 0 ? themeColors[i % themeColors.length] : undefined;
+    const baseColor = customStyle?.fill || paletteColor || themeVariables.primaryColor;
     group.classed(`venn-set-${i % 8}`, true);
     const fillOpacity = customStyle?.['fill-opacity'] ?? 0.1;
     const strokeColor = customStyle?.stroke || baseColor;

--- a/packages/mermaid/src/diagrams/venn/vennRenderer.ts
+++ b/packages/mermaid/src/diagrams/venn/vennRenderer.ts
@@ -123,10 +123,8 @@ export const draw: DrawDefinition = (
     const data = d as VennData;
     const setsKey = stableSetsKey([...data.sets].sort());
     const customStyle = styleByKey.get(setsKey);
-    // `themeColors` is empty for the themes that define no `venn*` variables. Falling back
-    // to one flat `primaryColor` is intended for those, but the route there was `i % 0`
-    // being NaN and indexing to `undefined` -- same result, and no way to tell a theme
-    // that opted out from one that forgot. Spelled out so the next reader can.
+    // Empty for themes that define no `venn*`; the flat fallback is intended for those.
+    // Spelled out because the old route to it was `i % 0` being NaN.
     const paletteColor = themeColors.length > 0 ? themeColors[i % themeColors.length] : undefined;
     const baseColor = customStyle?.fill || paletteColor || themeVariables.primaryColor;
     group.classed(`venn-set-${i % 8}`, true);

--- a/packages/mermaid/src/themes/theme-redux-color.js
+++ b/packages/mermaid/src/themes/theme-redux-color.js
@@ -322,6 +322,14 @@ class Theme {
     this.pieOpacity = this.pieOpacity || '0.7';
 
     /* venn */
+    /* The circles are the diagram's participants, so they take the categorical palette
+       rather than shades of one hue. `borderColorArray` and not `cScale`, which is a
+       shade lighter: the renderer paints the fill at 0.1 opacity and leans on the stroke
+       and the label, both of which want the more saturated tone. */
+    for (let i = 0; i < 8; i++) {
+      this['venn' + (i + 1)] =
+        this['venn' + (i + 1)] ?? this.borderColorArray[i % this.borderColorArray.length];
+    }
     this.vennTitleTextColor = this.vennTitleTextColor ?? this.titleColor;
     this.vennSetTextColor = this.vennSetTextColor ?? this.textColor;
 

--- a/packages/mermaid/src/themes/theme-redux-color.js
+++ b/packages/mermaid/src/themes/theme-redux-color.js
@@ -322,10 +322,8 @@ class Theme {
     this.pieOpacity = this.pieOpacity || '0.7';
 
     /* venn */
-    /* The circles are the diagram's participants, so they take the categorical palette
-       rather than shades of one hue. `borderColorArray` and not `cScale`, which is a
-       shade lighter: the renderer paints the fill at 0.1 opacity and leans on the stroke
-       and the label, both of which want the more saturated tone. */
+    /* `borderColorArray` and not the lighter `cScale`: the fill is painted at 0.1
+       opacity, so the stroke and the label carry the circle. */
     for (let i = 0; i < 8; i++) {
       this['venn' + (i + 1)] =
         this['venn' + (i + 1)] ?? this.borderColorArray[i % this.borderColorArray.length];

--- a/packages/mermaid/src/themes/theme-redux-dark-color.js
+++ b/packages/mermaid/src/themes/theme-redux-dark-color.js
@@ -347,6 +347,14 @@ class Theme {
     this.pieOpacity = this.pieOpacity || '0.7';
 
     /* venn */
+    /* The circles are the diagram's participants, so they take the categorical palette
+       rather than shades of one hue. `borderColorArray` and not `cScale`, which is a
+       shade lighter: the renderer paints the fill at 0.1 opacity and leans on the stroke
+       and the label, both of which want the more saturated tone. */
+    for (let i = 0; i < 8; i++) {
+      this['venn' + (i + 1)] =
+        this['venn' + (i + 1)] ?? this.borderColorArray[i % this.borderColorArray.length];
+    }
     this.vennTitleTextColor = this.vennTitleTextColor ?? this.titleColor;
     this.vennSetTextColor = this.vennSetTextColor ?? this.textColor;
 

--- a/packages/mermaid/src/themes/theme-redux-dark-color.js
+++ b/packages/mermaid/src/themes/theme-redux-dark-color.js
@@ -347,10 +347,8 @@ class Theme {
     this.pieOpacity = this.pieOpacity || '0.7';
 
     /* venn */
-    /* The circles are the diagram's participants, so they take the categorical palette
-       rather than shades of one hue. `borderColorArray` and not `cScale`, which is a
-       shade lighter: the renderer paints the fill at 0.1 opacity and leans on the stroke
-       and the label, both of which want the more saturated tone. */
+    /* `borderColorArray` and not the lighter `cScale`: the fill is painted at 0.1
+       opacity, so the stroke and the label carry the circle. */
     for (let i = 0; i < 8; i++) {
       this['venn' + (i + 1)] =
         this['venn' + (i + 1)] ?? this.borderColorArray[i % this.borderColorArray.length];


### PR DESCRIPTION
> Stacked on #8148 — **merge after it.** Found while reviewing that PR's Argos build, and it is #8148 that makes it user-facing: once `redux-color` is the default, every venn diagram rendered without an explicit theme is monochrome.

## The bug

`redux-color` and `redux-dark-color` define **no `venn*` variables at all**. `vennRenderer` reads `venn1`..`venn8` and falls back to a single `primaryColor` for any it does not find, so every circle came out the same flat grey — and in `redux-dark-color`, near-black rings on a dark background with labels to match.

| | before | after |
|---|---|---|
| `redux-color` | three identical `#cccccc` circles | Fuchsia / Teal / Orange, labels darkened to match |
| `redux-dark-color` | three identical `#1f2020` circles | same hues, labels lightened for the dark background |

Nothing reported it because the fallback is a valid colour — the diagram renders, it just renders in one tone. No test asserted the variables existed, and a screenshot of a monochrome venn looks like a monochrome theme.

## The fix

The sets take `borderColorArray` — the same categorical palette flowchart subgraphs and swimlane lanes are painted from — so a venn reads as part of the theme rather than as its own scheme.

`borderColorArray` and not `cScale`, which is a shade lighter: the renderer paints the fill at `0.1` opacity and leans on the stroke (`0.95`) and the label (`darken(base, 30)` / `lighten(base, 30)`), and both want the more saturated tone. I rendered both to choose.

An explicit `style` on a set still wins — `customStyle?.fill` is checked before the palette, and there is a test.

## Four themes deliberately left flat

`neo`, `neo-dark`, `redux` and `redux-dark` have the identical omission. I tried the obvious fix — their own `cScale`, which is what `theme-dark` and `theme-neutral` use for venn — and rendered it before deciding:

- `redux`'s `cScale` is `hsl(0, 0%, 75%)` for every entry, so nothing changes.
- `neo-dark` and `redux-dark`'s are near-black, which puts black rings and unreadable labels on a dark background — worse than today.
- Only `neo` improved, and shipping it alone would be inconsistent.

For a theme with no categorical palette, one flat tone is the better of the two, so that is left as-is. `vennPalette.spec.ts` names those four explicitly and checks the list against the registered themes, so a *new* theme added without venn colours fails that check rather than quietly rendering flat.

## One change that is not a fix

The renderer reached its fallback via `themeColors[i % themeColors.length]` with an empty array — `i % 0` is NaN, `[][NaN]` is `undefined`, `|| primaryColor`. Same result, but it meant a theme that opted out was indistinguishable from one that forgot. The empty case is now spelled out.

I mutation-tested it and it changes no output, so it is a readability change, and the test that covers the fallback says so rather than pretending to pin the guard.

## Tests

- `vennPalette.spec.ts` — the themes that should define all eight slots do; the four that should not, do not; the two colour themes match `borderColorArray` element for element and are all distinct. Asserted against the array rather than hex, so retuning the palette does not need this file edited. Plus two renderer tests driving `draw()` in jsdom: distinct fills with a palette, one flat fill without.
- `e2e/rendering/venn/venn-redux-color.spec.ts` — computed fills in a real browser for both colour themes, and that a user `style` still wins.
- The existing `e2e/diagrams/venn/*.mmd` fixtures are already swept by `mmd-snapshots.spec.ts`, so Argos picks the visual change up without a new fixture.

Mutation-checked: reverting the theme change fails 4 unit assertions and the `redux-color` e2e.

## Verification

- Full unit suite: **6158 passing**. The 2 failures are the pre-existing `.claude/skills/domus-improve-loop-2` harness shims that need env vars from their runner.
- Venn e2e green; `pnpm test:check:tsc` and `tsc --noEmit` clean.
- Rendered and inspected: 2, 3 and 4 sets, `neo` and `handDrawn`, both colour themes, plus the four themes left flat.

## For the reviewer

**Argos.** The venn sheets will change — that is the point of the PR. Worth an eye on `redux-dark-color` in particular, since it went from near-invisible to legible.

**A note on the local e2e.** My first mutation check on the browser test passed against a stale dev-server bundle and looked like the assertion was worthless. It was not — after waiting for the rebuild, reverting the theme fails it as expected. Flagging in case anyone else mutation-tests e2e here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added distinct Venn diagram colors for `redux-color` and `redux-dark-color` using each theme’s `borderColorArray`.
- Preserved explicit per-set `style` overrides.
- Added explicit fallback handling for empty Venn palettes.
- Kept `neo`, `neo-dark`, `redux`, and `redux-dark` flat because they lack suitable categorical palettes.
- Added unit and browser tests for palette coverage, fallback behavior, theme colors, rendering, and style overrides.
- Added a patch changeset for `mermaid`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->