### PR TITLE
docs: add AtlasDocs to Community integrations (Productivity tools)

### DIFF
--- a/docs/ecosystem/integrations-community.md
+++ b/docs/ecosystem/integrations-community.md
@@ -41,6 +41,7 @@ To add an integration to this list, see the [Integrations - create page](./integ
   - [Mermaid for Jira Cloud - Draw UML diagrams easily](https://marketplace.atlassian.com/apps/1223053/mermaid-for-jira-cloud-draw-uml-diagrams-easily?hosting=cloud&tab=overview)
   - [CloudScript.io Mermaid Addon](https://marketplace.atlassian.com/apps/1219878/cloudscript-io-mermaid-addon?hosting=cloud&tab=overview)
   - [Mermaid plus for Confluence](https://marketplace.atlassian.com/apps/1236814/mermaid-plus-for-confluence?hosting=cloud&tab=overview)
+- [AtlasDocs](https://atlasdocs.io/en/mermaid-diagram) - Browser-only Mermaid editor with live preview, PNG/SVG export and conversion to an editable Excalidraw file; nothing is uploaded
 - [Azure Devops](https://learn.microsoft.com/en-us/azure/devops/project/wiki/markdown-guidance?view=azure-devops#add-mermaid-diagrams-to-a-wiki-page) ✅
 - [Deepdwn](https://billiam.itch.io/deepdwn) ✅
 - [Doctave](https://www.doctave.com/) ✅
@@ -286,4 +287,4 @@ Communication tools and platforms
 - [termaid: Render Mermaid diagrams as Unicode art in the terminal](https://github.com/fasouto/termaid)
 - [Vitepress Plugin](https://github.com/sametcn99/vitepress-mermaid-renderer)
 
-<!--- cspell:ignore Blazorade HueHive --->
+<!--- cspell:ignore AtlasDocs Blazorade Excalidraw HueHive --->

--- a/packages/mermaid/src/docs/ecosystem/integrations-community.md
+++ b/packages/mermaid/src/docs/ecosystem/integrations-community.md
@@ -36,6 +36,7 @@ To add an integration to this list, see the [Integrations - create page](./integ
   - [Mermaid for Jira Cloud - Draw UML diagrams easily](https://marketplace.atlassian.com/apps/1223053/mermaid-for-jira-cloud-draw-uml-diagrams-easily?hosting=cloud&tab=overview)
   - [CloudScript.io Mermaid Addon](https://marketplace.atlassian.com/apps/1219878/cloudscript-io-mermaid-addon?hosting=cloud&tab=overview)
   - [Mermaid plus for Confluence](https://marketplace.atlassian.com/apps/1236814/mermaid-plus-for-confluence?hosting=cloud&tab=overview)
+- [AtlasDocs](https://atlasdocs.io/en/mermaid-diagram) - Browser-only Mermaid editor with live preview, PNG/SVG export and conversion to an editable Excalidraw file; nothing is uploaded
 - [Azure Devops](https://learn.microsoft.com/en-us/azure/devops/project/wiki/markdown-guidance?view=azure-devops#add-mermaid-diagrams-to-a-wiki-page) ✅
 - [Deepdwn](https://billiam.itch.io/deepdwn) ✅
 - [Doctave](https://www.doctave.com/) ✅
@@ -281,4 +282,4 @@ Communication tools and platforms
 - [termaid: Render Mermaid diagrams as Unicode art in the terminal](https://github.com/fasouto/termaid)
 - [Vitepress Plugin](https://github.com/sametcn99/vitepress-mermaid-renderer)
 
-<!--- cspell:ignore Blazorade HueHive --->
+<!--- cspell:ignore AtlasDocs Blazorade Excalidraw HueHive --->


### PR DESCRIPTION
## :bookmark_tabs: Summary

Adds **AtlasDocs** to *Community integrations → Productivity tools*.

AtlasDocs (https://atlasdocs.io) is a free document toolbox that runs entirely in the browser. Its Mermaid tool (https://atlasdocs.io/en/mermaid-diagram) renders Mermaid code with a live preview, exports PNG/SVG and converts the diagram to an editable Excalidraw file. Everything runs client-side on top of the `mermaid` npm package; nothing is uploaded to a server.

The two new words (AtlasDocs, Excalidraw) were added to the cspell ignore comment at the end of the file so the docs lint stays green.

## :straight_ruler: Design Decisions

Docs-only change in `packages/mermaid/src/docs`, as described in the contributing guide (the `docs/` folder is autogenerated and was not touched). Entry placed alphabetically in the list.

### :clipboard: Tasks

- [x] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [x] :computer: unit/e2e tests: not applicable (documentation only)
- [x] :notebook: documentation: this PR is the documentation change; no new feature, so `MERMAID_RELEASE_VERSION` does not apply
- [x] :butterfly: changeset: not applicable (no package change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added AtlasDocs to Mermaid’s Community integrations → Productivity tools.
- Documented live previews, PNG/SVG export, Excalidraw conversion, and client-side processing.
- Updated the cspell ignore list for `AtlasDocs` and `Excalidraw`.

## Testing

- Not run. Documentation-only change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->