### PR TITLE
fix(parser): ignore trailing whitespace in treemap lines

### DIFF
--- a/.changeset/treemap-trailing-whitespace.md
+++ b/.changeset/treemap-trailing-whitespace.md
@@ -1,0 +1,6 @@
+---
+'@mermaid-js/parser': patch
+'mermaid': patch
+---
+
+fix: ignore trailing whitespace after treemap section and leaf values

--- a/packages/parser/src/language/treemap/treemap.langium
+++ b/packages/parser/src/language/treemap/treemap.langium
@@ -73,10 +73,10 @@ Item returns Item:
 
 // Use a special rule order to handle the parsing precedence
 Section returns Section:
-    name=STRING2 (STYLE_SEPARATOR classSelector=ID2)?;
+    name=STRING2 (STYLE_SEPARATOR classSelector=ID2)? INDENTATION?;
 
 Leaf returns Leaf:
-    name=STRING2 INDENTATION? (SEPARATOR | COMMA) INDENTATION? value=MyNumber (STYLE_SEPARATOR classSelector=ID2)?;
+    name=STRING2 INDENTATION? (SEPARATOR | COMMA) INDENTATION? value=MyNumber (STYLE_SEPARATOR classSelector=ID2)? INDENTATION?;
 
 // Keywords with fixed text patterns
 terminal ID2: /[a-zA-Z_][a-zA-Z0-9_]*/;

--- a/packages/parser/tests/treemap.test.ts
+++ b/packages/parser/tests/treemap.test.ts
@@ -235,4 +235,30 @@ accDescr: This is an accessible description
       }
     });
   });
+
+  describe('Trailing whitespace', () => {
+    it('should parse a leaf with trailing space after the value', () => {
+      const result = parse('treemap\n"Root"\n  "Child": 100 ');
+      expectNoErrorsOrAlternatives(result);
+      expect(result.value.TreemapRows).toHaveLength(2);
+    });
+
+    it('should parse treemap-beta with trailing space on the last leaf line', () => {
+      const result = parse(`treemap-beta
+"Category A"
+    "Item A1": 10
+    "Item A2": 20
+"Category B"
+    "Item B1": 15
+    "Item C3": 10 `);
+      expectNoErrorsOrAlternatives(result);
+      expect(result.value.TreemapRows).toHaveLength(6);
+    });
+
+    it('should parse a section with trailing space', () => {
+      const result = parse('treemap\n"Root" \n  "Child": 100');
+      expectNoErrorsOrAlternatives(result);
+      expect(result.value.TreemapRows).toHaveLength(2);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Treemap diagrams failed to parse when a section or leaf line had trailing whitespace after the value (e.g. `"Item": 10 `). This fix allows optional trailing indentation at the end of `Section` and `Leaf` rules in the Langium grammar.

Resolves #8205
Related: mermaid-js/mermaid-live-editor#1936

## Design Decisions

The treemap grammar uses a non-hidden `INDENTATION` terminal for row-leading whitespace. Trailing spaces on a line were left unconsumed and caused the parser to fail when expecting the next row. Adding optional `INDENTATION?` at the end of `Section` and `Leaf` consumes benign trailing whitespace without affecting hierarchy semantics.

## Test plan

- [x] Added parser regression tests in `packages/parser/tests/treemap.test.ts`
- [x] `pnpm vitest run packages/parser/tests/treemap.test.ts` — 20/20 passed

### :clipboard: Tasks

- [x] Read the contribution guidelines
- [x] Added unit tests
- [x] Documentation not required (bug fix)
- [x] Added changeset (`fix: ignore trailing whitespace after treemap section and leaf values`)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What's working well

- 🎉 [praise] The grammar change addresses trailing whitespace after treemap sections.
- 🎉 [praise] Regression tests cover leaf, section, and `treemap-beta` inputs.
- 🎉 [praise] The changeset correctly declares patch releases for `@mermaid-js/parser` and `mermaid`.
- 🎉 [praise] No public API, renderer, or security-sensitive code changed.

## Things to address

- 🟡 [important] The issue affects both spaces and tabs, but the tests shown cover trailing spaces only. Please add a tab case.
- 🟡 [important] Add an explicit regression test for the `treemap` variant, not only `treemap-beta`, to verify both grammar entry points.

## Security

No XSS or injection issues identified.

## Verdict

COMMENT

## Self-check

- [x] Praise included
- [x] No duplicate findings
- [x] Severity tally: 0 blocking / 2 important / 0 nit / 0 suggestion / 4 praise
- [x] Verdict matches the findings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->