### PR TITLE
fix(rendering): remove temp element on parse failure

### DIFF
--- a/.changeset/render-temp-element-cleanup.md
+++ b/.changeset/render-temp-element-cleanup.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: `render` no longer stacks a new "Syntax error" diagram in the body for every failed parse; the newest one replaces the previous one.

--- a/packages/mermaid/src/mermaidAPI.spec.ts
+++ b/packages/mermaid/src/mermaidAPI.spec.ts
@@ -954,6 +954,16 @@ treeView-beta
       ensureNodeFromSelector('path', iconNode);
       expect(dom.window.document.querySelector('use')).toBeNull();
     });
+
+    jsdomIt('keeps only the newest error diagram when renders fail repeatedly', async () => {
+      const bad = 'this is not a mermaid diagram definition';
+
+      await expect(mermaidAPI.render('parse-failure-1', bad)).rejects.toThrow();
+      await expect(mermaidAPI.render('parse-failure-2', bad)).rejects.toThrow();
+
+      expect(document.querySelectorAll('#dparse-failure-1').length).toBe(0);
+      expect(document.querySelectorAll('#dparse-failure-2').length).toBe(1);
+    });
   });
 
   describe('getDiagramFromText', () => {

--- a/packages/mermaid/src/mermaidAPI.ts
+++ b/packages/mermaid/src/mermaidAPI.ts
@@ -3,7 +3,7 @@
  * and is not intended to be used by the end user.
  */
 // @ts-ignore TODO: Investigate D3 issue
-import { select } from 'd3';
+import { select, selectAll } from 'd3';
 import {
   COMMENT,
   compile,
@@ -47,6 +47,10 @@ import { toBase64 } from './utils/base64.js';
 import { sanitizeCss } from './utils/sanitizeDirective.js';
 
 const MAX_TEXTLENGTH = 50_000;
+// Marks an error diagram that render() deliberately leaves in the body after throwing, so
+// the next render can drop it instead of stacking a new one beside it.
+const ERROR_DIAGRAM_ATTR = 'data-mermaid-error-diagram';
+
 const MAX_TEXTLENGTH_EXCEEDED_MSG =
   'graph TB;a[Maximum text size in diagram exceeded];style a fill:#faa';
 
@@ -551,6 +555,10 @@ const renderDiagram = async function (
     // If there is an existing element with the id, we remove it. This likely a previously rendered diagram
     removeExistingElements(document, id, enclosingDivID, iFrameID);
 
+    // A previous render whose text failed to parse left its error diagram in the body on
+    // purpose, under an id of its own. Drop it so the body holds the newest one only.
+    selectAll(`[${ERROR_DIAGRAM_ATTR}]`).remove();
+
     // Add the temporary div used for rendering with the enclosingDivID.
     // This temporary div will contain a svg with the id == id
 
@@ -663,6 +671,12 @@ const renderDiagram = async function (
     : serializeSvg();
 
   if (parseEncounteredException) {
+    if (svgContainingElement === undefined) {
+      select(isSandboxed ? iFrameID_selector : enclosingDivID_selector).attr(
+        ERROR_DIAGRAM_ATTR,
+        ''
+      );
+    }
     throw parseEncounteredException;
   }
 


### PR DESCRIPTION
## The bug

With no container element, a `render()` whose text fails to parse leaves its error diagram in the body. That is deliberate: `render()` throws instead of returning the SVG, so that element is the only copy the caller can see, and `suppressErrorRendering` exists to opt out of it.

Nothing removes the earlier ones. `mermaid.run` mints a fresh id per element, so each failed parse stacks another error diagram under a new id.

```js
await mermaid.render("a", "not a diagram").catch(() => {});
await mermaid.render("b", "not a diagram").catch(() => {});
document.querySelectorAll("[id^=d]").length; // 2, and it keeps growing
```

A page that renders user-supplied text accumulates one error diagram per failure for the life of the page.

## The fix

Tag the element that is deliberately left behind, and drop any tagged leftover before appending the next temporary element. The newest error diagram is still in the body, so the documented behaviour and `suppressErrorRendering` are both unchanged.

The tag is only applied when no container element was passed. When the caller supplies one, the element lives inside it and the caller owns it.

Reverting the source hunk makes the added test fail with `expected 1 to be +0`.
