### PR TITLE
fix: handle fractional HTML label widths (#7794)

### DIFF
--- a/.changeset/fractional-html-label-wrapping.md
+++ b/.changeset/fractional-html-label-wrapping.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: wrap HTML labels when browser measurements differ from the configured width by a fractional pixel.

--- a/packages/mermaid/src/rendering-util/createText.spec.ts
+++ b/packages/mermaid/src/rendering-util/createText.spec.ts
@@ -99,4 +99,26 @@ describe('createText', () => {
       expect(output.textContent).toEqual(expected);
     }
   );
+
+  it('wraps HTML labels when max-width is rounded to a fractional pixel', async () => {
+    const wrappingWidth = 200;
+    const fractionalRoundingError = 0.5;
+    const getBoundingClientRect = vi
+      .spyOn(HTMLDivElement.prototype, 'getBoundingClientRect')
+      .mockReturnValue({ width: wrappingWidth - fractionalRoundingError } as DOMRect);
+
+    try {
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      const svgGroup = svg.appendChild(document.createElementNS('http://www.w3.org/2000/svg', 'g'));
+      const output = await createText(select(svgGroup), 'A long label', {
+        useHtmlLabels: true,
+        markdown: false,
+        width: wrappingWidth,
+      });
+
+      expect(output.querySelector('div')?.style.whiteSpace).toBe('break-spaces');
+    } finally {
+      getBoundingClientRect.mockRestore();
+    }
+  });
 });

--- a/packages/mermaid/src/rendering-util/createText.ts
+++ b/packages/mermaid/src/rendering-util/createText.ts
@@ -30,6 +30,7 @@ function applyStyle<T extends Element>(
 
 // We assume that nobody will want to create labels larger than 16384 pixels wide
 const maxSafeSizeForWidth = 16384;
+const maxRoundingError = 1;
 
 async function addHtmlSpan(
   element: D3Selection<SVGGElement>,
@@ -70,7 +71,7 @@ async function addHtmlSpan(
   }
 
   const bbox = await fastdom.measure(() => div.node()!.getBoundingClientRect());
-  if (bbox.width === width) {
+  if (bbox.width >= width - maxRoundingError) {
     div.style('display', 'table');
     div.style('white-space', 'break-spaces');
     div.style('width', width + 'px');


### PR DESCRIPTION
## :bookmark_tabs: Summary

- Treat HTML label widths within one pixel of the configured maximum as clamped.
- Preserve wrapping when Chrome reports fractional layout measurements.
- Add a regression test for the fractional-width case.

Resolves #7794

## :straight_ruler: Design Decisions

The wrapping decision remains in the shared HTML-label renderer. A named one-pixel tolerance replaces exact floating-point equality, matching browser sub-pixel rounding while leaving clearly shorter labels unchanged.

### :clipboard: Tasks

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: documentation is not required for this bug fix.
- [x] :butterfly: added a patch changeset prefixed with `fix:`.

## Test verification (RED → GREEN)

- Baseline full local suite: 6,411 passed, 16 skipped, 2 todo.
- Patched full local suite: 6,412 passed, 16 skipped, 2 todo.
- Regression proof: the new unit test fails with `nowrap` when the production fix is reverted and passes with `break-spaces` restored.
- Browser proof: a real Chromium run reproduces the failure with a 199.5px clamped measurement and passes with the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Review

### What's working well

- 🎉 The fix addresses the fractional-width Chrome case with a focused one-pixel tolerance.
- 🎉 The regression test covers a measured width of `199.5` against a configured width of `200`.
- 🎉 The test restores the DOM measurement mock in a `finally` block.
- 🎉 The patch includes an appropriate `fix:` changeset.

### Security

No XSS or injection issues identified.

### Things to address

No blocking or important issues found.

### Verdict

**APPROVE**

Checklist:
- [x] Praise included
- [x] No duplicate findings
- [x] Severity tally: 0 blocking / 0 important / 0 nit / 0 suggestions / 4 praise
- [x] Verdict matches findings
- [x] No inline comments used

<!-- end of auto-generated comment: release notes by coderabbit.ai -->