### PR TITLE
docs: improve font documentation

### DIFF
--- a/docs/config/usage.md
+++ b/docs/config/usage.md
@@ -78,10 +78,45 @@ Example:
 
 **Following these directions, mermaid starts at page load and (when the page has loaded) it will locate the graph definitions inside the `pre` tags with `class="mermaid"` and return diagrams in SVG form, following given definitions.**
 
+### Fonts
+
+Mermaid currently uses a few different default `fontFamily` settings, based on
+the diagram type and the given theme.
+
+The current preferred fonts are:
+
+- Recursive Variable (open-source font, since v11.15.0)
+- Open Sans (open-source font)
+- Arial ([Restrictive License](https://en.wikipedia.org/wiki/TrueType_core_fonts_for_the_Web))
+- Trebuchet MS ([Restrictive License](https://en.wikipedia.org/wiki/TrueType_core_fonts_for_the_Web))
+
+For a consistent look, we recommend you supply these as web fonts, when possible,
+e.g. like:
+
+```html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/open-sans@5/400.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/open-sans@5/400-italic.css" />
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/@fontsource-variable/recursive@5/index.css"
+/>
+```
+
 ## Simple full example:
 
 ```html
 <!doctype html>
+<head>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/open-sans@5/400.css" />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/@fontsource/open-sans@5/400-italic.css"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/@fontsource-variable/recursive@5/index.css"
+  />
+</head>
 <html lang="en">
   <body>
     <pre class="mermaid">

--- a/docs/intro/getting-started.md
+++ b/docs/intro/getting-started.md
@@ -297,6 +297,48 @@ In this example, `mermaid.js` is referenced in `src` as a separate JavaScript fi
 </html>
 ```
 
+##### Custom fonts
+
+Mermaid comes with some default recommended fonts that you can setup on your
+page as well.
+
+See [Usage § Fonts](../config/usage.md#fonts) for full details.
+
+```html
+<html>
+  <head>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/open-sans@5/400.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@fontsource/open-sans@5/400-italic.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@fontsource-variable/recursive@5/index.css"
+    />
+  </head>
+  <body>
+    Here is one mermaid diagram using the `redux-dark` theme:
+
+    <pre class="mermaid">
+      ---
+      config:
+        theme: redux-dark
+      ---
+      flowchart
+            A[Client] --> B[Load Balancer]
+            B --> C[Server1]
+            B --> D[Server2]
+    </pre>
+
+    <script type="module">
+      import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+      mermaid.initialize({ startOnLoad: true });
+    </script>
+  </body>
+</html>
+```
+
 ## 5. Adding Mermaid as a dependency
 
 Below are the steps for adding Mermaid as a dependency:

--- a/packages/mermaid/src/docs/.vitepress/theme/Mermaid.vue
+++ b/packages/mermaid/src/docs/.vitepress/theme/Mermaid.vue
@@ -18,6 +18,9 @@
 import { onMounted, onUnmounted, ref } from 'vue';
 import { render } from './mermaid';
 import { buildExampleConfig } from './exampleConfig';
+import '@fontsource/open-sans/400.css';
+import '@fontsource/open-sans/400-italic.css';
+import '@fontsource-variable/recursive/index.css';
 
 const props = defineProps({
   graph: {

--- a/packages/mermaid/src/docs/config/usage.md
+++ b/packages/mermaid/src/docs/config/usage.md
@@ -72,10 +72,36 @@ Example:
 
 **Following these directions, mermaid starts at page load and (when the page has loaded) it will locate the graph definitions inside the `pre` tags with `class="mermaid"` and return diagrams in SVG form, following given definitions.**
 
+### Fonts
+
+Mermaid currently uses a few different default `fontFamily` settings, based on
+the diagram type and the given theme.
+
+The current preferred fonts are:
+
+- Recursive Variable (open-source font, since v11.15.0)
+- Open Sans (open-source font)
+- Arial ([Restrictive License](https://en.wikipedia.org/wiki/TrueType_core_fonts_for_the_Web))
+- Trebuchet MS ([Restrictive License](https://en.wikipedia.org/wiki/TrueType_core_fonts_for_the_Web))
+
+For a consistent look, we recommend you supply these as web fonts, when possible,
+e.g. like:
+
+```html
+<link rel="stylesheet" href="<CDN_URL>/@fontsource/open-sans@5/400.css" />
+<link rel="stylesheet" href="<CDN_URL>/@fontsource/open-sans@5/400-italic.css" />
+<link rel="stylesheet" href="<CDN_URL>/@fontsource-variable/recursive@5/index.css" />
+```
+
 ## Simple full example:
 
 ```html
 <!doctype html>
+<head>
+  <link rel="stylesheet" href="<CDN_URL>/@fontsource/open-sans@5/400.css" />
+  <link rel="stylesheet" href="<CDN_URL>/@fontsource/open-sans@5/400-italic.css" />
+  <link rel="stylesheet" href="<CDN_URL>/@fontsource-variable/recursive@5/index.css" />
+</head>
 <html lang="en">
   <body>
     <pre class="mermaid">

--- a/packages/mermaid/src/docs/intro/getting-started.md
+++ b/packages/mermaid/src/docs/intro/getting-started.md
@@ -290,6 +290,42 @@ In this example, `mermaid.js` is referenced in `src` as a separate JavaScript fi
 </html>
 ```
 
+##### Custom fonts
+
+Mermaid comes with some default recommended fonts that you can setup on your
+page as well.
+
+See [Usage § Fonts](../config/usage.md#fonts) for full details.
+
+```html
+<html>
+  <head>
+    <link rel="stylesheet" href="<CDN_URL>/@fontsource/open-sans@5/400.css" />
+    <link rel="stylesheet" href="<CDN_URL>/@fontsource/open-sans@5/400-italic.css" />
+    <link rel="stylesheet" href="<CDN_URL>/@fontsource-variable/recursive@5/index.css" />
+  </head>
+  <body>
+    Here is one mermaid diagram using the `redux-dark` theme:
+
+    <pre class="mermaid">
+      ---
+      config:
+        theme: redux-dark
+      ---
+      flowchart
+            A[Client] --> B[Load Balancer]
+            B --> C[Server1]
+            B --> D[Server2]
+    </pre>
+
+    <script type="module">
+      import mermaid from '<CDN_URL>/mermaid@<MERMAID_VERSION>/dist/mermaid.esm.min.mjs';
+      mermaid.initialize({ startOnLoad: true });
+    </script>
+  </body>
+</html>
+```
+
 ## 5. Adding Mermaid as a dependency
 
 Below are the steps for adding Mermaid as a dependency:

--- a/packages/mermaid/src/docs/package.json
+++ b/packages/mermaid/src/docs/package.json
@@ -16,6 +16,8 @@
     "fetch-contributors": "tsx .vitepress/scripts/fetch-contributors.ts"
   },
   "dependencies": {
+    "@fontsource/open-sans": "^5.3.0",
+    "@fontsource-variable/recursive": "^5.3.0",
     "@mdi/font": "^7.4.47",
     "@plausible-analytics/tracker": "^0.4.5",
     "@vueuse/core": "^13.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -547,6 +547,12 @@ importers:
 
   packages/mermaid/src/docs:
     dependencies:
+      '@fontsource-variable/recursive':
+        specifier: ^5.3.0
+        version: 5.3.0
+      '@fontsource/open-sans':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@mdi/font':
         specifier: ^7.4.47
         version: 7.4.47
@@ -2523,8 +2529,14 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
+  '@fontsource-variable/recursive@5.3.0':
+    resolution: {integrity: sha512-4B4/lWCVeZgdbpJdIIU1sOVO/ECjjM673ohuxvyQ6uCK41TPlGzKRNokKY84noUgGYnpwc//MW4k2KrOMY19jQ==}
+
   '@fontsource/noto-sans-sc@5.3.0':
     resolution: {integrity: sha512-HeqIlGm0+ohOKxZLuHj1qW6r6avHH0OWdKERAcSDI0RQ+MXrteuLKA+M+5eOA8rYy0MFvOR5AT0fQo2rUkye0Q==}
+
+  '@fontsource/open-sans@5.3.0':
+    resolution: {integrity: sha512-V1bdMlGNyZrJwzrdusshMOw2YR0aqYDL7kOo9dkxUEKl8dFv66A9HLckOOXl572sG/7ohhDQrCrTFGSn9LZcSw==}
 
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
@@ -12908,7 +12920,11 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
+  '@fontsource-variable/recursive@5.3.0': {}
+
   '@fontsource/noto-sans-sc@5.3.0': {}
+
+  '@fontsource/open-sans@5.3.0': {}
 
   '@gerrit0/mini-shiki@3.23.0':
     dependencies:


### PR DESCRIPTION
## :bookmark_tabs: Summary

> [!Note]
>
> This PR targets the `master` branch to update the docs site straight away.

Updates the documentation site to:

1. Mention what fonts mermaid default configs recommend, and if they're web fonts, how to set them up.
2. Installs the given fonts in the site, so that mermaid diagrams (e.g. using the default `redux` theme, or any diagrams using the `Open Sans` font), render properly.

## :straight_ruler: Design Decisions

Partially adapted from https://github.com/mermaid-js/mermaid/pull/8240, which also adds E2E tests for web fonts.

### Before

<img width="1878" height="1803" alt="image" src="https://github.com/user-attachments/assets/e8df5f61-ca2b-48bf-9c44-1d1959baf617" />

### After

Recursive font is added to mermaid diagrams:

<img width="1878" height="1803" alt="image" src="https://github.com/user-attachments/assets/6c2afad2-6e6e-4e38-b4c9-14838d450e5f" />

New documentation about fonts:

<img width="1885" height="1158" alt="image" src="https://github.com/user-attachments/assets/46e485c7-a4de-4543-ba1a-784702d63aac" />

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
  - Documentation change only 
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
  - Change to the docs site only.
