### PR TITLE
fix(rendering): apply markdown around a math span in html labels

### DIFF
--- a/.changeset/markdown-alongside-math-labels.md
+++ b/.changeset/markdown-alongside-math-labels.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: apply markdown and icon substitution to the text around a math span, so a label holding both is no longer left literal

--- a/packages/mermaid/src/rendering-util/createText.spec.ts
+++ b/packages/mermaid/src/rendering-util/createText.spec.ts
@@ -99,4 +99,37 @@ describe('createText', () => {
       expect(output.textContent).toEqual(expected);
     }
   );
+
+  it('applies markdown to the text around a math span', async () => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    const svgGroup = svg.appendChild(document.createElementNS('http://www.w3.org/2000/svg', 'g'));
+    const output = await createText(select(svgGroup), '**sym**: $$\\pi$$', {
+      useHtmlLabels: true,
+      markdown: true,
+    });
+    expect(output.innerHTML).toContain('<strong>sym</strong>');
+    expect(output.innerHTML).not.toContain('**sym**');
+  });
+
+  it('keeps every math span in a label that has more than one', async () => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    const svgGroup = svg.appendChild(document.createElementNS('http://www.w3.org/2000/svg', 'g'));
+    const output = await createText(select(svgGroup), '*a* $$\\pi$$ and $$\\alpha$$ *b*', {
+      useHtmlLabels: true,
+      markdown: true,
+    });
+    expect(output.innerHTML).toContain('<em>a</em>');
+    expect(output.innerHTML).toContain('<em>b</em>');
+    expect(output.textContent).not.toContain('$$');
+  });
+
+  it('converts an icon in a label that also has math', async () => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    const svgGroup = svg.appendChild(document.createElementNS('http://www.w3.org/2000/svg', 'g'));
+    const output = await createText(select(svgGroup), 'user fa:fa-user $$\\pi$$', {
+      useHtmlLabels: true,
+      markdown: true,
+    });
+    expect(output.innerHTML).toContain('<i class="fa fa-user"></i>');
+  });
 });

--- a/packages/mermaid/src/rendering-util/createText.ts
+++ b/packages/mermaid/src/rendering-util/createText.ts
@@ -1,7 +1,12 @@
 import { select } from 'd3';
 import type { MermaidConfig } from '../config.type.js';
 import type { SVGGroup } from '../diagram-api/types.js';
-import common, { hasKatex, renderKatexSanitized, sanitizeText } from '../diagrams/common/common.js';
+import common, {
+  hasKatex,
+  katexRegex,
+  renderKatexSanitized,
+  sanitizeText,
+} from '../diagrams/common/common.js';
 import type { D3TSpanElement, D3TextElement } from '../diagrams/common/commonTypes.js';
 import { log } from '../logger.js';
 import { profiler } from '../profiler.js';
@@ -30,6 +35,12 @@ function applyStyle<T extends Element>(
 
 // We assume that nobody will want to create labels larger than 16384 pixels wide
 const maxSafeSizeForWidth = 16384;
+
+// A math span is set aside while the label goes through the markdown pass, so that a label
+// holding both markdown and math gets neither taken literally. The delimiter follows the
+// entity placeholders in utils.ts: something the markdown lexer has no meaning for.
+const mathPlaceholder = (index: number) => `¤math${index}¤`;
+const mathPlaceholderRegex = /¤math(\d+)¤/g;
 
 async function addHtmlSpan(
   element: D3Selection<SVGGElement>,
@@ -340,15 +351,24 @@ export const createText = async (
   if (useHtmlLabels) {
     // TODO: addHtmlLabel accepts a labelStyle. Do we possibly have that?
 
-    const htmlText = markdown ? markdownToHTML(text, config) : nonMarkdownToHTML(text);
-    const decodedReplacedText = await replaceIconSubstring(decodeEntities(htmlText), config);
-
     //for Katex the text could contain escaped characters, \\relax that should be transformed to \relax
-    const inputForKatex = text.replace(/\\\\/g, '\\');
+    const mathSpans: string[] = [];
+    const textWithoutMath = text.replace(katexRegex, (span) => {
+      mathSpans.push(span.replace(/\\\\/g, '\\'));
+      return mathPlaceholder(mathSpans.length - 1);
+    });
+
+    const htmlText = markdown
+      ? markdownToHTML(textWithoutMath, config)
+      : nonMarkdownToHTML(textWithoutMath);
+    const decodedReplacedText = await replaceIconSubstring(decodeEntities(htmlText), config);
 
     const node = {
       isNode,
-      label: hasKatex(text) ? inputForKatex : decodedReplacedText,
+      label: decodedReplacedText.replace(
+        mathPlaceholderRegex,
+        (_, index: string) => mathSpans[Number(index)]
+      ),
       labelStyle: style.replace('fill:', 'color:'),
     };
     const vertexNode = await addHtmlSpan(


### PR DESCRIPTION
## :bookmark_tabs: Summary

Resolves #7046

A label that holds both markdown and math shows the markdown literally. `**sym**: $$\pi$$` renders as bold-marker asterisks followed by a rendered pi, instead of a bold "sym".

`createText` picked one path for the whole label:

```ts
label: hasKatex(text) ? inputForKatex : decodedReplacedText,
```

so the moment any `$$...$$` is present the label skips `markdownToHTML` and `replaceIconSubstring` together. Icons go the same way, `user fa:fa-user $$\pi$$` keeps a literal `fa:fa-user`. HTML entities turned out not to be affected, they reach the DOM as entities and get decoded there regardless, so the issue is narrower than markdown plus icons.

## :straight_ruler: Design Decisions

Each `$$...$$` span is set aside before the markdown pass and put back after it. Running `markdownToHTML` over the whole label is not an option, `_` and `*` are ordinary characters inside LaTeX and would be eaten. The placeholder is a `¤math<n>¤` sentinel, same idea as the `ﬂ°`-style entity placeholders already in `utils.ts`.

The `\\` to `\` unescape that fed KaTeX now applies to the math spans rather than the whole label, which is what its comment always described.

One consequence worth flagging. A label that is nothing but math now gets the same `<p>` wrapper that every other html label already has, since it goes through `markdownToHTML`/`nonMarkdownToHTML` like the rest. `styles.ts` has `& p { margin: 0 }` globally, so I expect no visual difference, but I could not run the cypress image snapshots locally and did not want to claim otherwise. Worth a look at those in CI.

Three tests in `createText.spec.ts` for markdown around math, several math spans in one label, and an icon alongside math. All three fail on `develop` and pass with the change.

### :clipboard: Tasks

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Not applicable, no new feature or option.
- [x] :butterfly: changeset added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Review Summary

🎉 [praise] The fix preserves Markdown and Font Awesome processing around math spans.

🎉 [praise] Tests cover Markdown around math, multiple math spans, icons with math, and flat math-label layout. The changeset documents the patch release.

## Review Status

No current review findings or security-review results were supplied. Test execution results were not supplied. Severity counts and verdict are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->