### PR TITLE
fix(gantt): report excess task metadata

### DIFF
--- a/.changeset/gantt-extra-task-data.md
+++ b/.changeset/gantt-extra-task-data.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix(gantt): report task definitions with more than three metadata values instead of failing during rendering.

--- a/packages/mermaid/src/diagrams/gantt/ganttDb.js
+++ b/packages/mermaid/src/diagrams/gantt/ganttDb.js
@@ -545,6 +545,9 @@ const parseData = function (prevTaskId, dataStr) {
       };
       break;
     default:
+      throw new Error(
+        `Invalid Gantt task data: expected 1 to 3 comma-separated values, received ${data.length}: ${ds.trim()}`
+      );
   }
 
   return task;

--- a/packages/mermaid/src/diagrams/gantt/parser/gantt.spec.js
+++ b/packages/mermaid/src/diagrams/gantt/parser/gantt.spec.js
@@ -137,6 +137,17 @@ describe('when parsing a gantt diagram it', function () {
     expect(tasks[0].id).toEqual('des1');
     expect(tasks[0].task).toEqual('Design jison grammar');
   });
+  it('should report task data with more than three values', function () {
+    const str =
+      'gantt\n' +
+      'dateFormat YYYY-MM-DD\n' +
+      'section Documentation\n' +
+      'Task: task1, 2024-01-01, 2d, extra';
+
+    expect(parserFnConstructor(str)).toThrowError(
+      'Invalid Gantt task data: expected 1 to 3 comma-separated values, received 4: task1, 2024-01-01, 2d, extra'
+    );
+  });
   it('should handle a task with start/end time relative to other tasks', function () {
     const str =
       'gantt\n' +


### PR DESCRIPTION
## :bookmark_tabs: Summary

Gantt task definitions with more than three comma-separated metadata values currently leave the parsed task incomplete and later fail with an internal rendering error. Reject the unsupported syntax in `parseData` with a diagnostic that reports the expected and received value counts.

Resolves #8188

## :straight_ruler: Design Decisions

The documented one-, two-, and three-value forms are unchanged. The guard is placed in the parser path that creates raw Gantt tasks, so malformed input is rejected before rendering instead of being partially initialized.

Validation performed:

- `pnpm vitest run packages/mermaid/src/diagrams/gantt/parser/gantt.spec.js` — 29 passed
- `pnpm vitest run packages/mermaid/src/diagrams/gantt` — 77 passed, 1 skipped
- Prettier and ESLint on the changed source/test/changeset — passed
- `pnpm build` — passed
- `git diff --check` — passed

### :clipboard: Tasks

- [x] :book: have read the contribution guidelines.
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: documentation is not needed because valid Gantt syntax is unchanged; the new diagnostic is covered by a unit test.
- [x] :butterfly: added a patch changeset for `mermaid`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Review

### Scope

| Tier | Count | Files |
|---|---:|---|
| Tier 2 | 2 | `ganttDb.js`, `gantt.spec.js` |
| Tier 3 | 1 | `.changeset/gantt-extra-task-data.md` |

### What's working well

- 🎉 `parseData` now rejects task data with more than three values.
- 🎉 The error identifies the expected count, received count, and input data.
- 🎉 The regression test covers the reported failure.
- 🎉 Existing tests cover valid task forms and tag combinations.
- 🎉 The patch changeset is included.

### Security

No XSS or injection issues identified.

### Verdict

**APPROVE**

Checklist:
- [x] Praise included
- [x] No blocking findings
- [x] No important findings
- [x] Verdict matches findings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->