### PR TITLE
fix(tests): accept a released version in the appearance docs marker

### DIFF
--- a/packages/mermaid/src/defaultAppearanceDocs.spec.ts
+++ b/packages/mermaid/src/defaultAppearanceDocs.spec.ts
@@ -68,7 +68,12 @@ describe('per-diagram appearance documentation', () => {
     expect(examples).toHaveLength(2);
 
     // `contributing.md` asks for a version marker on newly documented behaviour.
-    expect(readPage(page)).toMatch(/^## Default theme[^\n]* \(v<MERMAID_RELEASE_VERSION>\+\)$/m);
+    // On `develop` that marker is still the placeholder; the changesets release
+    // (`docs:release-version`) rewrites it to the version being published, so the
+    // released docs carry a concrete number instead. Both are correct.
+    expect(readPage(page)).toMatch(
+      /^## Default theme[^\n]* \(v(?:<MERMAID_RELEASE_VERSION>|\d+\.\d+\.\d+)\+\)$/m
+    );
 
     const [withDefaults, pinnedBack] = examples;
     // The pair has to be the same diagram, or the comparison teaches nothing.


### PR DESCRIPTION
Unblocks the unit-test job on #8237 (Version Packages).

## The problem

`defaultAppearanceDocs.spec.ts` asserted on the literal placeholder string:

```ts
expect(readPage(page)).toMatch(/^## Default theme[^\n]* \(v<MERMAID_RELEASE_VERSION>\+\)$/m);
```

But the release flow is designed to remove that placeholder. `changeset:version` runs
`docs:release-version` (`scripts/update-release-version.mts`), which rewrites
`<MERMAID_RELEASE_VERSION>` to the version being published **in the docs sources** and commits
the result. On `changeset-release/master` all ten pages the spec covers now read `(v12.0.0+)`,
so all ten cases fail.

Reverting the docs is not an option either — `build-docs.yml` runs `docs:verify-version`, which
fails the build if any placeholder survives into a release.

This is not confined to the release branch. The substituted docs are part of #8237, so once it
merges, `master` carries `(v12.0.0+)` and this spec fails on `master` permanently.

## The fix

Accept either the placeholder or a concrete version. A heading with no version marker at all is
still rejected, so the `contributing.md` rule the assertion exists for is still enforced.

## Verification

| Docs state | Before | After |
| --- | --- | --- |
| `v12.0.0+` (the #8237 state) | 10 failed | 10 passed |
| `<MERMAID_RELEASE_VERSION>` (the `master` state) | 10 passed | 10 passed |
| version marker removed entirely | — | fails, as intended |

## Notes

- No changeset — test-only, nothing user-facing, and a changeset here would feed noise straight
  into the release PR this is meant to unblock.
- Targeting `master` rather than `develop` because the failure only exists on `master`; a
  develop-based PR would not unblock #8237. `develop` is currently fully contained in `master`,
  so the next back-merge carries this across with no conflict.