### PR TITLE
fix(sequence): size KaTeX Note over a single actor from MathML dimensions

### DIFF
--- a/.changeset/sequence-katex-note-over-padding.md
+++ b/.changeset/sequence-katex-note-over-padding.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: `Note over` a single actor no longer measures KaTeX content as plain text, which inflated the note's width with huge padding.

--- a/e2e/diagrams/katex/should-render-a-katex-note-over-a-single-actor-without-extra-padding.mmd
+++ b/e2e/diagrams/katex/should-render-a-katex-note-over-a-single-actor-without-extra-padding.mmd
@@ -1,0 +1,11 @@
+---
+config:
+  sequence:
+    useMaxWidth: false
+---
+sequenceDiagram
+    participant A
+    participant B
+    Note over B: $$(sk_B, pk_B)\leftarrow KeyGen(1^\lambda)$$
+    Note left of B: $$(sk_B, pk_B)\leftarrow KeyGen(1^\lambda)$$
+    A->>B: Message

--- a/packages/mermaid/src/diagrams/sequence/sequenceRenderer.spec.js
+++ b/packages/mermaid/src/diagrams/sequence/sequenceRenderer.spec.js
@@ -15,13 +15,27 @@ vi.mock('../../utils.js', async (importOriginal) => {
     ...actual,
     default: {
       ...actual.default,
-      calculateTextDimensions: vi.fn(() => ({ width: 40, height: 14 })),
+      // Raw `$$...$$` source is much wider than rendered math; measuring it as
+      // plain text is what inflated single-actor `Note over` padding (#6993).
+      calculateTextDimensions: vi.fn((text) =>
+        String(text).includes('$$') ? { width: 2000, height: 14 } : { width: 40, height: 14 }
+      ),
     },
   };
 });
 
+vi.mock('../common/common.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    calculateMathMLDimensions: vi.fn(() => Promise.resolve({ width: 200, height: 30 })),
+  };
+});
+
 import * as svgDraw from './svgDraw.js';
-import { drawMessage, setConf } from './sequenceRenderer.js';
+import { calculateMathMLDimensions } from '../common/common.js';
+import utils from '../../utils.js';
+import { buildNoteModel, drawMessage, setConf } from './sequenceRenderer.js';
 
 function mockDiagram(name = 'svg') {
   const children = [];
@@ -92,5 +106,82 @@ describe('drawMessage (#3594)', () => {
     const textObj = messageTextCalls[0][1];
     expect(textObj.x).toBe(Math.min(startx, stopx));
     expect(textObj.width).toBe(Math.abs(stopx - startx));
+  });
+});
+
+describe('buildNoteModel (#6993)', () => {
+  const diagObj = { db: { PLACEMENT: { LEFTOF: 0, RIGHTOF: 1, OVER: 2 } } };
+
+  beforeEach(() => {
+    setConf({
+      width: 80,
+      noteMargin: 10,
+      wrapPadding: 10,
+      noteFontFamily: 'sans-serif',
+      noteFontSize: 14,
+      noteFontWeight: '400',
+    });
+    vi.mocked(calculateMathMLDimensions).mockClear();
+    vi.mocked(utils.calculateTextDimensions).mockClear();
+  });
+
+  it('sizes a KaTeX note over a single actor from its MathML dimensions', async () => {
+    const actors = new Map([['B', { x: 100, width: 150 }]]);
+    const msg = {
+      from: 'B',
+      to: 'B',
+      message: '$$(sk_B, pk_B)\\leftarrow KeyGen(1^\\lambda)$$',
+      wrap: false,
+      placement: diagObj.db.PLACEMENT.OVER,
+    };
+
+    const noteModel = await buildNoteModel(msg, actors, diagObj);
+
+    // max(actor width, conf.width, MathML width (200) + 2 * noteMargin)
+    expect(noteModel.width).toBe(220);
+    expect(noteModel.startx).toBe(100 + (150 - 220) / 2);
+    expect(calculateMathMLDimensions).toHaveBeenCalledTimes(1);
+    // The raw `$$...$$` source must not be measured as plain text: doing so is
+    // what inflated the note's padding (mocked source width 2000 → width 2020).
+    expect(utils.calculateTextDimensions).not.toHaveBeenCalled();
+  });
+
+  it('still sizes a plain-text note over a single actor from its text dimensions', async () => {
+    const actors = new Map([['B', { x: 100, width: 150 }]]);
+    const msg = {
+      from: 'B',
+      to: 'B',
+      message: 'a plain note',
+      wrap: false,
+      placement: diagObj.db.PLACEMENT.OVER,
+    };
+
+    const noteModel = await buildNoteModel(msg, actors, diagObj);
+
+    // max(actor width, conf.width, text width (40) + 2 * noteMargin)
+    expect(noteModel.width).toBe(150);
+    expect(calculateMathMLDimensions).not.toHaveBeenCalled();
+    expect(utils.calculateTextDimensions).toHaveBeenCalledWith('a plain note', {
+      fontFamily: 'sans-serif',
+      fontSize: 14,
+      fontWeight: '400',
+    });
+  });
+
+  it('expands a wide plain-text note over a single actor to the text width', async () => {
+    vi.mocked(utils.calculateTextDimensions).mockReturnValue({ width: 400, height: 14 });
+    const actors = new Map([['B', { x: 100, width: 150 }]]);
+    const msg = {
+      from: 'B',
+      to: 'B',
+      message: 'a much longer plain note',
+      wrap: false,
+      placement: diagObj.db.PLACEMENT.OVER,
+    };
+
+    const noteModel = await buildNoteModel(msg, actors, diagObj);
+
+    expect(noteModel.width).toBe(420);
+    expect(calculateMathMLDimensions).not.toHaveBeenCalled();
   });
 });

