### PR TITLE
feat(themes): give state composites and concurrency regions a palette colour

### DIFF
--- a/.changeset/redux-color-state-composites.md
+++ b/.changeset/redux-color-state-composites.md
@@ -1,0 +1,9 @@
+---
+'mermaid': minor
+---
+
+feat(themes): composite states and concurrency regions now take a per-container colour under the `redux-color` and `redux-dark-color` themes, as flowchart subgraphs already do. Each composite gets the palette's border colour on its outline and its background tint behind the title strip; nested composites each take the next colour, so depth stays readable. `redux-dark-color` colours the outlines only, matching how it treats ER, requirement and sequence.
+
+The concurrency regions produced by a `--` divider are the exception: every region of one composite shares a single colour, so a divided composite reads as one thing split into parts rather than as several composites side by side. Regions of different composites still differ.
+
+States inside a composite stay uniform, and a composite carrying its own `classDef` or `style` keeps those colours and takes no palette slot — the slot is still spent, so styling one composite does not shift the colours of the ones after it.

--- a/.changeset/redux-color-state-composites.md
+++ b/.changeset/redux-color-state-composites.md
@@ -6,4 +6,6 @@ feat(themes): composite states now take a per-container colour under the `redux-
 
 The concurrency regions produced by a `--` divider share the colour of the composite they split, rather than taking one of their own — the author wrote a single composite, so it is drawn as one thing in parts. Adding a `--` therefore leaves every other composite's colour untouched.
 
+Under the `handDrawn` look, concurrency regions are now filled solid rather than hatched, so that they can carry the palette tint the same way every other look does.
+
 States inside a composite stay uniform. A composite carrying its own `classDef` or `style` keeps those colours and takes no palette slot, and neither do its concurrency regions; the slot is still spent, so styling one composite does not shift the colours of the ones after it. Note that this opt-out is all-or-nothing: a `classDef` that sets only text properties, such as `font-weight`, still takes that composite out of the palette.

--- a/.changeset/redux-color-state-composites.md
+++ b/.changeset/redux-color-state-composites.md
@@ -2,8 +2,8 @@
 'mermaid': minor
 ---
 
-feat(themes): composite states and concurrency regions now take a per-container colour under the `redux-color` and `redux-dark-color` themes, as flowchart subgraphs already do. Each composite gets the palette's border colour on its outline and its background tint behind the title strip; nested composites each take the next colour, so depth stays readable. `redux-dark-color` colours the outlines only, matching how it treats ER, requirement and sequence.
+feat(themes): composite states now take a per-container colour under the `redux-color` and `redux-dark-color` themes, as flowchart subgraphs already do. Each composite gets the palette's border colour on its outline and its background tint behind the title strip; nested composites each take the next colour, so depth stays readable. The body keeps the theme's own `compositeBackground`. `redux-dark-color` colours the outlines only, matching how it treats ER, requirement and sequence.
 
-The concurrency regions produced by a `--` divider are the exception: every region of one composite shares a single colour, so a divided composite reads as one thing split into parts rather than as several composites side by side. Regions of different composites still differ.
+The concurrency regions produced by a `--` divider share the colour of the composite they split, rather than taking one of their own — the author wrote a single composite, so it is drawn as one thing in parts. Adding a `--` therefore leaves every other composite's colour untouched.
 
-States inside a composite stay uniform, and a composite carrying its own `classDef` or `style` keeps those colours and takes no palette slot — the slot is still spent, so styling one composite does not shift the colours of the ones after it.
+States inside a composite stay uniform. A composite carrying its own `classDef` or `style` keeps those colours and takes no palette slot, and neither do its concurrency regions; the slot is still spent, so styling one composite does not shift the colours of the ones after it. Note that this opt-out is all-or-nothing: a `classDef` that sets only text properties, such as `font-weight`, still takes that composite out of the palette.

--- a/e2e/rendering/state/stateDiagram-redux-color-composites.spec.ts
+++ b/e2e/rendering/state/stateDiagram-redux-color-composites.spec.ts
@@ -1,0 +1,120 @@
+import { test } from '@playwright/test';
+import { imgSnapshotTest } from '../../helpers/util.ts';
+
+/**
+ * Composite states and concurrency regions take a per-container colour under the redux
+ * colour themes. The unit tests cover the two halves separately -- `dataFetcher` hands out
+ * the slots, `state/styles.js` emits the rules -- but only a render proves the stamped
+ * `data-color-id` actually meets the emitted selector on the element, which is where a
+ * container-shaped change is most likely to come apart: state composites are drawn by
+ * `roundedWithTitle` and `divider` rather than by the plain `rect` cluster the other
+ * diagrams use.
+ *
+ * The monochrome pair is included deliberately. `redux` and `redux-dark` carry no palette,
+ * so they must stay exactly as they render today -- these snapshots are what would catch
+ * the gate leaking colour into a theme that never asked for it.
+ */
+const reduxThemes = ['redux', 'redux-color', 'redux-dark', 'redux-dark-color'] as const;
+
+/** Three depths plus a sibling, so a cycle that failed to advance would be obvious. */
+const nested = `
+  stateDiagram-v2
+    [*] --> Boot
+    state Boot {
+      [*] --> Firmware
+      state Kernel {
+        [*] --> Sched
+        state Drivers {
+          [*] --> Probe
+        }
+      }
+    }
+    Boot --> Running
+    state Running {
+      [*] --> Serving
+    }
+    Running --> [*]
+`;
+
+/**
+ * Three concurrency regions in one composite. Three rather than two: with two, a rule that
+ * paired them by declaration order rather than by parent would still look right.
+ */
+const concurrency = `
+  stateDiagram-v2
+    [*] --> Active
+    state Active {
+      [*] --> NumOff
+      NumOff --> NumOn
+      --
+      [*] --> CapsOff
+      CapsOff --> CapsOn
+      --
+      [*] --> ScrollOff
+      ScrollOff --> ScrollOn
+    }
+    Active --> [*]
+`;
+
+/**
+ * The two rules pulling against each other in one diagram: the regions of `Concurrent`
+ * must match each other, while `Machine`, `Concurrent`, `Finish` and `Deep` must all
+ * differ.
+ */
+const regionsInsideNesting = `
+  stateDiagram-v2
+    state Machine {
+      state Concurrent {
+        [*] --> Left
+        --
+        [*] --> Right
+      }
+      Concurrent --> Finish
+      state Finish {
+        [*] --> Flush
+        state Deep {
+          [*] --> Done
+        }
+      }
+    }
+`;
+
+/**
+ * A composite the author has styled keeps its own colours and takes no palette slot at
+ * all. Half-and-half is the failure this guards: a state `classDef` compiles to
+ * `.name > * { ... }`, which reaches the body rect but not the title strip, so a composite
+ * that stayed in the cycle would show the author's fill under a palette-coloured title.
+ */
+const userStyled = `
+  stateDiagram-v2
+    classDef pinned fill:#111827,stroke:#F59E0B,color:#F9FAFB
+    state Outer {
+      [*] --> Step
+      state Pinned {
+        [*] --> Held
+      }
+      state Plain {
+        [*] --> Free
+      }
+    }
+    class Pinned pinned
+`;
+
+const diagrams = {
+  nested,
+  concurrency,
+  'regions inside nesting': regionsInsideNesting,
+  'user-styled': userStyled,
+} as const;
+
+test.describe('State diagram - Redux colour theme composites', () => {
+  for (const theme of reduxThemes) {
+    test.describe(`Theme: ${theme}`, () => {
+      for (const [name, diagram] of Object.entries(diagrams)) {
+        test(`should render ${name} composite containers`, async ({ page }, testInfo) => {
+          await imgSnapshotTest(page, testInfo, diagram, { theme });
+        });
+      }
+    });
+  }
+});

--- a/e2e/rendering/state/stateDiagram-redux-color-composites.spec.ts
+++ b/e2e/rendering/state/stateDiagram-redux-color-composites.spec.ts
@@ -100,11 +100,33 @@ const userStyled = `
     class Pinned pinned
 `;
 
+/**
+ * A styled composite that is also divided. The regions render in a sibling layer, out of
+ * reach of the author's \`.pinned \> *\` rule, so if they kept a palette slot the composite
+ * would be painted by the author and its own regions from the palette. \`Neighbour\` is
+ * there to show the opt-out does not shift the colours around it.
+ */
+const userStyledWithRegions = `
+  stateDiagram-v2
+    classDef pinned fill:#111827,stroke:#F59E0B,color:#F9FAFB
+    state Split {
+      [*] --> Left
+      --
+      [*] --> Right
+    }
+    Split --> Neighbour
+    state Neighbour {
+      [*] --> After
+    }
+    class Split pinned
+`;
+
 const diagrams = {
   nested,
   concurrency,
   'regions inside nesting': regionsInsideNesting,
   'user-styled': userStyled,
+  'user-styled with regions': userStyledWithRegions,
 } as const;
 
 test.describe('State diagram - Redux colour theme composites', () => {
@@ -116,5 +138,28 @@ test.describe('State diagram - Redux colour theme composites', () => {
         });
       }
     });
+  }
+});
+
+/**
+ * `handDrawn` draws these containers as roughjs shapes rather than rects, so it is served
+ * by a separate set of rules in `state/styles.js` -- and those were the only part of this
+ * feature with no render behind them. A bare `path` selector tinted the composite body as
+ * well as the title strip, which is what these snapshots now hold still.
+ *
+ * Only the two colour themes and two fixtures, rather than the full matrix: the rules under
+ * test are the `outer` / `inner` / `divider` ones, and `nested` plus `concurrency` reach all
+ * three. `redux-dark-color` is worth keeping because it ships no background palette, so it
+ * exercises the branch where the tint is omitted entirely.
+ */
+test.describe('State diagram - Redux colour theme composites, handDrawn', () => {
+  for (const theme of ['redux-color', 'redux-dark-color'] as const) {
+    for (const [name, diagram] of Object.entries({ nested, concurrency })) {
+      test(`should render ${name} composite containers for ${theme}`, async ({
+        page,
+      }, testInfo) => {
+        await imgSnapshotTest(page, testInfo, diagram, { theme, look: 'handDrawn' });
+      });
+    }
   }
 });

--- a/packages/mermaid/src/diagrams/common/colorThemeGate.spec.ts
+++ b/packages/mermaid/src/diagrams/common/colorThemeGate.spec.ts
@@ -14,6 +14,7 @@ import classStyles from '../class/styles.js';
 import erStyles from '../er/styles.js';
 import flowchartStyles from '../flowchart/styles.js';
 import requirementStyles from '../requirement/styles.js';
+import stateStyles from '../state/styles.js';
 import timelineStyles from '../timeline/styles.js';
 import {
   COLOR_THEMES,
@@ -22,6 +23,7 @@ import {
   colorSlotCount,
   paletteSlotCount,
   safeLook,
+  stampColorSlot,
 } from './colorThemeGate.js';
 
 const STYLESHEETS = {
@@ -29,6 +31,7 @@ const STYLESHEETS = {
   er: erStyles,
   flowchart: flowchartStyles,
   requirement: requirementStyles,
+  state: stateStyles,
   timeline: timelineStyles,
 } as const;
 
@@ -37,7 +40,7 @@ const STYLESHEETS = {
  * colours `.section-N` classes directly rather than stamping slots, so the slot-shaped
  * assertions do not apply to it — only the crash-safety pass at the bottom does.
  */
-const SLOT_STYLESHEETS = (['class', 'er', 'flowchart', 'requirement'] as const).filter(
+const SLOT_STYLESHEETS = (['class', 'er', 'flowchart', 'requirement', 'state'] as const).filter(
   (name) => name in STYLESHEETS
 );
 
@@ -313,6 +316,31 @@ describe('colorSlotCount stays a usable loop bound', () => {
  * palette and any limit. Both now derive from the palette, so this holds by construction --
  * and if anyone reintroduces a separate bound, it fails here rather than in review.
  */
+describe('stampColorSlot leaves an unnumbered element alone', () => {
+  const stamped = (colorIndex: number | undefined) => {
+    let attr: string | undefined;
+    const selection = {
+      attr: (_name: string, value: string) => {
+        attr = value;
+        return selection;
+      },
+    } as unknown as Parameters<typeof stampColorSlot>[0];
+    stampColorSlot(selection, colorIndex, 'redux-color', ['#a', '#b']);
+    return attr;
+  };
+
+  it('stamps nothing when there is no colorIndex', () => {
+    // Not `color-0`: an absent index means the element is outside the cycle, and painting
+    // it in the first palette colour is the opposite of that. State composites carrying
+    // the author's own `classDef` are the live case.
+    expect(stamped(undefined)).toBeUndefined();
+  });
+
+  it('still stamps slot zero when the index really is zero', () => {
+    expect(stamped(0)).toBe('color-0');
+  });
+});
+
 describe('emitted slots and stampable slots agree', () => {
   const paletteOf = (n: number) => Array.from({ length: n }, (_, i) => `#${i}`);
 

