### PR TITLE
docs: add Sanctuary Reader to community integrations

### DIFF
--- a/docs/ecosystem/integrations-community.md
+++ b/docs/ecosystem/integrations-community.md
@@ -281,6 +281,7 @@ Communication tools and platforms
   - [reveal.js-mermaid-plugin](https://github.com/ludwick/reveal.js-mermaid-plugin)
 - [Reveal CK](https://github.com/jedcn/reveal-ck)
   - [reveal-ck-mermaid-plugin](https://github.com/tmtm/reveal-ck-mermaid-plugin)
+- [Sanctuary Reader: Read Markdown documents with mermaid diagrams rendered in place](https://www.sanctuaryreader.com/en/tools/markdown-mermaid-viewer/)
 - [SchemaCrawler - Generate Mermaid diagrams from your database](https://dev.to/sualeh/how-to-generate-mermaid-diagrams-for-your-database-33bn)
 - [speccharts: Turn your test suites into specification diagrams](https://github.com/arnaudrenaud/speccharts)
 - [termaid: Render Mermaid diagrams as Unicode art in the terminal](https://github.com/fasouto/termaid)

--- a/packages/mermaid/src/docs/ecosystem/integrations-community.md
+++ b/packages/mermaid/src/docs/ecosystem/integrations-community.md
@@ -276,6 +276,7 @@ Communication tools and platforms
   - [reveal.js-mermaid-plugin](https://github.com/ludwick/reveal.js-mermaid-plugin)
 - [Reveal CK](https://github.com/jedcn/reveal-ck)
   - [reveal-ck-mermaid-plugin](https://github.com/tmtm/reveal-ck-mermaid-plugin)
+- [Sanctuary Reader: Read Markdown documents with mermaid diagrams rendered in place](https://www.sanctuaryreader.com/en/tools/markdown-mermaid-viewer/)
 - [SchemaCrawler - Generate Mermaid diagrams from your database](https://dev.to/sualeh/how-to-generate-mermaid-diagrams-for-your-database-33bn)
 - [speccharts: Turn your test suites into specification diagrams](https://github.com/arnaudrenaud/speccharts)
 - [termaid: Render Mermaid diagrams as Unicode art in the terminal](https://github.com/fasouto/termaid)


### PR DESCRIPTION
Adds Sanctuary Reader to the Other section of the community integrations list.

It is a browser-based Markdown reader that renders fenced mermaid blocks inline, alongside the document they belong to, rather than in a separate diagram editor. Free, no account, and the document is parsed in the browser — nothing is uploaded.

Placed alphabetically in the Other section. Edited the source file under packages/mermaid/src/docs/ so the generated page stays in sync.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added Sanctuary Reader to the “Other” community integrations list.
- Added the same entry to the source documentation under `packages/mermaid/src/docs/`.
- Placed the entry alphabetically and kept the generated page synchronized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->