--- a/packages/mermaid/src/diagrams/sequence/sequenceRenderer.ts
+++ b/packages/mermaid/src/diagrams/sequence/sequenceRenderer.ts
@@ -1698,14 +1698,16 @@ async function calculateActorMargins(
   return common.getMax(maxHeight, conf.height);
 }
 
-const buildNoteModel = async function (msg, actors, diagObj) {
+export const buildNoteModel = async function (msg, actors, diagObj) {
   const fromActor = actors.get(msg.from);
   const toActor = actors.get(msg.to);
   const startx = fromActor.x;
   const stopx = toActor.x;
   const shouldWrap = msg.wrap && msg.message;
 
-  let textDimensions: { width: number; height: number; lineHeight?: number } = hasKatex(msg.message)
+  const textDimensions: { width: number; height: number; lineHeight?: number } = hasKatex(
+    msg.message
+  )
     ? await calculateMathMLDimensions(msg.message, getConfig())
     : utils.calculateTextDimensions(
         shouldWrap ? utils.wrapLabel(msg.message, conf.width, noteFont(conf)) : msg.message,
@@ -1739,12 +1741,6 @@ const buildNoteModel = async function (msg, actors, diagObj) {
         );
     noteModel.startx = startx - noteModel.width + (fromActor.width - conf.actorMargin) / 2;
   } else if (msg.to === msg.from) {
-    textDimensions = utils.calculateTextDimensions(
-      shouldWrap
-        ? utils.wrapLabel(msg.message, common.getMax(conf.width, fromActor.width), noteFont(conf))
-        : msg.message,
-      noteFont(conf)
-    );
     noteModel.width = shouldWrap
       ? common.getMax(conf.width, fromActor.width)
       : common.getMax(fromActor.width, conf.width, textDimensions.width + 2 * conf.noteMargin);


### PR DESCRIPTION
## Summary

Sequence `Note over` a single actor with KaTeX (`$$...$$`) was sized from the raw LaTeX source width, so the note box got huge padding. `Note left of` / `Note right of` already used MathML dimensions and rendered correctly.

Fixes #6993

## Design Decisions

`buildNoteModel` already computes KaTeX-aware dimensions via `calculateMathMLDimensions`. The `msg.to === msg.from` branch then re-measured the raw `$$...$$` source with `calculateTextDimensions` and overwrote that width. The LaTeX source is much wider than the rendered math.

Removing that re-measurement restores MathML sizing for KaTeX `Note over` a single actor. For plain-text notes the second measurement used the same input, so it was a no-op.

This matches the diagnosis in closed PRs #8015 and #6994, re-verified on current `develop`.

## Tasks

- [x] have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] have added necessary unit/e2e tests
- [x] documentation: not needed (bugfix, existing KaTeX sequence notes already documented)
- [x] patch changeset with a `fix:` prefix

AI assistance: drafted with Cursor (Grok); reviewed before opening.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What's working well

🎉 [praise] The fix directly addresses issue `#6993`. KaTeX notes now keep MathML-derived dimensions, while plain-text notes keep text-based sizing.

🎉 [praise] The unit tests cover KaTeX notes, plain-text notes, and wide plain-text notes. The E2E fixture also covers the reported single-actor case.

## Security

No XSS or injection issues identified.

## Things to address

No blocking or important findings.

## Verdict

APPROVE

- 🔴 Blocking: 0
- 🟡 Important: 0
- 🟢 Nit: 0
- 💡 Suggestion: 0
- 🎉 Praise: 2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->