### PR TITLE
docs: update the contributing guide's Node.js requirement

### DIFF
--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -50,14 +50,14 @@ We support **development within Docker** environment along with **host setup**. 
 
 These are the tools we use for working with the code and documentation:
 
-- [Node.js](https://nodejs.org/en/).
+- [Node.js](https://nodejs.org/en/) v22.12.0 or higher.
 - [pnpm](https://pnpm.io/) package manager.
 
 The following commands must be sufficient enough to start with:
 
 ```bash
 curl -fsSL https://get.pnpm.io/install.sh | sh -
-pnpm env use --global 20
+pnpm env use --global 24
 ```
 
 You may also need to reload `.shrc` or `.bashrc` afterwards.

--- a/packages/mermaid/src/docs/community/contributing.md
+++ b/packages/mermaid/src/docs/community/contributing.md
@@ -45,14 +45,14 @@ We support **development within Docker** environment along with **host setup**. 
 
 These are the tools we use for working with the code and documentation:
 
-- [Node.js](https://nodejs.org/en/).
+- [Node.js](https://nodejs.org/en/) v22.12.0 or higher.
 - [pnpm](https://pnpm.io/) package manager.
 
 The following commands must be sufficient enough to start with:
 
 ```bash
 curl -fsSL https://get.pnpm.io/install.sh | sh -
-pnpm env use --global 20
+pnpm env use --global 24
 ```
 
 You may also need to reload `.shrc` or `.bashrc` afterwards.


### PR DESCRIPTION
The contributing guide recommends Node 20, but the workspace now requires Node >=22.12.0. Its CI uses Node 24.

Document the minimum version and update the optional `pnpm env use` command to Node 24. Only the documentation source is changed.

Validation: Prettier and `git diff --check` pass. A frozen, offline, lockfile-only install with pnpm 10.30.3 passes engine-strict validation on Node 24.15.0. Overriding pnpm's configured Node version to 20.20.1 reproduces `ERR_PNPM_UNSUPPORTED_ENGINE`; this checks the version guard, rather than running Node 20. No full dependency install, website build, or test suite was run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated both contributing guides to require Node.js v22.12.0 or higher.
- Updated `pnpm env use --global` to select Node.js 24.
- Verified formatting, diff checks, and Node.js engine validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->