### PR TITLE
fix: use Unicode-safe base64 for the data-points attribute in insertEdge

### DIFF
--- a/.changeset/spotty-lions-sin.md
+++ b/.changeset/spotty-lions-sin.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: use Unicode-safe base64 encoding for the `data-points` debug attribute in `insertEdge`. Raw `window.btoa` throws `InvalidCharacterError` when the serialized edge points contain characters outside the Latin1 range (e.g. when a browser extension interferes with object serialization in the page), which aborted rendering of the whole diagram.

--- a/packages/mermaid/src/rendering-util/rendering-elements/edges.js
+++ b/packages/mermaid/src/rendering-util/rendering-elements/edges.js
@@ -10,6 +10,7 @@ import {
   markerOffsets,
   markerOffsets2,
 } from '../../utils/lineWithOffset.js';
+import { toBase64 } from '../../utils/base64.js';
 import { getSubGraphTitleMargins } from '../../utils/subGraphTitleMargins.js';
 
 import {
@@ -663,7 +664,7 @@ export const insertEdge = function (
     points.unshift(tail.intersect(points[0]));
     points.push(head.intersect(points[points.length - 1]));
   }
-  const pointsStr = btoa(JSON.stringify(points));
+  const pointsStr = toBase64(JSON.stringify(points));
   if (edge.toCluster) {
     log.info('to cluster abc88', clusterDb.get(edge.toCluster));
     points = cutPathAtIntersect(edge.points, clusterDb.get(edge.toCluster).node);


### PR DESCRIPTION
## :bookmark_tabs: Summary

`insertEdge` builds the debug-only `data-points` attribute with raw `window.btoa`:

https://github.com/mermaid-js/mermaid/blob/develop/packages/mermaid/src/rendering-util/rendering-elements/edges.js#L666

`btoa` throws `InvalidCharacterError` when its input contains characters outside the Latin1 range. We hit this in production: on a machine where a browser extension (injected into the page's main world) interfered with object serialization, `JSON.stringify(points)` came out containing non-Latin1 characters, and the exception aborted rendering of the **entire diagram** — even though `data-points` is purely informational:

```
InvalidCharacterError: Failed to execute 'btoa' on 'Window': The string to be encoded contains characters outside of the Latin1 range.
    at insertEdge (mermaid.core.mjs:...)
    at paintLayoutEdge (...)
    at paintLayoutData (...)
```

This PR switches the call site to the existing `toBase64` helper (`src/utils/base64.ts`, the TextEncoder-based pattern from [MDN's Unicode guidance](https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem)), which the codebase already uses elsewhere for exactly this reason (e.g. `mermaidAPI.ts`).

## :straight_ruler: Design Decisions

- Reuse `toBase64` instead of adding a try/catch: the helper exists precisely for this, and an informational attribute should never be able to fail the render.
- No new unit test: `toBase64`'s Unicode safety is already covered by `src/utils/base64.spec.ts`, and this change only swaps the encoder at one call site. Happy to add an `insertEdge`-level test if you'd prefer.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Replaced `window.btoa` with the Unicode-safe `toBase64` helper in `insertEdge`.
- Prevents rendering failures when serialized edge points contain non-Latin1 characters.
- Added a patch changeset for `mermaid`.
- No public API changes or new tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->