### PR TITLE
feat(packet): support descending bit numbering

### DIFF
--- a/.changeset/packet-bit-order.md
+++ b/.changeset/packet-bit-order.md
@@ -1,0 +1,8 @@
+---
+'mermaid': minor
+---
+
+feat: add a `bitOrder` option to packet diagrams. It defaults to `ascending`, which is the current
+behaviour, and `descending` mirrors every row so it reads from that row's highest bit down to its
+lowest. Fields are still declared lowest bit first and keep their width, so switching a diagram
+between the two conventions only means changing `bitOrder`.

--- a/docs/syntax/packet.md
+++ b/docs/syntax/packet.md
@@ -110,6 +110,44 @@ title UDP Packet
 - **Ranges**: Each line after the title represents a different field in the packet. The range (e.g., `0-15`) indicates the bit positions in the packet.
 - **Field Description**: A brief description of what the field represents, enclosed in quotes.
 
+### Bit Numbering Order (v\<MERMAID_RELEASE_VERSION>+)
+
+Rows are numbered from their lowest bit on the left up to their highest bit on the right, which suits network packets. Hardware registers are conventionally drawn the other way round, with the most significant bit on the left and bit 0 on the right. Set `bitOrder: descending` to mirror every row:
+
+```mermaid-example
+---
+config:
+  packet:
+    showBits: true
+    bitOrder: descending
+    bitsPerRow: 16
+---
+packet
+0-7: "DATA"
+8-11: "TYPE"
+12: "EN"
+13-15: "RESERVED"
+```
+
+```mermaid
+---
+config:
+  packet:
+    showBits: true
+    bitOrder: descending
+    bitsPerRow: 16
+---
+packet
+0-7: "DATA"
+8-11: "TYPE"
+12: "EN"
+13-15: "RESERVED"
+```
+
+Only the drawing is mirrored. Fields are still declared lowest bit first (`0-7`, never `7-0`) and keep their width, so the same diagram can be switched between the two conventions by changing `bitOrder` alone.
+
+Each row is mirrored on its own, so a packet wider than `bitsPerRow` reads as a stack of words that each run from their highest bit down to their lowest: with the default `bitsPerRow: 32`, the second row runs from bit 63 down to bit 32, not down to bit 0. A row that is not completely filled is padded on the left, keeping its lowest bit flush against the right edge.
+
 ## Configuration
 
 Please refer to the [configuration](/config/schema-docs/config-defs-packet-diagram-config.html) guide for details.

--- a/e2e/diagrams/packet/should-render-a-packet-diagram-with-descending-bit-order.mmd
+++ b/e2e/diagrams/packet/should-render-a-packet-diagram-with-descending-bit-order.mmd
@@ -1,0 +1,13 @@
+---
+title: "Status Register"
+config:
+  packet:
+    showBits: true
+    bitOrder: descending
+    bitsPerRow: 16
+---
+packet
+  0-7: "DATA"
+  8-11: "TYPE"
+  12: "EN"
+  13-15: "RESERVED"

