### PR TITLE
fix: sequence diagram database shape padding for long labels

### DIFF
--- a/packages/mermaid/src/diagrams/sequence/actorBandModel.spec.ts
+++ b/packages/mermaid/src/diagrams/sequence/actorBandModel.spec.ts
@@ -45,13 +45,56 @@ const bboxOf = (el: Element): { x: number; y: number; width: number; height: num
     return { x: num(el, 'x'), y: num(el, 'y'), width: num(el, 'width'), height: num(el, 'height') };
   }
   if (tag === 'path') {
-    const ys = [...(el.getAttribute('d') ?? '').matchAll(/([\d.-]+)[\s,]([\d.-]+)/g)]
-      .map((m) => Number(m[2]))
-      .filter(Number.isFinite);
-    if (!ys.length) {
+    const d = el.getAttribute('d') ?? '';
+    let minY = Infinity,
+      maxY = -Infinity;
+    let currY = 0;
+    const commands = d.match(/[A-Za-z][^A-Za-z]*/g) ?? [];
+    for (const cmdStr of commands) {
+      const cmd = cmdStr[0];
+      const args = [...cmdStr.matchAll(/-?[\d.]+/g)].map((m) => Number(m[0]));
+      if (cmd === 'M' || cmd === 'L') {
+        for (let i = 1; i < args.length; i += 2) {
+          currY = args[i];
+          minY = Math.min(minY, currY);
+          maxY = Math.max(maxY, currY);
+        }
+      } else if (cmd === 'm' || cmd === 'l') {
+        for (let i = 1; i < args.length; i += 2) {
+          currY += args[i];
+          minY = Math.min(minY, currY);
+          maxY = Math.max(maxY, currY);
+        }
+      } else if (cmd === 'A') {
+        for (let i = 6; i < args.length; i += 7) {
+          currY = args[i];
+          minY = Math.min(minY, currY);
+          maxY = Math.max(maxY, currY);
+        }
+      } else if (cmd === 'a') {
+        for (let i = 6; i < args.length; i += 7) {
+          currY += args[i];
+          minY = Math.min(minY, currY);
+          maxY = Math.max(maxY, currY);
+        }
+      } else if (cmd === 'V') {
+        for (const arg of args) {
+          currY = arg;
+          minY = Math.min(minY, currY);
+          maxY = Math.max(maxY, currY);
+        }
+      } else if (cmd === 'v') {
+        for (const arg of args) {
+          currY += arg;
+          minY = Math.min(minY, currY);
+          maxY = Math.max(maxY, currY);
+        }
+      }
+    }
+    if (minY === Infinity) {
       return { x: 0, y: 0, width: 0, height: 0 };
     }
-    return { x: 0, y: Math.min(...ys), width: 10, height: Math.max(...ys) - Math.min(...ys) };
+    return { x: 0, y: minY, width: 10, height: maxY - minY };
   }
   if (tag === 'text' || tag === 'tspan') {
     const lines = Math.max(1, el.querySelectorAll('tspan').length);
@@ -202,7 +245,12 @@ describe('actor band model (neo, real pipeline)', () => {
         continue;
       }
       const bottoms = glyphs.map((el) => {
-        const b = applyOwnTranslate(el, bboxOf(el));
+        let b = bboxOf(el);
+        let curr: Element | null = el;
+        while (curr && curr !== g) {
+          b = applyOwnTranslate(curr, b);
+          curr = curr.parentElement;
+        }
         return b.y + b.height + (box.y - bboxOf(g).y);
       });
       glyphBottoms.set(g.getAttribute('data-id')!, Math.max(...bottoms));

--- a/packages/mermaid/src/diagrams/sequence/svgDraw.js
+++ b/packages/mermaid/src/diagrams/sequence/svgDraw.js
@@ -1063,7 +1063,7 @@ const drawActorTypeDatabase = function (elem, actor, conf, isFooter, diagramId, 
   // must not be able to move anything below it.
   rect.x = actor.x;
   rect.y = actorY;
-  const w = rect.width / 3;
+  const w = rect.width;
   const rx = w / 2;
   const ry = rx / (2.5 + w / 50);
   const h = bands ? GLYPH_BAND_HEIGHT : rect.width / 3;
@@ -1097,7 +1097,7 @@ const drawActorTypeDatabase = function (elem, actor, conf, isFooter, diagramId, 
   }
 
   // Both branches were identical — simplified to a single unconditional statement
-  cylinderGroup.attr('transform', `translate(${w}, ${ry})`);
+  cylinderGroup.attr('transform', `translate(0, ${ry})`);
   actor.rectData = rect;
   _drawTextCandidateFunc(conf, hasKatex(actor.description))(
     actor.description,


### PR DESCRIPTION
## :bookmark_tabs: Summary

This PR fixes an issue where the database participant shape in sequence diagrams does not scale its cylinder width properly, causing long text labels to spill out of the sides without padding. 

Resolves #8215

## :straight_ruler: Design Decisions

Previously, the cylinder in `drawActorTypeDatabase` statically computed its width as a fraction of the text's bounding box (`const w = rect.width / 3`) and translated it to the middle third of the container. 

This implementation updates the cylinder drawing logic to use the full `rect.width` (which appropriately includes the standard text margin and padding), removing the hardcoded `w / 3` constraint and adjusting the `translate` transform so the cylinder perfectly encompasses the label text.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes long database participant labels in sequence diagrams.

- Uses the full participant width for the cylinder.
- Removes the horizontal translation that shifted the cylinder.
- Keeps the cylinder aligned with its label and preserves end padding.
- Updates SVG path and transform handling in actor band tests.
- Resolves issue `#8215`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->