### PR TITLE
fix(gantt): warn when an after/until reference or a duration cannot be resolved

### DIFF
--- a/.changeset/gantt-warn-unresolved-task-references.md
+++ b/.changeset/gantt-warn-unresolved-task-references.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: warn when a gantt task references an unknown `after`/`until` task id, or when its end value is neither a valid date nor a valid duration

--- a/packages/mermaid/src/diagrams/gantt/ganttDb.js
+++ b/packages/mermaid/src/diagrams/gantt/ganttDb.js
@@ -287,6 +287,21 @@ const fixTaskDates = function (startTime, endTime, dateFormat, excludes, include
   return [endTime, renderEndTime];
 };
 
+/**
+ * Logs a warning about task ids that an `after` or `until` statement could not resolve.
+ *
+ * Unknown references fail silently and fall back to today's date, which makes typos and
+ * missing ids hard to spot. See https://github.com/mermaid-js/mermaid/issues/4121.
+ *
+ * @param {'after' | 'until'} keyword - The keyword holding the references.
+ * @param {string[]} ids - The ids that could not be found.
+ */
+const warnAboutUnknownTaskIds = function (keyword, ids) {
+  log.warn(
+    `Gantt: the "${keyword}" statement references unknown task id(s): ${ids.join(', ')}. Make sure the referenced tasks exist and declare an id. Milestones need both an id and a duration, e.g. "Milestone :milestone, m1, 2023-01-01, 0d".`
+  );
+};
+
 const getStartDate = function (prevTime, dateFormat, str) {
   str = str.trim();
 
@@ -307,11 +322,21 @@ const getStartDate = function (prevTime, dateFormat, str) {
   if (afterStatement !== null) {
     // check all after ids and take the latest
     let latestTask = null;
-    for (const id of afterStatement.groups.ids.split(' ')) {
-      let task = findTaskById(id);
-      if (task !== undefined && (!latestTask || task.endTime > latestTask.endTime)) {
+    const unknownIds = [];
+    const referencedIds = afterStatement.groups.ids.split(' ').filter((id) => id !== '');
+    for (const id of referencedIds) {
+      const task = findTaskById(id);
+      if (task === undefined) {
+        unknownIds.push(id);
+        continue;
+      }
+      if (!latestTask || task.endTime > latestTask.endTime) {
         latestTask = task;
       }
+    }
+
+    if (unknownIds.length > 0) {
+      warnAboutUnknownTaskIds('after', unknownIds);
     }
 
     if (latestTask) {
@@ -391,11 +416,21 @@ const getEndDate = function (prevTime, dateFormat, str, inclusive = false) {
   if (untilStatement !== null) {
     // check all until ids and take the earliest
     let earliestTask = null;
-    for (const id of untilStatement.groups.ids.split(' ')) {
-      let task = findTaskById(id);
-      if (task !== undefined && (!earliestTask || task.startTime < earliestTask.startTime)) {
+    const unknownIds = [];
+    const referencedIds = untilStatement.groups.ids.split(' ').filter((id) => id !== '');
+    for (const id of referencedIds) {
+      const task = findTaskById(id);
+      if (task === undefined) {
+        unknownIds.push(id);
+        continue;
+      }
+      if (!earliestTask || task.startTime < earliestTask.startTime) {
         earliestTask = task;
       }
+    }
+
+    if (unknownIds.length > 0) {
+      warnAboutUnknownTaskIds('until', unknownIds);
     }
 
     if (earliestTask) {
@@ -417,7 +452,11 @@ const getEndDate = function (prevTime, dateFormat, str, inclusive = false) {
 
   let endTime = dayjs(prevTime);
   const [durationValue, durationUnit] = parseDuration(str);
-  if (!Number.isNaN(durationValue)) {
+  if (Number.isNaN(durationValue)) {
+    log.warn(
+      `Gantt: "${str}" is neither a valid date for the "${dateFormat.trim()}" date format nor a valid duration (e.g. "3d"), so it is ignored and the task gets a zero duration. Milestones need a duration too, e.g. "Milestone :milestone, m1, 2023-01-01, 0d".`
+    );
+  } else {
     const newEndTime = endTime.add(durationValue, durationUnit);
     if (newEndTime.isValid()) {
       endTime = newEndTime;

--- a/packages/mermaid/src/diagrams/gantt/ganttDb.spec.ts
+++ b/packages/mermaid/src/diagrams/gantt/ganttDb.spec.ts
@@ -2,6 +2,7 @@
 import dayjs from 'dayjs';
 import ganttDb from './ganttDb.js';
 import { convert } from '../../tests/util.js';
+import { log } from '../../logger.js';
 
 describe('when using the ganttDb', function () {
   beforeEach(function () {
@@ -565,5 +566,55 @@ describe('when using the ganttDb', function () {
     expect(tasks[0].startTime.getFullYear()).toBe(2024);
     // Second task will be parsed as year 202 (fallback to new Date())
     expect(tasks[1].startTime.getFullYear()).toBe(202);
+  });
+
+  describe('when a task references a task id that does not exist', function () {
+    it('should warn about unknown ids in an "after" statement (issue #4121)', function () {
+      const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => undefined);
+      ganttDb.setDateFormat('YYYY-MM-DD');
+      ganttDb.addTask('task1', 'id1,2013-01-01,2d');
+      ganttDb.addTask('task2', 'id2,after m1,1d');
+
+      ganttDb.getTasks();
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('m1'));
+      warnSpy.mockRestore();
+    });
+
+    it('should warn about unknown ids in an "until" statement', function () {
+      const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => undefined);
+      ganttDb.setDateFormat('YYYY-MM-DD');
+      ganttDb.addTask('task1', 'id1,2013-01-01,until m1');
+
+      ganttDb.getTasks();
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('m1'));
+      warnSpy.mockRestore();
+    });
+
+    it('should not warn when every referenced id exists', function () {
+      const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => undefined);
+      ganttDb.setDateFormat('YYYY-MM-DD');
+      ganttDb.addTask('task1', 'id1,2013-01-01,2d');
+      ganttDb.addTask('task2', 'id2,after id1,1d');
+
+      ganttDb.getTasks();
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('should warn when a milestone is declared without a duration (issue #4121)', function () {
+      const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => undefined);
+      ganttDb.setDateFormat('YYYY-MM-DD');
+      // Without a duration, `m1` is parsed as the duration instead of as the id
+      ganttDb.addTask('M1', 'milestone, 2023-01-01, m1');
+
+      const tasks = ganttDb.getTasks();
+
+      expect(tasks[0].endTime).toEqual(tasks[0].startTime);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('m1'));
+      warnSpy.mockRestore();
+    });
   });
 });


### PR DESCRIPTION
## :bookmark_tabs: Summary

Refs #4121 (this PR makes the two silent failures behind that report visible; the scheduling fallback itself is unchanged, so the issue should stay open)

A gantt milestone written without a duration (`M1, :milestone, 2023-01-01, m1`) is parsed as a two-field task, so `m1` is consumed as the "duration" and the milestone never gets that id. A later `after m1` then finds nothing and silently falls back to today's date. Both failures are silent, which is what made the original report hard to diagnose.

This PR keeps the existing fallback behaviour - there are tests that rely on it - and only makes the failures visible:

- `after` and `until` now warn about task ids they could not resolve.
- An end value that is neither a valid date nor a valid duration now warns instead of being dropped silently.

Both warnings point at the correct milestone syntax (`Milestone :milestone, m1, 2023-01-01, 0d`).

## :straight_ruler: Design Decisions

Warnings rather than errors, so no existing diagram changes the way it renders. The unit tests use `vi.spyOn(log, 'warn')`, following the existing pattern in `flow-style.spec.js` and `gitGraph.spec.ts`. No documentation change is needed: the docs already state that invalid duration tokens are ignored and that the task defaults to zero duration.

### :clipboard: Tasks

Make sure you

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [x] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
