### PR TITLE
fix(sequence): allow hyphens in actor names with config objects

### DIFF
--- a/.changeset/hyphenated-actor-config.md
+++ b/.changeset/hyphenated-actor-config.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix(sequence): allow hyphenated actor and participant names when a config object is attached

--- a/packages/mermaid/src/diagrams/sequence/parser/sequenceDiagram.jison
+++ b/packages/mermaid/src/diagrams/sequence/parser/sequenceDiagram.jison
@@ -32,7 +32,7 @@
 <CONFIG>[^\}]+                                                  { return 'CONFIG_CONTENT'; }
 <CONFIG>\}(?=\s+as\s)                                           { this.popState(); this.begin('ALIAS'); return 'CONFIG_END'; }
 <CONFIG>\}                                                      { this.popState(); this.popState(); return 'CONFIG_END'; }
-<ID>[^\<->\->:\n,;@\s]+(?=\@\{)                                 { yytext = yytext.trim(); return 'ACTOR'; }
+<ID>[^<>:\n,;@\s]+(?=\@\{)                                       { yytext = yytext.trim(); return 'ACTOR'; }
 <ID>[^<>:\n,;@\s]+(?=\s+as\s)                                   { yytext = yytext.trim(); this.begin('ALIAS'); return 'ACTOR'; }
 <ID>[^<>:\n,;@]+(?=\s*[\n;#]|$)                                 { yytext = yytext.trim(); this.popState(); return 'ACTOR'; }
 <ID>[^<>:\n,;@]*\<[^\n]*                                        { this.popState(); return 'INVALID'; }

--- a/packages/mermaid/src/diagrams/sequence/sequenceDiagram.spec.js
+++ b/packages/mermaid/src/diagrams/sequence/sequenceDiagram.spec.js
@@ -2507,6 +2507,30 @@ Bob->>Alice:Got it!
       expect(messages[4].message).toBe('hello');
     });
 
+    it('should parse hyphenated names with an attached config object', async () => {
+      const diagram = await Diagram.fromText(`
+    sequenceDiagram
+        actor lead-actor@{ "type" : "database" }
+        participant order-svc@{ "type" : "queue" }
+        actor kebab-case@{ "type" : "control" } as Kebab Cased
+        participant web-ui@{ "type" : "entity" } as Web UI
+    `);
+
+      const actors = diagram.db.getActors();
+
+      expect(actors.get('lead-actor').type).toBe('database');
+      expect(actors.get('lead-actor').description).toBe('lead-actor');
+
+      expect(actors.get('order-svc').type).toBe('queue');
+      expect(actors.get('order-svc').description).toBe('order-svc');
+
+      expect(actors.get('kebab-case').type).toBe('control');
+      expect(actors.get('kebab-case').description).toBe('Kebab Cased');
+
+      expect(actors.get('web-ui').type).toBe('entity');
+      expect(actors.get('web-ui').description).toBe('Web UI');
+    });
+
     it('should fail for malformed JSON in participant definition', async () => {
       const invalidDiagram = `
     sequenceDiagram

--- a/packages/mermaid/src/diagrams/sequence/sequenceDiagram.spec.js
+++ b/packages/mermaid/src/diagrams/sequence/sequenceDiagram.spec.js
@@ -2512,7 +2512,7 @@ Bob->>Alice:Got it!
     sequenceDiagram
         actor lead-actor@{ "type" : "database" }
         participant order-svc@{ "type" : "queue" }
-        actor kebab-case@{ "type" : "control" } as Kebab Cased
+        actor kebab-case@{ "type" : "control" } as Kebab-Cased
         participant web-ui@{ "type" : "entity" } as Web UI
     `);
 
@@ -2525,7 +2525,7 @@ Bob->>Alice:Got it!
       expect(actors.get('order-svc').description).toBe('order-svc');
 
       expect(actors.get('kebab-case').type).toBe('control');
-      expect(actors.get('kebab-case').description).toBe('Kebab Cased');
+      expect(actors.get('kebab-case').description).toBe('Kebab-Cased');
 
       expect(actors.get('web-ui').type).toBe('entity');
       expect(actors.get('web-ui').description).toBe('Web UI');


### PR DESCRIPTION
## :bookmark_tabs: Summary

The lexer rule that matches an actor/participant right before an attached config object used a narrower character class than the plain and alias rules, so any name containing a hyphen failed with `Expecting 'ACTOR', got 'INVALID'` even though the same name parsed fine without the `@{...}` object:

```mermaid
sequenceDiagram
    actor kebab-case5@{ "type" : "database" }
    actor kebab-case6@{ "type" : "database" } as Kebab-Cased6
    participant kebab-case7@{ "type" : "database" }
    participant kebab-case8@{ "type" : "database" } as Kebab-Cased8
```

All four lines now parse. The token's character class is aligned with the alias rule (`[^<>:\n,;@\s]`), so the three ACTOR forms accept the same names.

Resolves #8085

## :straight_ruler: Design Decisions

The lookahead `(?=@{)` already scopes this rule to the config-object case, so nothing else changes: plain and alias matching already allow hyphens, and message parsing keeps its own arrow-aware rules. The grammar already supports `participant`/`actor` with a config object, with and without an alias, so only the token definition needed to change.

### :clipboard: Tasks

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. (n/a for a parser bug fix, no new syntax)
- [x] :butterfly: changeset added (`fix:`, patch)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## File classification

| Tier | Count | Files |
|---|---:|---|
| Tier 1 | 0 | — |
| Tier 2 | 2 | `packages/mermaid/src/diagrams/sequence/parser/sequenceDiagram.jison`, `packages/mermaid/src/diagrams/sequence/sequenceDiagram.spec.js` |
| Tier 3 | 1 | `.changeset/hyphenated-actor-config.md` |

## What's working well

- 🎉 [praise] The lexer supports hyphenated actor and participant names with attached configuration objects.
- 🎉 [praise] The test covers actor and participant declarations with and without aliases.
- 🎉 [praise] The changeset documents the patch release.
- 🎉 [praise] The supplied local test results show all reported sequence test suites passed.

## Security

No XSS or injection issues identified in the changed parser and test code.

## Things to address

No blocking, important, nit, or suggestion findings.

## Review verdict

**APPROVE**

### Self-check

- [x] Praise included
- [x] No duplicate findings
- [x] Severity tally: 0 blocking / 0 important / 0 nit / 0 suggestion / 4 praise
- [x] Test coverage matches the parser change
- [x] No public API or generated-file changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->