### PR TITLE
fix(flowchart): keep ELK edge labels centered

### DIFF
--- a/.changeset/elk-edge-label-margin.md
+++ b/.changeset/elk-edge-label-margin.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: keep ELK edge labels centered when flowchart subgraph title margins are configured

--- a/docs/config/setup/mermaid/functions/clearLayoutRenderState.md
+++ b/docs/config/setup/mermaid/functions/clearLayoutRenderState.md
@@ -12,7 +12,7 @@
 
 > **clearLayoutRenderState**(): `void`
 
-Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:207](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L207)
+Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:208](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L208)
 
 ## Returns
 

--- a/docs/config/setup/mermaid/functions/createCommonLayoutRenderer.md
+++ b/docs/config/setup/mermaid/functions/createCommonLayoutRenderer.md
@@ -12,7 +12,7 @@
 
 > **createCommonLayoutRenderer**<`CoreResult`, `PreparedLayout`, `MeasureResult`>(`__namedParameters`): (`data4Layout`, `svg`, `helpers?`, `options?`) => `Promise`<`void`>
 
-Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:108](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L108)
+Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:109](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L109)
 
 ## Type Parameters
 

--- a/docs/config/setup/mermaid/functions/defaultMeasureLayout.md
+++ b/docs/config/setup/mermaid/functions/defaultMeasureLayout.md
@@ -12,7 +12,7 @@
 
 > **defaultMeasureLayout**(`data4Layout`, `__namedParameters`, `options?`): `Promise`<{ `graph`: `Graph`; `groups`: { `clusters`: `D3Selection`<`SVGGElement`>; `edgeLabels`: `D3Selection`<`SVGGElement`>; `edgePaths`: `D3Selection`<`SVGGElement`>; `nodes`: `D3Selection`<`SVGGElement`>; `rootGroups`: `D3Selection`<`SVGGElement`>; }; `nodeElements`: `Map`<`string`, `D3Selection`<`SVGElement` | `SVGGElement`>>; }>
 
-Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:214](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L214)
+Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:215](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L215)
 
 ## Parameters
 

--- a/docs/config/setup/mermaid/functions/paintLayoutData.md
+++ b/docs/config/setup/mermaid/functions/paintLayoutData.md
@@ -12,7 +12,7 @@
 
 > **paintLayoutData**(`data4Layout`, `context`, `options`): `Promise`<`void`>
 
-Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:222](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L222)
+Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:223](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L223)
 
 ## Parameters
 

--- a/docs/config/setup/mermaid/interfaces/CommonLayoutPaintOptions.md
+++ b/docs/config/setup/mermaid/interfaces/CommonLayoutPaintOptions.md
@@ -22,11 +22,19 @@ Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.
 
 ---
 
+### edgeLabelOffsetY?
+
+> `optional` **edgeLabelOffsetY**: `number`
+
+Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:57](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L57)
+
+---
+
 ### getEdgeNode()?
 
 > `optional` **getEdgeNode**: (`id`, `edge`, `context`) => `object` | `Node` | `undefined`
 
-Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:61](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L61)
+Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:62](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L62)
 
 #### Parameters
 
@@ -52,7 +60,7 @@ Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.
 
 > `optional` **getNodes**: (`data4Layout`, `context`) => `Iterable`<`Node`>
 
-Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:57](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L57)
+Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:58](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L58)
 
 #### Parameters
 
@@ -74,7 +82,7 @@ Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.
 
 > `optional` **isCluster**: (`node`, `context`) => `boolean`
 
-Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:70](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L70)
+Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:71](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L71)
 
 #### Parameters
 
@@ -96,7 +104,7 @@ Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.
 
 > `optional` **skipEdge**: (`edge`) => `boolean`
 
-Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:74](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L74)
+Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:75](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L75)
 
 #### Parameters
 
@@ -114,7 +122,7 @@ Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.
 
 > `optional` **skipIntersect**: `boolean` | (`edge`) => `boolean`
 
-Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:75](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L75)
+Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:76](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L76)
 
 ---
 
@@ -122,7 +130,7 @@ Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.
 
 > `optional` **skipNode**: (`node`, `context`) => `boolean`
 
-Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:66](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L66)
+Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:67](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L67)
 
 #### Parameters
 

--- a/docs/config/setup/mermaid/interfaces/CommonLayoutRendererDefinition.md
+++ b/docs/config/setup/mermaid/interfaces/CommonLayoutRendererDefinition.md
@@ -10,7 +10,7 @@
 
 # Interface: CommonLayoutRendererDefinition\<CoreResult, PreparedLayout, MeasureResult>
 
-Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:78](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L78)
+Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:79](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L79)
 
 ## Type Parameters
 
