### PR TITLE
docs: document the per-diagram defaults, and make the docs site show them

### DIFF
--- a/docs/config/theming.md
+++ b/docs/config/theming.md
@@ -42,6 +42,7 @@ scope a setting to that diagram, which is not always the keyword the diagram sta
 
 | Config key    | Diagram              |
 | ------------- | -------------------- |
+| `agentflow`   | `agentflow-beta`     |
 | `flowchart`   | `flowchart`          |
 | `swimlane`    | `swimlane-beta`      |
 | `class`       | `classDiagram`       |

--- a/docs/config/theming.md
+++ b/docs/config/theming.md
@@ -91,6 +91,25 @@ config:
 ---
 ```
 
+### Going back to the previous appearance
+
+The nine types above changed appearance when these became their defaults. To draw one the
+way Mermaid drew it before, name the previous theme and look in its front matter:
+
+```yaml
+---
+config:
+  theme: default
+  look: classic
+---
+```
+
+For every diagram on a page, pass the same two keys to `mermaid.initialize()`:
+
+```javascript
+mermaid.initialize({ theme: 'default', look: 'classic' });
+```
+
 ## Site-wide Theme
 
 To customize themes site-wide, call the `initialize` method on the `mermaid`.

--- a/docs/config/theming.md
+++ b/docs/config/theming.md
@@ -36,8 +36,8 @@ Themes can now be customized at the site-wide level, or on individual Mermaid di
 
 ## Per-diagram defaults
 
-Not every diagram type defaults to the same theme and look. These do, to the `redux-color`
-theme and the `neo` look. The name on the left is the **config key** — what you write to
+Not every diagram type defaults to the same theme and look. Since v\<MERMAID_RELEASE_VERSION>
+these do, to the `redux-color` theme and the `neo` look. The name on the left is the **config key** — what you write to
 scope a setting to that diagram, which is not always the keyword the diagram starts with:
 
 | Config key    | Diagram              |

--- a/docs/syntax/agentflow.md
+++ b/docs/syntax/agentflow.md
@@ -46,6 +46,119 @@ agentflow-beta TB
   end
 ```
 
+## Default theme and look (v\<MERMAID_RELEASE_VERSION>+)
+
+Agentflow diagrams use the `redux-color` theme and the `neo` look by default. Not every
+diagram type does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for
+the list and for the order in which Mermaid decides.
+
+The same diagram, drawn both ways:
+
+### With the defaults
+
+```mermaid-example
+agentflow-beta TB
+  brief["Release brief"]@{ shape: input }
+  flow writer["Drafting Agent"]
+    draft["Draft the notes"]@{ shape: task }
+    lookup["changelog_search"]@{ shape: tool }
+    guide["Tone of voice"]@{ shape: refdoc }
+    draft --> lookup
+    draft -.- guide
+  end
+  flow reviewer["Review Agent"]
+    check["Check the claims"]@{ shape: task }
+    ok["Accurate?"]@{ shape: decision }
+    check --> ok
+  end
+  publish["Publish"]@{ shape: action }
+  brief --> writer
+  writer --> reviewer
+  ok --> publish
+```
+
+```mermaid
+agentflow-beta TB
+  brief["Release brief"]@{ shape: input }
+  flow writer["Drafting Agent"]
+    draft["Draft the notes"]@{ shape: task }
+    lookup["changelog_search"]@{ shape: tool }
+    guide["Tone of voice"]@{ shape: refdoc }
+    draft --> lookup
+    draft -.- guide
+  end
+  flow reviewer["Review Agent"]
+    check["Check the claims"]@{ shape: task }
+    ok["Accurate?"]@{ shape: decision }
+    check --> ok
+  end
+  publish["Publish"]@{ shape: action }
+  brief --> writer
+  writer --> reviewer
+  ok --> publish
+```
+
+### The previous appearance
+
+Both are only defaults, so anything you set yourself wins. Naming the previous theme and look
+in a diagram's front matter draws it the way Mermaid did before:
+
+```mermaid-example
+---
+config:
+  theme: default
+  look: classic
+---
+agentflow-beta TB
+  brief["Release brief"]@{ shape: input }
+  flow writer["Drafting Agent"]
+    draft["Draft the notes"]@{ shape: task }
+    lookup["changelog_search"]@{ shape: tool }
+    guide["Tone of voice"]@{ shape: refdoc }
+    draft --> lookup
+    draft -.- guide
+  end
+  flow reviewer["Review Agent"]
+    check["Check the claims"]@{ shape: task }
+    ok["Accurate?"]@{ shape: decision }
+    check --> ok
+  end
+  publish["Publish"]@{ shape: action }
+  brief --> writer
+  writer --> reviewer
+  ok --> publish
+```
+
+```mermaid
+---
+config:
+  theme: default
+  look: classic
+---
+agentflow-beta TB
+  brief["Release brief"]@{ shape: input }
+  flow writer["Drafting Agent"]
+    draft["Draft the notes"]@{ shape: task }
+    lookup["changelog_search"]@{ shape: tool }
+    guide["Tone of voice"]@{ shape: refdoc }
+    draft --> lookup
+    draft -.- guide
+  end
+  flow reviewer["Review Agent"]
+    check["Check the claims"]@{ shape: task }
+    ok["Accurate?"]@{ shape: decision }
+    check --> ok
+  end
+  publish["Publish"]@{ shape: action }
+  brief --> writer
+  writer --> reviewer
+  ok --> publish
+```
+
+Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
+and scoping them to one diagram type — `mermaid.initialize({ agentflow: { theme: 'default', look: 'classic' } })` —
+does it for that type alone.
+
 ## Declaring a diagram
 
 Every diagram starts with the `agentflow-beta` keyword, optionally followed by a direction — `TB`, `TD`, `BT`, `LR`, or `RL`.

--- a/docs/syntax/classDiagram.md
+++ b/docs/syntax/classDiagram.md
@@ -72,7 +72,7 @@ classDiagram
     }
 ```
 
-## Default theme and look
+## Default theme and look (v\<MERMAID_RELEASE_VERSION>+)
 
 Class diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
@@ -190,7 +190,7 @@ classDiagram
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
-and scoping them to one diagram type — `mermaid.initialize({ class: { look: 'classic' } })` —
+and scoping them to one diagram type — `mermaid.initialize({ class: { theme: 'default', look: 'classic' } })` —
 does it for that type alone.
 
 ## Syntax

--- a/docs/syntax/classDiagram.md
+++ b/docs/syntax/classDiagram.md
@@ -78,15 +78,115 @@ Class diagrams use the `redux-color` theme and the `neo` look by default. Not ev
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
 for the order in which Mermaid decides.
 
-Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
-did before these became the defaults, name the previous two in its front matter:
+The same diagram, drawn both ways:
 
-```yaml
+### With the defaults
+
+```mermaid-example
+classDiagram
+  class Customer {
+    +String name
+    +String email
+  }
+  class Order {
+    +String id
+    +Date placedAt
+    +total() Money
+  }
+  class LineItem {
+    +int quantity
+  }
+  class Payment {
+    <<interface>>
+    +authorise() bool
+  }
+  Customer "1" --> "*" Order : places
+  Order "1" *-- "*" LineItem : contains
+  Order --> Payment : settled by
+```
+
+```mermaid
+classDiagram
+  class Customer {
+    +String name
+    +String email
+  }
+  class Order {
+    +String id
+    +Date placedAt
+    +total() Money
+  }
+  class LineItem {
+    +int quantity
+  }
+  class Payment {
+    <<interface>>
+    +authorise() bool
+  }
+  Customer "1" --> "*" Order : places
+  Order "1" *-- "*" LineItem : contains
+  Order --> Payment : settled by
+```
+
+### The previous appearance
+
+Both are only defaults, so anything you set yourself wins. Naming the previous theme and look
+in a diagram's front matter draws it the way Mermaid did before:
+
+```mermaid-example
 ---
 config:
   theme: default
   look: classic
 ---
+classDiagram
+  class Customer {
+    +String name
+    +String email
+  }
+  class Order {
+    +String id
+    +Date placedAt
+    +total() Money
+  }
+  class LineItem {
+    +int quantity
+  }
+  class Payment {
+    <<interface>>
+    +authorise() bool
+  }
+  Customer "1" --> "*" Order : places
+  Order "1" *-- "*" LineItem : contains
+  Order --> Payment : settled by
+```
+
+```mermaid
+---
+config:
+  theme: default
+  look: classic
+---
+classDiagram
+  class Customer {
+    +String name
+    +String email
+  }
+  class Order {
+    +String id
+    +Date placedAt
+    +total() Money
+  }
+  class LineItem {
+    +int quantity
+  }
+  class Payment {
+    <<interface>>
+    +authorise() bool
+  }
+  Customer "1" --> "*" Order : places
+  Order "1" *-- "*" LineItem : contains
+  Order --> Payment : settled by
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,

--- a/docs/syntax/classDiagram.md
+++ b/docs/syntax/classDiagram.md
@@ -72,6 +72,27 @@ classDiagram
     }
 ```
 
+## Default theme and look
+
+Class diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
+does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
+for the order in which Mermaid decides.
+
+Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
+did before these became the defaults, name the previous two in its front matter:
+
+```yaml
+---
+config:
+  theme: default
+  look: classic
+---
+```
+
+Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
+and scoping them to one diagram type — `mermaid.initialize({ class: { look: 'classic' } })` —
+does it for that type alone.
+
 ## Syntax
 
 ### Class

--- a/docs/syntax/entityRelationshipDiagram.md
+++ b/docs/syntax/entityRelationshipDiagram.md
@@ -80,6 +80,27 @@ erDiagram
 
 When including attributes on ER diagrams, you must decide whether to include foreign keys as attributes. This probably depends on how closely you are trying to represent relational table structures. If your diagram is a _logical_ model which is not meant to imply a relational implementation, then it is better to leave these out because the associative relationships already convey the way that entities are associated. For example, a JSON data structure can implement a one-to-many relationship without the need for foreign key properties, using arrays. Similarly an object-oriented programming language may use pointers or references to collections. Even for models that are intended for relational implementation, you might decide that inclusion of foreign key attributes duplicates information already portrayed by the relationships, and does not add meaning to entities. Ultimately, it's your choice.
 
+## Default theme and look
+
+Entity relationship diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
+does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
+for the order in which Mermaid decides.
+
+Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
+did before these became the defaults, name the previous two in its front matter:
+
+```yaml
+---
+config:
+  theme: default
+  look: classic
+---
+```
+
+Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
+and scoping them to one diagram type — `mermaid.initialize({ er: { look: 'classic' } })` —
+does it for that type alone.
+
 ## Syntax
 
 ### Entities and Relationships

--- a/docs/syntax/entityRelationshipDiagram.md
+++ b/docs/syntax/entityRelationshipDiagram.md
@@ -86,15 +86,115 @@ Entity relationship diagrams use the `redux-color` theme and the `neo` look by d
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
 for the order in which Mermaid decides.
 
-Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
-did before these became the defaults, name the previous two in its front matter:
+The same diagram, drawn both ways:
 
