### PR TITLE
perf(frontmatter): replace the quadratic front matter regex on hot paths

### DIFF
--- a/.changeset/frontmatter-redos.md
+++ b/.changeset/frontmatter-redos.md
@@ -1,0 +1,10 @@
+---
+'mermaid': patch
+---
+
+perf(frontmatter): replace the quadratic front matter regex on hot paths
+
+`frontMatterRegex` backtracks polynomially on whitespace-heavy input, so a
+diagram well inside the default `maxTextSize` could stall parsing for over a
+second. `detectType` and `extractFrontMatter` now use a linear scanner that
+matches the regex result exactly, leaving no document stripped differently.

--- a/packages/mermaid/src/diagram-api/detectType.ts
+++ b/packages/mermaid/src/diagram-api/detectType.ts
@@ -6,7 +6,7 @@ import type {
   DiagramLoader,
   ExternalDiagramDefinition,
 } from './types.js';
-import { directiveRegex, frontMatterRegex, stripAnyComments } from './regexes.js';
+import { directiveRegex, matchFrontMatter, stripAnyComments } from './regexes.js';
 import { UnknownDiagramError } from '../errors.js';
 
 export const detectors: Record<string, DetectorRecord> = {};
@@ -34,7 +34,10 @@ export const detectors: Record<string, DetectorRecord> = {};
  * @returns A graph definition key
  */
 export const detectType = function (text: string, config?: MermaidConfig): string {
-  text = stripAnyComments(text.replace(frontMatterRegex, '').replace(directiveRegex, ''));
+  const frontMatter = matchFrontMatter(text);
+  text = stripAnyComments(
+    (frontMatter ? text.slice(frontMatter.length) : text).replace(directiveRegex, '')
+  );
   for (const [key, { detector }] of Object.entries(detectors)) {
     const diagram = detector(text, config);
     if (diagram) {

--- a/packages/mermaid/src/diagram-api/frontmatter.ts
+++ b/packages/mermaid/src/diagram-api/frontmatter.ts
@@ -1,5 +1,5 @@
 import type { GanttDiagramConfig, MermaidConfig } from '../config.type.js';
-import { frontMatterRegex } from './regexes.js';
+import { matchFrontMatter } from './regexes.js';
 // The "* as yaml" part is necessary for tree-shaking
 import * as yaml from 'js-yaml';
 
@@ -22,8 +22,8 @@ export interface FrontMatterResult {
  * @returns text with frontmatter stripped out
  */
 export function extractFrontMatter(text: string): FrontMatterResult {
-  const matches = text.match(frontMatterRegex);
-  if (!matches) {
+  const match = matchFrontMatter(text);
+  if (!match) {
     return {
       text,
       metadata: {},
@@ -31,13 +31,13 @@ export function extractFrontMatter(text: string): FrontMatterResult {
   }
 
   // Dedent by the captured indent — js-yaml rejects tab-indented documents.
-  const indent = matches[1];
+  const indent = match.indent;
   const yamlBody = indent
-    ? matches[2]
+    ? match.body
         .split('\n')
         .map((line) => (line.startsWith(indent) ? line.slice(indent.length) : line))
         .join('\n')
-    : matches[2];
+    : match.body;
 
   let parsed: FrontMatterMetadata =
     yaml.load(yamlBody, {
@@ -63,7 +63,7 @@ export function extractFrontMatter(text: string): FrontMatterResult {
   }
 
   return {
-    text: text.slice(matches[0].length),
+    text: text.slice(match.length),
     metadata,
   };
 }

--- a/packages/mermaid/src/diagram-api/regexes.spec.ts
+++ b/packages/mermaid/src/diagram-api/regexes.spec.ts
@@ -1,5 +1,25 @@
 import { describe, it, expect } from 'vitest';
-import { anyCommentRegex, stripAnyComments } from './regexes.js';
+import {
+  anyCommentRegex,
+  frontMatterRegex,
+  matchFrontMatter,
+  stripAnyComments,
+} from './regexes.js';
+
+/**
+ * Duration of the fastest of several runs. The tests below compare the cost of two input sizes, and
+ * the whole suite runs in parallel workers: a mean is skewed by any single scheduling stall, while
+ * the minimum reports the run that was not interrupted.
+ */
+const fastestRun = (run: () => unknown, attempts = 5): number => {
+  let fastest = Infinity;
+  for (let i = 0; i < attempts; i++) {
+    const t0 = performance.now();
+    run();
+    fastest = Math.min(fastest, performance.now() - t0);
+  }
+  return fastest;
+};
 
 // The exported `anyCommentRegex` is the published, pre-optimization pattern and serves as the
 // equivalence oracle: `stripAnyComments` must strip comments byte-for-byte identically to
@@ -59,11 +79,7 @@ describe('stripAnyComments', () => {
       const input = build(n);
       // Warm up so the first call does not carry compilation cost into the ratio.
       stripAnyComments(input);
-      const t0 = performance.now();
-      for (let i = 0; i < 5; i++) {
-        stripAnyComments(input);
-      }
-      return (performance.now() - t0) / 5;
+      return fastestRun(() => stripAnyComments(input));
     };
 
     const small = measure(4000);
@@ -71,6 +87,90 @@ describe('stripAnyComments', () => {
 
     // 4x the input. Linear predicts ~4x, quadratic ~16x. The bar is set at 8 so ordinary timing
     // noise on a loaded machine cannot fail it while a return to quadratic still does.
+    expect(large / Math.max(small, 0.01)).toBeLessThan(8);
+  });
+});
+
+// Same arrangement as above: the exported `frontMatterRegex` is the released pattern and the
+// equivalence oracle. `matchFrontMatter` must agree with it on which block matches, what the
+// indent and body are, and how much text is consumed — the only difference is avoiding the
+// O(n²) backtracking on ambiguous whitespace.
+
+const legacyMatch = (text: string) => {
+  const matches = text.match(frontMatterRegex);
+  return matches ? { indent: matches[1], body: matches[2], length: matches[0].length } : undefined;
+};
+
+const FRONT_MATTER_CORPUS: string[] = [
+  '---\ntitle: Hello\n---\ngraph TD\n  A-->B\n',
+  '---\ntitle: Hello\n---\n',
+  '---\r\ntitle: CRLF\r\n---\r\ngraph TD\n',
+  '  ---\n  title: indented\n  ---\ngraph TD\n',
+  '\t---\n\ttitle: tab indented\n\t---\ngraph TD\n',
+  // Indented `---` inside a multi-line scalar must not close the block (#7613).
+  '---\ntitle: |\n  ---\n  still the body\n---\ngraph TD\n',
+  // The divergence called out in #8200: greedy `\s*` in the opening pushes the body start past a
+  // newline, so the block closes at the *last* fence rather than the second one.
+  '---\n\n---\n\nMORE\n---\n',
+  '---\n\n\n---\ngraph TD\n',
+  '---   \ntitle: trailing spaces on the fence\n---   \ngraph TD\n',
+  '---\ntitle: many trailing newlines\n---\n\n\n\ngraph TD\n',
+  '---\ntitle: no trailing newline after close\n---',
+  '---\ntitle: unterminated\ngraph TD\n',
+  '---\n',
+  '---',
+  '----\nfour dashes\n----\n',
+  '  ---\nclose at a different indent\n---\n',
+  '---\nopen at col0\n  ---\n',
+  'graph TD\n---\nnot at the start\n---\n',
+  '',
+  '\n\n\n',
+  'graph TD\n  A-->B\n',
+  // The reported quadratic shape, small instance: agreement matters here, speed is asserted below.
+  '---\n' + ' \n'.repeat(20),
+  '---\n' + ' \n'.repeat(20) + '---\n',
+];
+
+describe('matchFrontMatter', () => {
+  it('matches identically to frontMatterRegex', () => {
+    for (const input of FRONT_MATTER_CORPUS) {
+      expect(matchFrontMatter(input), JSON.stringify(input)).toStrictEqual(legacyMatch(input));
+    }
+  });
+
+  it('matches identically to frontMatterRegex on random fence-and-whitespace strings', () => {
+    // The corpus above covers the shapes we reasoned about; this covers the ones we did not.
+    // Deterministic PRNG so a failure is reproducible from the printed input alone.
+    let seed = 0x2f6e2b1;
+    const random = () => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      return seed / 0x7fffffff;
+    };
+    const pieces = ['---', '----', '\n', '\r\n', '\r', ' ', '\t', 'a', 'title: x', ''];
+
+    for (let i = 0; i < 3000; i++) {
+      let input = '';
+      const length = 1 + Math.floor(random() * 12);
+      for (let j = 0; j < length; j++) {
+        input += pieces[Math.floor(random() * pieces.length)];
+      }
+      expect(matchFrontMatter(input), JSON.stringify(input)).toStrictEqual(legacyMatch(input));
+    }
+  });
+
+  it('scales linearly on whitespace-heavy input that never closes', () => {
+    // `'---\n' + ' \n'.repeat(n)` is the shape from the CodeQL alert: the released regex is
+    // quadratic on it (38ms / 161ms / 619ms at n = 4k / 8k / 16k). Ratio rather than a wall-clock
+    // bound, for the reason given above.
+    const measure = (n: number) => {
+      const input = '---\n' + ' \n'.repeat(n);
+      matchFrontMatter(input);
+      return fastestRun(() => matchFrontMatter(input));
+    };
+
+    const small = measure(4000);
+    const large = measure(16000);
+
     expect(large / Math.max(small, 0.01)).toBeLessThan(8);
   });
 });

--- a/packages/mermaid/src/diagram-api/regexes.ts
+++ b/packages/mermaid/src/diagram-api/regexes.ts
@@ -4,6 +4,9 @@
 // multiline mode.
 // Relevant YAML spec: https://yaml.org/spec/1.2.2/#914-explicit-documents
 // The \1 backreference anchors closing `---` to the same indent as the opening one, guards against indented `---` inside multi-line YAML scalars (#7613).
+// Kept byte-for-byte as released: it is part of the published surface. It backtracks quadratically
+// (see `matchFrontMatter` below), so internal hot paths must use `matchFrontMatter` instead of
+// matching with this regex directly.
 export const frontMatterRegex = /^([^\S\n\r]*)-{3}\s*[\n\r](.*?)[\n\r]\1-{3}\s*[\n\r]+/s;
 
 export const directiveRegex =
@@ -70,4 +73,122 @@ export const stripAnyComments = (text: string): string => {
   }
 
   return out + text.slice(consumed);
+};
+
+/** True for the characters `[\n\r]` means in `frontMatterRegex`. */
+const isLineBreak = (char: string | undefined): boolean => char === '\n' || char === '\r';
+
+/**
+ * Index of the last `[\n\r]` in the whitespace run starting at `from`, or `-1` if the run holds
+ * none. This is where a greedy `\s*[\n\r]+` stops: `\s*` takes the whole run, then gives
+ * characters back until the next one is a line break.
+ */
+const lastLineBreakInWhitespaceRun = (text: string, from: number): number => {
+  let index = -1;
+  for (let i = from; i < text.length && whitespace.test(text[i]); i++) {
+    if (isLineBreak(text[i])) {
+      index = i;
+    }
+  }
+  return index;
+};
+
+export interface FrontMatterMatch {
+  /** The horizontal indent of the opening fence — `frontMatterRegex`'s capture group 1. */
+  indent: string;
+  /** The YAML body between the fences — capture group 2. */
+  body: string;
+  /** Length of the whole match, so callers can slice the front matter off. */
+  length: number;
+}
+
+/**
+ * Locate a front matter block exactly like `text.match(frontMatterRegex)`, in linear time.
+ *
+ * A scanner rather than a regex, because `frontMatterRegex` is ambiguous: the opening `\s*[\n\r]`
+ * lets `\s*` consume line breaks as well, so every failed search for a closing fence backtracks
+ * into it. Each of the O(n) split points then rescans the lazy body, which is quadratic overall —
+ * on `'---\n' + ' \n'.repeat(n)`, well inside the default 50k `maxTextSize`:
+ *
+ * ```
+ *   n =  4_000    38ms
+ *   n =  8_000   161ms
+ *   n = 16_000   619ms
+ * ```
+ *
+ * Removing the ambiguity is not behaviour-preserving, so the scanner reproduces the
+ * backtracking result rather than a tidier reading of it. The engine tries the *longest* opening
+ * first and shortens it one line break at a time until the rest matches, which is equivalent to:
+ *
+ * 1. Take the closing fences that could terminate a block — a line break, `indent---`, then at
+ *    least one more line break in the following whitespace run.
+ * 2. The opening ends at the **last** line break of the run after `---` that still leaves a
+ *    closing fence after it, since a longer opening is preferred but must leave one behind.
+ * 3. The body ends at the **first** closing fence after that, because the body is lazy.
+ *
+ * This is why `'---\n\n---\n\nMORE\n---\n'` is stripped whole: the opening swallows both leading
+ * line breaks, so the second `---` lands inside the body and only the third one can close.
+ *
+ * Two forward passes, each visiting a character a bounded number of times: the trailing
+ * whitespace runs of two closing fences cannot overlap, since `---` separates them.
+ */
+export const matchFrontMatter = (text: string): FrontMatterMatch | undefined => {
+  let cursor = 0;
+  while (cursor < text.length && whitespace.test(text[cursor]) && !isLineBreak(text[cursor])) {
+    cursor++;
+  }
+  const indent = text.slice(0, cursor);
+
+  if (!text.startsWith('---', cursor)) {
+    return undefined;
+  }
+
+  // Candidate opening ends: the line breaks of the whitespace run after the opening `---`.
+  const openingEnds: number[] = [];
+  for (let i = cursor + 3; i < text.length && whitespace.test(text[i]); i++) {
+    if (isLineBreak(text[i])) {
+      openingEnds.push(i);
+    }
+  }
+  if (openingEnds.length === 0) {
+    return undefined;
+  }
+
+  const closingFence = `${indent}---`;
+  // A closing fence is only usable if the trailing `\s*[\n\r]+` matches too.
+  const closingEnd = (i: number): number =>
+    isLineBreak(text[i]) && text.startsWith(closingFence, i + 1)
+      ? lastLineBreakInWhitespaceRun(text, i + 1 + closingFence.length)
+      : -1;
+
+  const earliestBodyStart = openingEnds[0] + 1;
+
+  let lastClosingFence = -1;
+  for (let i = earliestBodyStart; i < text.length; i++) {
+    if (closingEnd(i) !== -1) {
+      lastClosingFence = i;
+    }
+  }
+  if (lastClosingFence === -1) {
+    return undefined;
+  }
+
+  // Longest opening that still leaves a closing fence behind. One always exists: every closing
+  // fence sits at or after `earliestBodyStart`, which is past `openingEnds[0]`.
+  let openingEnd = openingEnds[0];
+  for (const candidate of openingEnds) {
+    if (candidate < lastClosingFence) {
+      openingEnd = candidate;
+    }
+  }
+
+  const bodyStart = openingEnd + 1;
+  for (let i = bodyStart; i <= lastClosingFence; i++) {
+    const matchEnd = closingEnd(i);
+    if (matchEnd !== -1) {
+      return { indent, body: text.slice(bodyStart, i), length: matchEnd + 1 };
+    }
+  }
+
+  return undefined;
 };


### PR DESCRIPTION
## Description

Closes #8200 — `frontMatterRegex` backtracks polynomially (CodeQL `js/polynomial-redos`).

The opening `\s*[\n\r]` is ambiguous: `\s*` can also consume line breaks, so every failed search for a closing fence backtracks into it, and each of the O(n) split points then rescans the lazy body. Measured on `'---\n' + ' \n'.repeat(n)`, which fits inside the default 50k `maxTextSize`:

| n | `frontMatterRegex` | `matchFrontMatter` |
| --- | --- | --- |
| 4 000 | 34.6 ms | 1.33 ms |
| 8 000 | 144.9 ms | 1.99 ms |
| 16 000 | 581.7 ms | 2.78 ms |
| 24 000 | 1269.0 ms | 1.54 ms |

It is reachable from `detectType()` on raw user input.

## Approach

Same shape as the `stripAnyComments` fix in #7906: a linear scanner replaces the regex on the hot paths, and the regex stays as the test oracle.

As the issue notes, a linear rewrite is **not** automatically behaviour-preserving — de-ambiguating the opening changes which fence closes the block. So `matchFrontMatter` reproduces the *backtracking result* rather than a tidier reading of it. The engine tries the longest opening first and shortens it one line break at a time, which is equivalent to:

1. the opening ends at the **last** line break of the run after `---` that still leaves a closing fence after it;
2. the body ends at the **first** closing fence after that, since the body is lazy.

That is why the divergence example from the issue, `'---\n\n---\n\nMORE\n---\n'`, is still stripped whole: the opening swallows both leading line breaks, the second `---` lands inside the body, and only the third can close. **No document changes how it is stripped.**

Two forward passes, each visiting a character a bounded number of times — the trailing whitespace runs of two closing fences cannot overlap, since `---` separates them.

`frontMatterRegex` remains exported and byte-for-byte unchanged; it is published surface, and removing it would be a separate breaking decision. A comment now points internal callers at the scanner.

## Changes

- `regexes.ts` — add `matchFrontMatter`, returning `{ indent, body, length }` (the regex's groups 1, 2 and match length).
- `detectType.ts`, `frontmatter.ts` — the two callers that matched the regex on user input.
- `regexes.spec.ts` — equivalence against `frontMatterRegex` over a hand-written corpus (CRLF, tab indent, indented `---` inside a multi-line scalar per #7613, the #8200 divergence, unterminated blocks, four-dash fences, mismatched indents) **plus 3000 random fence-and-whitespace strings** from a seeded PRNG, and a scaling assertion.

## Also here

The existing `stripAnyComments` scaling test took the **mean** of its timed runs, which made it flake under parallel workers (I hit it at 28x on an otherwise-clean tree). Both scaling tests now take the **minimum**, which reports the run that was not interrupted. This is a test-only change; the ratio bar of 8 is untouched.

## Validation

- `vitest run packages/mermaid/src/diagram-api/` → 60 passed.
- Full `vitest run packages/mermaid/src/` → same failures as `develop` (unbuilt `@mermaid-js/parser` workspace dep locally); no new ones. Diffed the failing-file lists against a stashed tree to confirm.
- ESLint and Prettier clean on the touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Replaced hot-path use of `frontMatterRegex` with the linear `matchFrontMatter` scanner.
- Updated `detectType` and `extractFrontMatter`.
- Preserved `frontMatterRegex` unchanged for compatibility.
- Added equivalence, seeded random-input, and linear-scaling tests.
- Improved timing-test stability with minimum measurements.
- Added a Mermaid package changeset.
- Targeted tests, ESLint, and Prettier checks passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->