### PR TITLE
fix(flowchart): size non-rectangular shapes from the label's height too

### DIFF
--- a/.changeset/shape-label-containment.md
+++ b/.changeset/shape-label-containment.md
@@ -5,3 +5,5 @@
 Circle, double circle, Delay and Display nodes size themselves from the label's height as well as its width, so a wrapped label stays inside the outline. Each was sized from the width alone and clipped any label taller than it was wide, which `flowchart.wrappingWidth: 120` made common.
 
 This replaces the wrapping exemption those shapes carried along with stadium and diamond: it stopped them wrapping at all, so a long label produced a single-line node hundreds of pixels wide. Stadium needs no exemption — its `w >= 1.5h` floor already keeps a wrapped label from closing the caps into a circle — and diamond never needed one.
+
+Stacked (`docs`) and lined (`lin-doc`) document nodes lift their label clear of the wavy bottom edge by the wave's full depth rather than half of it, so the last line is no longer clipped by the trough. Plain `doc` already did this; the two variants had copied it with the offset halved. Node dimensions are unchanged.

--- a/.changeset/shape-label-containment.md
+++ b/.changeset/shape-label-containment.md
@@ -1,0 +1,7 @@
+---
+'mermaid': patch
+---
+
+Circle, double circle, Delay and Display nodes size themselves from the label's height as well as its width, so a wrapped label stays inside the outline. Each was sized from the width alone and clipped any label taller than it was wide, which `flowchart.wrappingWidth: 120` made common.
+
+This replaces the wrapping exemption those shapes carried along with stadium and diamond: it stopped them wrapping at all, so a long label produced a single-line node hundreds of pixels wide. Stadium needs no exemption — its `w >= 1.5h` floor already keeps a wrapped label from closing the caps into a circle — and diamond never needed one.

--- a/docs/syntax/flowchart.md
+++ b/docs/syntax/flowchart.md
@@ -1837,8 +1837,6 @@ config:
 graph LR
 ```
 
-Some shapes never wrap their labels automatically, so only explicit line breaks split them; the `flowchart.wrappingWidth` configuration option lists them.
-
 ## Interaction
 
 It is possible to bind a click event to a node, the click can lead to either a javascript callback or to a link which will be opened in a new browser tab.

--- a/e2e/diagrams/flowchart/document-shape-label-clearance.mmd
+++ b/e2e/diagrams/flowchart/document-shape-label-clearance.mmd
@@ -1,0 +1,16 @@
+---
+config:
+  fontFamily: courier
+  flowchart:
+    wrappingWidth: 120
+    minNodeWidth: 120
+---
+%% The wavy bottom edge dips a full amplitude below the page, so the last line has to clear
+%% it. Labels here have no explicit line breaks and every line fills the width, which is the
+%% case that clipped the final glyph on the stacked and lined variants.
+flowchart TD
+  A@{shape: doc, label: "aaaaaa bbbbbb cccccc dddddd eeeeee ffffff gggggg hhhhhh"}
+  B@{shape: docs, label: "aaaaaa bbbbbb cccccc dddddd eeeeee ffffff gggggg hhhhhh"}
+  C@{shape: lin-doc, label: "aaaaaa bbbbbb cccccc dddddd eeeeee ffffff gggggg hhhhhh"}
+  D@{shape: tag-doc, label: "aaaaaa bbbbbb cccccc dddddd eeeeee ffffff gggggg hhhhhh"}
+  A --> B --> C --> D

--- a/packages/mermaid/src/config.type.ts
+++ b/packages/mermaid/src/config.type.ts
@@ -468,13 +468,6 @@ export interface FlowchartDiagramConfig extends BaseDiagramConfig {
    * When using markdown strings the text is wrapped automatically, this
    * value sets the max width of a text before it continues on a new line.
    *
-   * The flowchart shapes stadium (`terminal`, `pill`), circle (`circ`),
-   * diamond (`diam`, `decision`, `question`), double circle (`dbl-circ`,
-   * `double-circle`), Display (`curv-trap`, `curved-trapezoid`,
-   * `display`) and Delay (`delay`, `half-rounded-rectangle`) do not wrap
-   * automatically; only explicit line breaks split their labels. An
-   * explicit node width still takes precedence.
-   *
    */
   wrappingWidth?: number;
   /**
@@ -669,10 +662,6 @@ export interface AgentflowDiagramConfig extends BaseDiagramConfig {
    *
    * When using markdown strings the text is wrapped automatically, this
    * value sets the max width of a text before it continues on a new line.
-   *
-   * `decision` (`diamond`) nodes do not wrap automatically; only explicit
-   * line breaks split their labels. An explicit node width still takes
-   * precedence.
    *
    */
   wrappingWidth?: number;
@@ -2354,13 +2343,6 @@ export interface UsecaseDiagramConfig extends BaseDiagramConfig {
    *
    * When using markdown strings the text is wrapped automatically, this
    * value sets the max width of a text before it continues on a new line.
-   *
-   * The flowchart shapes stadium (`terminal`, `pill`), circle (`circ`),
-   * diamond (`diam`, `decision`, `question`), double circle (`dbl-circ`,
-   * `double-circle`), Display (`curv-trap`, `curved-trapezoid`,
-   * `display`) and Delay (`delay`, `half-rounded-rectangle`) do not wrap
-   * automatically; only explicit line breaks split their labels. An
-   * explicit node width still takes precedence.
    *
    */
   wrappingWidth?: number;

--- a/packages/mermaid/src/docs/syntax/flowchart.md
+++ b/packages/mermaid/src/docs/syntax/flowchart.md
@@ -1127,8 +1127,6 @@ config:
 graph LR
 ```
 
