### PR TITLE
fix(xychart): support accented Latin axis labels

### DIFF
--- a/.changeset/tidy-charts-listen.md
+++ b/.changeset/tidy-charts-listen.md
@@ -1,0 +1,5 @@
+---
+'mermaid': patch
+---
+
+fix: support unquoted accented Latin characters in XY chart axis labels and titles

--- a/e2e/diagrams/xychart/should-render-accented-latin-axis-labels.mmd
+++ b/e2e/diagrams/xychart/should-render-accented-latin-axis-labels.mmd
@@ -1,0 +1,4 @@
+xychart
+  x-axis [jan, fév, août]
+  y-axis Température -20 --> 50
+  bar [22, 23, 24]

--- a/packages/mermaid/src/diagrams/xychart/parser/xychart.jison
+++ b/packages/mermaid/src/diagrams/xychart/parser/xychart.jison
@@ -58,7 +58,7 @@
 
 "["                                       return 'SQUARE_BRACES_START'
 "]"                                       return 'SQUARE_BRACES_END'
-[A-Za-z]+                                 return 'ALPHA';
+[A-Za-zÀ-ÖØ-öø-ÿ]+                         return 'ALPHA';
 ":"                                       return 'COLON';
 \+                                        return 'PLUS';
 ","                                       return 'COMMA';

--- a/packages/mermaid/src/diagrams/xychart/parser/xychart.jison.spec.ts
+++ b/packages/mermaid/src/diagrams/xychart/parser/xychart.jison.spec.ts
@@ -50,6 +50,22 @@ describe('Testing xychart jison file', () => {
     expect(parserFnConstructor(str)).not.toThrow();
   });
 
+  it('parses unquoted accented Latin axis labels and titles', () => {
+    parser.parse(`xychart
+      x-axis [jan, fév, août]
+      y-axis Température -20 --> 50
+      bar [22, 23, 24]
+    `);
+
+    expect(mockDB.setXAxisBand).toHaveBeenCalledWith([
+      { text: 'jan', type: 'text' },
+      { text: 'fév', type: 'text' },
+      { text: 'août', type: 'text' },
+    ]);
+    expect(mockDB.setYAxisTitle).toHaveBeenCalledWith({ text: 'Température', type: 'text' });
+    expect(mockDB.setYAxisRangeData).toHaveBeenCalledWith(-20, 50);
+  });
+
   it('parse title of the chart within "', () => {
     const str = 'xychart \n title "This is a title"';
     expect(parserFnConstructor(str)).not.toThrow();


### PR DESCRIPTION
## :bookmark_tabs: Summary

Allow unquoted accented Latin characters in XY chart labels and titles. The example below currently fails to parse at `fév`; with this change it renders the three bars and preserves both axis labels and the title.

```mermaid
xychart
  x-axis [jan, fév, août]
  y-axis Température -20 --> 50
  bar [22, 23, 24]
```

Fixes #7157.

Continues the fix from @estulpz202 in #7224, which was closed after the requested changeset and visual regression coverage were not added. This PR uses the same reviewed Latin-1 character range and supplies both missing pieces using the current `.mmd`/Playwright fixture infrastructure.

## :straight_ruler: Design Decisions

Extend the `ALPHA` lexer token with the Latin-1 letter ranges, excluding the multiplication and division symbols. Parsing rules and numeric ranges are unchanged.

Validation:

- Added parser regression fails on the base revision with “Unrecognized text” and passes with the fix. All 68 XY chart unit tests pass.
- The new `.mmd` visual fixture passes in Chromium; inspected the captured image and confirmed `fév`, `août`, and `Température` render correctly.
- Browser bundles built successfully. Jison lint and formatting pass; ESLint reports no errors (one pre-existing `any` warning in the test file).

Remote CI: unit tests, lint, build and CodeQL pass. The [E2E job](https://github.com/mermaid-js/mermaid/actions/runs/34707091831/job/103589107858) exceeded its configured 30-minute limit while processing snapshot 1089/1250, before reaching the XY chart fixtures. GitHub reports a timeout; the required E2E aggregate consequently fails. The focused new fixture passed locally as noted above.

AI-assisted: OpenAI Codex assisted with the follow-up implementation and validation.

### :clipboard: Tasks

- [x] Read the contribution guidelines.
- [x] Added unit and E2E visual coverage.
- [x] Documentation considered: no new syntax or API; the regression fixture shows the supported labels.
- [x] Added a patch changeset for `mermaid`.