--- a/packages/mermaid/src/config.type.ts
+++ b/packages/mermaid/src/config.type.ts
@@ -2168,6 +2168,14 @@ export interface PacketDiagramConfig extends BaseDiagramConfig {
    */
   showBits?: boolean;
   /**
+   * The direction each row is numbered in. `descending` mirrors every row so it reads from
+   * that row's highest bit on the left down to its lowest bit on the right, the convention
+   * used for hardware registers. Fields are still declared lowest bit first, and keep their
+   * width.
+   *
+   */
+  bitOrder?: 'ascending' | 'descending';
+  /**
    * The horizontal padding between the blocks in a row.
    */
   paddingX?: number;

--- a/packages/mermaid/src/diagrams/packet/renderer.spec.ts
+++ b/packages/mermaid/src/diagrams/packet/renderer.spec.ts
@@ -1,0 +1,240 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { Diagram } from '../../Diagram.js';
+import * as configApi from '../../config.js';
+import type { PacketDiagramConfig } from '../../config.type.js';
+import { PacketDB } from './db.js';
+import { parser } from './parser.js';
+import { renderer } from './renderer.js';
+
+const diagramId = 'packet-diagram';
+
+/** Where a bit number sits on its block, read back from the rendered text anchor. */
+type BitPosition = 'left' | 'center' | 'right';
+
+interface RenderedBit {
+  position: BitPosition;
+  text: string;
+  x: number;
+}
+
+interface RenderedBlock {
+  label: string;
+  x: number;
+  width: number;
+  bits: RenderedBit[];
+}
+
+const bitPositions: Record<string, BitPosition> = {
+  start: 'left',
+  middle: 'center',
+  end: 'right',
+};
+
+const classesOf = (element: Element) => element.getAttribute('class')?.split(' ') ?? [];
+const numberAttr = (element: Element, name: string) => Number(element.getAttribute(name));
+
+/**
+ * Reads the rendered SVG back as one entry per row, each listing that row's blocks left to right.
+ *
+ * The renderer appends a block's rectangle, then its label, then its bit numbers, so the elements
+ * of a row can be folded back into blocks by walking them in document order.
+ */
+const readRows = (): RenderedBlock[][] =>
+  [...document.querySelectorAll(`#${diagramId} > g`)].map((row) => {
+    const blocks: RenderedBlock[] = [];
+    for (const element of row.children) {
+      const classes = classesOf(element);
+      if (classes.includes('packetBlock')) {
+        blocks.push({
+          label: '',
+          x: numberAttr(element, 'x'),
+          width: numberAttr(element, 'width'),
+          bits: [],
+        });
+      } else if (classes.includes('packetLabel')) {
+        blocks.at(-1)!.label = element.textContent ?? '';
+      } else if (classes.includes('packetByte')) {
+        blocks.at(-1)!.bits.push({
+          position: bitPositions[element.getAttribute('text-anchor') ?? ''],
+          text: element.textContent ?? '',
+          x: numberAttr(element, 'x'),
+        });
+      }
+    }
+    return blocks.sort((a, b) => a.x - b.x);
+  });
+
+/** Every bit number of a row, in the order a reader meets them going left to right. */
+const bitNumbersLeftToRight = (row: RenderedBlock[]) =>
+  row.flatMap(({ bits }) => bits.map(({ text }) => Number(text)));
+
+/** Each field's drawn width, keyed by label, which `bitOrder` must not change. */
+const widthsByLabel = (rows: RenderedBlock[][]) =>
+  Object.fromEntries(rows.flat().map(({ label, width }) => [label, width]));
+
+const renderPacket = async (text: string, packet: PacketDiagramConfig = {}) => {
+  configApi.setConfig({ packet });
+  document.body.innerHTML = `<svg id="${diagramId}"></svg>`;
+  const db = new PacketDB();
+  if (parser.parser) {
+    parser.parser.yy = db;
+  }
+  await parser.parse(text);
+  await renderer.draw(text, diagramId, 'test', { db } as unknown as Diagram);
+  return readRows();
+};
+
+const twoFields = `packet
+0-7: "foo"
+8-15: "bar"
+`;
+
+const register = `packet
+0-7: "DATA"
+8-11: "TYPE"
+12: "EN"
+13-15: "RESERVED"
+`;
+
+describe('packet renderer', () => {
+  beforeEach(() => {
+    configApi.reset();
+  });
+
+  describe('ascending bit order', () => {
+    it('lays fields out from bit 0, each numbered from its start bit', async () => {
+      const [row] = await renderPacket(twoFields);
+      expect(row).toStrictEqual([
+        {
+          label: 'foo',
+          x: 1,
+          width: 251,
+          bits: [
+            { position: 'left', text: '0', x: 1 },
+            { position: 'right', text: '7', x: 252 },
+          ],
+        },
+        {
+          label: 'bar',
+          x: 257,
+          width: 251,
+          bits: [
+            { position: 'left', text: '8', x: 257 },
+            { position: 'right', text: '15', x: 508 },
+          ],
+        },
+      ]);
+    });
+
+    it('renders an explicit ascending bitOrder exactly like the default', async () => {
+      const byDefault = await renderPacket(register, { bitsPerRow: 16 });
+      const explicit = await renderPacket(register, { bitsPerRow: 16, bitOrder: 'ascending' });
+      expect(explicit).toStrictEqual(byDefault);
+    });
+  });
+
+  describe('descending bit order', () => {
+    it('mirrors the row so it reads from the most significant bit down', async () => {
+      const [row] = await renderPacket(twoFields, { bitsPerRow: 16, bitOrder: 'descending' });
+      expect(row).toStrictEqual([
+        {
+          label: 'bar',
+          x: 1,
+          width: 251,
+          bits: [
+            { position: 'left', text: '15', x: 1 },
+            { position: 'right', text: '8', x: 252 },
+          ],
+        },
+        {
+          label: 'foo',
+          x: 257,
+          width: 251,
+          bits: [
+            { position: 'left', text: '7', x: 257 },
+            { position: 'right', text: '0', x: 508 },
+          ],
+        },
+      ]);
+    });
+
+    it('numbers a row of mixed-width fields straight down from its highest bit', async () => {
+      const [ascending] = await renderPacket(register, { bitsPerRow: 16 });
+      const [descending] = await renderPacket(register, {
+        bitsPerRow: 16,
+        bitOrder: 'descending',
+      });
+      expect(descending.map(({ label }) => label)).toStrictEqual([
+        'RESERVED',
+        'EN',
+        'TYPE',
+        'DATA',
+      ]);
+      expect(bitNumbersLeftToRight(ascending)).toStrictEqual([0, 7, 8, 11, 12, 13, 15]);
+      expect(bitNumbersLeftToRight(descending)).toStrictEqual([15, 13, 12, 11, 8, 7, 0]);
+    });
+
+    it('keeps every field the width it has in ascending order', async () => {
+      const ascending = await renderPacket(register, { bitsPerRow: 16 });
+      const descending = await renderPacket(register, { bitsPerRow: 16, bitOrder: 'descending' });
+      expect(widthsByLabel(descending)).toStrictEqual(widthsByLabel(ascending));
+    });
+
+    it('centres the number on a single-bit field, as ascending order does', async () => {
+      const [ascending] = await renderPacket(register, { bitsPerRow: 16 });
+      const [descending] = await renderPacket(register, {
+        bitsPerRow: 16,
+        bitOrder: 'descending',
+      });
+      const enableBit = { position: 'center', text: '12' };
+      expect(ascending.find(({ label }) => label === 'EN')?.bits).toMatchObject([enableBit]);
+      expect(descending.find(({ label }) => label === 'EN')?.bits).toMatchObject([enableBit]);
+    });
+
+    it('mirrors each row of a multi-row packet on its own', async () => {
+      const rows = await renderPacket(twoFields, { bitsPerRow: 8, bitOrder: 'descending' });
+      expect(
+        rows.map((row) => row.map(({ label, x, width }) => ({ label, x, width })))
+      ).toStrictEqual([[{ label: 'foo', x: 1, width: 251 }], [{ label: 'bar', x: 1, width: 251 }]]);
+      expect(rows.map(bitNumbersLeftToRight)).toStrictEqual([
+        [7, 0],
+        [15, 8],
+      ]);
+    });
+
+    it('mirrors within bitsPerRow, so a part-filled row is flush right', async () => {
+      const [row] = await renderPacket(`packet
+0-7: "foo"
+`);
+      const [mirrored] = await renderPacket(
+        `packet
+0-7: "foo"
+`,
+        { bitOrder: 'descending' }
+      );
+      // 8 bits of a 32-bit row: flush left ascending, flush right descending.
+      expect(row).toMatchObject([{ x: 1, width: 251 }]);
+      expect(mirrored).toMatchObject([{ x: 24 * 32 + 1, width: 251 }]);
+    });
+  });
+
+  describe('showBits', () => {
+    it.each(['ascending', 'descending'] as const)(
+      'draws no bit numbers with showBits false and bitOrder %s',
+      async (bitOrder) => {
+        const rows = await renderPacket(register, { bitsPerRow: 16, showBits: false, bitOrder });
+        expect(rows.flat().flatMap(({ bits }) => bits)).toStrictEqual([]);
+        expect(document.querySelectorAll('.packetByte')).toHaveLength(0);
+      }
+    );
+
+    it('still mirrors the row with showBits false', async () => {
+      const [row] = await renderPacket(register, {
+        bitsPerRow: 16,
+        showBits: false,
+        bitOrder: 'descending',
+      });
+      expect(row.map(({ label }) => label)).toStrictEqual(['RESERVED', 'EN', 'TYPE', 'DATA']);
+    });
+  });
+});

--- a/packages/mermaid/src/diagrams/packet/renderer.ts
+++ b/packages/mermaid/src/diagrams/packet/renderer.ts
@@ -37,13 +37,27 @@ const drawWord = (
   svg: SVG,
   word: PacketWord,
   rowNumber: number,
-  { rowHeight, paddingX, paddingY, bitWidth, bitsPerRow, showBits }: Required<PacketDiagramConfig>
+  {
+    rowHeight,
+    paddingX,
+    paddingY,
+    bitWidth,
+    bitsPerRow,
+    showBits,
+    bitOrder,
+  }: Required<PacketDiagramConfig>
 ) => {
   const group: SVGGroup = svg.append('g');
   const wordY = rowNumber * (rowHeight + paddingY) + paddingY;
+  const descending = bitOrder === 'descending';
   for (const block of word) {
-    const blockX = (block.start % bitsPerRow) * bitWidth + 1;
-    const width = (block.end - block.start + 1) * bitWidth - paddingX;
+    const bits = block.end - block.start + 1;
+    // Column the block starts at within its row. `descending` mirrors the row, so the row
+    // reads from its highest bit down to its lowest, as hardware registers are drawn.
+    const firstColumn = block.start % bitsPerRow;
+    const column = descending ? bitsPerRow - firstColumn - bits : firstColumn;
+    const blockX = column * bitWidth + 1;
+    const width = bits * bitWidth - paddingX;
     // Block rectangle
     group
       .append('rect')
@@ -66,8 +80,13 @@ const drawWord = (
     if (!showBits) {
       continue;
     }
+    // A mirrored block runs from its highest bit on the left down to its lowest on the right.
+    const [leadingBit, trailingBit] = descending
+      ? [block.end, block.start]
+      : [block.start, block.end];
+
     // Start byte count
-    const isSingleBlock = block.end === block.start;
+    const isSingleBlock = bits === 1;
     const bitNumberY = wordY - 2;
     group
       .append('text')
@@ -76,7 +95,7 @@ const drawWord = (
       .attr('class', 'packetByte start')
       .attr('dominant-baseline', 'auto')
       .attr('text-anchor', isSingleBlock ? 'middle' : 'start')
-      .text(block.start);
+      .text(leadingBit);
 
     // Draw end byte count if it is not the same as start byte count
     if (!isSingleBlock) {
@@ -87,7 +106,7 @@ const drawWord = (
         .attr('class', 'packetByte end')
         .attr('dominant-baseline', 'auto')
         .attr('text-anchor', 'end')
-        .text(block.end);
+        .text(trailingBit);
     }
   }
 };

--- a/packages/mermaid/src/docs/syntax/packet.md
+++ b/packages/mermaid/src/docs/syntax/packet.md
@@ -70,6 +70,29 @@ title UDP Packet
 - **Ranges**: Each line after the title represents a different field in the packet. The range (e.g., `0-15`) indicates the bit positions in the packet.
 - **Field Description**: A brief description of what the field represents, enclosed in quotes.
 
+### Bit Numbering Order (v<MERMAID_RELEASE_VERSION>+)
+
+Rows are numbered from their lowest bit on the left up to their highest bit on the right, which suits network packets. Hardware registers are conventionally drawn the other way round, with the most significant bit on the left and bit 0 on the right. Set `bitOrder: descending` to mirror every row:
+
+```mermaid-example
+---
+config:
+  packet:
+    showBits: true
+    bitOrder: descending
+    bitsPerRow: 16
+---
+packet
+0-7: "DATA"
+8-11: "TYPE"
+12: "EN"
+13-15: "RESERVED"
+```
+
+Only the drawing is mirrored. Fields are still declared lowest bit first (`0-7`, never `7-0`) and keep their width, so the same diagram can be switched between the two conventions by changing `bitOrder` alone.
+
+Each row is mirrored on its own, so a packet wider than `bitsPerRow` reads as a stack of words that each run from their highest bit down to their lowest: with the default `bitsPerRow: 32`, the second row runs from bit 63 down to bit 32, not down to bit 0. A row that is not completely filled is padded on the left, keeping its lowest bit flush against the right edge.
+
 ## Configuration
 
 Please refer to the [configuration](/config/schema-docs/config-defs-packet-diagram-config.html) guide for details.

--- a/packages/mermaid/src/schemas/config.schema.yaml
+++ b/packages/mermaid/src/schemas/config.schema.yaml
@@ -2741,6 +2741,20 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
         description: Toggle to display or hide bit numbers.
         type: boolean
         default: true
+      bitOrder:
+        description: |
+          The direction each row is numbered in. `descending` mirrors every row so it reads from
+          that row's highest bit on the left down to its lowest bit on the right, the convention
+          used for hardware registers. Fields are still declared lowest bit first, and keep their
+          width.
+        type: string
+        enum:
+          - ascending
+          - descending
+        meta:enum:
+          ascending: Number each row from its lowest bit on the left up to its highest bit on the right.
+          descending: Number each row from its highest bit on the left down to its lowest bit on the right.
+        default: ascending
       paddingX:
         description: The horizontal padding between the blocks in a row.
         type: number


### PR DESCRIPTION
## :bookmark_tabs: Summary

Packet rows are numbered from bit 0 on the left up to the highest bit on the right, which suits e.g. network packets. Hardware registers are conventionally drawn the other way round with the most significant bit on the left, bit 0 on the right, and there is currently no way to get that out of a `packet` diagram.

This adds a `packet.bitOrder` option. It defaults to `ascending` (today's behaviour); `descending` mirrors every row so it reads from its highest bit down to bit 0.

```yaml
---
config:
  packet:
    showBits: true
    bitOrder: descending
    bitsPerRow: 16
---
packet
0-7: "DATA"
8-11: "TYPE"
12: "EN"
13-15: "RESERVED"
```

**`bitOrder: ascending`** (default, unchanged)

<img width="1557" height="158" alt="image" src="https://github.com/user-attachments/assets/c892708c-4129-4bc4-ba6d-dc68a245c3b3" />

**`bitOrder: descending`**

<img width="1557" height="158" alt="image" src="https://github.com/user-attachments/assets/65e18152-60c0-4d91-9655-ead3ad09d0ef" />

Same diagram source in both cases, only `bitOrder` differs. Fields are still declared lowest bit first (`0-7`, never `7-0`), so an existing diagram can be switched between the two conventions without rewriting a single range.

## :straight_ruler: Design Decisions

**`bitOrder: ascending | descending`.** The name describes the numbering direction rather than naming a particular bit, so it stays meaningful at any field width and for any `bitsPerRow`. It follows the existing schema enums (`er.layoutDirection`, `gantt.weekday`) and carries `meta:enum` descriptions for both values.

**The row is mirrored, not just the labels.** An earlier draft only swapped the two numbers drawn on each field and left the fields in ascending order. That is correct for a single-field register but gives a row whose numbers are not monotonic (`7…0`, then `11…8`, then `12`…), which no datasheet does. Mirroring the row is what "bit 0 on the right" actually means once a row holds more than one field.

**Mirroring is per row, within `bitsPerRow`.** Each row is reflected in its own coordinate system, so a packet wider than one row reads as a stack of words that each run high bit → low bit:

```yaml
---
config:
  packet:
    showBits: true
    bitOrder: descending
---
packet
0-15: "Source Port"
16-31: "Destination Port"
32-63: "Sequence Number"
```

<img width="1566" height="167" alt="image" src="https://github.com/user-attachments/assets/2f68810c-3bf5-4cb4-8323-be640081948d" />

Each row carries its own bit numbers, so the second row above runs from bit 63 down to bit 32 — not down to bit 0. A row that is not completely filled is padded on the left, so that row's lowest bit still lands flush against the right edge:

```yaml
---
config:
  packet:
    showBits: true
    bitOrder: descending
---
packet
0-15: "Source Port"
16-31: "Destination Port"
32-47: "Length"
```

<!-- paste partfilled-descending.png here -->

**Nothing changes for `ascending`.** The parser, the db and `PacketWord` are untouched — the whole change is a column index and which of two `<text>` elements gets which number:

```ts
const firstColumn = block.start % bitsPerRow;
const column = descending ? bitsPerRow - firstColumn - bits : firstColumn;
```

Field widths, padding and the SVG canvas size are identical in both orders, and a unit test asserts the default and an explicit `ascending` render the same SVG.

**`showBits` is orthogonal.** `bitOrder` mirrors the layout whether or not the numbers are drawn, so `showBits: false` still gives a mirrored row.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [x] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Review summary

🎉 The change is focused and backward compatible. It adds `packet.bitOrder`, updates the schema and generated type, and documents the new behavior.

🎉 Renderer tests cover ascending and descending layouts, multiple rows, partial rows, field widths, and `showBits`.

### Findings

No blocking or important issues identified.

### Security

No XSS or injection issues identified.

## Verdict

✅ APPROVE

Severity tally: 0 blocking / 0 important / 0 nit / 0 suggestions / 2 praise
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