-```yaml
+### With the defaults
+
+```mermaid-example
+erDiagram
+  CUSTOMER ||--o{ ORDER : places
+  ORDER ||--|{ LINE_ITEM : contains
+  PRODUCT ||--o{ LINE_ITEM : "appears in"
+  CUSTOMER {
+    string name
+    string email
+  }
+  ORDER {
+    int id
+    date placedAt
+  }
+  LINE_ITEM {
+    int quantity
+    float price
+  }
+  PRODUCT {
+    string sku
+    string title
+  }
+```
+
+```mermaid
+erDiagram
+  CUSTOMER ||--o{ ORDER : places
+  ORDER ||--|{ LINE_ITEM : contains
+  PRODUCT ||--o{ LINE_ITEM : "appears in"
+  CUSTOMER {
+    string name
+    string email
+  }
+  ORDER {
+    int id
+    date placedAt
+  }
+  LINE_ITEM {
+    int quantity
+    float price
+  }
+  PRODUCT {
+    string sku
+    string title
+  }
+```
+
+### The previous appearance
+
+Both are only defaults, so anything you set yourself wins. Naming the previous theme and look
+in a diagram's front matter draws it the way Mermaid did before:
+
+```mermaid-example
 ---
 config:
   theme: default
   look: classic
 ---
+erDiagram
+  CUSTOMER ||--o{ ORDER : places
+  ORDER ||--|{ LINE_ITEM : contains
+  PRODUCT ||--o{ LINE_ITEM : "appears in"
+  CUSTOMER {
+    string name
+    string email
+  }
+  ORDER {
+    int id
+    date placedAt
+  }
+  LINE_ITEM {
+    int quantity
+    float price
+  }
+  PRODUCT {
+    string sku
+    string title
+  }
+```
+
+```mermaid
+---
+config:
+  theme: default
+  look: classic
+---
+erDiagram
+  CUSTOMER ||--o{ ORDER : places
+  ORDER ||--|{ LINE_ITEM : contains
+  PRODUCT ||--o{ LINE_ITEM : "appears in"
+  CUSTOMER {
+    string name
+    string email
+  }
+  ORDER {
+    int id
+    date placedAt
+  }
+  LINE_ITEM {
+    int quantity
+    float price
+  }
+  PRODUCT {
+    string sku
+    string title
+  }
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,

--- a/docs/syntax/entityRelationshipDiagram.md
+++ b/docs/syntax/entityRelationshipDiagram.md
@@ -80,7 +80,7 @@ erDiagram
 
 When including attributes on ER diagrams, you must decide whether to include foreign keys as attributes. This probably depends on how closely you are trying to represent relational table structures. If your diagram is a _logical_ model which is not meant to imply a relational implementation, then it is better to leave these out because the associative relationships already convey the way that entities are associated. For example, a JSON data structure can implement a one-to-many relationship without the need for foreign key properties, using arrays. Similarly an object-oriented programming language may use pointers or references to collections. Even for models that are intended for relational implementation, you might decide that inclusion of foreign key attributes duplicates information already portrayed by the relationships, and does not add meaning to entities. Ultimately, it's your choice.
 
-## Default theme and look
+## Default theme and look (v\<MERMAID_RELEASE_VERSION>+)
 
 Entity relationship diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
@@ -198,7 +198,7 @@ erDiagram
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
-and scoping them to one diagram type — `mermaid.initialize({ er: { look: 'classic' } })` —
+and scoping them to one diagram type — `mermaid.initialize({ er: { theme: 'default', look: 'classic' } })` —
 does it for that type alone.
 
 ## Syntax

--- a/docs/syntax/flowchart.md
+++ b/docs/syntax/flowchart.md
@@ -150,15 +150,111 @@ Flowcharts use the `redux-color` theme and the `neo` look by default. Not every 
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
 for the order in which Mermaid decides.
 
-Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
-did before these became the defaults, name the previous two in its front matter:
+The same diagram, drawn both ways:
 
-```yaml
+### With the defaults
+
+```mermaid-example
+flowchart LR
+  subgraph Client
+    UI[Web app]
+    Cache[(Local cache)]
+  end
+  subgraph Services
+    API[API gateway]
+    Auth[Auth service]
+    Orders[Order service]
+  end
+  subgraph Storage
+    DB[(Orders DB)]
+  end
+  UI --> API
+  UI --> Cache
+  API --> Auth
+  API --> Orders
+  Orders --> DB
+  Auth -. token .-> UI
+```
+
+```mermaid
+flowchart LR
+  subgraph Client
+    UI[Web app]
+    Cache[(Local cache)]
+  end
+  subgraph Services
+    API[API gateway]
+    Auth[Auth service]
+    Orders[Order service]
+  end
+  subgraph Storage
+    DB[(Orders DB)]
+  end
+  UI --> API
+  UI --> Cache
+  API --> Auth
+  API --> Orders
+  Orders --> DB
+  Auth -. token .-> UI
+```
+
+### The previous appearance
+
+Both are only defaults, so anything you set yourself wins. Naming the previous theme and look
+in a diagram's front matter draws it the way Mermaid did before:
+
+```mermaid-example
 ---
 config:
   theme: default
   look: classic
 ---
+flowchart LR
+  subgraph Client
+    UI[Web app]
+    Cache[(Local cache)]
+  end
+  subgraph Services
+    API[API gateway]
+    Auth[Auth service]
+    Orders[Order service]
+  end
+  subgraph Storage
+    DB[(Orders DB)]
+  end
+  UI --> API
+  UI --> Cache
+  API --> Auth
+  API --> Orders
+  Orders --> DB
+  Auth -. token .-> UI
+```
+
+```mermaid
+---
+config:
+  theme: default
+  look: classic
+---
+flowchart LR
+  subgraph Client
+    UI[Web app]
+    Cache[(Local cache)]
+  end
+  subgraph Services
+    API[API gateway]
+    Auth[Auth service]
+    Orders[Order service]
+  end
+  subgraph Storage
+    DB[(Orders DB)]
+  end
+  UI --> API
+  UI --> Cache
+  API --> Auth
+  API --> Orders
+  Orders --> DB
+  Auth -. token .-> UI
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,

--- a/docs/syntax/flowchart.md
+++ b/docs/syntax/flowchart.md
@@ -144,7 +144,7 @@ Possible FlowChart orientations are:
 - RL - Right to left
 - LR - Left to right
 
-## Default theme and look
+## Default theme and look (v\<MERMAID_RELEASE_VERSION>+)
 
 Flowcharts use the `redux-color` theme and the `neo` look by default. Not every diagram type
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
@@ -258,7 +258,7 @@ flowchart LR
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
-and scoping them to one diagram type — `mermaid.initialize({ flowchart: { look: 'classic' } })` —
+and scoping them to one diagram type — `mermaid.initialize({ flowchart: { theme: 'default', look: 'classic' } })` —
 does it for that type alone.
 
 ## Node shapes

--- a/docs/syntax/flowchart.md
+++ b/docs/syntax/flowchart.md
@@ -144,6 +144,27 @@ Possible FlowChart orientations are:
 - RL - Right to left
 - LR - Left to right
 
+## Default theme and look
+
+Flowcharts use the `redux-color` theme and the `neo` look by default. Not every diagram type
+does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
+for the order in which Mermaid decides.
+
+Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
+did before these became the defaults, name the previous two in its front matter:
+
+```yaml
+---
+config:
+  theme: default
+  look: classic
+---
+```
+
+Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
+and scoping them to one diagram type — `mermaid.initialize({ flowchart: { look: 'classic' } })` —
+does it for that type alone.
+
 ## Node shapes
 
 ### A node with round edges

--- a/docs/syntax/requirementDiagram.md
+++ b/docs/syntax/requirementDiagram.md
@@ -44,7 +44,7 @@ Rendering requirements is straightforward.
     test_entity - satisfies -> test_req
 ```
 
-## Default theme and look
+## Default theme and look (v\<MERMAID_RELEASE_VERSION>+)
 
 Requirement diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
@@ -154,7 +154,7 @@ requirementDiagram
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
-and scoping them to one diagram type — `mermaid.initialize({ requirement: { look: 'classic' } })` —
+and scoping them to one diagram type — `mermaid.initialize({ requirement: { theme: 'default', look: 'classic' } })` —
 does it for that type alone.
 
 ## Syntax

--- a/docs/syntax/requirementDiagram.md
+++ b/docs/syntax/requirementDiagram.md
@@ -44,6 +44,27 @@ Rendering requirements is straightforward.
     test_entity - satisfies -> test_req
 ```
 
+## Default theme and look
+
+Requirement diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
+does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
+for the order in which Mermaid decides.
+
+Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
+did before these became the defaults, name the previous two in its front matter:
+
+```yaml
+---
+config:
+  theme: default
+  look: classic
+---
+```
+
+Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
+and scoping them to one diagram type — `mermaid.initialize({ requirement: { look: 'classic' } })` —
+does it for that type alone.
+
 ## Syntax
 
 There are three types of components to a requirement diagram: requirement, element, and relationship.

--- a/docs/syntax/requirementDiagram.md
+++ b/docs/syntax/requirementDiagram.md
@@ -50,15 +50,107 @@ Requirement diagrams use the `redux-color` theme and the `neo` look by default. 
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
 for the order in which Mermaid decides.
 
-Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
-did before these became the defaults, name the previous two in its front matter:
+The same diagram, drawn both ways:
 
-```yaml
+### With the defaults
+
+```mermaid-example
+requirementDiagram
+  requirement checkout_req {
+    id: 1
+    text: Orders must be payable online.
+    risk: high
+    verifymethod: test
+  }
+  functionalRequirement payment_req {
+    id: 1.1
+    text: Card payments must be authorised.
+    risk: high
+    verifymethod: test
+  }
+  element checkout_service {
+    type: service
+  }
+  checkout_req - contains -> payment_req
+  checkout_service - satisfies -> payment_req
+```
+
+```mermaid
+requirementDiagram
+  requirement checkout_req {
+    id: 1
+    text: Orders must be payable online.
+    risk: high
+    verifymethod: test
+  }
+  functionalRequirement payment_req {
+    id: 1.1
+    text: Card payments must be authorised.
+    risk: high
+    verifymethod: test
+  }
+  element checkout_service {
+    type: service
+  }
+  checkout_req - contains -> payment_req
+  checkout_service - satisfies -> payment_req
+```
+
+### The previous appearance
+
+Both are only defaults, so anything you set yourself wins. Naming the previous theme and look
+in a diagram's front matter draws it the way Mermaid did before:
+
+```mermaid-example
 ---
 config:
   theme: default
   look: classic
 ---
+requirementDiagram
+  requirement checkout_req {
+    id: 1
+    text: Orders must be payable online.
+    risk: high
+    verifymethod: test
+  }
+  functionalRequirement payment_req {
+    id: 1.1
+    text: Card payments must be authorised.
+    risk: high
+    verifymethod: test
+  }
+  element checkout_service {
+    type: service
+  }
+  checkout_req - contains -> payment_req
+  checkout_service - satisfies -> payment_req
+```
+
+```mermaid
+---
+config:
+  theme: default
+  look: classic
+---
+requirementDiagram
+  requirement checkout_req {
+    id: 1
+    text: Orders must be payable online.
+    risk: high
+    verifymethod: test
+  }
+  functionalRequirement payment_req {
+    id: 1.1
+    text: Card payments must be authorised.
+    risk: high
+    verifymethod: test
+  }
+  element checkout_service {
+    type: service
+  }
+  checkout_req - contains -> payment_req
+  checkout_service - satisfies -> payment_req
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,

--- a/docs/syntax/sequenceDiagram.md
+++ b/docs/syntax/sequenceDiagram.md
@@ -29,6 +29,27 @@ sequenceDiagram
 >
 > If unavoidable, one must use parentheses(), quotation marks "", or brackets {},\[], to enclose the word "end". i.e : (end), \[end], {end}.
 
+## Default theme and look
+
+Sequence diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
+does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
+for the order in which Mermaid decides.
+
+Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
+did before these became the defaults, name the previous two in its front matter:
+
+```yaml
+---
+config:
+  theme: default
+  look: classic
+---
+```
+
+Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
+and scoping them to one diagram type — `mermaid.initialize({ sequence: { look: 'classic' } })` —
+does it for that type alone.
+
 ## Syntax
 
 ### Participants

--- a/docs/syntax/sequenceDiagram.md
+++ b/docs/syntax/sequenceDiagram.md
@@ -35,15 +35,95 @@ Sequence diagrams use the `redux-color` theme and the `neo` look by default. Not
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
 for the order in which Mermaid decides.
 
-Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
-did before these became the defaults, name the previous two in its front matter:
+The same diagram, drawn both ways:
 
-```yaml
+### With the defaults
+
+```mermaid-example
+sequenceDiagram
+  autonumber
+  actor Customer
+  participant Web as Web app
+  participant API as API gateway
+  participant Bank
+  Customer->>Web: Place order
+  Web->>API: POST /orders
+  activate API
+  API->>Bank: Authorise payment
+  Bank-->>API: Approved
+  API-->>Web: 201 Created
+  deactivate API
+  Web-->>Customer: Order confirmed
+  Note over Customer,Bank: One order, one transaction
+```
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor Customer
+  participant Web as Web app
+  participant API as API gateway
+  participant Bank
+  Customer->>Web: Place order
+  Web->>API: POST /orders
+  activate API
+  API->>Bank: Authorise payment
+  Bank-->>API: Approved
+  API-->>Web: 201 Created
+  deactivate API
+  Web-->>Customer: Order confirmed
+  Note over Customer,Bank: One order, one transaction
+```
+
+### The previous appearance
+
+Both are only defaults, so anything you set yourself wins. Naming the previous theme and look
+in a diagram's front matter draws it the way Mermaid did before:
+
+```mermaid-example
 ---
 config:
   theme: default
   look: classic
 ---
+sequenceDiagram
+  autonumber
+  actor Customer
+  participant Web as Web app
+  participant API as API gateway
+  participant Bank
+  Customer->>Web: Place order
+  Web->>API: POST /orders
+  activate API
+  API->>Bank: Authorise payment
+  Bank-->>API: Approved
+  API-->>Web: 201 Created
+  deactivate API
+  Web-->>Customer: Order confirmed
+  Note over Customer,Bank: One order, one transaction
+```
+
+```mermaid
+---
+config:
+  theme: default
+  look: classic
+---
+sequenceDiagram
+  autonumber
+  actor Customer
+  participant Web as Web app
+  participant API as API gateway
+  participant Bank
+  Customer->>Web: Place order
+  Web->>API: POST /orders
+  activate API
+  API->>Bank: Authorise payment
+  Bank-->>API: Approved
+  API-->>Web: 201 Created
+  deactivate API
+  Web-->>Customer: Order confirmed
+  Note over Customer,Bank: One order, one transaction
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,

--- a/docs/syntax/sequenceDiagram.md
+++ b/docs/syntax/sequenceDiagram.md
@@ -29,7 +29,7 @@ sequenceDiagram
 >
 > If unavoidable, one must use parentheses(), quotation marks "", or brackets {},\[], to enclose the word "end". i.e : (end), \[end], {end}.
 
-## Default theme and look
+## Default theme and look (v\<MERMAID_RELEASE_VERSION>+)
 
 Sequence diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
@@ -127,7 +127,7 @@ sequenceDiagram
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
-and scoping them to one diagram type — `mermaid.initialize({ sequence: { look: 'classic' } })` —
+and scoping them to one diagram type — `mermaid.initialize({ sequence: { theme: 'default', look: 'classic' } })` —
 does it for that type alone.
 
 ## Syntax

--- a/docs/syntax/stateDiagram.md
+++ b/docs/syntax/stateDiagram.md
@@ -70,7 +70,7 @@ a _transition._ The example diagram above shows three states: **Still**, **Movin
 **Still** state. From **Still** you can change to the **Moving** state. From **Moving** you can change either back to the **Still** state or to
 the **Crash** state. There is no transition from **Still** to **Crash**. (You can't crash if you're still.)
 
-## Default theme and look
+## Default theme and look (v\<MERMAID_RELEASE_VERSION>+)
 
 State diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
@@ -152,7 +152,7 @@ stateDiagram-v2
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
-and scoping them to one diagram type — `mermaid.initialize({ state: { look: 'classic' } })` —
+and scoping them to one diagram type — `mermaid.initialize({ state: { theme: 'default', look: 'classic' } })` —
 does it for that type alone.
 
 ## States

--- a/docs/syntax/stateDiagram.md
+++ b/docs/syntax/stateDiagram.md
@@ -76,15 +76,79 @@ State diagrams use the `redux-color` theme and the `neo` look by default. Not ev
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
 for the order in which Mermaid decides.
 
-Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
-did before these became the defaults, name the previous two in its front matter:
+The same diagram, drawn both ways:
 
-```yaml
+### With the defaults
+
+```mermaid-example
+stateDiagram-v2
+  [*] --> Draft
+  Draft --> Submitted : submit
+  state Review {
+    [*] --> Screening
+    Screening --> Decision
+  }
+  Submitted --> Review
+  Review --> Published : approved
+  Review --> Draft : rejected
+  Published --> [*]
+```
+
+```mermaid
+stateDiagram-v2
+  [*] --> Draft
+  Draft --> Submitted : submit
+  state Review {
+    [*] --> Screening
+    Screening --> Decision
+  }
+  Submitted --> Review
+  Review --> Published : approved
+  Review --> Draft : rejected
+  Published --> [*]
+```
+
+### The previous appearance
+
+Both are only defaults, so anything you set yourself wins. Naming the previous theme and look
+in a diagram's front matter draws it the way Mermaid did before:
+
+```mermaid-example
 ---
 config:
   theme: default
   look: classic
 ---
+stateDiagram-v2
+  [*] --> Draft
+  Draft --> Submitted : submit
+  state Review {
+    [*] --> Screening
+    Screening --> Decision
+  }
+  Submitted --> Review
+  Review --> Published : approved
+  Review --> Draft : rejected
+  Published --> [*]
+```
+
+```mermaid
+---
+config:
+  theme: default
+  look: classic
+---
+stateDiagram-v2
+  [*] --> Draft
+  Draft --> Submitted : submit
+  state Review {
+    [*] --> Screening
+    Screening --> Decision
+  }
+  Submitted --> Review
+  Review --> Published : approved
+  Review --> Draft : rejected
+  Published --> [*]
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,

--- a/docs/syntax/stateDiagram.md
+++ b/docs/syntax/stateDiagram.md
@@ -70,6 +70,27 @@ a _transition._ The example diagram above shows three states: **Still**, **Movin
 **Still** state. From **Still** you can change to the **Moving** state. From **Moving** you can change either back to the **Still** state or to
 the **Crash** state. There is no transition from **Still** to **Crash**. (You can't crash if you're still.)
 
+## Default theme and look
+
+State diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
+does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
+for the order in which Mermaid decides.
+
+Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
+did before these became the defaults, name the previous two in its front matter:
+
+```yaml
+---
+config:
+  theme: default
+  look: classic
+---
+```
+
+Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
+and scoping them to one diagram type — `mermaid.initialize({ state: { look: 'classic' } })` —
+does it for that type alone.
+
 ## States
 
 A state can be declared in multiple ways. The simplest way is to define a state with just an id:

--- a/docs/syntax/swimlanes.md
+++ b/docs/syntax/swimlanes.md
@@ -13,6 +13,27 @@ A swimlane diagram shows a process divided by responsibility. Each lane represen
 
 Use swimlane diagrams when the most important question is not only "what happens next?" but also "who owns this step?" They are useful for approval flows, support processes, delivery workflows, and any process where work crosses teams or systems.
 
+## Default theme and look
+
+Swimlane diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
+does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
+for the order in which Mermaid decides.
+
+Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
+did before these became the defaults, name the previous two in its front matter:
+
+```yaml
+---
+config:
+  theme: default
+  look: classic
+---
+```
+
+Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
+and scoping them to one diagram type — `mermaid.initialize({ swimlane: { look: 'classic' } })` —
+does it for that type alone.
+
 ## Basic Example
 
 > The rendered examples on this page use the **Neo** look and the **Redux** theme. Out of the box, swimlanes use your configured default look and theme.

--- a/docs/syntax/swimlanes.md
+++ b/docs/syntax/swimlanes.md
@@ -13,7 +13,7 @@ A swimlane diagram shows a process divided by responsibility. Each lane represen
 
 Use swimlane diagrams when the most important question is not only "what happens next?" but also "who owns this step?" They are useful for approval flows, support processes, delivery workflows, and any process where work crosses teams or systems.
 
-## Default theme and look
+## Default theme and look (v\<MERMAID_RELEASE_VERSION>+)
 
 Swimlane diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
@@ -115,12 +115,10 @@ swimlane-beta LR
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
-and scoping them to one diagram type — `mermaid.initialize({ swimlane: { look: 'classic' } })` —
+and scoping them to one diagram type — `mermaid.initialize({ swimlane: { theme: 'default', look: 'classic' } })` —
 does it for that type alone.
 
 ## Basic Example
-
-> The rendered examples on this page use the **Neo** look and the **Redux** theme. Out of the box, swimlanes use your configured default look and theme.
 
 ```mermaid-example
 swimlane-beta LR

--- a/docs/syntax/swimlanes.md
+++ b/docs/syntax/swimlanes.md
@@ -19,15 +19,99 @@ Swimlane diagrams use the `redux-color` theme and the `neo` look by default. Not
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
 for the order in which Mermaid decides.
 
-Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
-did before these became the defaults, name the previous two in its front matter:
+The same diagram, drawn both ways:
 
-```yaml
+### With the defaults
+
+```mermaid-example
+swimlane-beta LR
+  subgraph Customer
+    Browse[Browse catalogue]
+    Pay[Pay]
+  end
+  subgraph Warehouse
+    Pick[Pick items]
+    Ship[Ship order]
+  end
+  subgraph Finance
+    Invoice[Raise invoice]
+  end
+  Browse --> Pay
+  Pay --> Pick
+  Pick --> Ship
+  Pay --> Invoice
+```
+
+```mermaid
+swimlane-beta LR
+  subgraph Customer
+    Browse[Browse catalogue]
+    Pay[Pay]
+  end
+  subgraph Warehouse
+    Pick[Pick items]
+    Ship[Ship order]
+  end
+  subgraph Finance
+    Invoice[Raise invoice]
+  end
+  Browse --> Pay
+  Pay --> Pick
+  Pick --> Ship
+  Pay --> Invoice
+```
+
+### The previous appearance
+
+Both are only defaults, so anything you set yourself wins. Naming the previous theme and look
+in a diagram's front matter draws it the way Mermaid did before:
+
+```mermaid-example
 ---
 config:
   theme: default
   look: classic
 ---
+swimlane-beta LR
+  subgraph Customer
+    Browse[Browse catalogue]
+    Pay[Pay]
+  end
+  subgraph Warehouse
+    Pick[Pick items]
+    Ship[Ship order]
+  end
+  subgraph Finance
+    Invoice[Raise invoice]
+  end
+  Browse --> Pay
+  Pay --> Pick
+  Pick --> Ship
+  Pay --> Invoice
+```
+
+```mermaid
+---
+config:
+  theme: default
+  look: classic
+---
+swimlane-beta LR
+  subgraph Customer
+    Browse[Browse catalogue]
+    Pay[Pay]
+  end
+  subgraph Warehouse
+    Pick[Pick items]
+    Ship[Ship order]
+  end
+  subgraph Finance
+    Invoice[Raise invoice]
+  end
+  Browse --> Pay
+  Pay --> Pick
+  Pick --> Ship
+  Pay --> Invoice
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,

--- a/docs/syntax/usecase.md
+++ b/docs/syntax/usecase.md
@@ -32,6 +32,27 @@ Customer --> Checkout
 
 Use `direction` with `TD`, `TB`, `BT`, `LR`, or `RL` to choose the layout direction.
 
+## Default theme and look
+
+Use case diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
+does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
+for the order in which Mermaid decides.
+
+Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
+did before these became the defaults, name the previous two in its front matter:
+
+```yaml
+---
+config:
+  theme: default
+  look: classic
+---
+```
+
+Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
+and scoping them to one diagram type — `mermaid.initialize({ usecase: { look: 'classic' } })` —
+does it for that type alone.
+
 ## Actors and use cases
 
 Actor and use case identifiers match `[A-Za-z0-9_]+`, so they may start with a digit — `1`, `1mg`, and `3rd` are all valid. Identifiers are diagram-wide and are shared by actors, use cases, boundaries, JSON nodes, and explicit edges.

--- a/docs/syntax/usecase.md
+++ b/docs/syntax/usecase.md
@@ -38,15 +38,99 @@ Use case diagrams use the `redux-color` theme and the `neo` look by default. Not
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
 for the order in which Mermaid decides.
 
-Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
-did before these became the defaults, name the previous two in its front matter:
+The same diagram, drawn both ways:
 
-```yaml
+### With the defaults
+
+```mermaid-example
+usecase-beta
+direction LR
+actor Customer
+actor Support
+systemBoundary Storefront
+  Browse("Browse catalogue")
+  Checkout("Checkout")
+end
+systemBoundary Fulfilment
+  Track("Track delivery")
+end
+Customer --> Browse
+Customer --> Checkout
+Customer --> Track
+Support --> Track
+Checkout ..> : include Browse
+```
+
+```mermaid
+usecase-beta
+direction LR
+actor Customer
+actor Support
+systemBoundary Storefront
+  Browse("Browse catalogue")
+  Checkout("Checkout")
+end
+systemBoundary Fulfilment
+  Track("Track delivery")
+end
+Customer --> Browse
+Customer --> Checkout
+Customer --> Track
+Support --> Track
+Checkout ..> : include Browse
+```
+
+### The previous appearance
+
+Both are only defaults, so anything you set yourself wins. Naming the previous theme and look
+in a diagram's front matter draws it the way Mermaid did before:
+
+```mermaid-example
 ---
 config:
   theme: default
   look: classic
 ---
+usecase-beta
+direction LR
+actor Customer
+actor Support
+systemBoundary Storefront
+  Browse("Browse catalogue")
+  Checkout("Checkout")
+end
+systemBoundary Fulfilment
+  Track("Track delivery")
+end
+Customer --> Browse
+Customer --> Checkout
+Customer --> Track
+Support --> Track
+Checkout ..> : include Browse
+```
+
+```mermaid
+---
+config:
+  theme: default
+  look: classic
+---
+usecase-beta
+direction LR
+actor Customer
+actor Support
+systemBoundary Storefront
+  Browse("Browse catalogue")
+  Checkout("Checkout")
+end
+systemBoundary Fulfilment
+  Track("Track delivery")
+end
+Customer --> Browse
+Customer --> Checkout
+Customer --> Track
+Support --> Track
+Checkout ..> : include Browse
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,

--- a/docs/syntax/usecase.md
+++ b/docs/syntax/usecase.md
@@ -32,7 +32,7 @@ Customer --> Checkout
 
 Use `direction` with `TD`, `TB`, `BT`, `LR`, or `RL` to choose the layout direction.
 
-## Default theme and look
+## Default theme and look (v\<MERMAID_RELEASE_VERSION>+)
 
 Use case diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
@@ -134,7 +134,7 @@ Checkout ..> : include Browse
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
-and scoping them to one diagram type — `mermaid.initialize({ usecase: { look: 'classic' } })` —
+and scoping them to one diagram type — `mermaid.initialize({ usecase: { theme: 'default', look: 'classic' } })` —
 does it for that type alone.
 
 ## Actors and use cases

--- a/docs/syntax/venn.md
+++ b/docs/syntax/venn.md
@@ -11,7 +11,7 @@ Venn diagrams show relationships between sets using overlapping circles.
 > **Warning**
 > This is a new diagram type in Mermaid. Its syntax may evolve in future versions.
 
-## Default theme and look
+## Default theme and look (v\<MERMAID_RELEASE_VERSION>+)
 
 Venn diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
@@ -85,7 +85,7 @@ venn-beta
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
-and scoping them to one diagram type — `mermaid.initialize({ venn: { look: 'classic' } })` —
+and scoping them to one diagram type — `mermaid.initialize({ venn: { theme: 'default', look: 'classic' } })` —
 does it for that type alone.
 
 ## Syntax

--- a/docs/syntax/venn.md
+++ b/docs/syntax/venn.md
@@ -11,6 +11,27 @@ Venn diagrams show relationships between sets using overlapping circles.
 > **Warning**
 > This is a new diagram type in Mermaid. Its syntax may evolve in future versions.
 
+## Default theme and look
+
+Venn diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
+does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
+for the order in which Mermaid decides.
+
+Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
+did before these became the defaults, name the previous two in its front matter:
+
+```yaml
+---
+config:
+  theme: default
+  look: classic
+---
+```
+
+Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
+and scoping them to one diagram type — `mermaid.initialize({ venn: { look: 'classic' } })` —
+does it for that type alone.
+
 ## Syntax
 
 - Start with `venn-beta`.

--- a/docs/syntax/venn.md
+++ b/docs/syntax/venn.md
@@ -17,15 +17,71 @@ Venn diagrams use the `redux-color` theme and the `neo` look by default. Not eve
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
 for the order in which Mermaid decides.
 
-Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
-did before these became the defaults, name the previous two in its front matter:
+The same diagram, drawn both ways:
 
-```yaml
+### With the defaults
+
+```mermaid-example
+venn-beta
+  title What makes a good feature
+  set Desirable
+  set Feasible
+  set Viable
+  union Desirable,Feasible["Buildable"]
+  union Feasible,Viable["Sustainable"]
+  union Desirable,Viable["Marketable"]
+  union Desirable,Feasible,Viable["Ship it"]
+```
+
+```mermaid
+venn-beta
+  title What makes a good feature
+  set Desirable
+  set Feasible
+  set Viable
+  union Desirable,Feasible["Buildable"]
+  union Feasible,Viable["Sustainable"]
+  union Desirable,Viable["Marketable"]
+  union Desirable,Feasible,Viable["Ship it"]
+```
+
+### The previous appearance
+
+Both are only defaults, so anything you set yourself wins. Naming the previous theme and look
+in a diagram's front matter draws it the way Mermaid did before:
+
+```mermaid-example
 ---
 config:
   theme: default
   look: classic
 ---
+venn-beta
+  title What makes a good feature
+  set Desirable
+  set Feasible
+  set Viable
+  union Desirable,Feasible["Buildable"]
+  union Feasible,Viable["Sustainable"]
+  union Desirable,Viable["Marketable"]
+  union Desirable,Feasible,Viable["Ship it"]
+```
+
+```mermaid
+---
+config:
+  theme: default
+  look: classic
+---
+venn-beta
+  title What makes a good feature
+  set Desirable
+  set Feasible
+  set Viable
+  union Desirable,Feasible["Buildable"]
+  union Feasible,Viable["Sustainable"]
+  union Desirable,Viable["Marketable"]
+  union Desirable,Feasible,Viable["Ship it"]
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,

--- a/packages/mermaid/src/defaultAppearanceDocs.spec.ts
+++ b/packages/mermaid/src/defaultAppearanceDocs.spec.ts
@@ -10,6 +10,7 @@ import { addDiagrams } from './diagram-api/diagram-orchestration.js';
 import { mermaidAPI } from './mermaidAPI.js';
 
 const PAGES = [
+  'agentflow',
   'flowchart',
   'swimlanes',
   'classDiagram',

--- a/packages/mermaid/src/defaultAppearanceDocs.spec.ts
+++ b/packages/mermaid/src/defaultAppearanceDocs.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * The nine pages that document the per-diagram defaults each show the same diagram twice --
+ * once with the defaults and once pinned back to `default`/`classic`. They render on the
+ * public docs site, so a syntax slip in one shows up there as an error diagram.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it, beforeAll } from 'vitest';
+import { addDiagrams } from './diagram-api/diagram-orchestration.js';
+import { mermaidAPI } from './mermaidAPI.js';
+
+const PAGES = [
+  'flowchart',
+  'swimlanes',
+  'classDiagram',
+  'entityRelationshipDiagram',
+  'requirementDiagram',
+  'sequenceDiagram',
+  'stateDiagram',
+  'usecase',
+  'venn',
+];
+
+const readPage = (page: string): string => {
+  const path = [
+    resolve(process.cwd(), `packages/mermaid/src/docs/syntax/${page}.md`),
+    resolve(process.cwd(), `src/docs/syntax/${page}.md`),
+  ].find((candidate) => existsSync(candidate));
+  if (!path) {
+    throw new Error(`Documentation page not found: ${page}.md`);
+  }
+  return readFileSync(path, 'utf8');
+};
+
+/** The `mermaid-example` fences inside the "Default theme and look" section. */
+const appearanceExamples = (page: string): string[] => {
+  const section = /## Default theme and look\n[\S\s]*?(?=\n## )/.exec(readPage(page))?.[0];
+  expect(section, `${page}.md has no "Default theme and look" section`).toBeDefined();
+  return [...section!.matchAll(/^```mermaid-example[^\n]*\r?\n([\S\s]*?)\r?\n```$/gm)].map(
+    ([, source]) => source
+  );
+};
+
+describe('per-diagram appearance documentation', () => {
+  beforeAll(() => {
+    addDiagrams();
+  });
+
+  it.each(PAGES)('%s.md shows the diagram with the defaults and pinned back', async (page) => {
+    const examples = appearanceExamples(page);
+    expect(examples).toHaveLength(2);
+
+    const [withDefaults, pinnedBack] = examples;
+    // The pair has to be the same diagram, or the comparison teaches nothing.
+    expect(pinnedBack).toContain(withDefaults.trim());
+    expect(pinnedBack).toContain('theme: default');
+    expect(pinnedBack).toContain('look: classic');
+
+    for (const source of examples) {
+      await expect(mermaidAPI.parse(source), `${page}.md:\n${source}`).resolves.toBeTruthy();
+    }
+  });
+});

--- a/packages/mermaid/src/defaultAppearanceDocs.spec.ts
+++ b/packages/mermaid/src/defaultAppearanceDocs.spec.ts
@@ -34,7 +34,7 @@ const readPage = (page: string): string => {
 
 /** The `mermaid-example` fences inside the "Default theme and look" section. */
 const appearanceExamples = (page: string): string[] => {
-  const section = /## Default theme and look\n[\S\s]*?(?=\n## )/.exec(readPage(page))?.[0];
+  const section = /## Default theme and look[^\n]*\n[\S\s]*?(?=\n## )/.exec(readPage(page))?.[0];
   expect(section, `${page}.md has no "Default theme and look" section`).toBeDefined();
   return [...section!.matchAll(/^```mermaid-example[^\n]*\r?\n([\S\s]*?)\r?\n```$/gm)].map(
     ([, source]) => source
@@ -49,6 +49,9 @@ describe('per-diagram appearance documentation', () => {
   it.each(PAGES)('%s.md shows the diagram with the defaults and pinned back', async (page) => {
     const examples = appearanceExamples(page);
     expect(examples).toHaveLength(2);
+
+    // `contributing.md` asks for a version marker on newly documented behaviour.
+    expect(readPage(page)).toContain('## Default theme and look (v<MERMAID_RELEASE_VERSION>+)');
 
     const [withDefaults, pinnedBack] = examples;
     // The pair has to be the same diagram, or the comparison teaches nothing.

--- a/packages/mermaid/src/diagrams/usecase/usecase.docs.spec.ts
+++ b/packages/mermaid/src/diagrams/usecase/usecase.docs.spec.ts
@@ -28,19 +28,26 @@ const extractMermaidExamples = (markdown: string): string[] =>
   );
 
 describe('usecase public documentation examples', () => {
-  jsdomIt('parses and renders every mermaid-example fence from the canonical page', async () => {
-    const examples = extractMermaidExamples(readDocumentation());
-    expect(examples.length).toBeGreaterThan(0);
+  jsdomIt(
+    'parses and renders every mermaid-example fence from the canonical page',
+    async () => {
+      const examples = extractMermaidExamples(readDocumentation());
+      expect(examples.length).toBeGreaterThan(0);
 
-    for (const [index, source] of examples.entries()) {
-      const id = `usecase-doc-example-${index}`;
-      try {
-        const { svg } = await mermaidAPI.render(id, source);
-        expect(svg, `documentation example ${index + 1}`).toContain('<svg');
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        throw new Error(`Use-case documentation example ${index + 1} failed: ${message}`);
+      for (const [index, source] of examples.entries()) {
+        const id = `usecase-doc-example-${index}`;
+        try {
+          const { svg } = await mermaidAPI.render(id, source);
+          expect(svg, `documentation example ${index + 1}`).toContain('<svg');
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          throw new Error(`Use-case documentation example ${index + 1} failed: ${message}`);
+        }
       }
-    }
-  });
+    },
+    // Renders every example on the page in one test, so the cost grows with the page and the
+    // default 5s was already marginal on CI. Generous rather than tuned: the point is that
+    // adding an example to the docs must not turn into a timeout here.
+    60_000
+  );
 });

--- a/packages/mermaid/src/docs/.vitepress/theme/Mermaid.vue
+++ b/packages/mermaid/src/docs/.vitepress/theme/Mermaid.vue
@@ -17,6 +17,7 @@
 <script setup>
 import { onMounted, onUnmounted, ref } from 'vue';
 import { render } from './mermaid';
+import { buildExampleConfig } from './exampleConfig';
 
 const props = defineProps({
   graph: {
@@ -84,35 +85,10 @@ onMounted(async () => {
 
 onUnmounted(() => mut.disconnect());
 
-// Detect the diagram type keyword, skipping an optional YAML frontmatter
-// block and/or `%%{init: ...}%%` directives that may precede it.
-const getDiagramType = (source) => {
-  const withoutFrontmatter = source.replace(/^\s*---[\s\S]*?---\s*/, '');
-  const withoutDirectives = withoutFrontmatter.replace(/^\s*(?:%%\{[\s\S]*?\}%%\s*)*/, '');
-  return withoutDirectives.trimStart().split(/\s|\n/, 1)[0] ?? '';
-};
-
 const renderChart = async () => {
   console.log('rendering chart' + props.id + code.value);
   const hasDarkClass = document.documentElement.classList.contains('dark');
-  const mermaidConfig = {
-    securityLevel: 'loose',
-    startOnLoad: false,
-    theme: hasDarkClass ? 'dark' : 'default',
-  };
-  // Swimlanes examples use the Neo look and follow the page's light/dark mode:
-  // Redux in light mode, Redux Dark in dark mode.
-  if (getDiagramType(code.value) === 'swimlanes') {
-    mermaidConfig.theme = hasDarkClass ? 'redux-dark' : 'redux';
-    mermaidConfig.look = 'neo';
-    mermaidConfig.flowchart = {
-      titleTopMargin: 10,
-    };
-    mermaidConfig.swimlanes = {
-      ignoreCrossLaneEdges: true,
-      optimizeRanksByCrossings: true,
-    };
-  }
+  const mermaidConfig = buildExampleConfig(code.value, hasDarkClass);
   let svgCode = await render(props.id, code.value, mermaidConfig);
   // This is a hack to force v-html to re-render, otherwise the diagram disappears
   // when **switching themes** or **reloading the page**.

--- a/packages/mermaid/src/docs/.vitepress/theme/exampleConfig.spec.ts
+++ b/packages/mermaid/src/docs/.vitepress/theme/exampleConfig.spec.ts
@@ -8,15 +8,18 @@ import { buildExampleConfig, getDiagramType, COLOR_THEME_DIAGRAMS } from './exam
  * Read as text rather than through the `?only-defaults` plugin, which is not registered for
  * the docs vitest project. This spec runs from more than one working directory.
  */
-const schemaPath = [
-  'packages/mermaid/src/schemas/config.schema.yaml',
-  'src/schemas/config.schema.yaml',
-  '../../schemas/config.schema.yaml',
-]
-  .map((candidate) => resolve(process.cwd(), candidate))
-  .find((candidate) => existsSync(candidate));
+const schemaCandidates = [
+  'packages/mermaid/src/schemas/config.schema.yaml', // repo root
+  'src/schemas/config.schema.yaml', // packages/mermaid
+  '../schemas/config.schema.yaml', // packages/mermaid/src/docs
+].map((candidate) => resolve(process.cwd(), candidate));
 
-const schema = load(readFileSync(schemaPath!, 'utf8')) as {
+const schemaPath = schemaCandidates.find((candidate) => existsSync(candidate));
+if (!schemaPath) {
+  throw new Error(`config.schema.yaml not found at any of: ${schemaCandidates.join(', ')}`);
+}
+
+const schema = load(readFileSync(schemaPath, 'utf8')) as {
   properties: Record<string, { $ref?: string }>;
   $defs: Record<string, { properties?: Record<string, { default?: unknown }> }>;
 };
@@ -29,6 +32,9 @@ const declaredColourDefaults = Object.entries(schema.properties)
     return declared === 'redux-color' ? [key] : [];
   })
   .sort();
+
+/** `buildExampleConfig`'s return, with the diagram sections it may add. */
+type SectionedConfig = Record<string, { theme?: string; [option: string]: unknown } | undefined>;
 
 describe('docs example config', () => {
   describe('light mode', () => {
@@ -67,7 +73,7 @@ describe('docs example config', () => {
     const swimlane = 'swimlane-beta LR\n  subgraph Customer\n  end';
 
     it('applies the layout options the syntax page should not repeat', () => {
-      const config = buildExampleConfig(swimlane, false) as Record<string, any>;
+      const config = buildExampleConfig(swimlane, false) as SectionedConfig;
       expect(config.swimlane).toMatchObject({
         ignoreCrossLaneEdges: true,
         optimizeRanksByCrossings: true,
@@ -76,7 +82,7 @@ describe('docs example config', () => {
     });
 
     it('keeps the dark counterpart alongside them', () => {
-      const config = buildExampleConfig(swimlane, true) as Record<string, any>;
+      const config = buildExampleConfig(swimlane, true) as SectionedConfig;
       expect(config.swimlane).toMatchObject({
         theme: 'redux-dark-color',
         ignoreCrossLaneEdges: true,
@@ -84,14 +90,14 @@ describe('docs example config', () => {
     });
 
     it('does not pin a theme or look of its own', () => {
-      const config = buildExampleConfig(swimlane, false) as Record<string, any>;
+      const config = buildExampleConfig(swimlane, false) as SectionedConfig;
       expect(config.theme).toBeUndefined();
       expect(config.look).toBeUndefined();
-      expect(config.swimlane.theme).toBeUndefined();
+      expect(config.swimlane?.theme).toBeUndefined();
     });
 
     it('leaves other diagram types without the swimlane options', () => {
-      const config = buildExampleConfig('flowchart TD\n  A --> B', false) as Record<string, any>;
+      const config = buildExampleConfig('flowchart TD\n  A --> B', false) as SectionedConfig;
       expect(config.swimlane).toBeUndefined();
       expect(config.flowchart).toBeUndefined();
     });

--- a/packages/mermaid/src/docs/.vitepress/theme/exampleConfig.spec.ts
+++ b/packages/mermaid/src/docs/.vitepress/theme/exampleConfig.spec.ts
@@ -65,7 +65,9 @@ describe('docs example config', () => {
   it('names exactly the diagram types the schema defaults to a colour theme', () => {
     // The list in `exampleConfig.ts` is written out by hand. Deriving the expectation from
     // the schema is what stops the docs site quietly missing a tenth type added later.
-    expect(declaredColourDefaults).toHaveLength(9);
+    expect(declaredColourDefaults.length, 'no colour defaults found in the schema').toBeGreaterThan(
+      0
+    );
     expect([...COLOR_THEME_DIAGRAMS].sort()).toEqual(declaredColourDefaults);
   });
 

--- a/packages/mermaid/src/docs/.vitepress/theme/exampleConfig.spec.ts
+++ b/packages/mermaid/src/docs/.vitepress/theme/exampleConfig.spec.ts
@@ -1,0 +1,111 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { load } from 'js-yaml';
+import { buildExampleConfig, getDiagramType, COLOR_THEME_DIAGRAMS } from './exampleConfig.js';
+
+/**
+ * Read as text rather than through the `?only-defaults` plugin, which is not registered for
+ * the docs vitest project. This spec runs from more than one working directory.
+ */
+const schemaPath = [
+  'packages/mermaid/src/schemas/config.schema.yaml',
+  'src/schemas/config.schema.yaml',
+  '../../schemas/config.schema.yaml',
+]
+  .map((candidate) => resolve(process.cwd(), candidate))
+  .find((candidate) => existsSync(candidate));
+
+const schema = load(readFileSync(schemaPath!, 'utf8')) as {
+  properties: Record<string, { $ref?: string }>;
+  $defs: Record<string, { properties?: Record<string, { default?: unknown }> }>;
+};
+
+/** Diagram config keys whose section declares `theme: redux-color` in the schema. */
+const declaredColourDefaults = Object.entries(schema.properties)
+  .flatMap(([key, value]) => {
+    const def = value.$ref?.replace('#/$defs/', '');
+    const declared = def ? schema.$defs[def]?.properties?.theme?.default : undefined;
+    return declared === 'redux-color' ? [key] : [];
+  })
+  .sort();
+
+describe('docs example config', () => {
+  describe('light mode', () => {
+    it('pins no theme or look, so examples show the defaults a reader gets', () => {
+      const config = buildExampleConfig('flowchart TD\n  A --> B', false);
+      expect(config.theme).toBeUndefined();
+      expect(config.look).toBeUndefined();
+    });
+  });
+
+  describe('dark mode', () => {
+    it('gives every redesigned diagram type its dark counterpart', () => {
+      const config = buildExampleConfig('flowchart TD\n  A --> B', true) as Record<
+        string,
+        { theme?: string }
+      >;
+      expect(config.theme).toBe('dark');
+      for (const key of COLOR_THEME_DIAGRAMS) {
+        expect(config[key]?.theme, `${key} kept the global dark theme`).toBe('redux-dark-color');
+      }
+    });
+
+    it('still leaves `look` to the defaults', () => {
+      expect(buildExampleConfig('flowchart TD\n  A --> B', true).look).toBeUndefined();
+    });
+  });
+
+  it('names exactly the diagram types the schema defaults to a colour theme', () => {
+    // The list in `exampleConfig.ts` is written out by hand. Deriving the expectation from
+    // the schema is what stops the docs site quietly missing a tenth type added later.
+    expect(declaredColourDefaults).toHaveLength(9);
+    expect([...COLOR_THEME_DIAGRAMS].sort()).toEqual(declaredColourDefaults);
+  });
+
+  describe('swimlane examples', () => {
+    const swimlane = 'swimlane-beta LR\n  subgraph Customer\n  end';
+
+    it('applies the layout options the syntax page should not repeat', () => {
+      const config = buildExampleConfig(swimlane, false) as Record<string, any>;
+      expect(config.swimlane).toMatchObject({
+        ignoreCrossLaneEdges: true,
+        optimizeRanksByCrossings: true,
+      });
+      expect(config.flowchart).toMatchObject({ titleTopMargin: 10 });
+    });
+
+    it('keeps the dark counterpart alongside them', () => {
+      const config = buildExampleConfig(swimlane, true) as Record<string, any>;
+      expect(config.swimlane).toMatchObject({
+        theme: 'redux-dark-color',
+        ignoreCrossLaneEdges: true,
+      });
+    });
+
+    it('does not pin a theme or look of its own', () => {
+      const config = buildExampleConfig(swimlane, false) as Record<string, any>;
+      expect(config.theme).toBeUndefined();
+      expect(config.look).toBeUndefined();
+      expect(config.swimlane.theme).toBeUndefined();
+    });
+
+    it('leaves other diagram types without the swimlane options', () => {
+      const config = buildExampleConfig('flowchart TD\n  A --> B', false) as Record<string, any>;
+      expect(config.swimlane).toBeUndefined();
+      expect(config.flowchart).toBeUndefined();
+    });
+  });
+
+  describe('getDiagramType', () => {
+    it.each([
+      ['swimlane-beta LR\n  A --> B', 'swimlane-beta'],
+      ['---\nconfig:\n  look: neo\n---\nswimlane-beta LR', 'swimlane-beta'],
+      ["%%{init: {'theme': 'forest'}}%%\nswimlane-beta LR", 'swimlane-beta'],
+      ['flowchart TD\n  A --> B', 'flowchart'],
+      ['  \n\nerDiagram\n  A ||--o{ B : has', 'erDiagram'],
+    ])('reads the keyword out of %j', (source, expected) => {
+      expect(getDiagramType(source)).toBe(expected);
+    });
+  });
+});

--- a/packages/mermaid/src/docs/.vitepress/theme/exampleConfig.ts
+++ b/packages/mermaid/src/docs/.vitepress/theme/exampleConfig.ts
@@ -1,0 +1,67 @@
+/**
+ * The mermaid config the docs site renders its examples with.
+ *
+ * Extracted from `Mermaid.vue` so it can be tested: the swimlane branch here was dead for
+ * as long as it existed, matching on `swimlanes` where the keyword is `swimlane-beta`, and
+ * nothing noticed because the config was built inside the component.
+ */
+
+/**
+ * Config keys of the diagram types that default to `redux-color`. Needed only for dark
+ * mode, where the page picks the theme and so has to pick each one's dark counterpart;
+ * `exampleConfig.spec.ts` checks this against the schema so it cannot drift.
+ */
+export const COLOR_THEME_DIAGRAMS = [
+  'flowchart',
+  'swimlane',
+  'class',
+  'er',
+  'requirement',
+  'sequence',
+  'state',
+  'usecase',
+  'venn',
+] as const;
+
+/**
+ * The diagram type keyword a source starts with, skipping optional YAML frontmatter and
+ * `%%{init: ...}%%` directives.
+ */
+export const getDiagramType = (source: string): string => {
+  const withoutFrontmatter = source.replace(/^\s*---[\S\s]*?---\s*/, '');
+  const withoutDirectives = withoutFrontmatter.replace(/^\s*(?:%%{[\S\s]*?}%%\s*)*/, '');
+  return withoutDirectives.trimStart().split(/\s|\n/, 1)[0] ?? '';
+};
+
+export const buildExampleConfig = (
+  source: string,
+  hasDarkClass: boolean
+): Record<string, unknown> => {
+  const config: Record<string, unknown> = {
+    securityLevel: 'loose',
+    startOnLoad: false,
+  };
+
+  // No theme in light mode: an example should show the default a reader actually gets.
+  // Dark mode is the page's choice, so each redesigned type needs its dark counterpart --
+  // `look` still comes from the defaults either way.
+  if (hasDarkClass) {
+    config.theme = 'dark';
+    for (const key of COLOR_THEME_DIAGRAMS) {
+      config[key] = { theme: 'redux-dark-color' };
+    }
+  }
+
+  // Layout options the swimlanes syntax page should not have to repeat on every example.
+  // Theme and look are left to the defaults.
+  if (getDiagramType(source) === 'swimlane-beta') {
+    config.flowchart = { titleTopMargin: 10 };
+    config.swimlane = {
+      ...(config.swimlane as Record<string, unknown> | undefined),
+      ignoreCrossLaneEdges: true,
+      optimizeRanksByCrossings: true,
+    };
+  }
+
+  return config;
+};

--- a/packages/mermaid/src/docs/.vitepress/theme/exampleConfig.ts
+++ b/packages/mermaid/src/docs/.vitepress/theme/exampleConfig.ts
@@ -12,6 +12,7 @@
  * `exampleConfig.spec.ts` checks this against the schema so it cannot drift.
  */
 export const COLOR_THEME_DIAGRAMS = [
+  'agentflow',
   'flowchart',
   'swimlane',
   'class',

--- a/packages/mermaid/src/docs/.vitepress/theme/exampleConfig.ts
+++ b/packages/mermaid/src/docs/.vitepress/theme/exampleConfig.ts
@@ -55,7 +55,12 @@ export const buildExampleConfig = (
   // Layout options the swimlanes syntax page should not have to repeat on every example.
   // Theme and look are left to the defaults.
   if (getDiagramType(source) === 'swimlane-beta') {
-    config.flowchart = { titleTopMargin: 10 };
+    // Both merge rather than replace: dark mode may already have put a theme on either key,
+    // and swimlanes read the shared flowchart section for `useMaxWidth` and friends.
+    config.flowchart = {
+      ...(config.flowchart as Record<string, unknown> | undefined),
+      titleTopMargin: 10,
+    };
     config.swimlane = {
       ...(config.swimlane as Record<string, unknown> | undefined),
       ignoreCrossLaneEdges: true,

--- a/packages/mermaid/src/docs/config/theming.md
+++ b/packages/mermaid/src/docs/config/theming.md
@@ -85,6 +85,25 @@ config:
 ---
 ```
 
+### Going back to the previous appearance
+
+The nine types above changed appearance when these became their defaults. To draw one the
+way Mermaid drew it before, name the previous theme and look in its front matter:
+
+```yaml
+---
+config:
+  theme: default
+  look: classic
+---
+```
+
+For every diagram on a page, pass the same two keys to `mermaid.initialize()`:
+
+```javascript
+mermaid.initialize({ theme: 'default', look: 'classic' });
+```
+
 ## Site-wide Theme
 
 To customize themes site-wide, call the `initialize` method on the `mermaid`.

--- a/packages/mermaid/src/docs/config/theming.md
+++ b/packages/mermaid/src/docs/config/theming.md
@@ -30,8 +30,8 @@ Themes can now be customized at the site-wide level, or on individual Mermaid di
 
 ## Per-diagram defaults
 
-Not every diagram type defaults to the same theme and look. These do, to the `redux-color`
-theme and the `neo` look. The name on the left is the **config key** — what you write to
+Not every diagram type defaults to the same theme and look. Since v<MERMAID_RELEASE_VERSION>
+these do, to the `redux-color` theme and the `neo` look. The name on the left is the **config key** — what you write to
 scope a setting to that diagram, which is not always the keyword the diagram starts with:
 
 | Config key    | Diagram              |

--- a/packages/mermaid/src/docs/config/theming.md
+++ b/packages/mermaid/src/docs/config/theming.md
@@ -36,6 +36,7 @@ scope a setting to that diagram, which is not always the keyword the diagram sta
 
 | Config key    | Diagram              |
 | ------------- | -------------------- |
+| `agentflow`   | `agentflow-beta`     |
 | `flowchart`   | `flowchart`          |
 | `swimlane`    | `swimlane-beta`      |
 | `class`       | `classDiagram`       |

--- a/packages/mermaid/src/docs/syntax/agentflow.md
+++ b/packages/mermaid/src/docs/syntax/agentflow.md
@@ -28,6 +28,72 @@ agentflow-beta TB
   end
 ```
 
+## Default theme and look (v<MERMAID_RELEASE_VERSION>+)
+
+Agentflow diagrams use the `redux-color` theme and the `neo` look by default. Not every
+diagram type does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for
+the list and for the order in which Mermaid decides.
+
+The same diagram, drawn both ways:
+
+### With the defaults
+
+```mermaid-example
+agentflow-beta TB
+  brief["Release brief"]@{ shape: input }
+  flow writer["Drafting Agent"]
+    draft["Draft the notes"]@{ shape: task }
+    lookup["changelog_search"]@{ shape: tool }
+    guide["Tone of voice"]@{ shape: refdoc }
+    draft --> lookup
+    draft -.- guide
+  end
+  flow reviewer["Review Agent"]
+    check["Check the claims"]@{ shape: task }
+    ok["Accurate?"]@{ shape: decision }
+    check --> ok
+  end
+  publish["Publish"]@{ shape: action }
+  brief --> writer
+  writer --> reviewer
+  ok --> publish
+```
+
+### The previous appearance
+
+Both are only defaults, so anything you set yourself wins. Naming the previous theme and look
+in a diagram's front matter draws it the way Mermaid did before:
+
+```mermaid-example
+---
+config:
+  theme: default
+  look: classic
+---
+agentflow-beta TB
+  brief["Release brief"]@{ shape: input }
+  flow writer["Drafting Agent"]
+    draft["Draft the notes"]@{ shape: task }
+    lookup["changelog_search"]@{ shape: tool }
+    guide["Tone of voice"]@{ shape: refdoc }
+    draft --> lookup
+    draft -.- guide
+  end
+  flow reviewer["Review Agent"]
+    check["Check the claims"]@{ shape: task }
+    ok["Accurate?"]@{ shape: decision }
+    check --> ok
+  end
+  publish["Publish"]@{ shape: action }
+  brief --> writer
+  writer --> reviewer
+  ok --> publish
+```
+
+Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
+and scoping them to one diagram type — `mermaid.initialize({ agentflow: { theme: 'default', look: 'classic' } })` —
+does it for that type alone.
+
 ## Declaring a diagram
 
 Every diagram starts with the `agentflow-beta` keyword, optionally followed by a direction — `TB`, `TD`, `BT`, `LR`, or `RL`.

--- a/packages/mermaid/src/docs/syntax/classDiagram.md
+++ b/packages/mermaid/src/docs/syntax/classDiagram.md
@@ -43,15 +43,64 @@ Class diagrams use the `redux-color` theme and the `neo` look by default. Not ev
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
 for the order in which Mermaid decides.
 
-Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
-did before these became the defaults, name the previous two in its front matter:
+The same diagram, drawn both ways:
 
-```yaml
+### With the defaults
+
+```mermaid-example
+classDiagram
+  class Customer {
+    +String name
+    +String email
+  }
+  class Order {
+    +String id
+    +Date placedAt
+    +total() Money
+  }
+  class LineItem {
+    +int quantity
+  }
+  class Payment {
+    <<interface>>
+    +authorise() bool
+  }
+  Customer "1" --> "*" Order : places
+  Order "1" *-- "*" LineItem : contains
+  Order --> Payment : settled by
+```
+
+### The previous appearance
+
+Both are only defaults, so anything you set yourself wins. Naming the previous theme and look
+in a diagram's front matter draws it the way Mermaid did before:
+
+```mermaid-example
 ---
 config:
   theme: default
   look: classic
 ---
+classDiagram
+  class Customer {
+    +String name
+    +String email
+  }
+  class Order {
+    +String id
+    +Date placedAt
+    +total() Money
+  }
+  class LineItem {
+    +int quantity
+  }
+  class Payment {
+    <<interface>>
+    +authorise() bool
+  }
+  Customer "1" --> "*" Order : places
+  Order "1" *-- "*" LineItem : contains
+  Order --> Payment : settled by
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,

--- a/packages/mermaid/src/docs/syntax/classDiagram.md
+++ b/packages/mermaid/src/docs/syntax/classDiagram.md
@@ -37,6 +37,27 @@ classDiagram
     }
 ```
 
+## Default theme and look
+
+Class diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
+does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
+for the order in which Mermaid decides.
+
+Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
+did before these became the defaults, name the previous two in its front matter:
+
+```yaml
+---
+config:
+  theme: default
+  look: classic
+---
+```
+
+Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
+and scoping them to one diagram type — `mermaid.initialize({ class: { look: 'classic' } })` —
+does it for that type alone.
+
 ## Syntax
 
 ### Class

--- a/packages/mermaid/src/docs/syntax/classDiagram.md
+++ b/packages/mermaid/src/docs/syntax/classDiagram.md
@@ -37,7 +37,7 @@ classDiagram
     }
 ```
 
-## Default theme and look
+## Default theme and look (v<MERMAID_RELEASE_VERSION>+)
 
 Class diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
@@ -104,7 +104,7 @@ classDiagram
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
-and scoping them to one diagram type — `mermaid.initialize({ class: { look: 'classic' } })` —
+and scoping them to one diagram type — `mermaid.initialize({ class: { theme: 'default', look: 'classic' } })` —
 does it for that type alone.
 
 ## Syntax

--- a/packages/mermaid/src/docs/syntax/entityRelationshipDiagram.md
+++ b/packages/mermaid/src/docs/syntax/entityRelationshipDiagram.md
@@ -50,15 +50,64 @@ Entity relationship diagrams use the `redux-color` theme and the `neo` look by d
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
 for the order in which Mermaid decides.
 
-Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
-did before these became the defaults, name the previous two in its front matter:
+The same diagram, drawn both ways:
 
-```yaml
+### With the defaults
+
+```mermaid-example
+erDiagram
+  CUSTOMER ||--o{ ORDER : places
+  ORDER ||--|{ LINE_ITEM : contains
+  PRODUCT ||--o{ LINE_ITEM : "appears in"
+  CUSTOMER {
+    string name
+    string email
+  }
+  ORDER {
+    int id
+    date placedAt
+  }
+  LINE_ITEM {
+    int quantity
+    float price
+  }
+  PRODUCT {
+    string sku
+    string title
+  }
+```
+
+### The previous appearance
+
+Both are only defaults, so anything you set yourself wins. Naming the previous theme and look
+in a diagram's front matter draws it the way Mermaid did before:
+
+```mermaid-example
 ---
 config:
   theme: default
   look: classic
 ---
+erDiagram
+  CUSTOMER ||--o{ ORDER : places
+  ORDER ||--|{ LINE_ITEM : contains
+  PRODUCT ||--o{ LINE_ITEM : "appears in"
+  CUSTOMER {
+    string name
+    string email
+  }
+  ORDER {
+    int id
+    date placedAt
+  }
+  LINE_ITEM {
+    int quantity
+    float price
+  }
+  PRODUCT {
+    string sku
+    string title
+  }
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,

--- a/packages/mermaid/src/docs/syntax/entityRelationshipDiagram.md
+++ b/packages/mermaid/src/docs/syntax/entityRelationshipDiagram.md
@@ -44,7 +44,7 @@ erDiagram
 
 When including attributes on ER diagrams, you must decide whether to include foreign keys as attributes. This probably depends on how closely you are trying to represent relational table structures. If your diagram is a _logical_ model which is not meant to imply a relational implementation, then it is better to leave these out because the associative relationships already convey the way that entities are associated. For example, a JSON data structure can implement a one-to-many relationship without the need for foreign key properties, using arrays. Similarly an object-oriented programming language may use pointers or references to collections. Even for models that are intended for relational implementation, you might decide that inclusion of foreign key attributes duplicates information already portrayed by the relationships, and does not add meaning to entities. Ultimately, it's your choice.
 
-## Default theme and look
+## Default theme and look (v<MERMAID_RELEASE_VERSION>+)
 
 Entity relationship diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
@@ -111,7 +111,7 @@ erDiagram
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
-and scoping them to one diagram type — `mermaid.initialize({ er: { look: 'classic' } })` —
+and scoping them to one diagram type — `mermaid.initialize({ er: { theme: 'default', look: 'classic' } })` —
 does it for that type alone.
 
 ## Syntax

--- a/packages/mermaid/src/docs/syntax/entityRelationshipDiagram.md
+++ b/packages/mermaid/src/docs/syntax/entityRelationshipDiagram.md
@@ -44,6 +44,27 @@ erDiagram
 
 When including attributes on ER diagrams, you must decide whether to include foreign keys as attributes. This probably depends on how closely you are trying to represent relational table structures. If your diagram is a _logical_ model which is not meant to imply a relational implementation, then it is better to leave these out because the associative relationships already convey the way that entities are associated. For example, a JSON data structure can implement a one-to-many relationship without the need for foreign key properties, using arrays. Similarly an object-oriented programming language may use pointers or references to collections. Even for models that are intended for relational implementation, you might decide that inclusion of foreign key attributes duplicates information already portrayed by the relationships, and does not add meaning to entities. Ultimately, it's your choice.
 
+## Default theme and look
+
+Entity relationship diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
+does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
+for the order in which Mermaid decides.
+
+Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
+did before these became the defaults, name the previous two in its front matter:
+
+```yaml
+---
+config:
+  theme: default
+  look: classic
+---
+```
+
+Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
+and scoping them to one diagram type — `mermaid.initialize({ er: { look: 'classic' } })` —
+does it for that type alone.
+
 ## Syntax
 
 ### Entities and Relationships

--- a/packages/mermaid/src/docs/syntax/flowchart.md
+++ b/packages/mermaid/src/docs/syntax/flowchart.md
@@ -102,6 +102,27 @@ Possible FlowChart orientations are:
 - RL - Right to left
 - LR - Left to right
 
+## Default theme and look
+
+Flowcharts use the `redux-color` theme and the `neo` look by default. Not every diagram type
+does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
+for the order in which Mermaid decides.
+
+Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
+did before these became the defaults, name the previous two in its front matter:
+
+```yaml
+---
+config:
+  theme: default
+  look: classic
+---
+```
+
+Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
+and scoping them to one diagram type — `mermaid.initialize({ flowchart: { look: 'classic' } })` —
+does it for that type alone.
+
 ## Node shapes
 
 ### A node with round edges

--- a/packages/mermaid/src/docs/syntax/flowchart.md
+++ b/packages/mermaid/src/docs/syntax/flowchart.md
@@ -102,7 +102,7 @@ Possible FlowChart orientations are:
 - RL - Right to left
 - LR - Left to right
 
-## Default theme and look
+## Default theme and look (v<MERMAID_RELEASE_VERSION>+)
 
 Flowcharts use the `redux-color` theme and the `neo` look by default. Not every diagram type
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
@@ -167,7 +167,7 @@ flowchart LR
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
-and scoping them to one diagram type — `mermaid.initialize({ flowchart: { look: 'classic' } })` —
+and scoping them to one diagram type — `mermaid.initialize({ flowchart: { theme: 'default', look: 'classic' } })` —
 does it for that type alone.
 
 ## Node shapes

--- a/packages/mermaid/src/docs/syntax/flowchart.md
+++ b/packages/mermaid/src/docs/syntax/flowchart.md
@@ -108,15 +108,62 @@ Flowcharts use the `redux-color` theme and the `neo` look by default. Not every 
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
 for the order in which Mermaid decides.
 
-Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
-did before these became the defaults, name the previous two in its front matter:
+The same diagram, drawn both ways:
 
-```yaml
+### With the defaults
+
+```mermaid-example
+flowchart LR
+  subgraph Client
+    UI[Web app]
+    Cache[(Local cache)]
+  end
+  subgraph Services
+    API[API gateway]
+    Auth[Auth service]
+    Orders[Order service]
+  end
+  subgraph Storage
+    DB[(Orders DB)]
+  end
+  UI --> API
+  UI --> Cache
+  API --> Auth
+  API --> Orders
+  Orders --> DB
+  Auth -. token .-> UI
+```
+
+### The previous appearance
+
+Both are only defaults, so anything you set yourself wins. Naming the previous theme and look
+in a diagram's front matter draws it the way Mermaid did before:
+
+```mermaid-example
 ---
 config:
   theme: default
   look: classic
 ---
+flowchart LR
+  subgraph Client
+    UI[Web app]
+    Cache[(Local cache)]
+  end
+  subgraph Services
+    API[API gateway]
+    Auth[Auth service]
+    Orders[Order service]
+  end
+  subgraph Storage
+    DB[(Orders DB)]
+  end
+  UI --> API
+  UI --> Cache
+  API --> Auth
+  API --> Orders
+  Orders --> DB
+  Auth -. token .-> UI
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,

--- a/packages/mermaid/src/docs/syntax/requirementDiagram.md
+++ b/packages/mermaid/src/docs/syntax/requirementDiagram.md
@@ -27,15 +27,60 @@ Requirement diagrams use the `redux-color` theme and the `neo` look by default. 
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
 for the order in which Mermaid decides.
 
-Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
-did before these became the defaults, name the previous two in its front matter:
+The same diagram, drawn both ways:
 
-```yaml
+### With the defaults
+
+```mermaid-example
+requirementDiagram
+  requirement checkout_req {
+    id: 1
+    text: Orders must be payable online.
+    risk: high
+    verifymethod: test
+  }
+  functionalRequirement payment_req {
+    id: 1.1
+    text: Card payments must be authorised.
+    risk: high
+    verifymethod: test
+  }
+  element checkout_service {
+    type: service
+  }
+  checkout_req - contains -> payment_req
+  checkout_service - satisfies -> payment_req
+```
+
+### The previous appearance
+
+Both are only defaults, so anything you set yourself wins. Naming the previous theme and look
+in a diagram's front matter draws it the way Mermaid did before:
+
+```mermaid-example
 ---
 config:
   theme: default
   look: classic
 ---
+requirementDiagram
+  requirement checkout_req {
+    id: 1
+    text: Orders must be payable online.
+    risk: high
+    verifymethod: test
+  }
+  functionalRequirement payment_req {
+    id: 1.1
+    text: Card payments must be authorised.
+    risk: high
+    verifymethod: test
+  }
+  element checkout_service {
+    type: service
+  }
+  checkout_req - contains -> payment_req
+  checkout_service - satisfies -> payment_req
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,

--- a/packages/mermaid/src/docs/syntax/requirementDiagram.md
+++ b/packages/mermaid/src/docs/syntax/requirementDiagram.md
@@ -21,7 +21,7 @@ Rendering requirements is straightforward.
     test_entity - satisfies -> test_req
 ```
 
-## Default theme and look
+## Default theme and look (v<MERMAID_RELEASE_VERSION>+)
 
 Requirement diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
@@ -84,7 +84,7 @@ requirementDiagram
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
-and scoping them to one diagram type — `mermaid.initialize({ requirement: { look: 'classic' } })` —
+and scoping them to one diagram type — `mermaid.initialize({ requirement: { theme: 'default', look: 'classic' } })` —
 does it for that type alone.
 
 ## Syntax

--- a/packages/mermaid/src/docs/syntax/requirementDiagram.md
+++ b/packages/mermaid/src/docs/syntax/requirementDiagram.md
@@ -21,6 +21,27 @@ Rendering requirements is straightforward.
     test_entity - satisfies -> test_req
 ```
 
+## Default theme and look
+
+Requirement diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
+does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
+for the order in which Mermaid decides.
+
+Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
+did before these became the defaults, name the previous two in its front matter:
+
+```yaml
+---
+config:
+  theme: default
+  look: classic
+---
+```
+
+Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
+and scoping them to one diagram type — `mermaid.initialize({ requirement: { look: 'classic' } })` —
+does it for that type alone.
+
 ## Syntax
 
 There are three types of components to a requirement diagram: requirement, element, and relationship.

--- a/packages/mermaid/src/docs/syntax/sequenceDiagram.md
+++ b/packages/mermaid/src/docs/syntax/sequenceDiagram.md
@@ -17,7 +17,7 @@ A note on nodes, the word "end" could potentially break the diagram, due to the 
 If unavoidable, one must use parentheses(), quotation marks "", or brackets {},[], to enclose the word "end". i.e : (end), [end], {end}.
 ```
 
-## Default theme and look
+## Default theme and look (v<MERMAID_RELEASE_VERSION>+)
 
 Sequence diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
@@ -74,7 +74,7 @@ sequenceDiagram
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
-and scoping them to one diagram type — `mermaid.initialize({ sequence: { look: 'classic' } })` —
+and scoping them to one diagram type — `mermaid.initialize({ sequence: { theme: 'default', look: 'classic' } })` —
 does it for that type alone.
 
 ## Syntax

--- a/packages/mermaid/src/docs/syntax/sequenceDiagram.md
+++ b/packages/mermaid/src/docs/syntax/sequenceDiagram.md
@@ -23,15 +23,54 @@ Sequence diagrams use the `redux-color` theme and the `neo` look by default. Not
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
 for the order in which Mermaid decides.
 
-Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
-did before these became the defaults, name the previous two in its front matter:
+The same diagram, drawn both ways:
 
-```yaml
+### With the defaults
+
+```mermaid-example
+sequenceDiagram
+  autonumber
+  actor Customer
+  participant Web as Web app
+  participant API as API gateway
+  participant Bank
+  Customer->>Web: Place order
+  Web->>API: POST /orders
+  activate API
+  API->>Bank: Authorise payment
+  Bank-->>API: Approved
+  API-->>Web: 201 Created
+  deactivate API
+  Web-->>Customer: Order confirmed
+  Note over Customer,Bank: One order, one transaction
+```
+
+### The previous appearance
+
+Both are only defaults, so anything you set yourself wins. Naming the previous theme and look
+in a diagram's front matter draws it the way Mermaid did before:
+
+```mermaid-example
 ---
 config:
   theme: default
   look: classic
 ---
+sequenceDiagram
+  autonumber
+  actor Customer
+  participant Web as Web app
+  participant API as API gateway
+  participant Bank
+  Customer->>Web: Place order
+  Web->>API: POST /orders
+  activate API
+  API->>Bank: Authorise payment
+  Bank-->>API: Approved
+  API-->>Web: 201 Created
+  deactivate API
+  Web-->>Customer: Order confirmed
+  Note over Customer,Bank: One order, one transaction
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,

--- a/packages/mermaid/src/docs/syntax/sequenceDiagram.md
+++ b/packages/mermaid/src/docs/syntax/sequenceDiagram.md
@@ -17,6 +17,27 @@ A note on nodes, the word "end" could potentially break the diagram, due to the 
 If unavoidable, one must use parentheses(), quotation marks "", or brackets {},[], to enclose the word "end". i.e : (end), [end], {end}.
 ```
 
+## Default theme and look
+
+Sequence diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
+does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
+for the order in which Mermaid decides.
+
+Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
+did before these became the defaults, name the previous two in its front matter:
+
+```yaml
+---
+config:
+  theme: default
+  look: classic
+---
+```
+
+Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
+and scoping them to one diagram type — `mermaid.initialize({ sequence: { look: 'classic' } })` —
+does it for that type alone.
+
 ## Syntax
 
 ### Participants

--- a/packages/mermaid/src/docs/syntax/stateDiagram.md
+++ b/packages/mermaid/src/docs/syntax/stateDiagram.md
@@ -39,6 +39,27 @@ a _transition._ The example diagram above shows three states: **Still**, **Movin
 **Still** state. From **Still** you can change to the **Moving** state. From **Moving** you can change either back to the **Still** state or to
 the **Crash** state. There is no transition from **Still** to **Crash**. (You can't crash if you're still.)
 
+## Default theme and look
+
+State diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
+does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
+for the order in which Mermaid decides.
+
+Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
+did before these became the defaults, name the previous two in its front matter:
+
+```yaml
+---
+config:
+  theme: default
+  look: classic
+---
+```
+
+Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
+and scoping them to one diagram type — `mermaid.initialize({ state: { look: 'classic' } })` —
+does it for that type alone.
+
 ## States
 
 A state can be declared in multiple ways. The simplest way is to define a state with just an id:

--- a/packages/mermaid/src/docs/syntax/stateDiagram.md
+++ b/packages/mermaid/src/docs/syntax/stateDiagram.md
@@ -45,15 +45,46 @@ State diagrams use the `redux-color` theme and the `neo` look by default. Not ev
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
 for the order in which Mermaid decides.
 
-Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
-did before these became the defaults, name the previous two in its front matter:
+The same diagram, drawn both ways:
 
-```yaml
+### With the defaults
+
+```mermaid-example
+stateDiagram-v2
+  [*] --> Draft
+  Draft --> Submitted : submit
+  state Review {
+    [*] --> Screening
+    Screening --> Decision
+  }
+  Submitted --> Review
+  Review --> Published : approved
+  Review --> Draft : rejected
+  Published --> [*]
+```
+
+### The previous appearance
+
+Both are only defaults, so anything you set yourself wins. Naming the previous theme and look
+in a diagram's front matter draws it the way Mermaid did before:
+
+```mermaid-example
 ---
 config:
   theme: default
   look: classic
 ---
+stateDiagram-v2
+  [*] --> Draft
+  Draft --> Submitted : submit
+  state Review {
+    [*] --> Screening
+    Screening --> Decision
+  }
+  Submitted --> Review
+  Review --> Published : approved
+  Review --> Draft : rejected
+  Published --> [*]
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,

--- a/packages/mermaid/src/docs/syntax/stateDiagram.md
+++ b/packages/mermaid/src/docs/syntax/stateDiagram.md
@@ -39,7 +39,7 @@ a _transition._ The example diagram above shows three states: **Still**, **Movin
 **Still** state. From **Still** you can change to the **Moving** state. From **Moving** you can change either back to the **Still** state or to
 the **Crash** state. There is no transition from **Still** to **Crash**. (You can't crash if you're still.)
 
-## Default theme and look
+## Default theme and look (v<MERMAID_RELEASE_VERSION>+)
 
 State diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
@@ -88,7 +88,7 @@ stateDiagram-v2
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
-and scoping them to one diagram type — `mermaid.initialize({ state: { look: 'classic' } })` —
+and scoping them to one diagram type — `mermaid.initialize({ state: { theme: 'default', look: 'classic' } })` —
 does it for that type alone.
 
 ## States

--- a/packages/mermaid/src/docs/syntax/swimlanes.md
+++ b/packages/mermaid/src/docs/syntax/swimlanes.md
@@ -13,6 +13,27 @@ A swimlane diagram shows a process divided by responsibility. Each lane represen
 
 Use swimlane diagrams when the most important question is not only "what happens next?" but also "who owns this step?" They are useful for approval flows, support processes, delivery workflows, and any process where work crosses teams or systems.
 
+## Default theme and look
+
+Swimlane diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
+does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
+for the order in which Mermaid decides.
+
+Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
+did before these became the defaults, name the previous two in its front matter:
+
+```yaml
+---
+config:
+  theme: default
+  look: classic
+---
+```
+
+Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
+and scoping them to one diagram type — `mermaid.initialize({ swimlane: { look: 'classic' } })` —
+does it for that type alone.
+
 ## Basic Example
 
 > The rendered examples on this page use the **Neo** look and the **Redux** theme. Out of the box, swimlanes use your configured default look and theme.

--- a/packages/mermaid/src/docs/syntax/swimlanes.md
+++ b/packages/mermaid/src/docs/syntax/swimlanes.md
@@ -19,15 +19,56 @@ Swimlane diagrams use the `redux-color` theme and the `neo` look by default. Not
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
 for the order in which Mermaid decides.
 
-Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
-did before these became the defaults, name the previous two in its front matter:
+The same diagram, drawn both ways:
 
-```yaml
+### With the defaults
+
+```mermaid-example
+swimlane-beta LR
+  subgraph Customer
+    Browse[Browse catalogue]
+    Pay[Pay]
+  end
+  subgraph Warehouse
+    Pick[Pick items]
+    Ship[Ship order]
+  end
+  subgraph Finance
+    Invoice[Raise invoice]
+  end
+  Browse --> Pay
+  Pay --> Pick
+  Pick --> Ship
+  Pay --> Invoice
+```
+
+### The previous appearance
+
+Both are only defaults, so anything you set yourself wins. Naming the previous theme and look
+in a diagram's front matter draws it the way Mermaid did before:
+
+```mermaid-example
 ---
 config:
   theme: default
   look: classic
 ---
+swimlane-beta LR
+  subgraph Customer
+    Browse[Browse catalogue]
+    Pay[Pay]
+  end
+  subgraph Warehouse
+    Pick[Pick items]
+    Ship[Ship order]
+  end
+  subgraph Finance
+    Invoice[Raise invoice]
+  end
+  Browse --> Pay
+  Pay --> Pick
+  Pick --> Ship
+  Pay --> Invoice
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,

--- a/packages/mermaid/src/docs/syntax/swimlanes.md
+++ b/packages/mermaid/src/docs/syntax/swimlanes.md
@@ -13,7 +13,7 @@ A swimlane diagram shows a process divided by responsibility. Each lane represen
 
 Use swimlane diagrams when the most important question is not only "what happens next?" but also "who owns this step?" They are useful for approval flows, support processes, delivery workflows, and any process where work crosses teams or systems.
 
-## Default theme and look
+## Default theme and look (v<MERMAID_RELEASE_VERSION>+)
 
 Swimlane diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
@@ -72,12 +72,10 @@ swimlane-beta LR
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
-and scoping them to one diagram type — `mermaid.initialize({ swimlane: { look: 'classic' } })` —
+and scoping them to one diagram type — `mermaid.initialize({ swimlane: { theme: 'default', look: 'classic' } })` —
 does it for that type alone.
 
 ## Basic Example
-
-> The rendered examples on this page use the **Neo** look and the **Redux** theme. Out of the box, swimlanes use your configured default look and theme.
 
 ```mermaid-example
 swimlane-beta LR

--- a/packages/mermaid/src/docs/syntax/usecase.md
+++ b/packages/mermaid/src/docs/syntax/usecase.md
@@ -22,15 +22,56 @@ Use case diagrams use the `redux-color` theme and the `neo` look by default. Not
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
 for the order in which Mermaid decides.
 
-Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
-did before these became the defaults, name the previous two in its front matter:
+The same diagram, drawn both ways:
 
-```yaml
+### With the defaults
+
+```mermaid-example
+usecase-beta
+direction LR
+actor Customer
+actor Support
+systemBoundary Storefront
+  Browse("Browse catalogue")
+  Checkout("Checkout")
+end
+systemBoundary Fulfilment
+  Track("Track delivery")
+end
+Customer --> Browse
+Customer --> Checkout
+Customer --> Track
+Support --> Track
+Checkout ..> : include Browse
+```
+
+### The previous appearance
+
+Both are only defaults, so anything you set yourself wins. Naming the previous theme and look
+in a diagram's front matter draws it the way Mermaid did before:
+
+```mermaid-example
 ---
 config:
   theme: default
   look: classic
 ---
+usecase-beta
+direction LR
+actor Customer
+actor Support
+systemBoundary Storefront
+  Browse("Browse catalogue")
+  Checkout("Checkout")
+end
+systemBoundary Fulfilment
+  Track("Track delivery")
+end
+Customer --> Browse
+Customer --> Checkout
+Customer --> Track
+Support --> Track
+Checkout ..> : include Browse
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,

--- a/packages/mermaid/src/docs/syntax/usecase.md
+++ b/packages/mermaid/src/docs/syntax/usecase.md
@@ -16,6 +16,27 @@ Customer --> Checkout
 
 Use `direction` with `TD`, `TB`, `BT`, `LR`, or `RL` to choose the layout direction.
 
+## Default theme and look
+
+Use case diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
+does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
+for the order in which Mermaid decides.
+
+Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
+did before these became the defaults, name the previous two in its front matter:
+
+```yaml
+---
+config:
+  theme: default
+  look: classic
+---
+```
+
+Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
+and scoping them to one diagram type — `mermaid.initialize({ usecase: { look: 'classic' } })` —
+does it for that type alone.
+
 ## Actors and use cases
 
 Actor and use case identifiers match `[A-Za-z0-9_]+`, so they may start with a digit — `1`, `1mg`, and `3rd` are all valid. Identifiers are diagram-wide and are shared by actors, use cases, boundaries, JSON nodes, and explicit edges.

--- a/packages/mermaid/src/docs/syntax/usecase.md
+++ b/packages/mermaid/src/docs/syntax/usecase.md
@@ -16,7 +16,7 @@ Customer --> Checkout
 
 Use `direction` with `TD`, `TB`, `BT`, `LR`, or `RL` to choose the layout direction.
 
-## Default theme and look
+## Default theme and look (v<MERMAID_RELEASE_VERSION>+)
 
 Use case diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
@@ -75,7 +75,7 @@ Checkout ..> : include Browse
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
-and scoping them to one diagram type — `mermaid.initialize({ usecase: { look: 'classic' } })` —
+and scoping them to one diagram type — `mermaid.initialize({ usecase: { theme: 'default', look: 'classic' } })` —
 does it for that type alone.
 
 ## Actors and use cases

--- a/packages/mermaid/src/docs/syntax/venn.md
+++ b/packages/mermaid/src/docs/syntax/venn.md
@@ -5,6 +5,27 @@ Venn diagrams show relationships between sets using overlapping circles.
 > **Warning**
 > This is a new diagram type in Mermaid. Its syntax may evolve in future versions.
 
+## Default theme and look
+
+Venn diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
+does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
+for the order in which Mermaid decides.
+
+Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
+did before these became the defaults, name the previous two in its front matter:
+
+```yaml
+---
+config:
+  theme: default
+  look: classic
+---
+```
+
+Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
+and scoping them to one diagram type — `mermaid.initialize({ venn: { look: 'classic' } })` —
+does it for that type alone.
+
 ## Syntax
 
 - Start with `venn-beta`.

--- a/packages/mermaid/src/docs/syntax/venn.md
+++ b/packages/mermaid/src/docs/syntax/venn.md
@@ -11,15 +11,42 @@ Venn diagrams use the `redux-color` theme and the `neo` look by default. Not eve
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
 for the order in which Mermaid decides.
 
-Both are only defaults, so anything you set yourself wins. To draw a diagram the way Mermaid
-did before these became the defaults, name the previous two in its front matter:
+The same diagram, drawn both ways:
 
-```yaml
+### With the defaults
+
+```mermaid-example
+venn-beta
+  title What makes a good feature
+  set Desirable
+  set Feasible
+  set Viable
+  union Desirable,Feasible["Buildable"]
+  union Feasible,Viable["Sustainable"]
+  union Desirable,Viable["Marketable"]
+  union Desirable,Feasible,Viable["Ship it"]
+```
+
+### The previous appearance
+
+Both are only defaults, so anything you set yourself wins. Naming the previous theme and look
+in a diagram's front matter draws it the way Mermaid did before:
+
+```mermaid-example
 ---
 config:
   theme: default
   look: classic
 ---
+venn-beta
+  title What makes a good feature
+  set Desirable
+  set Feasible
+  set Viable
+  union Desirable,Feasible["Buildable"]
+  union Feasible,Viable["Sustainable"]
+  union Desirable,Viable["Marketable"]
+  union Desirable,Feasible,Viable["Ship it"]
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,

--- a/packages/mermaid/src/docs/syntax/venn.md
+++ b/packages/mermaid/src/docs/syntax/venn.md
@@ -5,7 +5,7 @@ Venn diagrams show relationships between sets using overlapping circles.
 > **Warning**
 > This is a new diagram type in Mermaid. Its syntax may evolve in future versions.
 
-## Default theme and look
+## Default theme and look (v<MERMAID_RELEASE_VERSION>+)
 
 Venn diagrams use the `redux-color` theme and the `neo` look by default. Not every diagram type
 does — see [Per-diagram defaults](../config/theming.md#per-diagram-defaults) for the list and
@@ -50,7 +50,7 @@ venn-beta
 ```
 
 Passing the same two keys to `mermaid.initialize()` does it for every diagram on the page,
-and scoping them to one diagram type — `mermaid.initialize({ venn: { look: 'classic' } })` —
+and scoping them to one diagram type — `mermaid.initialize({ venn: { theme: 'default', look: 'classic' } })` —
 does it for that type alone.
 
 ## Syntax

--- a/packages/mermaid/src/tests/util.ts
+++ b/packages/mermaid/src/tests/util.ts
@@ -81,39 +81,47 @@ interface JsdomItInput {
  *
  * This makes it possible to make structural tests instead of mocking everything.
  */
-export function jsdomIt(message: string, run: (input: JsdomItInput) => void | Promise<void>) {
-  return it(message, async (): Promise<void> => {
-    const oldWindow = global.window;
-    const oldDocument = global.document;
+export function jsdomIt(
+  message: string,
+  run: (input: JsdomItInput) => void | Promise<void>,
+  timeout?: number
+) {
+  return it(
+    message,
+    async (): Promise<void> => {
+      const oldWindow = global.window;
+      const oldDocument = global.document;
 
-    try {
-      const baseHtml = `
+      try {
+        const baseHtml = `
         <html lang="en">
           <body id="cy">
             <svg id="svg"/>
           </body>
         </html>
       `;
-      const dom = new JSDOM(baseHtml, {
-        resources: 'usable',
-        beforeParse(_window) {
-          // Mocks DOM functions that require rendering, JSDOM doesn't
-          setOnProtectedConstant(_window.Element.prototype, 'getBBox', () => MOCKED_BBOX);
-          setOnProtectedConstant(_window.Element.prototype, 'getComputedTextLength', () => 200);
-        },
-      });
-      setOnProtectedConstant(global, 'window', dom.window); // Fool D3 into thinking it's in a browser
-      setOnProtectedConstant(global, 'document', dom.window.document); // Fool D3 into thinking it's in a browser
-      setOnProtectedConstant(global, 'MutationObserver', undefined); // JSDOM doesn't like cytoscape elements
+        const dom = new JSDOM(baseHtml, {
+          resources: 'usable',
+          beforeParse(_window) {
+            // Mocks DOM functions that require rendering, JSDOM doesn't
+            setOnProtectedConstant(_window.Element.prototype, 'getBBox', () => MOCKED_BBOX);
+            setOnProtectedConstant(_window.Element.prototype, 'getComputedTextLength', () => 200);
+          },
+        });
+        setOnProtectedConstant(global, 'window', dom.window); // Fool D3 into thinking it's in a browser
+        setOnProtectedConstant(global, 'document', dom.window.document); // Fool D3 into thinking it's in a browser
+        setOnProtectedConstant(global, 'MutationObserver', undefined); // JSDOM doesn't like cytoscape elements
 
-      const body = select(document.body);
-      const svg = select<SVGSVGElement, unknown>('svg');
-      await run({ body, svg });
-    } finally {
-      setOnProtectedConstant(global, 'window', oldWindow);
-      setOnProtectedConstant(global, 'document', oldDocument);
-    }
-  });
+        const body = select(document.body);
+        const svg = select<SVGSVGElement, unknown>('svg');
+        await run({ body, svg });
+      } finally {
+        setOnProtectedConstant(global, 'window', oldWindow);
+        setOnProtectedConstant(global, 'document', oldDocument);
+      }
+    },
+    timeout
+  );
 }
 
 /**


### PR DESCRIPTION
Targets #8148. Docs for the per-diagram defaults added in #8193, plus the fix that makes the docs site actually show them.

## The headline finding

**None of the new defaults were reaching the documentation site.** [`Mermaid.vue`](https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/docs/.vitepress/theme/Mermaid.vue) pinned `theme: hasDarkClass ? 'dark' : 'default'` on every example and never set `look`. There is one render path, so every diagram on every page rendered in the old appearance — the prose would have described something the examples beside it did not show.

Light mode now pins nothing, so an example shows exactly what a reader gets. Dark mode is the page's own choice, so it keeps a global `dark` and names each redesigned type's dark counterpart; `look` comes from the defaults in both.

```js
const config = { securityLevel: 'loose', startOnLoad: false };
if (hasDarkClass) {
  config.theme = 'dark';
  for (const key of COLOR_THEME_DIAGRAMS) {
    config[key] = { theme: 'redux-dark-color' };
  }
}
```

## A second bug found on the way

The swimlanes branch in that component was **dead, three times over**:

- it matched `getDiagramType(code) === 'swimlanes'`, but that function returns the first word of the source, which is `swimlane-beta`;
- it wrote its options to `mermaidConfig.swimlanes`, where the config key is `swimlane`;
- so neither the `redux`/`neo` it pinned nor `ignoreCrossLaneEdges` / `optimizeRanksByCrossings` / `titleTopMargin` had ever applied to a single example.

The guard and the key are fixed and the layout options now work. The theme and look pin is dropped, since the defaults already give swimlanes `redux-color`/`neo` — and `redux-dark-color` in dark mode.

## Testability

The config building moves out of the `.vue` file into `exampleConfig.ts`, which is how the dead branch was found — it was unreachable to a test while it lived inside the component. `exampleConfig.spec.ts` covers light/dark, the swimlane options, and `getDiagramType` against frontmatter and directives.

One test earns its place beyond that: it derives the list of colour-theme diagram types **from the schema** and asserts the docs site's list matches. A tenth type opting in later cannot silently miss the docs site.

## Docs content

Each of the nine pages gains a `Default theme and look` section, placed before the first `##` so it sits after the intro and ahead of the syntax:

> Flowcharts use the `redux-color` theme and the `neo` look by default. […] To draw a diagram the way Mermaid did before these became the defaults, name the previous two in its front matter:
>
> ```yaml
> ---
> config:
>   theme: default
>   look: classic
> ---
> ```

`theming.md` gains a `Going back to the previous appearance` subsection for the global equivalent.

## Verification — measured, on a running docs server

Not read off the source. I started vitepress and probed every example on every page with Playwright, reading `data-look` and `data-color-id`:

| Page | look | palette slots |
| --- | --- | --- |
| flowchart (112 diagrams) | `neo` | 15 |
| swimlanes (11) | `neo` | 28 |
| class (36) | `neo` | 102 |
| er (23) | `neo` | 65 |
| requirement (7) | `neo` | 20 |
| sequence (36) | `neo` | actor fills are redux-color's |
| state (20) | `neo` | 13 |
| usecase (22) | `neo` | 80 |
| venn (6) | n/a — no nodes | circles are `#E879F9`, redux-color's `venn1` |
| **block (30)** | **`classic`** | 0 |
| **mindmap (13)** | **`classic`** | 0 |
| **kanban (3)** | **`classic`** | 0 |

Dark mode checked separately: `er` keeps `neo` and all 65 palette slots, `mindmap` stays `classic`.

**The controls are the important half.** An earlier run showed mindmap and kanban as `neo`, which looked like a leak and was in fact a stale `packages/mermaid/dist` — the docs site imports the built package, not the source. After a rebuild they are `classic`. Worth knowing before anyone repeats this check.

Only one of the nine pages pins a theme in its own examples: `usecase.md`, twice, on `theme: redux-color` to illustrate `colorScheme`. Now redundant but still correct, so left alone. Everything else pinning theme or look (gantt, gitgraph, radar, railroad, timeline, treeView, treemap, wardley) is outside the nine.

## Checks

Full `packages/mermaid` suite: 5675 passing. 0 lint errors, cspell clean, generated `docs/` regenerated from `src/docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What's working well

- 🎉 The configuration logic is isolated in `exampleConfig.ts`, which makes the docs rendering behavior easier to test.
- 🎉 Schema-derived coverage verifies that all nine `redux-color` diagram types remain listed.
- 🎉 The swimlane tests cover the corrected detector and layout options.
- 🎉 Light mode now reflects the defaults that readers receive.

## Things to address

- 🟡 **[important] Preserve the dark flowchart theme for swimlane examples.** In `exampleConfig.ts`, the swimlane branch replaces `config.flowchart` with `{ titleTopMargin: 10 }`. In dark mode, this removes the earlier `theme: 'redux-dark-color'` value assigned to `flowchart`. As a result, swimlane examples may use the wrong theme for their flowchart configuration. Please merge the existing `config.flowchart` values when adding `titleTopMargin`, and add an assertion for `config.flowchart.theme` in the dark swimlane test.

## Security

- No XSS or injection issues identified in the changed configuration and documentation logic.

## Review checklist

- [x] At least one praise item exists.
- [x] No duplicate findings.
- [x] Severity tally: 0 blocking / 1 important / 0 nit / 0 suggestion / 4 praise.
- [x] The finding has a file reference and a targeted test recommendation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->