### PR TITLE
fix(ci): shard scoped e2e runs to avoid snapshot timeouts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,9 +63,9 @@ env:
   # per-screenshot runs then both diff cleanly against it (each marked --subset).
   ARGOS_UPLOAD_BOTH: >-
     ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
-  # Shard JSON for a full-suite run vs a scoped (single-container) run.
+  # Scoped runs include the global mmd snapshots, so keep them sharded too.
   E2E_FULL_MATRIX: '[1,2,3,4,5,6,7,8]'
-  E2E_SCOPED_MATRIX: '[1]'
+  E2E_SCOPED_MATRIX: '[1,2]'
 
 jobs:
   cache:


### PR DESCRIPTION
## :bookmark_tabs: Summary

Scoped diagram changes still include the global Markdown snapshot runner. With a single CI shard, that work is close to the 30-minute job limit; #8235 documents three timed-out runs on unrelated contributions.

Run scoped E2E jobs on two shards and update the nearby comment to explain why. This distributes the snapshot workload using the workflow's existing sharding support.

Resolves #8235

## :straight_ruler: Design Decisions

- Use two scoped shards to reduce the per-runner test workload while keeping the scoped matrix smaller than the eight-shard full suite.
- The Playwright command already derives its denominator from `strategy.job-total`, and `fullyParallel: true` allows the single snapshot spec to be split between workers.
- Screenshot and coverage artifacts already have shard-specific names. Argos downloads `screenshots-*` with `merge-multiple: true` and waits for the complete E2E matrix to succeed.
- Keep the complete selected test set and the existing 30-minute limit.

### Validation

- Executed the workflow's actual scope-detection Bash and `scripts/e2e-diagram-scope.mjs` in temporary Git repositories. Before the change, five scoped entry paths selected one shard; afterwards, all 11 checked scenarios passed: diagram changes, fixture-only changes, diagram plus docs, merge queue, manual scoped/full runs, shared-renderer changes, workflow changes, the kill switch, direct develop pushes, and docs-only skipping.
- Used Playwright **1.62.1** in `--list` mode on a registration-only suite built from the current **1,228** Markdown fixture paths, preserving the snapshot runner's nested suites and parallel setting. The two shards contain **614 + 614** tests, with **zero overlap and zero omissions**. This verifies scheduling, not diagram rendering.
- Checked YAML parsing, the dynamic shard total, artifact naming/collection, and the success gate. `git diff --check` passed.
- **Not run locally:** the full Mermaid build and visual E2E suite. Dependency downloads are restricted in this environment. CI and a scoped run should confirm actual wall-clock improvement before merging.

### :clipboard: Tasks

- [x] Read the contribution guidelines.
- [x] Validated the changed CI workflow and shard partitioning.
- [x] Updated the inline workflow documentation.
- [x] No package changeset needed: CI configuration only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated scoped E2E runs to use two shards instead of one.
- Distributed the global `mmd-snapshots` workload while retaining the full selected test set and 30-minute job limit.
- Documented the sharding rationale in `.github/workflows/e2e.yml`.
- Preserved existing sharding, artifact naming, Argos collection, and success-gate behavior.

## Validation

- Verified scope detection, shard partitioning, YAML parsing, artifact handling, and configuration.
- Full build and visual E2E execution were not run locally due to dependency restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->