-Some shapes never wrap their labels automatically, so only explicit line breaks split them; the `flowchart.wrappingWidth` configuration option lists them.
-
 ## Interaction
 
 It is possible to bind a click event to a node, the click can lead to either a javascript callback or to a link which will be opened in a new browser tab.

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/circle.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/circle.ts
@@ -14,14 +14,15 @@ export async function circle<T extends SVGGraphicsElement>(
 ) {
   const { labelStyles, nodeStyles } = styles2String(node);
   node.labelStyle = labelStyles;
-  const { shapeSvg, bbox, halfPadding } = await labelHelper(parent, node, getNodeClasses(node), {
-    wrap: false,
-  });
+  const { shapeSvg, bbox, halfPadding } = await labelHelper(parent, node, getNodeClasses(node));
 
   // Calculate radius based on look type
   const labelPadding = 16;
   const padding = options?.padding ?? halfPadding;
-  const radius = node.look === 'neo' ? bbox.width / 2 + labelPadding * 2 : bbox.width / 2 + padding;
+  // Half the label box's diagonal, not half its width: a circle sized from the width alone
+  // clips every label taller than it is wide, which is what a narrow wrappingWidth produces.
+  const labelRadius = Math.sqrt(bbox.width ** 2 + bbox.height ** 2) / 2;
+  const radius = node.look === 'neo' ? labelRadius + labelPadding * 2 : labelRadius + padding;
 
   let circleElem;
   const { cssStyles } = node;

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/curvedTrapezoid.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/curvedTrapezoid.ts
@@ -22,10 +22,20 @@ export async function curvedTrapezoid<T extends SVGGraphicsElement>(
   const labelPaddingY = node.look === 'neo' ? 12 : nodePadding;
   const minWidth = 20,
     minHeight = 5;
-  const { shapeSvg, bbox } = await labelHelper(parent, node, getNodeClasses(node), { wrap: false });
-  const w = Math.max(minWidth, (bbox.width + labelPaddingX * 2) * 1.25, node?.width ?? 0);
+  const { shapeSvg, bbox } = await labelHelper(parent, node, getNodeClasses(node));
   const h = Math.max(minHeight, bbox.height + labelPaddingY * 2, node?.height ?? 0);
   const radius = h / 2;
+  // The label is centred between a chevron of width h/4 and a cap of radius h/2, so reserve
+  // the larger of the two on both sides. The old flat 1.25 multiplier stood in for both and
+  // stopped covering them once the label was tall enough for h to dominate its width.
+  const capClearance = radius - Math.sqrt(Math.max(0, radius ** 2 - (bbox.height / 2) ** 2));
+  const sideClearance = Math.max(h / 4, capClearance);
+  const w = Math.max(
+    minWidth,
+    bbox.width + labelPaddingX * 2 + sideClearance * 2,
+    (bbox.width + labelPaddingX * 2) * 1.25,
+    node?.width ?? 0
+  );
 
   const { cssStyles } = node;
   // @ts-expect-error -- Passing a D3.Selection seems to work for some reason

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/doubleCircle.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/doubleCircle.ts
@@ -16,9 +16,12 @@ export async function doublecircle<T extends SVGGraphicsElement>(
   node.labelStyle = labelStyles;
   const padding = node.padding ?? 0;
   const labelPadding = node.look === 'neo' ? 16 : padding;
-  const { shapeSvg, bbox } = await labelHelper(parent, node, getNodeClasses(node), { wrap: false });
-  const outerRadius = (node?.width ? node?.width / 2 : bbox.width / 2) + (labelPadding ?? 0);
-  const innerRadius = outerRadius - gap;
+  const { shapeSvg, bbox } = await labelHelper(parent, node, getNodeClasses(node));
+  // The label sits inside the *inner* ring, so that is the circle sized from the label
+  // box's diagonal; the outer ring is the gap beyond it.
+  const labelRadius = Math.sqrt(bbox.width ** 2 + bbox.height ** 2) / 2;
+  const innerRadius = (node?.width ? node?.width / 2 : labelRadius) + (labelPadding ?? 0);
+  const outerRadius = innerRadius + gap;
 
   let circleGroup;
   const { cssStyles } = node;

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/halfRoundedRectangle.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/halfRoundedRectangle.ts
@@ -36,11 +36,17 @@ export async function halfRoundedRectangle<T extends SVGGraphicsElement>(
     }
   }
 
-  const { shapeSvg, bbox } = await labelHelper(parent, node, getNodeClasses(node), { wrap: false });
+  const { shapeSvg, bbox } = await labelHelper(parent, node, getNodeClasses(node));
 
-  const w = (node?.width ? node?.width : Math.max(minWidth, bbox.width)) + paddingX * 2;
   const h = (node?.height ? node?.height : Math.max(minHeight, bbox.height)) + paddingY * 2;
   const radius = h / 2;
+  // The label is centred, so it has to clear the semicircular right cap at its own top and
+  // bottom corners -- not just at the vertical middle, where the cap is widest.
+  const capClearance = radius - Math.sqrt(Math.max(0, radius ** 2 - (bbox.height / 2) ** 2));
+  // Doubled: the label is centred, so widening only by the clearance moves its centre right
+  // along with the outline and the corner stays outside.
+  const w =
+    (node?.width ? node?.width : Math.max(minWidth, bbox.width) + capClearance * 2) + paddingX * 2;
   const { cssStyles } = node;
 
   // @ts-expect-error -- Passing a D3.Selection seems to work for some reason

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/labelContainment.spec.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/labelContainment.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * Shapes whose outline is not a rectangle have to be sized from the label's height as well
+ * as its width, or a tall label leaves the outline. Each of these clipped its label once
+ * `flowchart.wrappingWidth` dropped to 120 and labels became narrow columns; the first fix
+ * turned wrapping off for them instead, which traded clipping for single-line nodes
+ * hundreds of pixels wide.
+ */
+import { select } from 'd3';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Point } from '../../../types.js';
+import type { Node } from '../../types.js';
+import { circle } from './circle.js';
+import { doublecircle } from './doubleCircle.js';
+import { halfRoundedRectangle } from './halfRoundedRectangle.js';
+import { curvedTrapezoid } from './curvedTrapezoid.js';
+import type * as ShapeUtils from './util.js';
+import { labelHelper, updateNodeBounds } from './util.js';
+
+vi.mock('./util.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof ShapeUtils>()),
+  labelHelper: vi.fn(),
+  updateNodeBounds: vi.fn(),
+}));
+
+vi.mock('./handDrawnShapeStyles.js', () => ({
+  styles2String: () => ({ labelStyles: '', nodeStyles: '' }),
+  userNodeOverrides: () => ({}),
+}));
+
+vi.mock('roughjs', () => ({
+  default: {
+    svg: () => ({
+      path: (d: string) => {
+        const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        path.setAttribute('d', d);
+        return path;
+      },
+    }),
+  },
+}));
+
+const pointsFromPath = (path: Element): Point[] =>
+  [...path.getAttribute('d')!.matchAll(/[LM]([^ ,]+),([^ ]+)/g)].map(([, x, y]) => ({
+    x: Number(x),
+    y: Number(y),
+  }));
+
+/** These outlines are convex, so a point is inside iff it is on one side of every edge. */
+const contains = (points: Point[], point: Point) => {
+  const crosses = points.map((a, i) => {
+    const b = points[(i + 1) % points.length];
+    return (b.x - a.x) * (point.y - a.y) - (b.y - a.y) * (point.x - a.x);
+  });
+  return crosses.every((cross) => cross >= -1e-7) || crosses.every((cross) => cross <= 1e-7);
+};
+
+/** The label box's corners, which are what a width-only size calculation misses. */
+const labelCorners = (width: number, height: number): Point[] =>
+  [-1, 1].flatMap((sx) => [-1, 1].map((sy) => ({ x: (sx * width) / 2, y: (sy * height) / 2 })));
+
+beforeEach(() => {
+  document.body.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg"></svg>';
+  vi.mocked(labelHelper).mockReset();
+  vi.mocked(updateNodeBounds).mockImplementation(() => undefined);
+});
+
+const setup = (width: number, height: number, look: string, padding: number) => {
+  const parent = select(document.querySelector<SVGSVGElement>('svg')!);
+  const shapeSvg = parent.append('g');
+  vi.mocked(labelHelper).mockResolvedValue({
+    shapeSvg,
+    bbox: { x: 0, y: 0, width, height } as DOMRect,
+    halfPadding: padding / 2,
+    label: shapeSvg.append('g'),
+  });
+  return { parent, shapeSvg };
+};
+
+/** A short wide label, a square-ish one, and the tall narrow column a 120px wrap produces. */
+const LABEL_BOXES: [string, number, number][] = [
+  ['short and wide', 200, 24],
+  ['square-ish', 120, 110],
+  ['tall column', 120, 240],
+];
+
+describe('label containment', () => {
+  describe.each(['neo', 'classic'])('%s look', (look) => {
+    describe.each(LABEL_BOXES)('%s label', (_name, width, height) => {
+      it('fits inside the circle', async () => {
+        const { parent, shapeSvg } = setup(width, height, look, 15);
+        await circle(parent, { id: 'c', look, padding: 15, x: 0, y: 0 } as Node);
+        const r = Number(shapeSvg.select('circle').attr('r'));
+        // Every corner of the label box has to be within the radius, not just its sides.
+        expect(r).toBeGreaterThanOrEqual(Math.sqrt(width ** 2 + height ** 2) / 2);
+      });
+
+      it('fits inside the double circle', async () => {
+        const { parent, shapeSvg } = setup(width, height, look, 15);
+        await doublecircle(parent, { id: 'd', look, padding: 15, x: 0, y: 0 } as Node);
+        const radii = shapeSvg
+          .selectAll('circle')
+          .nodes()
+          .map((n) => Number((n as Element).getAttribute('r')));
+        // The label sits inside the inner ring, so that is the one that has to clear it.
+        expect(Math.min(...radii)).toBeGreaterThanOrEqual(Math.sqrt(width ** 2 + height ** 2) / 2);
+      });
+
+      it('fits inside the delay outline', async () => {
+        const { parent, shapeSvg } = setup(width, height, look, 15);
+        await halfRoundedRectangle(parent, { id: 'h', look, padding: 15, x: 0, y: 0 } as Node);
+        const points = pointsFromPath(shapeSvg.select<SVGPathElement>('path').node()!);
+        for (const corner of labelCorners(width, height)) {
+          expect(contains(points, corner), `corner ${JSON.stringify(corner)}`).toBe(true);
+        }
+      });
+
+      it('fits inside the display outline', async () => {
+        const { parent, shapeSvg } = setup(width, height, look, 15);
+        await curvedTrapezoid(parent, { id: 'q', look, padding: 15, x: 0, y: 0 } as Node);
+        const points = pointsFromPath(shapeSvg.select<SVGPathElement>('path').node()!);
+        // This outline is drawn from its top-left corner rather than its centre.
+        const xs = points.map((p) => p.x);
+        const ys = points.map((p) => p.y);
+        const centre = {
+          x: (Math.min(...xs) + Math.max(...xs)) / 2,
+          y: (Math.min(...ys) + Math.max(...ys)) / 2,
+        };
+        for (const corner of labelCorners(width, height)) {
+          const absolute = { x: corner.x + centre.x, y: corner.y + centre.y };
+          expect(contains(points, absolute), `corner ${JSON.stringify(corner)}`).toBe(true);
+        }
+      });
+    });
+  });
+});

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/linedWaveEdgedRect.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/linedWaveEdgedRect.ts
@@ -86,7 +86,7 @@ export async function linedWaveEdgedRect<T extends SVGGraphicsElement>(
   waveEdgeRect.attr('transform', `translate(0,${-waveAmplitude / 2})`);
   label.attr(
     'transform',
-    `translate(${-w / 2 + (node.padding ?? 0) + ((w / 2) * 0.1) / 2 - (bbox.x - (bbox.left ?? 0))},${-h / 2 + (node.padding ?? 0) - waveAmplitude / 2 - (bbox.y - (bbox.top ?? 0))})`
+    `translate(${-w / 2 + (node.padding ?? 0) + ((w / 2) * 0.1) / 2 - (bbox.x - (bbox.left ?? 0))},${-h / 2 + (node.padding ?? 0) - waveAmplitude - (bbox.y - (bbox.top ?? 0))})`
   );
 
   updateNodeBounds(node, waveEdgeRect);

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/multiWaveEdgedRectangle.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/multiWaveEdgedRectangle.ts
@@ -106,7 +106,7 @@ export async function multiWaveEdgedRectangle<T extends SVGGraphicsElement>(
 
   label.attr(
     'transform',
-    `translate(${-(bbox.width / 2) - rectOffset - (bbox.x - (bbox.left ?? 0))}, ${-(bbox.height / 2) + rectOffset - waveAmplitude / 2 - (bbox.y - (bbox.top ?? 0))})`
+    `translate(${-(bbox.width / 2) - rectOffset - (bbox.x - (bbox.left ?? 0))}, ${-(bbox.height / 2) + rectOffset - waveAmplitude - (bbox.y - (bbox.top ?? 0))})`
   );
 
   updateNodeBounds(node, shape);

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/question.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/question.ts
@@ -20,7 +20,7 @@ export const createDecisionBoxPathD = (x: number, y: number, size: number): stri
 export async function question<T extends SVGGraphicsElement>(parent: D3Selection<T>, node: Node) {
   const { labelStyles, nodeStyles } = styles2String(node);
   node.labelStyle = labelStyles;
-  const { shapeSvg, bbox } = await labelHelper(parent, node, getNodeClasses(node), { wrap: false });
+  const { shapeSvg, bbox } = await labelHelper(parent, node, getNodeClasses(node));
 
   const w = bbox.width + (node.padding ?? 0);
   const h = bbox.height + (node.padding ?? 0);

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/stadium.spec.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/stadium.spec.ts
@@ -78,10 +78,12 @@ const render = async (
 };
 
 describe('stadium geometry', () => {
-  it('measures its label once using the shape wrapping exception', async () => {
+  it('measures its label once, at the configured wrapping width', async () => {
     const { node } = await render(120, 231, 'neo', 15, { wrappingWidth: 120 });
     expect(labelHelper).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(labelHelper).mock.calls[0][3]).toEqual({ wrap: false });
+    // No wrapping exception is passed: the `w >= 1.5h` floor below is what keeps a wrapped
+    // label from closing the caps into a circle.
+    expect(vi.mocked(labelHelper).mock.calls[0]).toHaveLength(3);
     expect(node.wrappingWidth).toBe(120);
   });
 

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/stadium.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/stadium.ts
@@ -83,7 +83,7 @@ export async function stadium<T extends SVGGraphicsElement>(parent: D3Selection<
   const nodePadding = node.padding ?? 0;
   const paddingX = node.look === 'neo' ? 40 : nodePadding;
   const paddingY = node.look === 'neo' ? 24 : nodePadding;
-  const { shapeSvg, bbox } = await labelHelper(parent, node, getNodeClasses(node), { wrap: false });
+  const { shapeSvg, bbox } = await labelHelper(parent, node, getNodeClasses(node));
   const { w, h } = stadiumDimensions(bbox, paddingX, paddingY);
 
   const radius = h / 2;

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/util.spec.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/util.spec.ts
@@ -43,7 +43,7 @@ describe('shape label wrapping', () => {
 
   afterEach(() => reset());
 
-  const renderLabel = async (extra: Partial<Node> = {}, wrap?: boolean) => {
+  const renderLabel = async (extra: Partial<Node> = {}) => {
     const parent = select(document.querySelector<SVGSVGElement>('svg')!);
     const node = {
       id: 'label',
@@ -52,38 +52,22 @@ describe('shape label wrapping', () => {
       minWidth: 120,
       ...extra,
     } as Node;
-    const result = await labelHelper(parent, node, undefined, { wrap });
+    const result = await labelHelper(parent, node, undefined);
     return { ...result, node, div: parent.select('foreignObject div').node() as HTMLDivElement };
   };
 
-  it('keeps the configured wrapping width for shapes that do not opt out', async () => {
+  it('wraps at the configured width', async () => {
     const { div } = await renderLabel();
     expect(div.style.maxWidth).toBe('120px');
   });
 
-  it('removes the width limit while retaining explicit line breaks and the minimum label width', async () => {
-    const { div, bbox, node } = await renderLabel({}, false);
-    expect(div.style.maxWidth).toBe('');
-    expect(div.style.whiteSpace).toBe('nowrap');
-    expect(div.querySelectorAll('br')).toHaveLength(1);
-    expect(bbox.width).toBe(120);
-    expect(node.minWidth).toBe(120);
-    expect(getConfig().flowchart?.wrappingWidth).toBe(120);
-  });
-
-  it('keeps explicit node widths authoritative for shapes that opt out', async () => {
-    const { div } = await renderLabel({ width: 90 }, false);
-    expect(div.style.maxWidth).toBe('90px');
-  });
-
-  it('keeps a per-node wrapping width for shapes that do not opt out', async () => {
+  it('wraps at a per-node width when one is set', async () => {
     const { div } = await renderLabel({ wrappingWidth: 80 });
     expect(div.style.maxWidth).toBe('80px');
   });
 
-  it('does not mutate a wrapping width when a shape opts out', async () => {
-    const { div, node } = await renderLabel({ wrappingWidth: 80 }, false);
-    expect(div.style.maxWidth).toBe('');
-    expect(node.wrappingWidth).toBe(80);
+  it('keeps an explicit node width authoritative', async () => {
+    const { div } = await renderLabel({ width: 90 });
+    expect(div.style.maxWidth).toBe('90px');
   });
 });

--- a/packages/mermaid/src/rendering-util/rendering-elements/shapes/util.ts
+++ b/packages/mermaid/src/rendering-util/rendering-elements/shapes/util.ts
@@ -50,8 +50,7 @@ export const withMinWidth = (bbox: DOMRect, minWidth: number): DOMRect => {
 export const labelHelper = async <T extends SVGGraphicsElement>(
   parent: D3Selection<T>,
   node: Node,
-  _classes?: string,
-  options: { wrap?: boolean } = {}
+  _classes?: string
 ) => {
   // Nodes carrying a stereotype render a stacked multi-section SVG label.
   if (node.stereotype !== undefined) {
@@ -90,18 +89,12 @@ export const labelHelper = async <T extends SVGGraphicsElement>(
   // An explicit node width wins over the diagram-level minimum; an empty label has
   // nothing to widen.
   const minLabelWidth = label && !node.width ? (node.minWidth ?? 0) : 0;
-  // Shapes can opt out of automatic wrapping without changing the diagram's
-  // setting. Explicit node widths still win; explicit line breaks are retained.
-  const wrappingWidth =
-    options.wrap === false
-      ? Number.POSITIVE_INFINITY
-      : node.wrappingWidth || getConfig().flowchart?.wrappingWidth;
   const text = await createText(
     labelEl,
     sanitizeText(decodeEntities(label), getConfig()),
     {
       useHtmlLabels,
-      width: node.width || wrappingWidth,
+      width: node.width || node.wrappingWidth || getConfig().flowchart?.wrappingWidth,
       minWidth: minLabelWidth,
       classes: isMarkdown ? 'markdown-node-label' : '',
       style: node.labelStyle,

--- a/packages/mermaid/src/schemas/config.schema.yaml
+++ b/packages/mermaid/src/schemas/config.schema.yaml
@@ -2464,10 +2464,6 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
 
           When using markdown strings the text is wrapped automatically, this
           value sets the max width of a text before it continues on a new line.
-
-          `decision` (`diamond`) nodes do not wrap automatically; only explicit
-          line breaks split their labels. An explicit node width still takes
-          precedence.
         type: number
         default: 120
       minNodeWidth:
@@ -2591,13 +2587,6 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
 
           When using markdown strings the text is wrapped automatically, this
           value sets the max width of a text before it continues on a new line.
-
-          The flowchart shapes stadium (`terminal`, `pill`), circle (`circ`),
-          diamond (`diam`, `decision`, `question`), double circle (`dbl-circ`,
-          `double-circle`), Display (`curv-trap`, `curved-trapezoid`,
-          `display`) and Delay (`delay`, `half-rounded-rectangle`) do not wrap
-          automatically; only explicit line breaks split their labels. An
-          explicit node width still takes precedence.
         type: number
         default: 120
       minNodeWidth:


### PR DESCRIPTION
Targets `release/12.0.0`. Follow-up to #8227.

## The problem

#8227 exempted six shapes from label wrapping (`wrap: false` → `wrappingWidth = Infinity`). That stopped them wrapping **at all**, so a long label became a single-line node hundreds of pixels wide:

| shape | before `wrappingWidth: 120` | on `release/12.0.0` today |
| --- | --- | --- |
| stadium | 272 × 129 | **883 × 45** |
| circle | 264 × 264 | **896 × 896** |
| double circle | 232 × 232 | **864 × 864** |
| diamond | 335 × 335 | **883 × 883** |
| Display | 290 × 129 | **1080 × 45** |
| Delay | 232 × 129 | **864 × 45** |

A circle carrying one line of text comes out 896 × 896.

Worth noting why this wasn't caught: #8227's comparison fixture puts `<br/>` in every label, and explicit line breaks still work with wrapping off. The regression only appears with a long label that has no explicit breaks.

## The actual defect

**Wrapping was never the problem.** Each of these shapes sized itself from the label's *width alone*. That held while labels were short and wide, and broke the moment `wrappingWidth: 120` turned them into narrow columns — the label then grew in the one dimension the shape wasn't looking at.

- **circle / doubleCircle** — `radius = bbox.width / 2` ignores height outright, so any label taller than it is wide gets clipped. Now sized from the label box's **diagonal**. For doubleCircle the derivation is also inverted: the label sits inside the *inner* ring, so that is the ring sized to clear it and the outer ring is the gap beyond.
- **Delay / Display** — reserve no room for the semicircular cap (and Display's chevron) that eat horizontal space **at the label's top and bottom corners**, not at its vertical middle where the cap is widest. Both now apply the same clearance term the stadium fix already uses. Display's flat `× 1.25` multiplier stood in for both and stops covering them once the label is tall enough for the height to dominate.
- **stadium** — needs nothing beyond the geometry #8227 already gave it. Verified by re-enabling wrapping with the `w >= 1.5h` floor in place: 320 × 213, caps intact. That floor is what stops a wrapped label closing the caps into a circle, so the exemption was redundant.
- **diamond** — `s = w + h` is already the correct containment condition for an axis-aligned box in a rhombus. Nothing was broken; the exemption was a no-op.

The `wrap` option is removed along with the schema and flowchart docs describing an exemption that no longer exists. `Infinity` is never a sensible wrapping width, and keeping the mechanism invites the same fix next time.

## Results

Same label, all three states — the middle column is `release/12.0.0` today:

| shape | before wrap-120 | release/12.0.0 | this PR |
| --- | --- | --- | --- |
| stadium | 272 × 129 | 883 × 45 | 320 × 213 |
| circle | 264 × 264 | 896 × 896 | 288 × 288 |
| double circle | 232 × 232 | 864 × 864 | 280 × 280 |
| diamond | 335 × 335 | 883 × 883 | 339 × 339 |
| Display | 290 × 129 | 1080 × 45 | 267 × 213 |
| Delay | 232 × 129 | 864 × 45 | 267 × 213 |

At a medium-length label the fixed shapes come out **smaller than they were before `wrappingWidth: 120`** (circle 210 vs 264, diamond 234 vs 293, double circle 202 vs 232), which is the uniform-sizing outcome a31ecb7d8 was after — now with the shapes intact. Short labels are unchanged across all three states, bar two small corrections where the text previously touched the outline (double circle 152 → 178, Delay 152 → 157).

## Tests

New `labelContainment.spec.ts`: all four corners of the label box must lie inside the outline, across `neo`/`classic` × three label aspect ratios (short-and-wide, square-ish, and the tall column a 120px wrap produces) — 24 cases. Corners rather than sides, because the corner is exactly what a width-only calculation misses.

It earned its place immediately: it caught that my first Delay fix applied the cap clearance once where a centred label needs it on **both** sides.

`stadium.spec.ts` and `util.spec.ts` are updated for the removed option. Full `packages/mermaid` suite: 5887 passing. `tsc` clean, generated types in sync.

## For the reviewer

- Screenshot baselines for `e2e/diagrams/flowchart/selected-shape-wrapping.mmd` and `stadium-tall-labels.mmd` will change.
- `e2e/platform/dev-diagrams/tmp-v12.0.0-faulty-diags/shape-wrapping-comparison.mmd` uses `<br/>` in every label, so it cannot show this class of bug. Worth switching to unbroken labels.
- I am auditing the remaining shapes for the same defect separately; anything found will come as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