@@ -32,7 +32,7 @@ Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.
 
 > `optional` **afterPaint**: (`data4Layout`, `context`, `coreResult`) => `void` | `Promise`<`void`>
 
-Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:100](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L100)
+Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:101](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L101)
 
 #### Parameters
 
@@ -58,7 +58,7 @@ Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.
 
 > `optional` **measureLayout**: (`data4Layout`, `context`) => `Promise`<`MeasureResult`>
 
-Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:87](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L87)
+Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:88](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L88)
 
 #### Parameters
 
@@ -80,7 +80,7 @@ Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.
 
 > `optional` **paintLayout**: (`data4Layout`, `context`, `coreResult`) => `void` | `Promise`<`void`>
 
-Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:95](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L95)
+Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:96](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L96)
 
 #### Parameters
 
@@ -106,7 +106,7 @@ Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.
 
 > `optional` **paintOptions**: [`CommonLayoutPaintOptions`](CommonLayoutPaintOptions.md)
 
-Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:105](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L105)
+Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:106](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L106)
 
 ---
 
@@ -114,7 +114,7 @@ Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.
 
 > `optional` **prepareLayout**: (`data4Layout`, `context`) => `PreparedLayout` | `Promise`<`PreparedLayout`>
 
-Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:83](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L83)
+Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:84](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L84)
 
 #### Parameters
 
@@ -136,7 +136,7 @@ Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.
 
 > **runLayoutCore**: (`data4Layout`, `context`) => `CoreResult` | `Promise`<`CoreResult`>
 
-Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:91](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L91)
+Defined in: [packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts:92](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts#L92)
 
 #### Parameters
 

--- a/e2e/rendering/flowchart/flowchart.spec.js
+++ b/e2e/rendering/flowchart/flowchart.spec.js
@@ -71,4 +71,35 @@ test.describe('Graph', () => {
     await expect(page.locator('path[id$="-L_A_B_0"]')).toHaveClass(/edge-animation-slow/);
     await expect(page.locator('path[id$="-L_B_D_0"]')).toHaveClass(/edge-animation-fast/);
   });
+
+  test('keeps ELK edge labels centered when subgraph title margins are set', async ({
+    page,
+  }, testInfo) => {
+    await renderGraph(
+      page,
+      testInfo,
+      `flowchart LR
+      subgraph subgraph1
+        direction LR
+        n1 -- my --- n2
+      end`,
+      {
+        layout: 'elk',
+        flowchart: {
+          htmlLabels: false,
+          subGraphTitleMargin: { top: 10, bottom: 10 },
+        },
+        screenshot: false,
+      }
+    );
+
+    const edgeBox = await page.locator('.edgePaths path').boundingBox();
+    const labelBox = await page.locator('.edgeLabel').boundingBox();
+    expect(edgeBox).not.toBeNull();
+    expect(labelBox).not.toBeNull();
+    const labelCenterTolerance = 1;
+    const edgeCenterY = edgeBox.y + edgeBox.height / 2;
+    const labelCenterY = labelBox.y + labelBox.height / 2;
+    expect(Math.abs(labelCenterY - edgeCenterY)).toBeLessThanOrEqual(labelCenterTolerance);
+  });
 });

--- a/packages/mermaid/src/rendering-util/layout-algorithms/common/index.spec.ts
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/common/index.spec.ts
@@ -437,6 +437,17 @@ describe('paintLayoutData', () => {
     expect(mocks.labelElement.attr).toHaveBeenCalledWith('transform', 'translate(10, 22)');
   });
 