--- a/packages/mermaid/src/diagrams/common/colorThemeGate.ts
+++ b/packages/mermaid/src/diagrams/common/colorThemeGate.ts
@@ -95,6 +95,14 @@ export const colorSlotCount = (themeColorLimit: unknown, palette?: unknown): num
  *
  * The slot wraps at the palette length rather than indexing raw, so a palette shorter
  * than the emitted slot count cannot produce `stroke: undefined`.
+ *
+ * An absent `colorIndex` means "this element is not part of the cycle", so nothing is
+ * stamped. It used to fall back to `colorIndex ?? 0`, which says the opposite -- an
+ * unnumbered element was stamped `color-0` and painted in the first palette colour. That
+ * was invisible while the only unnumbered containers were ones whose diagram emits no
+ * matching rules (class namespaces, block containers), and it stops being invisible the
+ * moment such a diagram gains palette rules: state's composites opt out of the cycle when
+ * the author has styled them, and would otherwise all come back as `color-0`.
  */
 export const stampColorSlot = <T extends SVGGraphicsElement>(
   shapeSvg: D3Selection<T>,
@@ -102,9 +110,9 @@ export const stampColorSlot = <T extends SVGGraphicsElement>(
   theme: string | undefined,
   palette: unknown
 ): void => {
-  if (!isColorTheme(theme, palette)) {
+  if (colorIndex === undefined || !isColorTheme(theme, palette)) {
     return;
   }
-  const slot = (colorIndex ?? 0) % paletteSlotCount(palette);
+  const slot = colorIndex % paletteSlotCount(palette);
   shapeSvg.attr('data-color-id', `color-${slot}`);
 };

--- a/packages/mermaid/src/diagrams/state/dataFetcher.ts
+++ b/packages/mermaid/src/diagrams/state/dataFetcher.ts
@@ -41,40 +41,56 @@ const nodeDb = new Map<string, NodeData>();
 
 let graphItemCount = 0; // used to construct ids, etc.
 
-// Next palette slot to hand out, and the slot already handed to a parent's concurrency
-// regions. Both are per-render and cleared by `reset()` alongside `nodeDb`.
+// Next palette slot to hand out, and the slot each container ended up with. Both are
+// per-render and cleared by `reset()` alongside `nodeDb`.
 let nextColorIndex = 0;
-const dividerColorIndex = new Map<string, number>();
+const containerColorIndex = new Map<string, number | undefined>();
 
 /**
- * Palette slot for a container, in declaration order.
+ * Palette slot for a container.
  *
  * `dataFetcher` recurses depth-first and takes a slot as it inserts each container, so the
  * numbering is a pre-order walk of the containment tree -- the same order flowchart gives
  * its subgraphs, and the reason a nested composite never shares its parent's colour.
  *
- * Concurrency regions are the exception. A `--` divider splits one composite into regions
- * that `stateDb.docTranslator` models as sibling `divider` containers, so numbering them
- * one by one would paint a single composite in three colours and read as three separate
- * composites. Regions therefore share one slot, keyed by the parent they belong to: that
- * keeps them reading as parts of one whole, while still separating them from the composite
- * that holds them.
+ * Concurrency regions are the exception: they reuse their parent's slot rather than taking
+ * one. A `--` divider splits one composite into regions that `stateDb.docTranslator` models
+ * as sibling `divider` containers, and those are synthetic -- the author wrote one
+ * composite, and the trailing region does not even get a stable id. Giving them a colour of
+ * their own said there were several composites, and spent slots on containers nobody wrote,
+ * so adding a `--` silently recoloured every composite after it. Reusing the parent's slot
+ * says what is true: one composite, drawn in parts.
+ *
+ * It also carries the opt-out down for free. A container the author has styled resolves to
+ * `undefined`, and its regions now inherit that, so they stay unpainted with it. Left to
+ * take their own slot they were painted from the palette while the composite around them
+ * was painted by the author -- the same one-container-two-sources split `userStyled` exists
+ * to prevent, one level down, and out of reach of the author's `.name > *` rule because the
+ * regions render in a sibling layer.
  *
  * Only containers are numbered. Plain states keep the uniform look for the same reason
  * flowchart leaves its nodes alone -- a state is a step, not a participant, and `classDef`
  * / `style` is how colour carries meaning there.
  */
-const nextColorSlot = (shape: string, parent: StateStmt | undefined): number => {
-  if (shape !== SHAPE_DIVIDER) {
-    return nextColorIndex++;
+const colorSlotFor = (
+  shape: string,
+  itemId: string,
+  parent: StateStmt | undefined,
+  userStyled: boolean
+): number | undefined => {
+  // `has`, not a truthy check: a styled parent records `undefined` deliberately, and that
+  // is exactly the value its regions have to inherit.
+  if (shape === SHAPE_DIVIDER && parent?.id !== undefined && containerColorIndex.has(parent.id)) {
+    const inherited = containerColorIndex.get(parent.id);
+    containerColorIndex.set(itemId, inherited);
+    return inherited;
   }
-  const parentKey = parent?.id ?? 'root';
-  const shared = dividerColorIndex.get(parentKey);
-  if (shared !== undefined) {
-    return shared;
-  }
-  dividerColorIndex.set(parentKey, nextColorIndex);
-  return nextColorIndex++;
+  // Everything else takes the next slot. A `--` at the top level lands here too: there is
+  // no composite to belong to, so it is its own container.
+  const slot = nextColorIndex++;
+  const effective = userStyled ? undefined : slot;
+  containerColorIndex.set(itemId, effective);
+  return effective;
 };
 
 /**
@@ -320,11 +336,10 @@ export const dataFetcher = (
       newNode.isGroup = true;
       newNode.dir = getDir(parsedItem);
       newNode.shape = parsedItem.type === DIVIDER_TYPE ? SHAPE_DIVIDER : SHAPE_GROUP;
-      // The slot is spent either way, so giving one composite a `classDef` does not shift
-      // every later composite's colour. It is only *stamped* when the container has no
-      // styling of its own -- see `userStyled`.
-      const slot = nextColorSlot(newNode.shape, parent);
-      newNode.colorIndex = userStyled ? undefined : slot;
+      // A styled container still spends its slot, so giving one composite a `classDef` does
+      // not shift the colour of every composite after it; it simply resolves to
+      // `undefined` and goes unstamped. See `colorSlotFor`.
+      newNode.colorIndex = colorSlotFor(newNode.shape, itemId, parent, userStyled);
       newNode.cssClasses = `${newNode.cssClasses} ${CSS_DIAGRAM_CLUSTER} ${altFlag ? CSS_DIAGRAM_CLUSTER_ALT : ''}`;
     }
 
@@ -447,5 +462,5 @@ export const reset = () => {
   nodeDb.clear();
   graphItemCount = 0;
   nextColorIndex = 0;
-  dividerColorIndex.clear();
+  containerColorIndex.clear();
 };

--- a/packages/mermaid/src/diagrams/state/dataFetcher.ts
+++ b/packages/mermaid/src/diagrams/state/dataFetcher.ts
@@ -41,6 +41,42 @@ const nodeDb = new Map<string, NodeData>();
 
 let graphItemCount = 0; // used to construct ids, etc.
 
+// Next palette slot to hand out, and the slot already handed to a parent's concurrency
+// regions. Both are per-render and cleared by `reset()` alongside `nodeDb`.
+let nextColorIndex = 0;
+const dividerColorIndex = new Map<string, number>();
+
+/**
+ * Palette slot for a container, in declaration order.
+ *
+ * `dataFetcher` recurses depth-first and takes a slot as it inserts each container, so the
+ * numbering is a pre-order walk of the containment tree -- the same order flowchart gives
+ * its subgraphs, and the reason a nested composite never shares its parent's colour.
+ *
+ * Concurrency regions are the exception. A `--` divider splits one composite into regions
+ * that `stateDb.docTranslator` models as sibling `divider` containers, so numbering them
+ * one by one would paint a single composite in three colours and read as three separate
+ * composites. Regions therefore share one slot, keyed by the parent they belong to: that
+ * keeps them reading as parts of one whole, while still separating them from the composite
+ * that holds them.
+ *
+ * Only containers are numbered. Plain states keep the uniform look for the same reason
+ * flowchart leaves its nodes alone -- a state is a step, not a participant, and `classDef`
+ * / `style` is how colour carries meaning there.
+ */
+const nextColorSlot = (shape: string, parent: StateStmt | undefined): number => {
+  if (shape !== SHAPE_DIVIDER) {
+    return nextColorIndex++;
+  }
+  const parentKey = parent?.id ?? 'root';
+  const shared = dividerColorIndex.get(parentKey);
+  if (shared !== undefined) {
+    return shared;
+  }
+  dividerColorIndex.set(parentKey, nextColorIndex);
+  return nextColorIndex++;
+};
+
 /**
  * Create a standard string for the dom ID of an item.
  * If a type is given, insert that before the counter, preceded by the type spacer
@@ -202,6 +238,18 @@ export const dataFetcher = (
   const style = getStylesFromDbInfo(dbState);
   const config = getConfig();
 
+  /**
+   * Whether the author has styled this state themselves, via `classDef`/`class` or a
+   * `style` statement. Such a container opts out of the palette entirely.
+   *
+   * It has to be all-or-nothing. A state `classDef` compiles to `.name > * { ... }` with
+   * `!important`, and the composite's title strip is *not* a direct child -- it sits inside
+   * an intermediate `g` -- so the author's rule reaches the body rect but not the title.
+   * Leaving the slot stamped therefore paints the two halves of one container from two
+   * different sources, which is worse than either on its own.
+   */
+  const userStyled = classStr.trim() !== '' || style.length > 0;
+
   log.info('dataFetcher parsedItem', parsedItem, dbState, style);
 
   if (itemId !== 'root') {
@@ -272,6 +320,11 @@ export const dataFetcher = (
       newNode.isGroup = true;
       newNode.dir = getDir(parsedItem);
       newNode.shape = parsedItem.type === DIVIDER_TYPE ? SHAPE_DIVIDER : SHAPE_GROUP;
+      // The slot is spent either way, so giving one composite a `classDef` does not shift
+      // every later composite's colour. It is only *stamped* when the container has no
+      // styling of its own -- see `userStyled`.
+      const slot = nextColorSlot(newNode.shape, parent);
+      newNode.colorIndex = userStyled ? undefined : slot;
       newNode.cssClasses = `${newNode.cssClasses} ${CSS_DIAGRAM_CLUSTER} ${altFlag ? CSS_DIAGRAM_CLUSTER_ALT : ''}`;
     }
 
@@ -288,6 +341,7 @@ export const dataFetcher = (
       domId: stateDomId(itemId, graphItemCount),
       type: newNode.type,
       isGroup: newNode.type === 'group',
+      colorIndex: newNode.colorIndex,
       padding: 8,
       rx: 10,
       ry: 10,
@@ -392,4 +446,6 @@ export const dataFetcher = (
 export const reset = () => {
   nodeDb.clear();
   graphItemCount = 0;
+  nextColorIndex = 0;
+  dividerColorIndex.clear();
 };

--- a/packages/mermaid/src/diagrams/state/stateDb.ts
+++ b/packages/mermaid/src/diagrams/state/stateDb.ts
@@ -165,6 +165,8 @@ export interface NodeData {
   position?: string;
   description?: string | string[];
   labelType?: string;
+  /** Palette slot for container shapes; see `nextColorSlot` in `dataFetcher.ts`. */
+  colorIndex?: number;
 }
 
 export interface Edge {

--- a/packages/mermaid/src/diagrams/state/stateDiagram-colorIndex.spec.ts
+++ b/packages/mermaid/src/diagrams/state/stateDiagram-colorIndex.spec.ts
@@ -96,9 +96,63 @@ describe('state diagram colour slots', () => {
     // remainder. Asserting only on the distinct values would pass if a region went missing.
     expect(regions).toHaveLength(3);
     expect(new Set(regions).size).toBe(1);
-    // ...and distinct from the composite that holds them, so the split stays legible.
+    // ...and it is the composite's own slot, not a fresh one. The regions are synthetic --
+    // the author wrote one composite -- so they are drawn as parts of it rather than as
+    // something with a colour of its own.
     expect(byId.get('Active')).toBe(0);
-    expect(regions[0]).toBe(1);
+    expect(regions[0]).toBe(0);
+  });
+
+  it('does not shift later composites when a divider is added', () => {
+    // The reason regions reuse the parent's slot rather than taking one. Spending slots on
+    // containers the author never wrote meant adding a `--` recoloured everything after it.
+    const withoutDivider = slots(`stateDiagram-v2
+      state First {
+        [*] --> A
+      }
+      state Second {
+        [*] --> B
+      }
+    `);
+    stateDb = new StateDB(2);
+    parser.yy = stateDb;
+    stateDiagram.parser.yy = stateDb;
+    stateDiagram.parser.yy.clear();
+    const withDivider = slots(`stateDiagram-v2
+      state First {
+        [*] --> A
+        --
+        [*] --> C
+      }
+      state Second {
+        [*] --> B
+      }
+    `);
+
+    expect(withoutDivider.get('First')).toBe(withDivider.get('First'));
+    expect(withoutDivider.get('Second')).toBe(withDivider.get('Second'));
+    expect(withDivider.get('Second')).toBe(1);
+  });
+
+  it("carries a styled composite's opt-out into its concurrency regions", () => {
+    // The regions render in a sibling layer, so the author's `.pinned > *` rule cannot
+    // reach them. Were they to keep a palette slot, the composite would be painted by the
+    // author and its own regions from the palette -- one container, two sources, which is
+    // the split `userStyled` exists to prevent.
+    const nodes = parse(`stateDiagram-v2
+      classDef pinned fill:#111827,stroke:#F59E0B
+      state Active {
+        [*] --> A
+        --
+        [*] --> B
+      }
+      class Active pinned
+    `);
+    const byId = new Map(nodes.map((node) => [node.id, node.colorIndex]));
+    expect(byId.get('Active')).toBeUndefined();
+    const regions = regionSlots(nodes);
+    expect(regions).toHaveLength(2);
+    expect(regions.every((region) => region.colorIndex === undefined)).toBe(true);
   });
 
   it('does not share one slot between two separately divided composites', () => {
@@ -123,14 +177,16 @@ describe('state diagram colour slots', () => {
     expect(regions).toHaveLength(4);
     // Two composites, two regions each: two distinct region colours, not one and not four.
     expect(new Set(regions.map((node) => node.colorIndex)).size).toBe(2);
-    // And the pairing is by parent, not by declaration order -- both of First's regions
-    // share one slot and both of Second's share the other.
+    // And the pairing is by parent, not by declaration order -- each composite's regions
+    // carry that composite's own slot.
     const byParent = new Map<string, Set<number | undefined>>();
     for (const region of regions) {
       const key = region.parentId ?? 'root';
       byParent.set(key, (byParent.get(key) ?? new Set()).add(region.colorIndex));
     }
     expect([...byParent.values()].map((set) => set.size)).toEqual([1, 1]);
+    expect(byParent.get('First')).toEqual(new Set([byId.get('First')]));
+    expect(byParent.get('Second')).toEqual(new Set([byId.get('Second')]));
   });
 
   it('leaves a composite with its own classDef unstamped, but still spends its slot', () => {

--- a/packages/mermaid/src/diagrams/state/stateDiagram-colorIndex.spec.ts
+++ b/packages/mermaid/src/diagrams/state/stateDiagram-colorIndex.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * Container colour slots for state diagrams: `dataFetcher` assigns the slot, `clusters.js`
+ * stamps it as `data-color-id`, and `state/styles.js` maps it to a border and a title tint.
+ *
+ * Two rules have to hold together, and they pull in opposite directions:
+ *
+ *  1. Nested composites must differ, or a machine nested three deep reads as one box.
+ *  2. The concurrency regions of a single composite must match, or one composite split by
+ *     `--` reads as several composites sitting side by side.
+ *
+ * Both fail silently -- the diagram still renders, just with the wrong colours -- so pin
+ * the assignment here rather than relying on a screenshot to notice.
+ */
+import { describe, expect, it, beforeEach } from 'vitest';
+import stateDiagram, { parser } from './parser/stateDiagram.jison';
+import { StateDB } from './stateDb.js';
+
+describe('state diagram colour slots', () => {
+  let stateDb: StateDB;
+
+  beforeEach(() => {
+    stateDb = new StateDB(2);
+    parser.yy = stateDb;
+    stateDiagram.parser.yy = stateDb;
+    stateDiagram.parser.yy.clear();
+  });
+
+  const parse = (diagram: string) => {
+    parser.parse(diagram);
+    return stateDb.getData().nodes;
+  };
+
+  const slots = (diagram: string) =>
+    new Map(parse(diagram).map((node) => [node.id, node.colorIndex]));
+
+  /**
+   * Concurrency regions are matched on shape, not on id. Only the regions that follow a
+   * `--` keep the `divider-id-N` name; `stateDb.docTranslator` gives the trailing one a
+   * random id, and an id prefix match would also pick up each region's `_start` child.
+   */
+  const regionSlots = (nodes: { shape: string; parentId?: string; colorIndex?: number }[]) =>
+    nodes.filter((node) => node.shape === 'divider');
+
+  it('gives each composite its own slot, in containment order', () => {
+    const byId = slots(`stateDiagram-v2
+      [*] --> Boot
+      state Boot {
+        [*] --> Firmware
+        state Kernel {
+          [*] --> Scheduler
+          state Drivers {
+            [*] --> Probe
+          }
+        }
+      }
+      Boot --> Running
+      state Running {
+        [*] --> Serving
+      }
+    `);
+    // Pre-order: a composite is numbered before the composites it contains, so depth is
+    // what separates the colours rather than declaration order across the whole file.
+    expect(byId.get('Boot')).toBe(0);
+    expect(byId.get('Kernel')).toBe(1);
+    expect(byId.get('Drivers')).toBe(2);
+    expect(byId.get('Running')).toBe(3);
+  });
+
+  it('leaves plain states unslotted, so only containers are painted', () => {
+    const byId = slots(`stateDiagram-v2
+      state Outer {
+        [*] --> Inner
+        Inner --> Done
+      }
+    `);
+    expect(byId.get('Outer')).toBe(0);
+    expect(byId.get('Inner')).toBeUndefined();
+    expect(byId.get('Done')).toBeUndefined();
+  });
+
+  it('gives every concurrency region of one composite the same slot', () => {
+    const nodes = parse(`stateDiagram-v2
+      state Active {
+        [*] --> NumLockOff
+        --
+        [*] --> CapsLockOff
+        --
+        [*] --> ScrollLockOff
+      }
+    `);
+    const byId = new Map(nodes.map((node) => [node.id, node.colorIndex]));
+    const regions = regionSlots(nodes).map((node) => node.colorIndex);
+
+    // Counted, because two `--` produce three regions: one per separator plus the trailing
+    // remainder. Asserting only on the distinct values would pass if a region went missing.
+    expect(regions).toHaveLength(3);
+    expect(new Set(regions).size).toBe(1);
+    // ...and distinct from the composite that holds them, so the split stays legible.
+    expect(byId.get('Active')).toBe(0);
+    expect(regions[0]).toBe(1);
+  });
+
+  it('does not share one slot between two separately divided composites', () => {
+    // The shared slot is keyed by parent. Keying it globally, or by nothing at all, would
+    // paint every concurrency region in the diagram the same colour.
+    const nodes = parse(`stateDiagram-v2
+      state First {
+        [*] --> A
+        --
+        [*] --> B
+      }
+      state Second {
+        [*] --> C
+        --
+        [*] --> D
+      }
+    `);
+    const byId = new Map(nodes.map((node) => [node.id, node.colorIndex]));
+    const regions = regionSlots(nodes);
+
+    expect(byId.get('First')).not.toBe(byId.get('Second'));
+    expect(regions).toHaveLength(4);
+    // Two composites, two regions each: two distinct region colours, not one and not four.
+    expect(new Set(regions.map((node) => node.colorIndex)).size).toBe(2);
+    // And the pairing is by parent, not by declaration order -- both of First's regions
+    // share one slot and both of Second's share the other.
+    const byParent = new Map<string, Set<number | undefined>>();
+    for (const region of regions) {
+      const key = region.parentId ?? 'root';
+      byParent.set(key, (byParent.get(key) ?? new Set()).add(region.colorIndex));
+    }
+    expect([...byParent.values()].map((set) => set.size)).toEqual([1, 1]);
+  });
+
+  it('leaves a composite with its own classDef unstamped, but still spends its slot', () => {
+    const byId = slots(`stateDiagram-v2
+      classDef pinned fill:#111827,stroke:#F59E0B
+      state First {
+        [*] --> A
+      }
+      state Second {
+        [*] --> B
+      }
+      state Third {
+        [*] --> C
+      }
+      class Second pinned
+    `);
+    expect(byId.get('First')).toBe(0);
+    // Unstamped, so no `[data-color-id]` rule can match it and the author's class -- which
+    // is emitted `!important` -- is the only thing painting the container.
+    expect(byId.get('Second')).toBeUndefined();
+    // The slot is still consumed: `Third` keeps the colour it would have had anyway, so
+    // styling one composite does not recolour every composite after it.
+    expect(byId.get('Third')).toBe(2);
+  });
+
+  it('leaves a composite with its own style statement unstamped', () => {
+    const byId = slots(`stateDiagram-v2
+      state First {
+        [*] --> A
+      }
+      state Second {
+        [*] --> B
+      }
+      style Second fill:#111827
+    `);
+    expect(byId.get('First')).toBe(0);
+    expect(byId.get('Second')).toBeUndefined();
+  });
+
+  it('spends one slot on a composite named twice, so the cycle does not skip', () => {
+    // `dataFetcher` runs once per relation endpoint, so a composite on both sides of two
+    // transitions is visited more than once. Taking a slot each time would leave gaps in
+    // the cycle and shift every later container's colour.
+    const byId = slots(`stateDiagram-v2
+      [*] --> Loop
+      state Loop {
+        [*] --> Spin
+      }
+      Loop --> Loop
+      Loop --> Exit
+      state Exit {
+        [*] --> Bye
+      }
+    `);
+    expect(byId.get('Loop')).toBe(0);
+    expect(byId.get('Exit')).toBe(1);
+  });
+});

--- a/packages/mermaid/src/diagrams/state/stateDiagram-colorIndex.spec.ts
+++ b/packages/mermaid/src/diagrams/state/stateDiagram-colorIndex.spec.ts
@@ -12,6 +12,7 @@
  * the assignment here rather than relying on a screenshot to notice.
  */
 import { describe, expect, it, beforeEach } from 'vitest';
+// @ts-expect-error No types available for JISON
 import stateDiagram, { parser } from './parser/stateDiagram.jison';
 import { StateDB } from './stateDb.js';
 

--- a/packages/mermaid/src/diagrams/state/styles.js
+++ b/packages/mermaid/src/diagrams/state/styles.js
@@ -54,13 +54,40 @@ const genColor = (options) => {
       ${tint}
     }
 
-    /* handDrawn draws the same container as roughjs paths, which carry no \`outer\` /
-       \`inner\` class -- without this the sketch look stays monochrome. Clusters hold only
-       their own shapes and label; child states live in a sibling layer, so the descendant
-       selector cannot reach them. */
-    ${slot}.statediagram-cluster path {
-      stroke: ${borderColor};
+    /* handDrawn draws the same container as roughjs shapes rather than plain rects, so it
+       needs its own rules. \`roundedWithTitle\` and \`divider\` name those groups \`outer\`,
+       \`inner\` and \`divider\` to match the classic branch, which is what lets these
+       discriminate -- a bare \`.statediagram-cluster path\` rule reached the body as well and
+       tinted the whole composite, losing \`compositeBackground\` and diverging from what
+       classic and neo do.
+
+       roughjs emits two paths per shape and marks them: the filled shape carries
+       \`stroke="none"\` and the sketched outline carries \`fill="none"\`. Splitting on that is
+       what keeps \`fill\` off the outline -- a rough outline is open squiggles, not a closed
+       region, so filling it produces smears -- and keeps \`stroke\` off the fill shape, which
+       would otherwise gain an edge it was drawn without. */
+    ${slot}.statediagram-cluster .outer path[stroke='none'] {
       ${tint}
+    }
+
+    ${slot}.statediagram-cluster .outer path[fill='none'] {
+      stroke: ${borderColor};
+    }
+
+    /* No \`.inner\` rule on purpose. The body shape is left entirely alone under handDrawn,
+       where a rect's \`inner\` counterpart cannot be recoloured safely: roughjs draws a
+       hachure fill as *stroked* lines, so its fill paths carry \`fill="none"\` exactly like
+       the outline and no selector separates them. An \`.inner\` stroke rule therefore
+       repainted the hatching of every alt composite in the palette colour instead of
+       leaving it on \`altBackground\`. The container still reads as palette-coloured: the
+       \`outer\` shape spans the whole composite, so its outline already frames the body. */
+
+    ${slot}.statediagram-cluster .divider path[stroke='none'] {
+      ${tint}
+    }
+
+    ${slot}.statediagram-cluster .divider path[fill='none'] {
+      stroke: ${borderColor};
     }
     `;
   }

--- a/packages/mermaid/src/diagrams/state/styles.js
+++ b/packages/mermaid/src/diagrams/state/styles.js
@@ -1,5 +1,75 @@
+import { hasPalette, isColorTheme, paletteSlotCount, safeLook } from '../common/colorThemeGate.js';
+
+/**
+ * Cycling per-container colour for composite states and concurrency regions.
+ *
+ * Only the containers are painted. A plain state is a step in the machine rather than a
+ * distinct participant, and `classDef` / `style` is already how colour carries meaning
+ * there -- the same line flowchart draws between its subgraphs and its nodes.
+ *
+ * The treatment follows the swimlane header: the palette's border colour on the outline,
+ * its background tint behind the title strip, and the theme's own `compositeBackground`
+ * left on the body. Tinting the body as well would stack tint on tint once composites
+ * nest, and nesting is exactly where the colours have to stay separable.
+ *
+ * `redux-dark-color` ships a border palette and an empty background palette, so on that
+ * theme the `fill` declarations are omitted entirely and only the outlines take colour --
+ * the same outlines-only treatment it gives ER, requirement and sequence.
+ *
+ * Not `!important`: a state's own `classDef` / `style` has to keep winning over the theme.
+ */
+const genColor = (options) => {
+  const { theme, bkgColorArray, borderColorArray } = options;
+  if (!isColorTheme(theme, borderColorArray)) {
+    return '';
+  }
+  // `look` is validated before it reaches the selector -- see `safeLook`.
+  const look = safeLook(options.look);
+  const hasBkgColors = hasPalette(bkgColorArray);
+  let sections = '';
+
+  // One rule per slot `dataFetcher` can hand out; `stampColorSlot` wraps at the palette
+  // length, so those are exactly `0 .. borderColorArray.length - 1`.
+  for (let i = 0; i < paletteSlotCount(borderColorArray); i++) {
+    const borderColor = borderColorArray[i];
+    const tint = hasBkgColors ? `fill: ${bkgColorArray[i % bkgColorArray.length]};` : '';
+    const slot = `[data-look="${look}"][data-color-id="color-${i}"]`;
+    sections += `
+
+    /* The title strip: \`rect.outer\` spans the whole composite and \`rect.inner\` covers
+       the body, so what stays visible of \`outer\` is the band behind the label. */
+    ${slot}.statediagram-cluster rect.outer {
+      stroke: ${borderColor};
+      ${tint}
+    }
+
+    ${slot}.statediagram-cluster rect.inner {
+      stroke: ${borderColor};
+    }
+
+    /* Concurrency regions. Siblings of one composite share a slot, so a divided composite
+       reads as one thing split into parts rather than as several composites. */
+    ${slot}.statediagram-cluster rect.divider {
+      stroke: ${borderColor};
+      ${tint}
+    }
+
+    /* handDrawn draws the same container as roughjs paths, which carry no \`outer\` /
+       \`inner\` class -- without this the sketch look stays monochrome. Clusters hold only
+       their own shapes and label; child states live in a sibling layer, so the descendant
+       selector cannot reach them. */
+    ${slot}.statediagram-cluster path {
+      stroke: ${borderColor};
+      ${tint}
+    }
+    `;
+  }
+  return sections;
+};
+
 const getStyles = (options) =>
   `
+${genColor(options)}
 defs [id$="-barbEnd"] {
     fill: ${options.transitionColor};
     stroke: ${options.transitionColor};

--- a/packages/mermaid/src/diagrams/state/styles.js
+++ b/packages/mermaid/src/diagrams/state/styles.js
@@ -82,6 +82,10 @@ const genColor = (options) => {
        leaving it on \`altBackground\`. The container still reads as palette-coloured: the
        \`outer\` shape spans the whole composite, so its outline already frames the body. */
 
+    /* Regions split the same way, which is why \`divider\` fills solid rather than taking
+       roughjs's default hachure -- see the note on that call. Hatched, both of its paths
+       carried \`fill="none"\` and these two rules degenerated: the tint matched nothing and
+       the border rule repainted the hatching. */
     ${slot}.statediagram-cluster .divider path[stroke='none'] {
       ${tint}
     }

--- a/packages/mermaid/src/rendering-util/rendering-elements/clusters.js
+++ b/packages/mermaid/src/rendering-util/rendering-elements/clusters.js
@@ -420,7 +420,7 @@ const divider = (parent, node) => {
   const siteConfig = getConfig();
 
   const { theme, themeVariables, handDrawnSeed } = siteConfig;
-  const { nodeBorder, borderColorArray } = themeVariables;
+  const { altBackground, nodeBorder, borderColorArray } = themeVariables;
 
   // Sibling regions of one composite share a slot -- see `nextColorSlot` in the state
   // diagram's `dataFetcher.ts`.
@@ -452,7 +452,19 @@ const divider = (parent, node) => {
   if (node.look === 'handDrawn') {
     const rc = rough.svg(shapeSvg);
     const roughOuterNode = rc.rectangle(x, y, width, height, {
-      fill: 'lightgrey',
+      // The theme's own value, matching what `rect.divider` gets from CSS under the other
+      // looks -- and the same fallback. It was hardcoded `lightgrey`, which no dark theme
+      // ever asked for; that stayed tolerable only while the fill was sparse hatching, and
+      // turns into a bright block on a dark canvas once it is solid.
+      fill: altBackground ?? '#efefef',
+      // Solid rather than roughjs's default hachure. A hachure fill is drawn as *stroked*
+      // lines, so both of the group's paths come out with `fill="none"` and a stylesheet
+      // cannot tell the fill from the outline -- which is the same trap documented on
+      // `roundedWithTitle`'s inner shape in `state/styles.js`. Solid splits them the way
+      // the composite's outer shape already does, so a region can take the palette's tint
+      // and border without its hatching being repainted. `roundedWithTitle` fills solid
+      // too, except for its deliberately hatched alt variant.
+      fillStyle: 'solid',
       roughness: 0.5,
       strokeLineDash: [5],
       stroke: nodeBorder,

--- a/packages/mermaid/src/rendering-util/rendering-elements/clusters.js
+++ b/packages/mermaid/src/rendering-util/rendering-elements/clusters.js
@@ -175,9 +175,10 @@ const noteGroup = (parent, node) => {
 const roundedWithTitle = async (parent, node) => {
   const siteConfig = getConfig();
 
-  const { themeVariables, handDrawnSeed } = siteConfig;
+  const { theme, themeVariables, handDrawnSeed } = siteConfig;
   const { altBackground, compositeBackground, compositeTitleBackground, nodeBorder } =
     themeVariables;
+  const { borderColorArray } = themeVariables;
 
   // Add outer g element
   const shapeSvg = parent
@@ -186,6 +187,10 @@ const roundedWithTitle = async (parent, node) => {
     .attr('id', node.domId)
     .attr('data-id', node.id)
     .attr('data-look', node.look);
+
+  // Per-composite colour slot, painted by the `[data-color-id]` rules in `state/styles.js`.
+  // A no-op unless the active theme carries a palette.
+  stampColorSlot(shapeSvg, node.colorIndex, theme, borderColorArray);
 
   // add the rect
   const outerRectG = shapeSvg.insert('g', ':first-child');
@@ -405,15 +410,18 @@ const kanbanSection = async (parent, node) => {
 const divider = (parent, node) => {
   const siteConfig = getConfig();
 
-  const { themeVariables, handDrawnSeed } = siteConfig;
-  const { nodeBorder } = themeVariables;
+  const { theme, themeVariables, handDrawnSeed } = siteConfig;
+  const { nodeBorder, borderColorArray } = themeVariables;
 
-  // Add outer g element
+  // Sibling regions of one composite share a slot -- see `nextColorSlot` in the state
+  // diagram's `dataFetcher.ts`.
   const shapeSvg = parent
     .insert('g')
     .attr('class', node.cssClasses)
     .attr('id', node.domId)
     .attr('data-look', node.look);
+
+  stampColorSlot(shapeSvg, node.colorIndex, theme, borderColorArray);
 
   // add the rect
   const outerRectG = shapeSvg.insert('g', ':first-child');

--- a/packages/mermaid/src/rendering-util/rendering-elements/clusters.js
+++ b/packages/mermaid/src/rendering-util/rendering-elements/clusters.js
@@ -176,9 +176,13 @@ const roundedWithTitle = async (parent, node) => {
   const siteConfig = getConfig();
 
   const { theme, themeVariables, handDrawnSeed } = siteConfig;
-  const { altBackground, compositeBackground, compositeTitleBackground, nodeBorder } =
-    themeVariables;
-  const { borderColorArray } = themeVariables;
+  const {
+    altBackground,
+    borderColorArray,
+    compositeBackground,
+    compositeTitleBackground,
+    nodeBorder,
+  } = themeVariables;
 
   // Add outer g element
   const shapeSvg = parent
@@ -258,6 +262,11 @@ const roundedWithTitle = async (parent, node) => {
 
     rect = shapeSvg.insert(() => roughOuterNode, ':first-child');
     innerRect = shapeSvg.insert(() => roughInnerNode);
+    // The classic branch below gives its two rects `outer` and `inner`; roughjs wraps each
+    // shape in a `g` with no class, so without the same names here a stylesheet cannot tell
+    // the title shape from the body and any `path` rule hits both.
+    rect.attr('class', 'outer');
+    innerRect.attr('class', 'inner');
   } else {
     rect = outerRectG.insert('rect', ':first-child');
     const outerRectClass = 'outer';
@@ -450,7 +459,7 @@ const divider = (parent, node) => {
       seed: handDrawnSeed,
     });
 
-    rect = shapeSvg.insert(() => roughOuterNode, ':first-child');
+    rect = shapeSvg.insert(() => roughOuterNode, ':first-child').attr('class', 'divider');
   } else {
     rect = outerRectG.insert('rect', ':first-child');
     let outerRectClass = 'outer';


### PR DESCRIPTION
Stacked on #8148 — base is `claude/redux-color-default-theme`, so the diff shown here is only this change. Retarget to `develop` once #8148 lands.

Composite states were the last containers still rendering monochrome under the redux colour themes. Flowchart subgraphs, class boxes, ER entities and requirement boxes all cycle a per-item colour; a state machine nested three deep came out as identical grey boxes inside identical grey boxes.

## What it does

Composites take the palette's border colour on the outline and its background tint behind the title strip — the swimlane header treatment — with the theme's own `compositeBackground` left on the body. Tinting the body too would stack tint on tint once composites nest, and nesting is exactly where the colours have to stay separable. `redux-dark-color` ships an empty background palette, so it colours outlines only, as it already does for ER, requirement and sequence.

Slots come from a pre-order walk of the containment tree, so a nested composite never shares its parent's colour.

**Concurrency regions are the exception.** A `--` divider splits one composite into regions that `stateDb.docTranslator` models as sibling `divider` containers, so numbering them one by one would paint a single composite in three colours and read as three composites. Regions share one slot, keyed by parent — they read as parts of one whole while still separating from the composite holding them, and regions of *different* composites stay different.

States inside a composite keep the uniform look, for the reason flowchart leaves its nodes alone: a state is a step, not a participant, and `classDef` / `style` is already how colour carries meaning there.

## Two things this turned up

**A composite carrying the author's own `classDef` or `style` opts out of the cycle entirely.** It cannot be half-and-half: a state `classDef` compiles to `.name > * { … !important }`, and the title strip is not a direct child — it sits inside an intermediate `g` — so the author's rule reaches the body rect but not the title. Left in the cycle, one container would be painted from two sources. The slot is still spent, so styling one composite does not shift the colour of every composite after it.

**`stampColorSlot` treated a missing `colorIndex` as slot 0**, stamping `color-0` on elements that are not in the cycle at all. That was invisible while the only unnumbered containers belonged to diagrams emitting no matching rules (class namespaces, block containers) — the attribute was inert. It stops being inert the moment such a diagram gains palette rules, which is what the opt-out above needs, so an absent index now stamps nothing. Flowchart and class are unaffected: every element they stamp has a real index.

## Verification

- 7 unit tests on the slot assignment, replayed against two broken variants — no region sharing, and one global region slot — which fail 2 and 1 assertions respectively.
- `state` added to the shared `colorThemeGate` spec, which gives it the plain-theme-silence, no-`!important`, hostile-`look`, crash-safety and emitted-vs-stampable-slot invariants for free.
- 16 e2e snapshots across the four redux themes, including the two monochrome ones, so a gate leaking colour into a theme that never asked for it would show.
- Rendered classic, neo and handDrawn in both colour themes and diffed against the same fixtures on the parent branch.
- Unit suite 6069 passing (2 pre-existing `domus` harness env-var failures); lint, Prettier, cspell and `build:types` clean.

Argos will show the new snapshots plus every existing state-diagram render, since composites change appearance by design under the new default theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds palette colouring for state diagram composite states and concurrency regions under Redux colour themes.

- Composite outlines use palette border colours.
- Composite title strips use palette background tints.
- Composite bodies retain `compositeBackground`.
- Nested composites receive distinct pre-order colour slots.
- Concurrency regions share their parent composite’s slot.
- Custom `classDef` and `style` values disable palette styling but still consume slots.
- Missing colour indices no longer apply `color-0`.
- Adds unit tests and 16 end-to-end theme snapshots.
- Adds a minor Mermaid changeset.

All checks pass except two pre-existing `domus` harness environment-variable failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->