### PR TITLE
chore: trim the swimlane palette comments

### DIFF
--- a/.changeset/redux-color-swimlane-lanes.md
+++ b/.changeset/redux-color-swimlane-lanes.md
@@ -2,4 +2,4 @@
 'mermaid': minor
 ---
 
-feat(themes): swimlane lanes take a per-lane colour under the `redux-color` and `redux-dark-color` themes, cycling every 12 as flowchart subgraphs do. The lane holding ungrouped nodes takes its own slot instead of the first lane's, and now follows the diagram's `look` rather than always rendering classic.
+feat(themes): swimlane lanes take a per-lane colour under the `redux-color` and `redux-dark-color` themes, cycling every 12 as flowchart subgraphs do. The lane holding ungrouped nodes takes its own slot and now follows the diagram's `look`.

--- a/e2e/rendering/swimlanes/swimlanes.spec.ts
+++ b/e2e/rendering/swimlanes/swimlanes.spec.ts
@@ -225,11 +225,7 @@ test.describe('Swimlanes diagram', () => {
     await expect(shape).toHaveCSS('stroke-width', '4px');
   });
 
-  /**
-   * The unit tests pin the generated CSS; only a render proves the stamped
-   * `data-color-id` meets the emitted selector on the element. Asserted as "distinct and
-   * self-consistent" rather than against hex values, which `lanePalette.spec.ts` pins.
-   */
+  /** Only a render proves the stamped slot meets the emitted selector. */
   test.describe('redux colour theme lanes', () => {
     const fiveLanes = `swimlane-beta TD
         subgraph Intake
@@ -278,11 +274,7 @@ test.describe('Swimlanes diagram', () => {
       });
     }
 
-    /**
-     * The handDrawn selectors encode roughjs's emission order -- hachure fill first, then
-     * the outline -- which no unit test can confirm. The assertions above never reach it:
-     * `rect.swimlane-*` does not exist under this look.
-     */
+    /** roughjs's emission order, which no unit test can confirm. */
     test.describe('handDrawn', () => {
       const lanePaths = (page: Page, half: 'title' | 'body', nth: 1 | 2) =>
         page
@@ -305,10 +297,7 @@ test.describe('Swimlanes diagram', () => {
         }
       });
 
-      /**
-       * The hachure path's *stroke* is the lane fill, since roughjs draws a fill as lines.
-       * It is the rule `hasBkgColors` turns on and off, so both cases are checked.
-       */
+      /** roughjs draws a fill as lines, so the hachure path's stroke is the lane fill. */
       test('fills both halves where the theme ships a background palette', async ({
         page,
       }, testInfo) => {
@@ -375,10 +364,7 @@ test.describe('Swimlanes diagram', () => {
       await expect(styled).toHaveCSS('fill', 'rgb(0, 255, 0)');
     });
 
-    /**
-     * The synthetic lane gets no `look` or colour slot from upstream. Without them it
-     * renders as a classic rect inside a handDrawn diagram and reuses the first slot.
-     */
+    /** The synthetic lane gets no `look` or colour slot from upstream. */
     test('colours the synthetic default lane distinctly', async ({ page }, testInfo) => {
       await renderSwimlanes(
         page,

--- a/packages/mermaid/src/diagrams/common/colorThemeGate.spec.ts
+++ b/packages/mermaid/src/diagrams/common/colorThemeGate.spec.ts
@@ -25,10 +25,7 @@ import {
   safeLook,
 } from './colorThemeGate.js';
 
-/**
- * `swimlanes` wraps flowchart's stylesheet and appends its own lane rules, including an
- * `!important` one next to the palette, so it is listed separately from what it inherits.
- */
+/** `swimlanes` appends its own lane rules to flowchart's, so it is listed separately. */
 const STYLESHEETS = {
   class: classStyles,
   er: erStyles,
@@ -99,8 +96,7 @@ it('covers every registered theme between the two lists', () => {
 
 describe.each(SLOT_STYLESHEETS)('%s stylesheet', (name) => {
   it.each(PLAIN_THEMES)('emits no per-item colour rules for %s', (themeName) => {
-    // The slot marker, not the bare attribute: `swimlanes` keys a rule off
-    // `:not([data-color-id])`, which is the absence of a slot rather than a rule for one.
+    // The slot marker, not the bare attribute: `swimlanes` keys a rule off its absence.
     expect(render(name, themeName)).not.toContain('data-color-id="color-');
   });
 

--- a/packages/mermaid/src/diagrams/flowchart/styles.ts
+++ b/packages/mermaid/src/diagrams/flowchart/styles.ts
@@ -42,12 +42,9 @@ export interface FlowChartStyleOptions {
  * collapsed form's own colours are presentation attributes (`fill=` / `stroke=`), which
  * these rules correctly outrank while still losing to that inline style.
  *
- * Swimlane lanes are clusters too but need their own rules: a lane is two rectangles, and
- * under handDrawn its body asks roughjs for `fill: 'none'`, which it answers with a
- * hachure path carrying `stroke="none"` -- the generic `path` rule would paint that
- * invisible hachure and fill both outlines solid. Hence `:not(.swimlane)`. Emitted here
- * rather than in `swimlanes/styles.ts` so a plain flowchart given `layout: swimlane`,
- * which never loads that stylesheet, is covered too.
+ * Lanes are excluded by `:not(.swimlane)` and ruled separately below: a lane is two
+ * rectangles, and the generic `path` rule would paint the hachure roughjs emits for its
+ * unfilled body. Here, not in `swimlanes/styles.ts`, so `layout: swimlane` is covered too.
  */
 const genColor = (options: FlowChartStyleOptions) => {
   const { theme, bkgColorArray, borderColorArray } = options;

--- a/packages/mermaid/src/diagrams/swimlanes/lanePalette.spec.ts
+++ b/packages/mermaid/src/diagrams/swimlanes/lanePalette.spec.ts
@@ -1,13 +1,6 @@
 /**
- * Lanes take a per-lane colour under the redux colour themes, as flowchart subgraphs do.
- *
- * These assertions are about the shape of the emitted CSS, because that is where this
- * fails silently: a lane renders identically whether a declaration was discarded,
- * outranked, or never emitted. The four things that can go wrong are a half-painted lane
- * (title band and body are separate elements), the generic `.cluster` rules reaching a
- * lane (wrong under handDrawn, where the body's hachure carries `stroke="none"`), the
- * `!important` lane border outranking the palette, and `redux-dark-color`'s empty
- * `bkgColorArray` producing a declaration with a missing value.
+ * Asserts the shape of the emitted CSS, because a lane renders identically whether a
+ * declaration was discarded, outranked, or never emitted.
  */
 import { describe, expect, it } from 'vitest';
 import themes from '../../themes/index.js';
@@ -57,7 +50,7 @@ describe.each(COLOUR_THEMES)('%s lane palette', (themeName) => {
       expect(laneRect![1]).toContain(`fill: ${bkgColorArray[slot]};`);
     }
 
-    // handDrawn: roughjs draws the hachure fill first, so the outline is the second path.
+    // roughjs draws the hachure fill first, so the outline is the second path.
     const laneOutline = new RegExp(
       `${prefix} \\.swimlane-title path:nth-of-type\\(2\\), ` +
         `${prefix} \\.swimlane-body path:nth-of-type\\(2\\) \\{([^}]*)\\}`

--- a/packages/mermaid/src/diagrams/swimlanes/styles.ts
+++ b/packages/mermaid/src/diagrams/swimlanes/styles.ts
@@ -12,10 +12,8 @@ import type { FlowChartStyleOptions } from '../flowchart/styles.js';
  * `.cluster rect` border is suppressed by matching its stroke to the cluster
  * background — theme-adaptive, rather than a hardcoded colour.
  *
- * The `!important` is only there to outrank `[data-look="neo"].cluster rect`, which ties
- * with it on specificity. Palette lanes are exempted because they already outrank that
- * rule on their own, and an `!important` here would beat them too — leaving lanes grey
- * with nothing to say why. Nothing stamps `data-color-id` outside the colour themes.
+ * The `!important` only outranks `[data-look="neo"].cluster rect`, which ties with it on
+ * specificity. Palette lanes are exempt because it would beat them too.
  */
 const getStyles = (options: FlowChartStyleOptions): string =>
   `${getFlowchartStyles(options)}

--- a/packages/mermaid/src/rendering-util/layout-algorithms/swimlanes/__tests__/helpers.prepareLayout.spec.ts
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/swimlanes/__tests__/helpers.prepareLayout.spec.ts
@@ -44,11 +44,8 @@ describe('prepareLayoutForSwimlanes', () => {
     expect(grouped?.parentId).toBe('lane1');
   });
 
-  /**
-   * Neither omission fails loudly: without `look` the lane renders classic inside a
-   * handDrawn diagram and matches no palette rule, and slot 0 collides with the first
-   * declared lane.
-   */
+  // Neither omission fails loudly: no `look` renders classic in a handDrawn diagram, and
+  // slot 0 collides with the first declared lane.
   it('gives the synthetic default lane the diagram look and a free colour slot', () => {
     const layout: LayoutData = {
       nodes: [

--- a/packages/mermaid/src/rendering-util/layout-algorithms/swimlanes/helpers.ts
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/swimlanes/helpers.ts
@@ -114,10 +114,8 @@ export function prepareLayoutForSwimlanes(layout: LayoutData): void {
 
   let defaultLane = nodes.find((node) => node.id === DEFAULT_SWIMLANE_ID);
   if (!defaultLane) {
-    /* Synthesised rather than declared, so nothing upstream gave it the two properties a
-     * declared lane arrives with. Without `look` it renders classic inside a handDrawn
-     * diagram and matches no `[data-look="..."]` palette rule; `flowDb` numbers declared
-     * subgraphs from 0, so reusing 0 here would clash with the first of them. */
+    /* Synthesised, so nothing upstream gave it a `look` or a slot. Without `look` it
+     * renders classic in a handDrawn diagram; slot 0 would clash with the first lane. */
     defaultLane = {
       id: DEFAULT_SWIMLANE_ID,
       label: '',

--- a/scripts/tsc-check.ts
+++ b/scripts/tsc-check.ts
@@ -17,10 +17,7 @@ const MERMAID_PACKAGE_JSON = JSON.parse(
   readFileSync(path.join(__dirname, '..', 'packages', 'mermaid', 'package.json'), 'utf8')
 ) as Record<'dependencies' | 'devDependencies', Record<string, string> | undefined>;
 
-/**
- * The range mermaid itself declares for `name`. Throws rather than falling back, so that
- * moving a dependency between the two maps cannot quietly restore the floating version.
- */
+/** The range mermaid declares. Throws rather than falling back to a floating version. */
 const mermaidDependency = (name: string): string => {
   const range =
     MERMAID_PACKAGE_JSON.devDependencies?.[name] ?? MERMAID_PACKAGE_JSON.dependencies?.[name];
@@ -52,15 +49,11 @@ const SRC = {
         dependencies: tarballs,
         scripts: { build: 'tsc -b --verbose' },
         devDependencies: {
-          // these are somewhat-unexpectedly required, and a downstream would need to
-          // match the real `package.json` values -- so they are read from there rather
-          // than floated. `type-fest: '*'` resolved to 5.x, whose `typed-array.d.ts`
-          // names `Float16Array`, which the `lib: es2020` below does not have: an
-          // upstream release that changed nothing here failed every PR.
+          // Read from mermaid rather than floated: `type-fest: '*'` resolved to 5.x,
+          // which names `Float16Array` and does not compile under `lib: es2020` below.
           'type-fest': mermaidDependency('type-fest'),
           '@types/d3': mermaidDependency('@types/d3'),
-          // Left floating on purpose: compiling against the newest TypeScript is the
-          // signal this check exists for.
+          // Floating on purpose: the newest TypeScript is the signal this check wants.
           typescript: '*',
         },
       },


### PR DESCRIPTION
> Stacked on #8148, where the code being edited now lives.

Comment-only follow-up to #8176, which had already merged by the time I trimmed these. No behaviour change — the only edits are comment text plus one changeset sentence.

Every comment added by #8176 is cut to one or two lines. What stays is the part that is not recoverable from the code:

- the roughjs emission order the `path:nth-of-type(2)` / `path:first-of-type` selectors depend on
- why the lane rules carry `:not(.swimlane)` instead of riding the generic cluster rules
- why the `!important` lane border exempts palette lanes
- why `type-fest` is pinned in `scripts/tsc-check.ts` while `typescript` stays floating

The narrative around each — how the bug was found, what the alternatives were — is dropped; it is in #8176's commits and description if anyone needs it.

Pre-existing comments in the same files are left alone, so the diff is only what #8176 added.

**Verified:** 1386 unit tests and 52 swimlanes e2e pass; eslint and prettier clean.