+  it('uses a layout-specific edge label offset when provided', async () => {
+    const { paintLayoutData } = await import('./index.js');
+    const labelledEdge = edge('labelled', { label: 'Yes', x: 0, y: 0 } as Partial<Edge>);
+    const data = layout({ edges: [labelledEdge] });
+    const measured = measure();
+
+    await paintLayoutData(data, { measure: measured } as never, { edgeLabelOffsetY: 0 });
+
+    expect(mocks.labelElement.attr).toHaveBeenCalledWith('transform', 'translate(10, 20)');
+  });
+
   it('inserts and positions terminal labels without a center edge label', async () => {
     const { paintLayoutData } = await import('./index.js');
     const terminalEdge = edge('terminal', {

--- a/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/common/index.ts
@@ -54,6 +54,7 @@ export interface CommonLayoutPaintContext<
 
 export interface CommonLayoutPaintOptions {
   clusterDb?: ClusterDb;
+  edgeLabelOffsetY?: number;
   getNodes?: (
     data4Layout: LayoutData,
     context: CommonLayoutPaintContext<unknown, CommonLayoutMeasure>
@@ -306,7 +307,7 @@ async function paintLayoutEdge(
     if (!edgeLabels.has(edge.id)) {
       await insertEdgeLabel(groups.edgeLabels, edge);
     }
-    positionRenderedEdgeLabel(edge, paths);
+    positionRenderedEdgeLabel(edge, paths, options.edgeLabelOffsetY);
   }
 }
 
@@ -326,12 +327,17 @@ function shouldSkipIntersect(edge: Edge, options: CommonLayoutPaintOptions): boo
     : (options.skipIntersect ?? false);
 }
 
-function positionRenderedEdgeLabel(edge: RenderedEdge, paths?: EdgeRenderPaths): void {
+function positionRenderedEdgeLabel(
+  edge: RenderedEdge,
+  paths?: EdgeRenderPaths,
+  configuredOffsetY?: number
+): void {
   const path = paths?.updatedPath ?? paths?.originalPath;
   const siteConfig = getConfig();
   const { subGraphTitleTotalMargin } = getSubGraphTitleMargins({
     flowchart: siteConfig.flowchart ?? {},
   });
+  const labelOffsetY = configuredOffsetY ?? subGraphTitleTotalMargin / 2;
   if (edge.label) {
     const el = edgeLabels.get(edge.id);
     let x = edge.x;
@@ -354,7 +360,7 @@ function positionRenderedEdgeLabel(edge: RenderedEdge, paths?: EdgeRenderPaths):
         y = pos.y;
       }
     }
-    el.attr('transform', `translate(${x}, ${y! + subGraphTitleTotalMargin / 2})`);
+    el.attr('transform', `translate(${x}, ${y! + labelOffsetY})`);
   }
 
   if (edge?.startLabelLeft) {

--- a/packages/mermaid/src/rendering-util/layout-algorithms/elk/render.ts
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/elk/render.ts
@@ -678,6 +678,8 @@ export const render = createCommonLayoutRenderer<ElkLayoutResult, ElkPreparedLay
     defaultMeasureLayout(data4Layout, context, { unwrapGroupLabels: true }),
   runLayoutCore: runElkLayoutCore,
   paintOptions: {
+    // ELK returns edge-label coordinates in the same final space as its routed edges.
+    edgeLabelOffsetY: 0,
     skipIntersect: true,
   },
 });


### PR DESCRIPTION
## :bookmark_tabs: Summary

Keep ELK edge labels centered when `flowchart.subGraphTitleMargin` is configured. The common renderer now accepts a layout-specific vertical label offset, and ELK explicitly uses zero because its label coordinates already share the routed edge's final coordinate space.

Resolves #7341

## :straight_ruler: Design Decisions

The common painter preserves its existing title-margin offset by default, so Dagre and swimlanes are unchanged. Only ELK opts out. This keeps the fix at the shared rendering boundary without changing ELK's layout data or duplicating label positioning logic.

## Test verification (RED → GREEN)

- RED on unmodified `develop`: the issue diagram rendered in Chromium with edge center `y=88.5`, label center `y=98`, a `9.5px` error.
- GREEN: the same Chromium assertion passes with a maximum `1px` tolerance.
- Mutation check: reverting the ELK offset reproduced the same `9.5px` RED failure.
- Full local suite on Node 24.16.0: lint, build/install, 313 Vitest files, TypeScript package checks, config generation verification, and circular-dependency checks passed. Tests improved from 6,411 baseline passes to 6,412 patched passes with the same 16 skips and 2 todos.
- Browser replay improved from 3/3 baseline tests to 4/4 patched tests. Changed executable production lines are 100% covered (8/8).
- `docs:verify` reaches the same pre-existing missing generated parser AST error on both untouched baseline and patched trees; no failure identity changed.
- Two independent Codex-high reviews approved with no actionable findings.

### :clipboard: Tasks

- [x] :book: have read the contribution guidelines.
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: documentation is not needed for this bug fix.
- [x] :butterfly: added a patch changeset for `mermaid`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Review Summary

## What's working well

- 🎉 The fix directly addresses issue `#7341`.
- 🎉 The shared renderer supports a layout-specific `edgeLabelOffsetY`.
- 🎉 ELK sets the offset to `0`, while other layouts retain the existing behavior.
- 🎉 Unit and end-to-end tests cover the regression.
- 🎉 A patch changeset is included.

## Security

No XSS or injection issues identified.

## Things to address

No blocking or important issues found.

## Verdict

APPROVE

Severity tally: 0 blocking / 0 important / 0 nit / 0 suggestion / 5 praise
<!-- end of auto-generated comment: release notes by coderabbit.ai -->