### PR TITLE
fix(ci): publish the preview packages with public access

### DIFF
--- a/.github/workflows/release-preview-publish.yml
+++ b/.github/workflows/release-preview-publish.yml
@@ -86,7 +86,10 @@ jobs:
               # unmet-peer warning on every install.
               json -I -f package.json -e 'delete this.peerDependencies'
               pnpm pack
-              npm publish --tag preview *.tgz
+              # `--access public` is not optional here: neither package exists in
+              # the org's registry yet, and a scoped package defaults to
+              # `restricted`, so the create is refused with `write_package`.
+              npm publish --access public --tag preview *.tgz
             )
           done
         env:

--- a/packages/mermaid-layout-elk/package.json
+++ b/packages/mermaid-layout-elk/package.json
@@ -25,6 +25,9 @@
     "type": "git",
     "url": "https://github.com/mermaid-js/mermaid"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "contributors": [
     "Knut Sveidqvist",
     "Sidharth Vinod"


### PR DESCRIPTION
The preview publish [failed](https://github.com/mermaid-js/mermaid/actions/runs/34131125537/job/101771237926) after #8222 added `layout-elk` and `tiny` to it:

```
npm error 403 Forbidden - PUT https://npm.pkg.github.com/mermaid-js/@mermaid-js%2flayout-elk
  - Permission permission_denied: write_package
```

## Why `mermaid` publishes and these two don't

The same token published `@mermaid-js/mermaid` seconds earlier, so the denial is package-specific. Two things line up:

| | `@mermaid-js/mermaid` | `@mermaid-js/layout-elk` |
| --- | --- | --- |
| In the org's GitHub Packages registry? | **yes** — created Oct 2019, already linked to `mermaid-js/mermaid` | **no** — this publish has to create it |
| `publishConfig.access` | `"public"` | **absent** |
| npm's own log line | `with tag preview and **public** access` | `with tag preview and **default** access` |

`packages/mermaid-layout-elk` was the only one of the three without a `publishConfig` — `mermaid` and `tiny` both have `access: "public"`. For a **scoped** package npm defaults to `restricted`, and GitHub's docs state *"When you first publish a package, the default visibility is private."* So the request asked GitHub Packages to create a **new private** package linked to a public repo, and that comes back as `write_package`.

`mermaid` never hits it because nothing is being created — the 2019 package already carries the repo link, and a repo that publishes via a workflow is automatically granted admin on its own packages.

`@mermaid-js/tiny` does declare `access: "public"`, so it was probably fine; the loop just died on `layout-elk` first and never reached it.

## The change

- `--access public` on the loop's `npm publish`, so the step does not depend on each package's `publishConfig`.
- `publishConfig.access: "public"` added to `packages/mermaid-layout-elk/package.json`, bringing it in line with `mermaid` and `tiny`.

Belt and braces on purpose: the flag fixes the preview, and the field removes the inconsistency that caused it — which would otherwise bite the first real scoped publish too.

## Verification

Reproduced all three states with `npm publish --dry-run` on the real package:

| state | npm's notice |
| --- | --- |
| as it was in CI (no `publishConfig`, no flag) | `with tag preview and **default** access` ← matches the failing log |
| `publishConfig` present | `with tag preview and **public** access` |
| `--access public` only | `with tag preview and **public** access` |

Prettier clean on both files.

## If it still 403s

Then the cause is the org side rather than the request, and the next places to look are:

1. **Org package-creation policy** — https://github.com/organizations/mermaid-js/settings/packages, which can forbid creating public and/or private packages regardless of the token.
2. **Create the two packages once with a PAT** holding `write:packages`. After the first publish the package is linked to the repo and `GITHUB_TOKEN` can write it, exactly as it does for `@mermaid-js/mermaid`.

Worth noting either way: only `mermaid` exists in the org's npm registry today, so both names are being created for the first time.